### PR TITLE
add unit test for some key functions

### DIFF
--- a/test/key_test.py
+++ b/test/key_test.py
@@ -11,13 +11,21 @@ else:
     is_pygame_pkg = __name__.startswith('pygame.tests.')
 
 import unittest
+import pygame
+import pygame.key
 
 
 class KeyModuleTest(unittest.TestCase):
+    def setUp(self):
+        pygame.init()
+
+    def tearDown(self):
+        pygame.quit()
+
     def test_import(self):
         'does it import'
         import pygame.key
-        
+
     def todo_test_get_focused(self):
 
         # __doc__ (as of 2008-08-02) for pygame.key.get_focused:
@@ -28,20 +36,6 @@ class KeyModuleTest(unittest.TestCase):
           # This is true when the display window has keyboard focus from the
           # system. If the display needs to ensure it does not lose keyboard
           # focus, it can use pygame.event.set_grab() to grab all input.
-          # 
-
-        self.fail() 
-
-    def todo_test_get_mods(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.key.get_mods:
-
-          # pygame.key.get_mods(): return int
-          # determine which modifier keys are being held
-          # 
-          # Returns a single integer representing a bitmask of all the modifier
-          # keys being held. Using bitwise operators you can test if specific
-          # shift keys are pressed, the state of the capslock button, and more.
           # 
 
         self.fail() 
@@ -68,63 +62,30 @@ class KeyModuleTest(unittest.TestCase):
 
         self.fail() 
 
-    def todo_test_get_repeat(self):
+    def test_name(self):
+        self.assertEqual(pygame.key.name(pygame.K_RETURN), "return")
+        self.assertEqual(pygame.key.name(pygame.K_0), "0")
 
-        # __doc__ (as of 2008-08-02) for pygame.key.get_repeat:
+    def test_set_and_get_mods(self):
+        self.assertEqual(pygame.key.get_mods(), pygame.KMOD_NONE)
 
-          # pygame.key.get_repeat(): return (delay, interval)
-          # see how held keys are repeated
-          # 
-          # When the keyboard repeat is enabled, keys that are held down will
-          # generate multiple pygame.KEYDOWN events. The delay is the number of
-          # milliseconds before the first repeated pygame.KEYDOWN will be sent.
-          # After that another pygame.KEYDOWN will be sent every interval
-          # milliseconds.
-          # 
-          # When pygame is initialized the key repeat is disabled. 
-          # New in pygame 1.8. 
+        pygame.key.set_mods(pygame.KMOD_CTRL)
+        self.assertEqual(pygame.key.get_mods(), pygame.KMOD_CTRL)
 
-        self.fail() 
+        pygame.key.set_mods(pygame.KMOD_ALT)
+        self.assertEqual(pygame.key.get_mods(), pygame.KMOD_ALT)
+        pygame.key.set_mods(pygame.KMOD_CTRL | pygame.KMOD_ALT)
+        self.assertEqual(pygame.key.get_mods(), pygame.KMOD_CTRL | pygame.KMOD_ALT)
 
-    def todo_test_name(self):
+    def test_set_and_get_repeat(self):
+        self.assertEqual(pygame.key.get_repeat(), (0, 0))
 
-        # __doc__ (as of 2008-08-02) for pygame.key.name:
+        pygame.key.set_repeat(10, 15)
+        self.assertEqual(pygame.key.get_repeat(), (10, 15))
 
-          # pygame.key.name(key): return string
-          # get the name of a key identifier
-          # 
-          # Get the descriptive name of the button from a keyboard button id constant. 
+        pygame.key.set_repeat()
+        self.assertEqual(pygame.key.get_repeat(), (0, 0))
 
-        self.fail() 
-
-    def todo_test_set_mods(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.key.set_mods:
-
-          # pygame.key.set_mods(int): return None
-          # temporarily set which modifier keys are pressed
-          # 
-          # Create a bitmask of the modifier constants you want to impose on your program. 
-
-        self.fail() 
-
-    def todo_test_set_repeat(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.key.set_repeat:
-
-          # pygame.key.set_repeat(): return None
-          # pygame.key.set_repeat(delay, interval): return None
-          # control how held keys are repeated
-          # 
-          # When the keyboard repeat is enabled, keys that are held down will
-          # generate multiple pygame.KEYDOWN events. The delay is the number of
-          # milliseconds before the first repeated pygame.KEYDOWN will be sent.
-          # After that another pygame.KEYDOWN will be sent every interval
-          # milliseconds. If no arguments are passed the key repeat is disabled.
-          # 
-          # When pygame is initialized the key repeat is disabled. 
-
-        self.fail() 
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add unit tests for:

key.get_mods
key.set_mods
key.get_repeat
key.set_repeat
key.name

I wanted to resolve #309 but since the SDL_GetKeyFromName is not available within SDL 1.2 I just added the unit tests that I started when I looked into the issues. I had no idea how to implement the tests for the other functions.