### PR TITLE
Add pypy builder to travis ci, and allow it to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
     - os: linux
       sudo: required
       python: 3.7-dev
+    - os: linux
+      sudo: required
+      python: pypy
+
     # Should only need one OSX build because older builds can work on newer machines ok.
     #https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
     - os: osx
@@ -39,6 +43,9 @@ matrix:
         - PY_VERSION=2
         - MAKEFLAGS=-j8
         # - MACOSX_DEPLOYMENT_TARGET=10.6
+
+  allow_failures:
+  - python: pypy
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis_osx_before_install.sh;  fi


### PR DESCRIPTION
Travis CI now builds for `python: pypy`, but because there are lots of errors still, we allow it to fail. So that people can still see how changes affect pypy.

- [pypy on travis docs](https://docs.travis-ci.com/user/languages/python/#PyPy-Support) 
- [allowed to fail on travis docs](https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail)