### PR TITLE
pygame.draw.circle with a thickness had a weird moiré pattern.

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -515,11 +515,19 @@ static PyObject* circle(PyObject* self, PyObject* arg)
 
     if(!PySurface_Lock(surfobj)) return NULL;
 
-    if(!width)
+    if(!width) {
         draw_fillellipse(surf, (Sint16)posx, (Sint16)posy, (Sint16)radius, (Sint16)radius, color);
-    else
-        for(loop=0; loop<width; ++loop)
+    } else {
+        for(loop=0; loop<width; ++loop) {
             draw_ellipse(surf, posx, posy, radius-loop, radius-loop, color);
+            /* To avoid moiré pattern. Don't do an extra one on the outer ellipse.
+               We draw another ellipse offset by a pixel, over drawing the missed
+               spots in the filled circle caused by which pixels are filled.
+            */
+            if (width > 1 && loop > 0)
+                draw_ellipse(surf, posx+1, posy, radius-loop, radius-loop, color);
+        }
+    }
 
     if(!PySurface_Unlock(surfobj)) return NULL;
 
@@ -1535,7 +1543,7 @@ static void draw_fillpoly(SDL_Surface *dst, int *vx, int *vy, int n, Uint32 colo
                 /* Special case: polygon only 1 pixel high. */
                 int j;
                 int minx, maxx;
-                
+
                 /* Determine X bounds */
                 minx = vx[0];
                 maxx = vx[0];


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/388
circles with width draw nicely now.

Here is a test script to see the patterns. You can set thickness to 2 as well for another good test.
[circle.py](https://gist.githubusercontent.com/illume/40f86d53d157592843bcef0a08c3db9b/raw/73bf7ecbc7319e4f918f49b934a10a75d7f4d753/circle.py)

Before:
<img width="501" alt="screen shot 2018-02-10 at 00 53 30" src="https://user-images.githubusercontent.com/9541/36055457-c75fee6e-0dfc-11e8-90a4-e524213ad24b.png">

After:
<img width="568" alt="screen shot 2018-02-10 at 00 34 24" src="https://user-images.githubusercontent.com/9541/36055069-176068a6-0dfa-11e8-822f-d62a3a7f7db9.png">

```python
#circle.py
import pygame

def draw_outlined_circle2(surf, color, origin, radius, thickness):
    width = radius * 2 + thickness * 2
    background = (0, 0, 0, 0)
    circle = pygame.Surface((width, width)).convert_alpha()
    rect = circle.get_rect()
    circle.fill(background)
    pygame.draw.circle(circle, color, rect.center, radius)
    pygame.draw.circle(circle, background, rect.center, radius - thickness)
    surf.blit(circle, (origin[0] - (rect.w / 2), origin[1] - (rect.w / 2)))

def draw_outlined_circle0(surf, color, origin, radius, thickness):
    pygame.draw.circle(surf, color, origin, radius)
    pygame.draw.circle(surf, (0, 0, 0, 255), origin, radius - thickness)

surf = pygame.Surface((2000,2000))
radius = 508
thickness = 50
draw_with_pygame = True


pygame.init()
screen = pygame.display.set_mode((1024, 768))
pygame.display.set_caption('space - toggle draw with pygame(red), escape - quit')
pygame.display.flip()

pygame.draw.circle(surf, pygame.Color("red"), (500, 500), radius, thickness)

screen.blit(surf, (0,0))
pygame.display.flip()
going = True

while going:
    events = pygame.event.get()
    for e in events:
        if (e.type == pygame.QUIT or
           (e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE)):
            going = False
        if e.type == pygame.KEYDOWN and e.key == pygame.K_SPACE:
            draw_with_pygame = not draw_with_pygame
            if draw_with_pygame:
                pygame.draw.circle(surf, pygame.Color("red"), (500, 500), radius, thickness)
            else:
                draw_outlined_circle2(surf, pygame.Color("white"), (750, 750), radius, thickness)
            screen.blit(surf, (0,0))
            color_name = 'red' if draw_with_pygame else 'white'
            msg = 'space - toggle draw with pygame(%s):%s, escape - quit' % (color_name, draw_with_pygame)
            pygame.display.set_caption(msg)
            pygame.display.flip()


```