### PR TITLE
Enable python3.7-dev on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     - os: linux
       sudo: required
       python: 3.6
+    - os: linux
+      sudo: required
+      python: 3.7-dev
     # Should only need one OSX build because older builds can work on newer machines ok.
     #https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
     - os: osx


### PR DESCRIPTION
Tests pass on 3.7-dev 😎 

I tried the travis pypy on here too just for fun. Still quite a few errors of course, so disabled it. https://travis-ci.org/pygame/pygame/jobs/339654493

cc https://github.com/pygame/pygame/issues/382