### PR TITLE
Update math.c

### DIFF
--- a/src/math.c
+++ b/src/math.c
@@ -801,7 +801,6 @@ vector_GetSlice(PyVector *self, Py_ssize_t ilow, Py_ssize_t ihigh)
     /* some code was taken from the CPython source listobject.c */
     PyListObject *slice;
     Py_ssize_t i, len;
-    PyObject **dest;
 
     /* make sure boundaries are sane */
     if (ilow < 0)
@@ -819,7 +818,7 @@ vector_GetSlice(PyVector *self, Py_ssize_t ilow, Py_ssize_t ihigh)
         return NULL;
 
     for (i = 0; i < len; i++) {
-        PyList_SET_ITEM(dest, i, PyFloat_FromDouble(self->coords[ilow + i]));
+        PyList_SET_ITEM(slice, i, PyFloat_FromDouble(self->coords[ilow + i]));
     }
     return (PyObject *)slice;
 }
@@ -897,7 +896,6 @@ vector_subscript (PyVector *self, PyObject *key)
         Py_ssize_t start, stop, step, slicelength, cur;
         PyObject *result;
         PyObject *it;
-        PyObject **dest;
 
         if (PySlice_GetIndicesEx ((PySliceObject*)key, self->dim,
                  &start, &stop, &step, &slicelength) < 0) {
@@ -921,7 +919,7 @@ vector_subscript (PyVector *self, PyObject *key)
                     Py_DECREF (result);
                     return NULL;
                 }
-                PyList_SET_ITEM(dest, i, it);
+                PyList_SET_ITEM(result, i, it);
             }
             return result;
         }

--- a/src/math.c
+++ b/src/math.c
@@ -818,9 +818,8 @@ vector_GetSlice(PyVector *self, Py_ssize_t ilow, Py_ssize_t ihigh)
     if (slice == NULL)
         return NULL;
 
-    dest = slice->ob_item;
     for (i = 0; i < len; i++) {
-        dest[i] = PyFloat_FromDouble(self->coords[ilow + i]);
+        PyList_SET_ITEM(dest, i, PyFloat_FromDouble(self->coords[ilow + i]));
     }
     return (PyObject *)slice;
 }
@@ -916,14 +915,13 @@ vector_subscript (PyVector *self, PyObject *key)
             if (!result)
                 return NULL;
 
-            dest = ((PyListObject *)result)->ob_item;
             for (cur = start, i = 0; i < slicelength; cur += step, i++) {
                 it = PyFloat_FromDouble (self->coords[cur]);
                 if (it == NULL) {
                     Py_DECREF (result);
                     return NULL;
                 }
-                dest[i] = it;
+                PyList_SET_ITEM(dest, i, it);
             }
             return result;
         }


### PR DESCRIPTION
Replace ob_item access in math.c with macros so pygame compiles in pypy.

(Thanks to Armin Rigo of Pypy for suggesting how to do this).

With this change, pygame seems to work in pypy.

I tried all the examples, the only problems seemed to be:

Errors on any keyboard events e.g.

```
Traceback (most recent call last):
  File "aliens.py", line 321, in <module>
    if __name__ == '__main__': main()
  File "aliens.py", line 257, in main
    (event.type == KEYDOWN and event.key == K_ESCAPE):
AttributeError: 'Event' object has no attribute 'key'
```

The fastevents example seemed to be frozen, all the examples displayed graphics and played sounds.