### PR TITLE
pygame.math.Vector2/3 not experimental

### DIFF
--- a/docs/py-modindex.html
+++ b/docs/py-modindex.html
@@ -4,7 +4,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>Python Module Index &#8212; Pygame v1.9.4.dev0 documentation</title>
     <link rel="stylesheet" href="_static/pygame.css" type="text/css" />

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -21,27 +21,8 @@ In addition vec*vec will perform a scalar-product (a.k.a. dot-product). If you
 want to multiply every element from vector v with every element from vector w
 you can use the elementwise method: ``v.elementwise()`` ``\*`` w
 
-New in pygame 1.9.2pre.
+New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
 
-.. function:: enable_swizzling
-
-   | :sl:`globally enables swizzling for vectors.`
-   | :sg:`enable_swizzling() -> None`
-
-   Enables swizzling for all vectors until ``disable_swizzling()`` is called.
-   By default swizzling is disabled.
-
-   .. ## pygame.math.enable_swizzling ##
-
-.. function:: disable_swizzling
-
-   | :sl:`globally disables swizzling for vectors.`
-   | :sg:`disable_swizzling() -> None`
-
-   Disables swizzling for all vectors until ``enable_swizzling()`` is called.
-   By default swizzling is disabled.
-
-   .. ## pygame.math.disable_swizzling ##
 
 .. class:: Vector2
 
@@ -521,5 +502,26 @@ New in pygame 1.9.2pre.
    .. ##  ##
 
    .. ## pygame.math.Vector3 ##
+
+
+.. function:: enable_swizzling
+
+   | :sl:`globally enables swizzling for vectors.`
+   | :sg:`enable_swizzling() -> None`
+
+   Enables swizzling for all vectors until ``disable_swizzling()`` is called.
+   By default swizzling is disabled.
+
+   .. ## pygame.math.enable_swizzling ##
+
+.. function:: disable_swizzling
+
+   | :sl:`globally disables swizzling for vectors.`
+   | :sg:`disable_swizzling() -> None`
+
+   Disables swizzling for all vectors until ``enable_swizzling()`` is called.
+   By default swizzling is disabled.
+
+   .. ## pygame.math.disable_swizzling ##
 
 .. ## pygame.math ##

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -8,9 +8,6 @@
 
 | :sl:`pygame module for vector classes`
 
-!!!EXPERIMENTAL!!! Note: This module is still in development and the ``API``
-might change. Please report bugs and suggestions to pygame-users@seul.org.
-
 The pygame math module currently provides Vector classes in two and three
 dimensions, Vector2 and Vector3 respectively.
 
@@ -509,6 +506,8 @@ New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
    | :sl:`globally enables swizzling for vectors.`
    | :sg:`enable_swizzling() -> None`
 
+   DEPRECATED: Not needed anymore. Will be removed in a later version.
+
    Enables swizzling for all vectors until ``disable_swizzling()`` is called.
    By default swizzling is disabled.
 
@@ -518,6 +517,8 @@ New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
 
    | :sl:`globally disables swizzling for vectors.`
    | :sg:`disable_swizzling() -> None`
+
+   DEPRECATED: Not needed anymore. Will be removed in a later version.
 
    Disables swizzling for all vectors until ``enable_swizzling()`` is called.
    By default swizzling is disabled.

--- a/src/doc/math_doc.h
+++ b/src/doc/math_doc.h
@@ -1,10 +1,6 @@
 /* Auto generated file: with makeref.py .  Docs go in src/ *.doc . */
 #define DOC_PYGAMEMATH "pygame module for vector classes"
 
-#define DOC_PYGAMEMATHENABLESWIZZLING "enable_swizzling() -> None\nglobally enables swizzling for vectors."
-
-#define DOC_PYGAMEMATHDISABLESWIZZLING "disable_swizzling() -> None\nglobally disables swizzling for vectors."
-
 #define DOC_PYGAMEMATHVECTOR2 "Vector2() -> Vector2\nVector2(Vector2) -> Vector2\nVector2(x, y) -> Vector2\nVector2((x, y)) -> Vector2\na 2-Dimensional Vector"
 
 #define DOC_VECTOR2DOT "dot(Vector2) -> float\ncalculates the dot- or scalar-product with the other vector"
@@ -101,6 +97,10 @@
 
 #define DOC_VECTOR3FROMSPHERICAL "from_spherical((r, theta, phi)) -> None\nSets x, y and z from a spherical coordinates 3-tuple."
 
