### PR TITLE
add UYVY support

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -150,6 +150,8 @@ void rgb_to_hsv (const void* src, void* dst, int length,
                  unsigned long source, SDL_PixelFormat* format);
 void yuyv_to_rgb (const void* src, void* dst, int length, SDL_PixelFormat* format);
 void yuyv_to_yuv (const void* src, void* dst, int length, SDL_PixelFormat* format);
+void uyvy_to_rgb (const void* src, void* dst, int length, SDL_PixelFormat* format);
+void uyvy_to_yuv (const void* src, void* dst, int length, SDL_PixelFormat* format);
 void sbggr8_to_rgb (const void* src, void* dst, int width, int height,
                     SDL_PixelFormat* format);
 void yuv420_to_rgb (const void* src, void* dst, int width, int height,

--- a/src/camera_v4l2.c
+++ b/src/camera_v4l2.c
@@ -233,17 +233,17 @@ int v4l2_process_image (PyCameraObject* self, const void *image,
                 return 0;
             }
             break;
-    case V4L2_PIX_FMT_UYVY:	    /* FIXME: wrong, just copied from V4L2_PIX_FMT_YUYV above */
+    case V4L2_PIX_FMT_UYVY:
             if (buffer_size >= self->size * 2) {
                 switch (self->color_out) {
                     case YUV_OUT:
-                        yuyv_to_yuv(image, surf->pixels, self->size, surf->format);
+                        uyvy_to_yuv(image, surf->pixels, self->size, surf->format);
                         break;
                     case RGB_OUT:
-                        yuyv_to_rgb(image, surf->pixels, self->size, surf->format);
+                        uyvy_to_rgb(image, surf->pixels, self->size, surf->format);
                         break;
                     case HSV_OUT:
-                        yuyv_to_rgb(image, surf->pixels, self->size, surf->format);
+                        uyvy_to_rgb(image, surf->pixels, self->size, surf->format);
                         rgb_to_hsv(surf->pixels, surf->pixels, self->size, V4L2_PIX_FMT_YUYV, surf->format);
                         break;
                 }

--- a/src/camera_v4l2.c
+++ b/src/camera_v4l2.c
@@ -233,6 +233,25 @@ int v4l2_process_image (PyCameraObject* self, const void *image,
                 return 0;
             }
             break;
+    case V4L2_PIX_FMT_UYVY:	    /* FIXME: wrong, just copied from V4L2_PIX_FMT_YUYV above */
+            if (buffer_size >= self->size * 2) {
+                switch (self->color_out) {
+                    case YUV_OUT:
+                        yuyv_to_yuv(image, surf->pixels, self->size, surf->format);
+                        break;
+                    case RGB_OUT:
+                        yuyv_to_rgb(image, surf->pixels, self->size, surf->format);
+                        break;
+                    case HSV_OUT:
+                        yuyv_to_rgb(image, surf->pixels, self->size, surf->format);
+                        rgb_to_hsv(surf->pixels, surf->pixels, self->size, V4L2_PIX_FMT_YUYV, surf->format);
+                        break;
+                }
+            } else {
+                SDL_UnlockSurface (surf);
+                return 0;
+            }
+            break;
         case V4L2_PIX_FMT_SBGGR8:
             if (buffer_size >= self->size) {
                 switch (self->color_out) {
@@ -524,6 +543,8 @@ int v4l2_init_device (PyCameraObject* self)
                 self->pixelformat = V4L2_PIX_FMT_YUYV;
             } else if (v4l2_pixelformat(self->fd, &fmt, V4L2_PIX_FMT_YUV420)) {
                 self->pixelformat = V4L2_PIX_FMT_YUV420;
+            } else if (v4l2_pixelformat(self->fd, &fmt, V4L2_PIX_FMT_UYVY)) {
+                self->pixelformat = V4L2_PIX_FMT_UYVY;
             } else if (v4l2_pixelformat(self->fd, &fmt, V4L2_PIX_FMT_RGB24)) {
                 self->pixelformat = V4L2_PIX_FMT_RGB24;
             } else if (v4l2_pixelformat(self->fd, &fmt, V4L2_PIX_FMT_RGB444)) {

--- a/src/camera_v4l2.c
+++ b/src/camera_v4l2.c
@@ -568,6 +568,8 @@ int v4l2_init_device (PyCameraObject* self)
                 self->pixelformat = V4L2_PIX_FMT_SBGGR8;
             } else if (v4l2_pixelformat(self->fd, &fmt, V4L2_PIX_FMT_YUV420)) {
                 self->pixelformat = V4L2_PIX_FMT_YUV420;
+            } else if (v4l2_pixelformat(self->fd, &fmt, V4L2_PIX_FMT_UYVY)) {
+                self->pixelformat = V4L2_PIX_FMT_UYVY;
             } else {
                 PyErr_Format(PyExc_SystemError,
                            "ioctl(VIDIOC_S_FMT) failure: no supported formats");


### PR DESCRIPTION
Consider a camera like this:

```
Driver Info (not using libv4l2):
	Driver name   : stk1160
	Card type     : stk1160
	Bus info      : usb-0000:00:14.0-10.7
	Driver version: 4.12.6
	Capabilities  : 0x85200001
		Video Capture
		Read/Write
		Streaming
		Extended Pix Format
		Device Capabilities
	Device Caps   : 0x05200001
		Video Capture
		Read/Write
		Streaming
		Extended Pix Format
Priority: 2
Video input : 0 (Composite0: ok)
Video Standard = 0x00001000
	NTSC-M
Format Video Capture:
	Width/Height      : 640/480
	Pixel Format      : 'UYVY'
	Field             : Interlaced
	Bytes per Line    : 1280
	Size Image        : 614400
	Colorspace        : SMPTE 170M
	Transfer Function : Default
	YCbCr/HSV Encoding: Default
	Quantization      : Default
	Flags             : 
Streaming Parameters Video Capture:
	Frames per second: 29.970 (30000/1001)
	Read buffers     : 2

User Controls

                     brightness (int)    : min=0 max=255 step=1 default=128 value=128 flags=slider
                       contrast (int)    : min=0 max=127 step=1 default=64 value=64 flags=slider
                     saturation (int)    : min=0 max=127 step=1 default=64 value=64 flags=slider
                            hue (int)    : min=-128 max=127 step=1 default=0 value=0 flags=slider
                     chroma_agc (bool)   : default=1 value=1 flags=update
                    chroma_gain (int)    : min=0 max=127 step=1 default=40 value=47 flags=inactive, slider, volatile
```

Note the pixel format here is UYVY.  Attempting to start capture with pygame.camera will give you an error like this:

```
    cam.start()
SystemError: ioctl(VIDIOC_S_FMT) failure: no supported formats
```

The attached patch allows pygame to make use of this sort of camera.

I have tested this and I get good output in RGB, and, I *think*, expected output in YUV, its hard to say, since it doens't look normal like RGB, but its consistent with what I get with other camers in YUV mode.

