### PR TITLE
zip_safe:False added to setup for python37b1 build failure.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -560,6 +560,7 @@ PACKAGEDATA = {
        "headers":     headers,
        "ext_modules": extensions,
        "data_files":  data_files,
+       "zip_safe":  False,
 }
 PACKAGEDATA.update(METADATA)
 PACKAGEDATA.update(EXTRAS)


### PR DESCRIPTION
Was getting a build failure with python37 beta 1.
To avoid it, I set zip_safe:False. Which I think is the case anyway. I'm not sure anyone uses bdist_egg these days anyway, and I doubt it still works well everywhere.

With this change, I was able to get all tests passing on ubuntu xenial with a source install of python 3.7.0b1
`SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk python3.7 -m pygame.tests --exclude opengl`

```
zip_safe flag not set; analyzing archive contents...
Traceback (most recent call last):
  File "setup.py", line 566, in <module>
    setup(**PACKAGEDATA)
  File "/usr/local/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.7/site-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/usr/local/lib/python3.7/site-packages/setuptools/command/install.py", line 109, in do_egg_install
    self.run_command('bdist_egg')
  File "/usr/local/lib/python3.7/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 209, in run
    os.path.join(archive_root, 'EGG-INFO'), self.zip_safe()
  File "/usr/local/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 245, in zip_safe
    return analyze_egg(self.bdist_dir, self.stubs)
  File "/usr/local/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 355, in analyze_egg
    safe = scan_module(egg_dir, base, name, stubs) and safe
  File "/usr/local/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 392, in scan_module
    code = marshal.load(f)
ValueError: bad marshal data (unknown type code)
```

cc https://github.com/pygame/pygame/issues/382