+#define DOC_PYGAMEMATHENABLESWIZZLING "enable_swizzling() -> None\nglobally enables swizzling for vectors."
+
+#define DOC_PYGAMEMATHDISABLESWIZZLING "disable_swizzling() -> None\nglobally disables swizzling for vectors."
+
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -109,14 +109,6 @@
 
 pygame.math
 pygame module for vector classes
-
-pygame.math.enable_swizzling
- enable_swizzling() -> None
-globally enables swizzling for vectors.
-
-pygame.math.disable_swizzling
- disable_swizzling() -> None
-globally disables swizzling for vectors.
 
 pygame.math.Vector2
  Vector2() -> Vector2
@@ -315,5 +307,13 @@ returns a tuple with radial distance, inclination and azimuthal angle.
 pygame.math.Vector3.from_spherical
  from_spherical((r, theta, phi)) -> None
 Sets x, y and z from a spherical coordinates 3-tuple.
+
+pygame.math.enable_swizzling
+ enable_swizzling() -> None
+globally enables swizzling for vectors.
+
+pygame.math.disable_swizzling
+ disable_swizzling() -> None
+globally disables swizzling for vectors.
 
 */

--- a/src/math.c
+++ b/src/math.c
@@ -228,7 +228,7 @@ static int vector_elementwiseproxy_nonzero(vector_elementwiseproxy *self);
 static PyObject *vector_elementwise(PyVector *vec);
 
 
-static int swizzling_enabled = 0;
+static int swizzling_enabled = 1;
 
 
 /********************************

--- a/src/math.c
+++ b/src/math.c
@@ -1538,10 +1538,10 @@ vector_getAttr_swizzle(PyVector *self, PyObject *attr_name)
     if (attr == NULL)
         goto internal_error;
     /* If we are not a swizzle, go straight to GenericGetAttr. */
-    if ((attr[i] != 'x') &&
-        (attr[i] != 'y') &&
-        (attr[i] != 'z') &&
-        (attr[i] != 'w')) {
+    if ((attr[0] != 'x') &&
+        (attr[0] != 'y') &&
+        (attr[0] != 'z') &&
+        (attr[0] != 'w')) {
         goto swizzle_failed;
     }
 

--- a/src/math.c
+++ b/src/math.c
@@ -1537,7 +1537,12 @@ vector_getAttr_swizzle(PyVector *self, PyObject *attr_name)
         attr = PyUnicode_AsUnicode(attr_unicode);
         if (attr == NULL)
             goto internal_error;
-        res = (PyObject*)PyTuple_New(len);
+        if (len == 2 || len == 3) {
+            res = (PyObject*)PyVector_NEW((int)len);
+        } else {
+            /* More than 3, we return a tuple. */
+            res = (PyObject*)PyTuple_New(len);
+        }
         if (res == NULL)
             goto internal_error;
         for (i = 0; i < len; i++) {
@@ -1553,7 +1558,10 @@ vector_getAttr_swizzle(PyVector *self, PyObject *attr_name)
             default:
                 goto swizzle_failed;
             }
-            if (idx < self->dim) {
+            if (len == 2 || len == 3) {
+                ((PyVector*)res)->coords[i] = coords[idx];
+            }
+            else if (idx < self->dim) {
                 if (PyTuple_SetItem(res, i, PyFloat_FromDouble(coords[idx])) != 0)
                     goto internal_error;
             }

--- a/src/math.c
+++ b/src/math.c
@@ -1589,7 +1589,7 @@ vector_setAttr_swizzle(PyVector *self, PyObject *attr_name, PyObject *val)
     int i;
 
     /* if swizzling is disabled always default to generic implementation */
-    if (!swizzling_enabled)
+    if (!swizzling_enabled || len == 1)
         return PyObject_GenericSetAttr((PyObject*)self, attr_name, val);
 
     /* if swizzling is enabled first try swizzle */

--- a/src/math.c
+++ b/src/math.c
@@ -1905,7 +1905,7 @@ static PyObject *
 vector2_cross(PyVector *self, PyObject *other)
 {
     double other_coords[2];
-    if (self == other)
+    if (self == (PyVector *)other)
         return PyFloat_FromDouble(0.0);
 
     if (!PyVectorCompatible_Check(other, self->dim)) {
@@ -1962,6 +1962,18 @@ vector2_from_polar(PyVector *self, PyObject *args)
     self->coords[1] = r * sin(phi);
 
     Py_RETURN_NONE;
+}
+static PyObject*
+vector_getsafepickle (PyRectObject *self, void *closure)
+{
+    Py_RETURN_TRUE;
+}
+/* for pickling */
+static PyObject*
+vector2_reduce (PyObject* oself)
+{
+    PyVector* self = (PyVector*)oself;
+    return Py_BuildValue ("(O(dd))", oself->ob_type, self->coords[0], self->coords[1]);
 }
 
 
@@ -2026,10 +2038,11 @@ static PyMethodDef vector2_methods[] = {
     {"from_polar", (PyCFunction)vector2_from_polar, METH_VARARGS,
      DOC_VECTOR2FROMPOLAR
     },
+    { "__safe_for_unpickling__", (PyCFunction)vector_getsafepickle, METH_NOARGS, NULL },
+    { "__reduce__", (PyCFunction) vector2_reduce, METH_NOARGS, NULL },
 
     {NULL}  /* Sentinel */
 };
-
 
 static PyGetSetDef vector2_getsets[] = {
     { "x", (getter)vector_getx, (setter)vector_setx, NULL, NULL },
@@ -2615,6 +2628,17 @@ vector3_from_spherical(PyVector *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+/* For pickling. */
+static PyObject*
+vector3_reduce (PyObject* oself)
+{
+    PyVector* self = (PyVector*)oself;
+    return Py_BuildValue ("(O(ddd))", oself->ob_type,
+        self->coords[0],
+        self->coords[1],
+        self->coords[2]);
+}
+
 static PyMethodDef vector3_methods[] = {
     {"length", (PyCFunction)vector_length, METH_NOARGS,
      DOC_VECTOR3LENGTH
@@ -2694,6 +2718,8 @@ static PyMethodDef vector3_methods[] = {
     {"from_spherical", (PyCFunction)vector3_from_spherical, METH_VARARGS,
      DOC_VECTOR3FROMSPHERICAL
     },
+    { "__safe_for_unpickling__", (PyCFunction)vector_getsafepickle, METH_NOARGS, NULL },
+    { "__reduce__", (PyCFunction) vector3_reduce, METH_NOARGS, NULL },
 
     {NULL}  /* Sentinel */
 };

--- a/src/math.c
+++ b/src/math.c
@@ -1537,6 +1537,14 @@ vector_getAttr_swizzle(PyVector *self, PyObject *attr_name)
     attr = PyUnicode_AsUnicode(attr_unicode);
     if (attr == NULL)
         goto internal_error;
+    /* If we are not a swizzle, go straight to GenericGetAttr. */
+    if ((attr[i] != 'x') &&
+        (attr[i] != 'y') &&
+        (attr[i] != 'z') &&
+        (attr[i] != 'w')) {
+        goto swizzle_failed;
+    }
+
     if (len == 2 || len == 3) {
         res = (PyObject*)PyVector_NEW((int)len);
     } else {

--- a/src/math.c
+++ b/src/math.c
@@ -1524,7 +1524,7 @@ vector_getAttr_swizzle(PyVector *self, PyObject *attr_name)
 
     len = PySequence_Length(attr_name);
 
-    if (len == 1) {
+    if (len == 1 || !swizzling_enabled) {
         return PyObject_GenericGetAttr((PyObject*)self, attr_name);
     }
 
@@ -1575,11 +1575,15 @@ vector_getAttr_swizzle(PyVector *self, PyObject *attr_name)
 
     /* swizzling failed! clean up and return NULL */
 swizzle_failed:
+    Py_XDECREF(res);
+    Py_XDECREF(attr_unicode);
+    return PyObject_GenericGetAttr((PyObject*)self, attr_name);
 internal_error:
     Py_XDECREF(res);
     Py_XDECREF(attr_unicode);
     return NULL;
 }
+
 
 static int
 vector_setAttr_swizzle(PyVector *self, PyObject *attr_name, PyObject *val)

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -23,6 +23,7 @@ import gc
 
 class Vector2TypeTest(unittest.TestCase):
     def setUp(self):
+        pygame.math.enable_swizzling()
 #        gc.collect()
         self.zeroVec = Vector2()
         self.e1 = Vector2(1, 0)
@@ -40,7 +41,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.s1 = 5.6
         self.s2 = 7.8
     def tearDown(self):
-        pygame.math.disable_swizzling()
+        pygame.math.enable_swizzling()
 
 
     def testConstructionDefault(self):
@@ -438,7 +439,8 @@ class Vector2TypeTest(unittest.TestCase):
     def testSwizzle(self):
         self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
         self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
-        # swizzling disabled by default
+        # swizzling not disabled by default
+        pygame.math.disable_swizzling()
         self.assertRaises(AttributeError, lambda : self.v1.yx)
         pygame.math.enable_swizzling()
 
@@ -1302,7 +1304,8 @@ class Vector3TypeTest(unittest.TestCase):
     def testSwizzle(self):
         self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
         self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
-        # swizzling disabled by default
+        # swizzling enabled by default
+        pygame.math.disable_swizzling()
         self.assertRaises(AttributeError, lambda : self.v1.yx)
         pygame.math.enable_swizzling()
 

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -701,8 +701,14 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda : v1.slerp(-v1, 0.5))
 
     def test_lerp(self):
-        """TODO"""
-        pass
+        v1 = Vector2(0, 0)
+        v2 = Vector2(10, 10)
+        self.assertEqual(v1.lerp(v2, 0.5), (5, 5))
+        self.assertRaises(ValueError, lambda : v1.lerp(v2, 2.5))
+
+        v1 = Vector2(-10, -5)
+        v2 = Vector2(10, 10)
+        self.assertEqual(v1.lerp(v2, 0.5), (0, 2.5))
 
     def test_polar(self):
         v = Vector2()
@@ -1502,8 +1508,14 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda : v1.slerp(-v1, 0.5))
 
     def test_lerp(self):
-        """TODO"""
-        pass
+        v1 = Vector3(0, 0, 0)
+        v2 = Vector3(10, 10, 10)
+        self.assertEqual(v1.lerp(v2, 0.5), (5, 5, 5))
+        self.assertRaises(ValueError, lambda : v1.lerp(v2, 2.5))
+
+        v1 = Vector3(-10, -5, -20)
+        v2 = Vector3(10, 10, -20)
+        self.assertEqual(v1.lerp(v2, 0.5), (0, 2.5, -20))
 
     def test_spherical(self):
         v = Vector3()

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -437,8 +437,8 @@ class Vector2TypeTest(unittest.TestCase):
                          self.v2.distance_squared_to(self.v1))
 
     def test_swizzle(self):
-        self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
-        self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
+        self.assertEqual(hasattr(pygame.math, "enable_swizzling"), True)
+        self.assertEqual(hasattr(pygame.math, "disable_swizzling"), True)
         # swizzling not disabled by default
         pygame.math.disable_swizzling()
         self.assertRaises(AttributeError, lambda : self.v1.yx)
@@ -1310,8 +1310,8 @@ class Vector3TypeTest(unittest.TestCase):
                          self.v2.distance_squared_to(self.v1))
 
     def test_swizzle(self):
-        self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
-        self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
+        self.assertEqual(hasattr(pygame.math, "enable_swizzling"), True)
+        self.assertEqual(hasattr(pygame.math, "disable_swizzling"), True)
         # swizzling enabled by default
         pygame.math.disable_swizzling()
         self.assertRaises(AttributeError, lambda : self.v1.yx)
@@ -1352,13 +1352,11 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(type(self.v1.xyxy), tuple)
         self.assertEqual(type(self.v1.xyxyx), tuple)
 
-
     def test_dir_works(self):
         # not every single one of the attributes...
         attributes = set(['lerp', 'normalize', 'normalize_ip', 'reflect', 'slerp', 'x', 'y'])
         # check if this selection of attributes are all there.
         self.assertTrue(attributes.issubset(set(dir(self.v1))))
-
 
     def test_elementwise(self):
         # behaviour for "elementwise op scalar"

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -1352,6 +1352,14 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(type(self.v1.xyxy), tuple)
         self.assertEqual(type(self.v1.xyxyx), tuple)
 
+
+    def test_dir_works(self):
+        # not every single one of the attributes...
+        attributes = set(['lerp', 'normalize', 'normalize_ip', 'reflect', 'slerp', 'x', 'y'])
+        # check if this selection of attributes are all there.
+        self.assertTrue(attributes.issubset(set(dir(self.v1))))
+
+
     def test_elementwise(self):
         # behaviour for "elementwise op scalar"
         self.assertEqual(self.v1.elementwise() + self.s1,

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -42,7 +42,7 @@ class Vector2TypeTest(unittest.TestCase):
     def tearDown(self):
         pygame.math.disable_swizzling()
 
-        
+
     def testConstructionDefault(self):
         v = Vector2()
         self.assertEqual(v.x, 0.)
@@ -84,7 +84,7 @@ class Vector2TypeTest(unittest.TestCase):
             v.x = "spam"
         self.assertRaises(TypeError, assign_nonfloat)
 
-        
+
     def testSequence(self):
         v = Vector2(1.2, 3.4)
         Vector2()[:]
@@ -236,7 +236,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(v.x, -self.v1.x)
         self.assertEqual(v.y, -self.v1.y)
         self.assertNotEqual(id(v), id(self.v1))
-        
+
     def testCompare(self):
         int_vec = Vector2(3, -2)
         flt_vec = Vector2(3.0, -2.0)
@@ -257,7 +257,7 @@ class Vector2TypeTest(unittest.TestCase):
     def testStr(self):
         v = Vector2(1.2, 3.4)
         self.assertEqual(str(v), "[1.2, 3.4]")
-        
+
     def testRepr(self):
         v = Vector2(1.2, 3.4)
         self.assertEqual(v.__repr__(), "<Vector2(1.2, 3.4)>")
@@ -285,7 +285,7 @@ class Vector2TypeTest(unittest.TestCase):
         for val in self.v1:
             self.assertEqual(val, self.v1[idx])
             idx += 1
-        
+
     def test_rotate(self):
         v1 = Vector2(1, 0)
         v2 = v1.rotate(90)
@@ -329,7 +329,7 @@ class Vector2TypeTest(unittest.TestCase):
         # v2 is paralell to v1
         self.assertAlmostEqual(self.v1.x * v.y - self.v1.y * v.x, 0.)
         self.assertRaises(ValueError, lambda : self.zeroVec.normalize())
-        
+
     def test_normalize_ip(self):
         v = +self.v1
         # v has length != 1 before normalizing
@@ -348,7 +348,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(v.is_normalized(), True)
         self.assertEqual(self.e2.is_normalized(), True)
         self.assertEqual(self.zeroVec.is_normalized(), False)
-        
+
     def test_cross(self):
         self.assertEqual(self.v1.cross(self.v2),
                          self.v1.x * self.v2.y - self.v1.y * self.v2.x)
@@ -389,7 +389,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(Vector2(3, 4).length(), 5)
         self.assertEqual(Vector2(-3, 4).length(), 5)
         self.assertEqual(self.zeroVec.length(), 0)
-        
+
     def test_length_squared(self):
         self.assertEqual(Vector2(3, 4).length_squared(), 25)
         self.assertEqual(Vector2(-3, 4).length_squared(), 25)
@@ -402,7 +402,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(v.reflect(3*n), v.reflect(n))
         self.assertEqual(v.reflect(-v), -v)
         self.assertRaises(ValueError, lambda : v.reflect(self.zeroVec))
-        
+
     def test_reflect_ip(self):
         v1 = Vector2(1, -1)
         v2 = Vector2(v1)
@@ -434,7 +434,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(self.v1.distance_squared_to(self.v1), 0)
         self.assertEqual(self.v1.distance_squared_to(self.v2),
                          self.v2.distance_squared_to(self.v1))
-        
+
     def testSwizzle(self):
         self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
         self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
@@ -679,7 +679,7 @@ class Vector2TypeTest(unittest.TestCase):
             self.assertAlmostEqual(u.length(), 1)
             self.assertAlmostEqual(v1.angle_to(u), i * angle_step)
         self.assertEqual(u, v2)
-        
+
         v1 = Vector2(100, 0)
         v2 = Vector2(0, 10)
         radial_factor = v2.length() / v1.length()
@@ -693,7 +693,7 @@ class Vector2TypeTest(unittest.TestCase):
     def test_lerp(self):
         """TODO"""
         pass
-        
+
     def test_polar(self):
         v = Vector2()
         v.from_polar(self.v1.as_polar())
@@ -735,7 +735,7 @@ class Vector3TypeTest(unittest.TestCase):
 #        self.s2 = random()
         self.s1 = 5.6
         self.s2 = 7.8
-        
+
     def testConstructionDefault(self):
         v = Vector3()
         self.assertEqual(v.x, 0.)
@@ -961,7 +961,7 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(v.y, -self.v1.y)
         self.assertEqual(v.z, -self.v1.z)
         self.assertNotEqual(id(v), id(self.v1))
-        
+
     def testCompare(self):
         int_vec = Vector3(3, -2, 13)
         flt_vec = Vector3(3.0, -2.0, 13.)
@@ -982,7 +982,7 @@ class Vector3TypeTest(unittest.TestCase):
     def testStr(self):
         v = Vector3(1.2, 3.4, 5.6)
         self.assertEqual(str(v), "[1.2, 3.4, 5.6]")
-        
+
     def testRepr(self):
         v = Vector3(1.2, 3.4, -9.6)
         self.assertEqual(v.__repr__(), "<Vector3(1.2, 3.4, -9.6)>")
@@ -1011,7 +1011,7 @@ class Vector3TypeTest(unittest.TestCase):
         for val in self.v1:
             self.assertEqual(val, self.v1[idx])
             idx += 1
-        
+
     def test_rotate(self):
         v1 = Vector3(1, 0, 0)
         axis = Vector3(0, 1, 0)
@@ -1187,7 +1187,7 @@ class Vector3TypeTest(unittest.TestCase):
                  (self.v1.x * v.y - self.v1.y * v.x) ** 2)
         self.assertAlmostEqual(cross, 0.)
         self.assertRaises(ValueError, lambda : self.zeroVec.normalize())
-        
+
     def test_normalize_ip(self):
         v = +self.v1
         # v has length != 1 before normalizing
@@ -1209,7 +1209,7 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(v.is_normalized(), True)
         self.assertEqual(self.e2.is_normalized(), True)
         self.assertEqual(self.zeroVec.is_normalized(), False)
-        
+
     def test_cross(self):
         def cross(a, b):
             return Vector3(a[1] * b[2] - a[2] * b[1],
@@ -1253,7 +1253,7 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(Vector3(3, 4, 5).length(), math.sqrt(3 * 3 + 4 * 4 + 5 * 5))
         self.assertEqual(Vector3(-3, 4, 5).length(), math.sqrt(-3 * -3 + 4 * 4 + 5 * 5))
         self.assertEqual(self.zeroVec.length(), 0)
-        
+
     def test_length_squared(self):
         self.assertEqual(Vector3(3, 4, 5).length_squared(), 3 * 3 + 4 * 4 + 5 * 5)
         self.assertEqual(Vector3(-3, 4, 5).length_squared(), -3 * -3 + 4 * 4 + 5 * 5)
@@ -1266,7 +1266,7 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(v.reflect(3*n), v.reflect(n))
         self.assertEqual(v.reflect(-v), -v)
         self.assertRaises(ValueError, lambda : v.reflect(self.zeroVec))
-        
+
     def test_reflect_ip(self):
         v1 = Vector3(1, -1, 1)
         v2 = Vector3(v1)
@@ -1298,14 +1298,14 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(self.v1.distance_squared_to(self.v1), 0)
         self.assertEqual(self.v1.distance_squared_to(self.v2),
                          self.v2.distance_squared_to(self.v1))
-        
+
     def testSwizzle(self):
         self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
         self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
         # swizzling disabled by default
         self.assertRaises(AttributeError, lambda : self.v1.yx)
         pygame.math.enable_swizzling()
-        
+
         self.assertEqual(self.v1.yxz, (self.v1.y, self.v1.x, self.v1.z))
         self.assertEqual(self.v1.xxyyzzxyz, (self.v1.x, self.v1.x, self.v1.y,
                                              self.v1.y, self.v1.z, self.v1.z,
@@ -1452,8 +1452,8 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertRaises(ZeroDivisionError, lambda : 2 / self.zeroVec.elementwise())
         self.assertRaises(ZeroDivisionError, lambda : 2 // self.zeroVec.elementwise())
         self.assertRaises(ZeroDivisionError, lambda : 2 % self.zeroVec.elementwise())
-        
-        
+
+
     def test_slerp(self):
         self.assertRaises(ValueError, lambda : self.zeroVec.slerp(self.v1, .5))
         self.assertRaises(ValueError, lambda : self.v1.slerp(self.zeroVec, .5))
@@ -1465,7 +1465,7 @@ class Vector3TypeTest(unittest.TestCase):
             self.assertAlmostEqual(u.length(), 1)
             self.assertAlmostEqual(self.e1.angle_to(u), i * angle_step)
         self.assertEqual(u, self.e2)
-        
+
         v1 = Vector3(100, 0, 0)
         v2 = Vector3(0, 10, 7)
         radial_factor = v2.length() / v1.length()
@@ -1496,7 +1496,7 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertRaises(TypeError, lambda : v.from_spherical(1, 2, 3))
         v.from_spherical((.5, 90, 90))
         self.assertEqual(v, .5 * self.e2)
-        
+
     def test_inplace_operators(self):
 
         v = Vector3(1,1,1)
@@ -1516,8 +1516,12 @@ class Vector3TypeTest(unittest.TestCase):
         v += (1,1,1)
         self.assertEqual(v, (4.0,4.0,4.0))
 
-
-
+    def test_pickle(self):
+        import pickle
+        v2 = Vector2(1, 2)
+        v3 = Vector3(1, 2, 3)
+        self.assertEqual(pickle.loads(pickle.dumps(v2)), v2)
+        self.assertEqual(pickle.loads(pickle.dumps(v3)), v3)
 
 
 

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -159,51 +159,51 @@ class Vector2TypeTest(unittest.TestCase):
 
     def testAdd(self):
         v3 = self.v1 + self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x + self.v2.x)
         self.assertEqual(v3.y, self.v1.y + self.v2.y)
         v3 = self.v1 + self.t2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x + self.t2[0])
         self.assertEqual(v3.y, self.v1.y + self.t2[1])
         v3 = self.v1 + self.l2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x + self.l2[0])
         self.assertEqual(v3.y, self.v1.y + self.l2[1])
         v3 = self.t1 + self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.t1[0] + self.v2.x)
         self.assertEqual(v3.y, self.t1[1] + self.v2.y)
         v3 = self.l1 + self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.l1[0] + self.v2.x)
         self.assertEqual(v3.y, self.l1[1] + self.v2.y)
 
     def testSub(self):
         v3 = self.v1 - self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x - self.v2.x)
         self.assertEqual(v3.y, self.v1.y - self.v2.y)
         v3 = self.v1 - self.t2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x - self.t2[0])
         self.assertEqual(v3.y, self.v1.y - self.t2[1])
         v3 = self.v1 - self.l2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x - self.l2[0])
         self.assertEqual(v3.y, self.v1.y - self.l2[1])
         v3 = self.t1 - self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.t1[0] - self.v2.x)
         self.assertEqual(v3.y, self.t1[1] - self.v2.y)
         v3 = self.l1 - self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.l1[0] - self.v2.x)
         self.assertEqual(v3.y, self.l1[1] - self.v2.y)
 
     def testScalarMultiplication(self):
         v = self.s1 * self.v1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, self.s1 * self.v1.x)
         self.assertEqual(v.y, self.s1 * self.v1.y)
         v = self.v1 * self.s2
@@ -212,28 +212,28 @@ class Vector2TypeTest(unittest.TestCase):
 
     def testScalarDivision(self):
         v = self.v1 / self.s1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertAlmostEqual(v.x, self.v1.x / self.s1)
         self.assertAlmostEqual(v.y, self.v1.y / self.s1)
         v = self.v1 // self.s2
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, self.v1.x // self.s2)
         self.assertEqual(v.y, self.v1.y // self.s2)
 
     def testBool(self):
         self.assertEqual(bool(self.zeroVec), False)
         self.assertEqual(bool(self.v1), True)
-        self.assert_(not self.zeroVec)
-        self.assert_(self.v1)
+        self.assertTrue(not self.zeroVec)
+        self.assertTrue(self.v1)
 
     def testUnary(self):
         v = +self.v1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, self.v1.x)
         self.assertEqual(v.y, self.v1.y)
         self.assertNotEqual(id(v), id(self.v1))
         v = -self.v1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, -self.v1.x)
         self.assertEqual(v.y, -self.v1.y)
         self.assertNotEqual(id(v), id(self.v1))
@@ -877,61 +877,61 @@ class Vector3TypeTest(unittest.TestCase):
 
     def testAdd(self):
         v3 = self.v1 + self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x + self.v2.x)
         self.assertEqual(v3.y, self.v1.y + self.v2.y)
         self.assertEqual(v3.z, self.v1.z + self.v2.z)
         v3 = self.v1 + self.t2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x + self.t2[0])
         self.assertEqual(v3.y, self.v1.y + self.t2[1])
         self.assertEqual(v3.z, self.v1.z + self.t2[2])
         v3 = self.v1 + self.l2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x + self.l2[0])
         self.assertEqual(v3.y, self.v1.y + self.l2[1])
         self.assertEqual(v3.z, self.v1.z + self.l2[2])
         v3 = self.t1 + self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.t1[0] + self.v2.x)
         self.assertEqual(v3.y, self.t1[1] + self.v2.y)
         self.assertEqual(v3.z, self.t1[2] + self.v2.z)
         v3 = self.l1 + self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.l1[0] + self.v2.x)
         self.assertEqual(v3.y, self.l1[1] + self.v2.y)
         self.assertEqual(v3.z, self.l1[2] + self.v2.z)
 
     def testSub(self):
         v3 = self.v1 - self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x - self.v2.x)
         self.assertEqual(v3.y, self.v1.y - self.v2.y)
         self.assertEqual(v3.z, self.v1.z - self.v2.z)
         v3 = self.v1 - self.t2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x - self.t2[0])
         self.assertEqual(v3.y, self.v1.y - self.t2[1])
         self.assertEqual(v3.z, self.v1.z - self.t2[2])
         v3 = self.v1 - self.l2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.v1.x - self.l2[0])
         self.assertEqual(v3.y, self.v1.y - self.l2[1])
         self.assertEqual(v3.z, self.v1.z - self.l2[2])
         v3 = self.t1 - self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.t1[0] - self.v2.x)
         self.assertEqual(v3.y, self.t1[1] - self.v2.y)
         self.assertEqual(v3.z, self.t1[2] - self.v2.z)
         v3 = self.l1 - self.v2
-        self.assert_(isinstance(v3, type(self.v1)))
+        self.assertTrue(isinstance(v3, type(self.v1)))
         self.assertEqual(v3.x, self.l1[0] - self.v2.x)
         self.assertEqual(v3.y, self.l1[1] - self.v2.y)
         self.assertEqual(v3.z, self.l1[2] - self.v2.z)
 
     def testScalarMultiplication(self):
         v = self.s1 * self.v1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, self.s1 * self.v1.x)
         self.assertEqual(v.y, self.s1 * self.v1.y)
         self.assertEqual(v.z, self.s1 * self.v1.z)
@@ -942,12 +942,12 @@ class Vector3TypeTest(unittest.TestCase):
 
     def testScalarDivision(self):
         v = self.v1 / self.s1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertAlmostEqual(v.x, self.v1.x / self.s1)
         self.assertAlmostEqual(v.y, self.v1.y / self.s1)
         self.assertAlmostEqual(v.z, self.v1.z / self.s1)
         v = self.v1 // self.s2
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, self.v1.x // self.s2)
         self.assertEqual(v.y, self.v1.y // self.s2)
         self.assertEqual(v.z, self.v1.z // self.s2)
@@ -955,18 +955,18 @@ class Vector3TypeTest(unittest.TestCase):
     def testBool(self):
         self.assertEqual(bool(self.zeroVec), False)
         self.assertEqual(bool(self.v1), True)
-        self.assert_(not self.zeroVec)
-        self.assert_(self.v1)
+        self.assertTrue(not self.zeroVec)
+        self.assertTrue(self.v1)
 
     def testUnary(self):
         v = +self.v1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, self.v1.x)
         self.assertEqual(v.y, self.v1.y)
         self.assertEqual(v.z, self.v1.z)
         self.assertNotEqual(id(v), id(self.v1))
         v = -self.v1
-        self.assert_(isinstance(v, type(self.v1)))
+        self.assertTrue(isinstance(v, type(self.v1)))
         self.assertEqual(v.x, -self.v1.x)
         self.assertEqual(v.y, -self.v1.y)
         self.assertEqual(v.z, -self.v1.z)

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -436,7 +436,7 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(self.v1.distance_squared_to(self.v2),
                          self.v2.distance_squared_to(self.v1))
 
-    def testSwizzle(self):
+    def test_swizzle(self):
         self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
         self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
         # swizzling not disabled by default
@@ -464,6 +464,14 @@ class Vector2TypeTest(unittest.TestCase):
         def unicodeAttribute():
             getattr(Vector2(), "ä")
         self.assertRaises(AttributeError, unicodeAttribute)
+
+    def test_swizzle_return_types(self):
+        self.assertEqual(type(self.v1.x), float)
+        self.assertEqual(type(self.v1.xy), Vector2)
+        self.assertEqual(type(self.v1.xyx), Vector3)
+        # but we don't have vector4 or above... so tuple.
+        self.assertEqual(type(self.v1.xyxy), tuple)
+        self.assertEqual(type(self.v1.xyxyx), tuple)
 
     def test_elementwise(self):
         # behaviour for "elementwise op scalar"
@@ -1301,7 +1309,7 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(self.v1.distance_squared_to(self.v2),
                          self.v2.distance_squared_to(self.v1))
 
-    def testSwizzle(self):
+    def test_swizzle(self):
         self.assertEquals(hasattr(pygame.math, "enable_swizzling"), True)
         self.assertEquals(hasattr(pygame.math, "disable_swizzling"), True)
         # swizzling enabled by default
@@ -1335,6 +1343,14 @@ class Vector3TypeTest(unittest.TestCase):
         def invalidAssignment():
             Vector3().xy = 3
         self.assertRaises(TypeError, invalidAssignment)
+
+    def test_swizzle_return_types(self):
+        self.assertEqual(type(self.v1.x), float)
+        self.assertEqual(type(self.v1.xy), Vector2)
+        self.assertEqual(type(self.v1.xyz), Vector3)
+        # but we don't have vector4 or above... so tuple.
+        self.assertEqual(type(self.v1.xyxy), tuple)
+        self.assertEqual(type(self.v1.xyxyx), tuple)
 
     def test_elementwise(self):
         # behaviour for "elementwise op scalar"


### PR DESCRIPTION
- pickle/unpickle
- swizzle on by default
- speed up swizzle access.
- swizzle returns a Vector2 or Vector3 if of length 2 or 3.
- more tests, removed some DeprecationWarning in tests.
- removed experimental notice.