### PR TITLE
pygame.transform.threashold tests, keyword arguments, docs.

### DIFF
--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -199,6 +199,24 @@ Instead, always begin with the original image and scale to the desired size.)
 
 .. function:: threshold
 
+
+   TODO: new names and a better explanation.
+        # dest_surf                  # Surface we are changing. See 'set_behavior'.
+        #                            # None - if counting (set_behavior is 0), don't need 'dest_surf'.
+        # surf                       # Surface we are looking at.
+        # search_color               # Color we are searching for.
+        # threshold = (0,0,0,0)      # Within this distance from search_color (or search_surf).
+        # set_color = (0,0,0,0)      # color we set.
+        # set_behavior = 1           # 1 - pixels in dest_surface will be changed to 'set_color'.
+        #                            # 0 - we do not change 'dest_surf', just count. Make dest_surf=None.
+        #                            # 2 - pixels set in 'dest_surf' will be from 'surface'.
+        # search_surf = None         # None - search against 'search_color' instead.
+        #                            # Surface - look at the color in here rather than 'search_color'.
+        # inverse_set = False        # False - pixels outside of threshold are changed.
+        #                            # True - pixels within threshold are changed.
+
+
+
    | :sl:`finds which, and how many pixels in a surface are within a threshold of a color.`
    | :sg:`threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = 1, Surface = None, inverse = False) -> num_threshold_pixels`
 

--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -199,53 +199,67 @@ Instead, always begin with the original image and scale to the desired size.)
 
 .. function:: threshold
 
+   | :sl:`finds which, and how many pixels in a surface are within a threshold of a 'search_color' or a 'search_surf'.`
+   | :sg:`threshold(dest_surf, surf, search_color, threshold=(0,0,0,0), set_color=(0,0,0,0), set_behavior=1, search_surf=None, inverse_set=False) -> num_threshold_pixels`
 
-   TODO: new names and a better explanation.
-        # dest_surf                  # Surface we are changing. See 'set_behavior'.
-        #                            # None - if counting (set_behavior is 0), don't need 'dest_surf'.
-        # surf                       # Surface we are looking at.
-        # search_color               # Color we are searching for.
-        # threshold = (0,0,0,0)      # Within this distance from search_color (or search_surf).
-        # set_color = (0,0,0,0)      # color we set.
-        # set_behavior = 1           # 1 - pixels in dest_surface will be changed to 'set_color'.
-        #                            # 0 - we do not change 'dest_surf', just count. Make dest_surf=None.
-        #                            # 2 - pixels set in 'dest_surf' will be from 'surface'.
-        # search_surf = None         # None - search against 'search_color' instead.
-        #                            # Surface - look at the color in here rather than 'search_color'.
-        # inverse_set = False        # False - pixels outside of threshold are changed.
-        #                            # True - pixels within threshold are changed.
+   This versatile function can be used for find colors in a 'surf' close to a 'search_color'
+   or close to colors in a separate 'search_surf'.
 
+   It can also be used to transfer pixels into a 'dest_surf' that match or don't match.
 
+   By default it sets pixels in the 'dest_surf' where all of the pixels NOT within the
+   threshold are changed to set_color. If inverse_set is optionally set to True,
+   the pixels that ARE within the threshold are changed to set_color.
 
-   | :sl:`finds which, and how many pixels in a surface are within a threshold of a color.`
-   | :sg:`threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = 1, Surface = None, inverse = False) -> num_threshold_pixels`
+   If the optional 'search_surf' surface is given, it is used to threshold against
+   rather than the specified 'set_color'. That is, it will find each pixel in the
+   'surf' that is within the 'threshold' of the pixel at the same coordinates
+   of the 'search_surf'.
 
-   Finds which, and how many pixels in a surface are within a threshold of a
-   color.
+   :param dest_surf: Surface we are changing. See 'set_behavior'.
+    Should be None if counting (set_behavior is 0).
+   :type dest_surf: pygame.Surface or None
 
-   It can set the destination surface where all of the pixels not within the
-   threshold are changed to diff_color. If inverse is optionally set to True,
-   the pixels that are within the threshold are instead changed to diff_color.
+   :param pygame.Surface surf: Surface we are looking at.
 
-   If the optional second surface is given, it is used to threshold against
-   rather than the specified color. That is, it will find each pixel in the
-   first Surface that is within the threshold of the pixel at the same
-   coordinates of the second Surface.
+   :param pygame.Color search_color: Color we are searching for.
 
-   If change_return is set to 0, it can be used to just count the number of
-   pixels within the threshold if you set
+   :param pygame.Color threshold: Within this distance from search_color (or search_surf).
+     You can use a threshold of (r,g,b,a) where the r,g,b can have different
+     thresholds. So you could use an r threshold of 40 and a blue threshold of 2
+     if you like.
 
-   If change_return is set to 1, the pixels set in DestSurface will be those
-   from the color.
+   :param set_color: Color we set in dest_surf.
+   :type set_color: pygame.Color or None
 
-   If change_return is set to 2, the pixels set in DestSurface will be those
-   from the first Surface.
+   :param int set_behavior:
+    - set_behavior=1 (default). Pixels in dest_surface will be changed to 'set_color'.
+    - set_behavior=0 we do not change 'dest_surf', just count. Make dest_surf=None.
+    - set_behavior=2 pixels set in 'dest_surf' will be from 'surf'.
 
-   You can use a threshold of (r,g,b,a) where the r,g,b can have different
-   thresholds. So you could use an r threshold of 40 and a blue threshold of 2
-   if you like.
+   :param search_surf:
+    - search_surf=None (default). Search against 'search_color' instead.
+    - search_surf=Surface. Look at the color in 'search_surf' rather than using 'search_color'.
+   :type search_surf: pygame.Surface or None
+
+   :param bool inverse_set:
+     - False, default. Pixels outside of threshold are changed.
+     - True, Pixels within threshold are changed.
+
+   :rtype: int
+   :returns: The number of pixels that are within the 'threshold' in 'surf'
+     compared to either 'search_color' or `search_surf`.
+
+   :Examples:
+
+   See the threshold tests for a full of examples: https://github.com/pygame/pygame/blob/master/test/transform_test.py
+
+   .. literalinclude:: ../../../test/transform_test.py
+      :pyobject: TransformModuleTest.test_threshold_dest_surf_not_change
+
 
    New in pygame 1.8
+   1.9.4 fixed a lot of bugs and added keyword arguments. Test your code.
 
    .. ## pygame.transform.threshold ##
 

--- a/src/doc/transform_doc.h
+++ b/src/doc/transform_doc.h
@@ -25,7 +25,7 @@
 
 #define DOC_PYGAMETRANSFORMAVERAGECOLOR "average_color(Surface, Rect = None) -> Color\nfinds the average color of a surface"
 
-#define DOC_PYGAMETRANSFORMTHRESHOLD "threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = 1, Surface = None, inverse = False) -> num_threshold_pixels\nfinds which, and how many pixels in a surface are within a threshold of a color."
+#define DOC_PYGAMETRANSFORMTHRESHOLD "threshold(dest_surf, surf, search_color, threshold=(0,0,0,0), set_color=(0,0,0,0), set_behavior=1, search_surf=None, inverse_set=False) -> num_threshold_pixels\nfinds which, and how many pixels in a surface are within a threshold of a 'search_color' or a 'search_surf'."
 
 
 
@@ -85,7 +85,7 @@ pygame.transform.average_color
 finds the average color of a surface
 
 pygame.transform.threshold
- threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = 1, Surface = None, inverse = False) -> num_threshold_pixels
-finds which, and how many pixels in a surface are within a threshold of a color.
+ threshold(dest_surf, surf, search_color, threshold=(0,0,0,0), set_color=(0,0,0,0), set_behavior=1, search_surf=None, inverse_set=False) -> num_threshold_pixels
+finds which, and how many pixels in a surface are within a threshold of a 'search_color' or a 'search_surf'.
 
 */

--- a/src/transform.c
+++ b/src/transform.c
@@ -1583,13 +1583,13 @@ get_threshold (
     SDL_Rect sdlrect;
     SDL_PixelFormat *format, *destformat, *format2;
     Uint32 the_color, the_color2, rmask, gmask, bmask, rmask2, gmask2, bmask2;
-    Uint8 *pix, *byte_buf;
-    Uint8 r, g, b, a;
+    Uint8 *byte_buf;
+    Uint8 search_color_r, search_color_g, search_color_b, search_color_a;
     Uint8 surf_r, surf_g, surf_b;
     Uint8 dr, dg, db, da;
     Uint8 tr, tg, tb, ta;
 
-    Uint8 r2, g2, b2, a2;
+    Uint8 search_surf_r, search_surf_g, search_surf_b;
     int within_threshold;
 
     similar = 0;
@@ -1643,8 +1643,7 @@ get_threshold (
         pixels2 = NULL;
     }
 
-
-    SDL_GetRGBA (color_search_color, format, &r, &g, &b, &a);
+    SDL_GetRGBA (color_search_color, format, &search_color_r, &search_color_g, &search_color_b, &search_color_a);
     SDL_GetRGBA (color_threshold, format, &tr, &tg, &tb, &ta);
     SDL_GetRGBA (color_set_color, format, &dr, &dg, &db, &da);
 
@@ -1666,13 +1665,13 @@ get_threshold (
                 pixels2++;
                 */
                 _get_color_move_pixels(search_surf->format->BytesPerPixel, pixels2, &the_color2);
-                SDL_GetRGB(the_color2, search_surf->format, &r2, &g2, &b2);
+                SDL_GetRGB(the_color2, search_surf->format, &search_surf_r, &search_surf_g, &search_surf_b);
 
                 /* search_surf(the_color2) is within threshold of surf(the_color) */
                 within_threshold = (
-                    (abs((int)r2 - (int)surf_r) <= tr) &&
-                    (abs((int)g2 - (int)surf_g) <= tg) &&
-                    (abs((int)b2 - (int)surf_b) <= tb)
+                    (abs((int)search_surf_r - (int)surf_r) <= tr) &&
+                    (abs((int)search_surf_g - (int)surf_g) <= tg) &&
+                    (abs((int)search_surf_b - (int)surf_b) <= tb)
                 );
                 if (within_threshold)
                     similar++;
@@ -1744,9 +1743,9 @@ get_threshold (
                         }
                     }
                 }
-            } else if (((abs((((the_color & rmask) >> rshift) << rloss) - r) <= tr) &
-                        (abs((((the_color & gmask) >> gshift) << gloss) - g) <= tg) &
-                        (abs((((the_color & bmask) >> bshift) << bloss) - b) <= tb))
+            } else if (((abs((((the_color & rmask) >> rshift) << rloss) - search_color_r) <= tr) &
+                        (abs((((the_color & gmask) >> gshift) << gloss) - search_color_g) <= tg) &
+                        (abs((((the_color & bmask) >> bshift) << bloss) - search_color_b) <= tb))
                        ^ inverse_set) {
 
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -1772,14 +1772,40 @@ static int get_threshold (SDL_Surface *destsurf, SDL_Surface *surf,
 }
 
 
+/*
+        # dest_surf                  # Surface we are changing. See 'set_behavior'.
+        #                            # None - if counting (set_behavior is 0), don't need 'dest_surf'.
+        # surf                       # Surface we are looking at.
+        # search_color               # Color we are searching for.
+        # threshold = (0,0,0,0)      # Within this distance from search_color (or search_surf).
+        # set_color = (0,0,0,0)      # color we set.
+        # set_behavior = 1           # 1 - pixels in dest_surface will be changed to 'set_color'.
+        #                            # 0 - we do not change 'dest_surf', just count. Make dest_surf=None.
+        #                            # 2 - pixels set in 'dest_surf' will be from 'surface'.
+        # search_surf = None         # None - search against 'search_color' instead.
+        #                            # Surface - look at the color in here rather than 'search_color'.
+        # inverse_set = False        # False - pixels outside of threshold are changed.
+        #                            # True - pixels within threshold are changed.
+*/
 
-
-static PyObject* surf_threshold(PyObject* self, PyObject* arg)
+static PyObject* surf_threshold(PyObject* self, PyObject* arg, PyObject *kwds)
 {
     PyObject *surfobj, *surfobj2 = NULL, *surfobj3 = NULL;
     SDL_Surface* surf = NULL, *destsurf = NULL, *surf2 = NULL;
     int bpp, change_return = 1, inverse = 0;
     int num_threshold_pixels = 0;
+
+    static char *kwlist[] =  {
+        "dest_surf",
+        "surf",
+        "search_color",
+        "threshold",
+        "set_color",
+        "set_behavior",
+        "search_surf",
+        "inverse_set",
+        0
+    };
 
     PyObject *rgba_obj_color;
     PyObject *rgba_obj_threshold = NULL;
@@ -1799,6 +1825,16 @@ static PyObject* surf_threshold(PyObject* self, PyObject* arg)
                            &change_return,
                            &PySurface_Type, &surfobj3, &inverse))
         return NULL;
+
+
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iO&O&", kwlist,
+                                     &textobj, &style,
+                                     obj_to_rotation, (void *)&rotation,
+                                     obj_to_scale, (void *)&face_size))
+        goto error;
+
+
 
 
     destsurf = PySurface_AsSurface (surfobj);

--- a/src/transform.c
+++ b/src/transform.c
@@ -1881,6 +1881,13 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
             return RAISE (PyExc_TypeError, "invalid set_color argument");
     }
 
+    if (dest_surf && surf && (surf->h != dest_surf->h || surf->w != dest_surf->w)) {
+        return RAISE (PyExc_TypeError, "surf and dest_surf not the same size");
+    }
+    if (search_surf && surf && (surf->h != search_surf->h || surf->w != search_surf->w)) {
+        return RAISE (PyExc_TypeError, "surf and search_surf not the same size");
+    }
+
     if (dest_surf)
         PySurface_Lock(dest_surf_obj);
     PySurface_Lock(surf_obj);

--- a/src/transform.c
+++ b/src/transform.c
@@ -1793,30 +1793,32 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
 
     /*
     https://www.pygame.org/docs/ref/transform.html#pygame.transform.threshold
-
-    dest_surf             # Surface we are changing. See 'set_behavior'.
-                          # None - if counting (set_behavior is 0), don't need 'dest_surf'.
-    surf                  # Surface we are looking at.
-    search_color          # Color we are searching for.
-    threshold = (0,0,0,0) # Within this distance from search_color (or search_surf).
-    set_color = (0,0,0,0) # color we set.
-    set_behavior = 1      # 1 - pixels in dest_surface will be changed to 'set_color'.
-                          # 0 - we do not change 'dest_surf', just count. Make dest_surf=None.
-                          # 2 - pixels set in 'dest_surf' will be from 'surface'.
-    search_surf = None    # None - search against 'search_color' instead.
-                          # Surface - look at the color in here rather than 'search_color'.
-    inverse_set = False   # False - pixels outside of threshold are changed.
-                          # True - pixels within threshold are changed.
     */
     static char *kwlist[] =  {
-        "dest_surf",
-        "surf",
-        "search_color",
-        "threshold",
-        "set_color",
-        "set_behavior",
-        "search_surf",
-        "inverse_set",
+        "dest_surf",    /* Surface we are changing. See 'set_behavior'.
+                             None - if counting (set_behavior is 0),
+                                    don't need 'dest_surf'. */
+        "surf",         /* Surface we are looking at. */
+        "search_color", /* Color we are searching for. */
+        "threshold",    /* =(0,0,0,0)  Within this distance from
+                                       search_color (or search_surf). */
+        "set_color",    /* =(0,0,0,0)  Color we set. */
+        "set_behavior", /* =1 What and where we set pixels (if at all)
+                             1 - pixels in dest_surface will be changed
+                                 to 'set_color'.
+                             0 - we do not change 'dest_surf', just count.
+                                 Make dest_surf=None.
+                             2 - pixels set in 'dest_surf' will be from 'surface'.
+                        */
+        "search_surf",  /* =None If set, compare to this surface.
+                             None - search against 'search_color' instead.
+                             Surface - look at the color in here rather
+                                       than 'search_color'.
+                        */
+        "inverse_set",  /* =False.
+                             False - pixels outside of threshold are changed.
+                             True - pixels within threshold are changed.
+                        */
         0
     };
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -1512,6 +1512,23 @@ surf_set_smoothscale_backend (PyObject *self, PyObject *args, PyObject *kwds)
 #endif /* defined(SCALE_MMX_SUPPORT) */
 }
 
+
+
+#ifndef PG_INLINE
+  #if defined(__clang__)
+    #define PG_INLINE __inline__ __attribute__ ((__unused__))
+  #elif defined(__GNUC__)
+    #define PG_INLINE __inline__
+  #elif defined(_MSC_VER)
+    #define PG_INLINE __inline
+  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+    #define PG_INLINE inline
+  #else
+    #define PG_INLINE
+  #endif
+#endif
+
+
 /*
     num_threshold_pixels = get_threshold(dest_surf,
                                          surf,
@@ -1531,7 +1548,7 @@ pixels is advanced by one pixel.
 _get_color_move_pixels(surf->format->BytesPerPixel, pixels, &the_color) {
 
  */
-void
+static PG_INLINE void
 _get_color_move_pixels(
     Uint8 bpp,
     Uint8 *pixels,
@@ -1569,7 +1586,7 @@ _get_color_move_pixels(
 _set_at_pixels(x, y, pixels, surf->format, surf->pitch, the_color)
 
  */
-void
+static PG_INLINE void
 _set_at_pixels(
     int x,
     int y,

--- a/src/transform.c
+++ b/src/transform.c
@@ -1826,7 +1826,7 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     https://docs.python.org/3/c-api/arg.html#parsing-arguments
     */
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O|OOiO!i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O|OOiOi", kwlist,
         /* required */
         &PySurface_Type, &dest_surf_obj,   /* O! python object from c type  */
         &PySurface_Type, &surfobj2,        /* O! python object from c type */
@@ -1835,14 +1835,17 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
         &rgba_obj_threshold,               /* O  python object. */
         &rgba_obj_diff_color,              /* O  python object. */
         &change_return,                    /* i  plain python int. */
-        &PySurface_Type, &surfobj3,        /* O! python object from c type */
+        &surfobj3,                         /* O python object. */
         &inverse))                         /* i  plain python int. */
         return NULL;
 
     dest_surf = PySurface_AsSurface (dest_surf_obj);
     surf = PySurface_AsSurface (surfobj2);
-    if(surfobj3) {
-        surf2 = PySurface_AsSurface (surfobj3);
+    printf("surf\n");
+
+    if (surfobj3 && PySurface_Check(surfobj3)) {
+        printf("if surfobj3 true\n");
+        surf2 = PySurface_AsSurface(surfobj3);
     }
 
     printf("surf\n");
@@ -1938,7 +1941,7 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
 
     PySurface_Unlock(dest_surf_obj);
     PySurface_Unlock(surfobj2);
-    if(surfobj3) {
+    if(surfobj3 && PySurface_Check(surfobj3)) {
         PySurface_Unlock(surfobj3);
     }
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -1695,7 +1695,7 @@ get_threshold (
 
             if (within_threshold)
                 similar++;
-            if (set_behavior && ((within_threshold && inverse_set) || (!within_threshold))) {
+            if (set_behavior && ((within_threshold && inverse_set) || (!within_threshold && !inverse_set))) {
                 _set_at_pixels(x, y, destpixels,
                     dest_surf->format,
                     dest_surf->pitch,

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -562,81 +562,140 @@ class TransformModuleTest( unittest.TestCase ):
 
         ################################################################
 
+    def test_threshold_set_behavior2(self):
+        """ raises an error when set_behavior=2 and set_color is not None.
+        """
+        from pygame.transform import threshold
+        s1 = pygame.Surface((32,32), SRCALPHA, 32)
+        s2 = pygame.Surface((32,32), SRCALPHA, 32)
+        THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF = 2
+        self.assertRaises(TypeError, threshold,
+            dest_surf=s2,
+            surf=s1,
+            search_color=(30, 30, 30),
+            threshold=(11, 11, 11),
+            set_color=(255, 0, 0),
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF)
+
+    def test_threshold_set_behavior0(self):
+        """ raises an error when set_behavior=1
+                and set_color is not None,
+                and dest_surf is not None.
+        """
+        from pygame.transform import threshold
+        s1 = pygame.Surface((32,32), SRCALPHA, 32)
+        s2 = pygame.Surface((32,32), SRCALPHA, 32)
+        THRESHOLD_BEHAVIOR_COUNT = 0
+
+        self.assertRaises(TypeError, threshold,
+            dest_surf=None,
+            surf=s2,
+            search_color=(30, 30, 30),
+            threshold=(11, 11, 11),
+            set_color=(0, 0, 0),
+            set_behavior=THRESHOLD_BEHAVIOR_COUNT)
+
+        self.assertRaises(TypeError, threshold,
+            dest_surf=s1,
+            surf=s2,
+            search_color=(30, 30, 30),
+            threshold=(11, 11, 11),
+            set_color=None,
+            set_behavior=THRESHOLD_BEHAVIOR_COUNT)
+
+        threshold(
+            dest_surf=None,
+            surf=s2,
+            search_color=(30, 30, 30),
+            threshold=(11, 11, 11),
+            set_color=None,
+            set_behavior=THRESHOLD_BEHAVIOR_COUNT)
+
+
+    def test_threshold_from_surface(self):
+        """ Set similar pixels in 'dest_surf' to color in the 'surf'.
+        """
+        from pygame.transform import threshold
+
+        surf = pygame.Surface((32,32), SRCALPHA, 32)
+        dest_surf = pygame.Surface((32,32), SRCALPHA, 32)
+        surf_color = (40, 40, 40, 255)
+        dest_color = (255, 255, 255)
+        surf.fill(surf_color)
+        dest_surf.fill(dest_color)
+        THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF = 2
+
+        num_threshold_pixels = threshold(
+            dest_surf=dest_surf,
+            surf=surf,
+            search_color=(30, 30, 30),
+            threshold=(11, 11, 11),
+            set_color=None,
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,
+            inverse_set=1)
+
+        self.assertEqual(num_threshold_pixels, dest_surf.get_height() * dest_surf.get_width())
+        self.assertEqual(dest_surf.get_at((0, 0)), surf_color)
+
+
     def test_threshold__surface(self):
         """
         """
-
-        #pygame.transform.threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = True): return num_threshold_pixels
-        threshold = pygame.transform.threshold
+        from pygame.transform import threshold
 
         s1 = pygame.Surface((32,32), SRCALPHA, 32)
         s2 = pygame.Surface((32,32), SRCALPHA, 32)
         s3 = pygame.Surface((1,1), SRCALPHA, 32)
+        THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF = 2
 
-        s1.fill((40,40,40))
-        s2.fill((255,255,255))
+        # if 1:
+        #     # only one pixel should not be changed.
+        #     s1.fill((40,40,40))
+        #     s2.fill((255,255,255))
+        #     s1.set_at( (0,0), (170, 170, 170) )
+        #     # set the similar pixels in destination surface to the color
+        #     #     in the first surface.
+        #     num_threshold_pixels = threshold(
+        #         dest_surf=s2,
+        #         surf=s1,
+        #         search_color=(30,30,30),
+        #         threshold=(11,11,11),
+        #         set_color=None,
+        #         set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF)
 
-
-
-
-        dest_surface = s2
-        surface1 = s1
-        color = (30,30,30)
-        the_threshold = (11,11,11)
-        diff_color = (255,0,0)
-        change_return = 2
-
-        # set the similar pixels in destination surface to the color
-        #     in the first surface.
-        num_threshold_pixels = threshold(dest_surface, surface1, color,
-                                         the_threshold, diff_color,
-                                         change_return)
-
-        #num_threshold_pixels = threshold(s2, s1, (30,30,30))
-        self.assertEqual(num_threshold_pixels, s1.get_height() * s1.get_width())
-        self.assertEqual(s2.get_at((0,0)), (40, 40, 40, 255))
-
+        #     #num_threshold_pixels = threshold(s2, s1, (30,30,30))
+        #     self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
+        #     self.assertEqual(s2.get_at((0,0)), (0,0,0, 255))
+        #     self.assertEqual(s2.get_at((0,1)), (40, 40, 40, 255))
+        #     self.assertEqual(s2.get_at((17,1)), (40, 40, 40, 255))
 
 
+        # # abs(40 - 255) < 100
+        # #(abs(c1[0] - r) < tr)
 
+        # if 1:
+        #     s1.fill((160,160,160))
+        #     s2.fill((255,255,255))
+        #     num_threshold_pixels = threshold(s2, s1, (255,255,255), (100,100,100), (0,0,0), True)
 
-        if 1:
-
-            # only one pixel should not be changed.
-            s1.fill((40,40,40))
-            s2.fill((255,255,255))
-            s1.set_at( (0,0), (170, 170, 170) )
-            # set the similar pixels in destination surface to the color
-            #     in the first surface.
-            num_threshold_pixels = threshold(s2, s1, (30,30,30), (11,11,11),
-                                             (0,0,0), 2)
-
-            #num_threshold_pixels = threshold(s2, s1, (30,30,30))
-            self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
-            self.assertEqual(s2.get_at((0,0)), (0,0,0, 255))
-            self.assertEqual(s2.get_at((0,1)), (40, 40, 40, 255))
-            self.assertEqual(s2.get_at((17,1)), (40, 40, 40, 255))
-
-
-        # abs(40 - 255) < 100
-        #(abs(c1[0] - r) < tr)
-
-        if 1:
-            s1.fill((160,160,160))
-            s2.fill((255,255,255))
-            num_threshold_pixels = threshold(s2, s1, (255,255,255), (100,100,100), (0,0,0), True)
-
-            self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()))
+        #     self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()))
 
 
 
 
         if 1:
             # only one pixel should not be changed.
-            s1.fill((40,40,40))
-            s2.fill((255,255,255))
+            s1.fill((40, 40, 40))
+            s2.fill((255, 255, 255))
             s1.set_at( (0,0), (170, 170, 170) )
-            num_threshold_pixels = threshold(s3, s1, (30,30,30), (11,11,11), (0,0,0), False)
+            num_threshold_pixels = threshold(
+                dest_surf=None,
+                surf=s1,
+                search_color=(30, 30, 30),
+                threshold=(11, 11, 11),
+                set_color=None,
+                set_behavior=0)
+
             #num_threshold_pixels = threshold(s2, s1, (30,30,30))
             self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -200,35 +200,51 @@ class TransformModuleTest( unittest.TestCase ):
         self.assertEqual(w*h, pixels_within_threshold)
 
 
-        ################################################################
-        # Change dest_surface on return (not expected)
 
-        change_color = (255, 10, 10, 10)
+    def test_threshold_dest_surf_not_change(self):
+        """ the pixels within the threshold.
 
+        All pixels not within threshold are changed to set_color.
+        So there should be none changed in this test.
+        """
 
-        # threshold = (20, 20, 20, 20)
-        # original_color = (25,25,25,25)
-        # third threshold_color = (10, 10, 10, 10)
+        (w, h) = size = (32, 32)
+        threshold = (20, 20, 20, 20)
+        original_color = (25, 25, 25, 25)
+        original_dest_color = (65, 65, 65, 55)
+        threshold_color = (10, 10, 10, 10)
+        set_color = (255, 10, 10, 10)
+
+        surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+        dest_surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+        search_surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+
+        surf.fill(original_color)
+        search_surf.fill(threshold_color)
+        dest_surf.fill(original_dest_color)
+
+        dest_rect = dest_surf.get_rect()
 
         # set_behavior=1, set dest_surface from set_color.
         # all within threshold of third_surface, so no color is set.
 
-
-        pixels_within_threshold = pygame.transform.threshold (
-            dest_surface,
-            original_surface,
-            None,                                        # color
-            threshold,
-            change_color,                                # diff_color
-            1,                                           # change_return
-            third_surface,
+        print('test_threshold_dest_surf_not_change')
+        THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR = 1
+        pixels_within_threshold = pygame.transform.threshold(
+            dest_surf=dest_surf,
+            surf=surf,
+            search_color=None,
+            threshold=threshold,
+            set_color=set_color,
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR,
+            search_surf=search_surf,
         )
 
-        # Return, of pixels within threshold is correct
+        # # Return, of pixels within threshold is correct
         self.assertEqual(w*h, pixels_within_threshold)
 
-        # Size of dest surface is correct
-        dest_rect = dest_surface.get_rect()
+        # # Size of dest surface is correct
+        dest_rect = dest_surf.get_rect()
         dest_size = dest_rect.size
         self.assertEqual(size, dest_size)
 
@@ -236,34 +252,35 @@ class TransformModuleTest( unittest.TestCase ):
         # pixels are within threshold
 
         for pt in test_utils.rect_area_pts(dest_rect):
-            self.assertNotEqual(dest_surface.get_at(pt), change_color)
+            self.assertNotEqual(dest_surf.get_at(pt), set_color)
+            self.assertEqual(dest_surf.get_at(pt), original_dest_color)
+
+
 
         ################################################################
         # Lowering the threshold, expecting changed surface
-
         pixels_within_threshold = pygame.transform.threshold (
-            dest_surface,
-            original_surface,
-            0,                                           # color
-            0,                                           # threshold
-            change_color,                                # diff_color
-            1,                                           # change_return
-            third_surface,
+            dest_surf,
+            surf,
+            search_color=None,
+            set_color=set_color,
+            set_behavior=1,
+            search_surf=search_surf,
         )
 
         # Return, of pixels within threshold is correct
         self.assertEqual(0, pixels_within_threshold)
 
         # Size of dest surface is correct
-        dest_rect = dest_surface.get_rect()
+        dest_rect = dest_surf.get_rect()
         dest_size = dest_rect.size
         self.assertEqual(size, dest_size)
 
-        # The color is the change_color specified for every pixel As all
+        # The color is the set_color specified for every pixel As all
         # pixels are not within threshold
 
         for pt in test_utils.rect_area_pts(dest_rect):
-            self.assertEqual(dest_surface.get_at(pt), change_color)
+            self.assertEqual(dest_surf.get_at(pt), set_color)
 
 
     def test_threshold_count(self):
@@ -345,13 +362,15 @@ class TransformModuleTest( unittest.TestCase ):
             search_surf=search_surf)
 
         # surf, dest_surf, and search_surf should all be the same size.
-        different_sized_surf = pygame.Surface((22, 33), pygame.SRCALPHA, 32)
-        self.assertRaises(TypeError, pygame.transform.threshold,
-            dest_surf,
-            surf,
-            search_color=None,
-            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,
-            search_surf=different_sized_surf)
+        # TODO: FIXME: need to check surface sizes are the same.
+        if 0:
+            different_sized_surf = pygame.Surface((22, 33), pygame.SRCALPHA, 32)
+            self.assertRaises(TypeError, pygame.transform.threshold,
+                dest_surf,
+                surf,
+                search_color=None,
+                set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,
+                search_surf=different_sized_surf)
 
         # We look to see if colors in search_surf are in surf.
         num_threshold_pixels = pygame.transform.threshold(
@@ -375,8 +394,7 @@ class TransformModuleTest( unittest.TestCase ):
             search_surf=search_surf,
             inverse_set=True)
 
-        num_pixels_within = (32 * 32) - 2
-        self.assertEqual(num_threshold_pixels, num_pixels_within)
+        self.assertEqual(num_threshold_pixels, 2)
 
         #TODO: check out if dest_surf is modified correctly.
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -257,6 +257,38 @@ class TransformModuleTest( unittest.TestCase ):
             self.assertEqual(dest_surface.get_at(pt), change_color)
 
 
+    def test_threshold_count(self):
+        """ counts the colors, and not changes them.
+        """
+        surf_size = (32, 32)
+        surf = pygame.Surface(surf_size, pygame.SRCALPHA, 32)
+        search_color = (55, 55, 55, 255)
+        original_color = (10, 10, 10, 255)
+
+        surf.fill(original_color)
+        # set 2 pixels to the color we are searching for.
+        surf.set_at((0, 0), search_color)
+        surf.set_at((12, 5), search_color)
+
+        self.assertRaises(TypeError, pygame.transform.threshold,
+            None,
+            surf,
+            search_color)
+
+        # num_threshold_pixels = pygame.transform.threshold(
+        #     None,
+        #     surf,
+        #     search_color)
+
+        # # 32x32 -> 1024. 1022 are within the threshold. 2 are not.
+        # num_pixels_within = (32 * 32) - 2
+        # self.assertEqual(num_threshold_pixels, num_pixels_within)
+        # # no pixels changed.
+        # self.assertEqual(dest_surf.get_at((0, 0)), original_color)
+        # self.assertEqual(dest_surf.get_at((12, 5)), original_color)
+        # self.assertEqual(dest_surf.get_at((2, 2)), original_color)
+
+
     def test_threshold_inverse_set(self):
         """ changes the pixels within the threshold, and outside.
         """

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -90,10 +90,6 @@ def threshold(return_surf, surf, color, threshold = (0,0,0), diff_color = (0,0,0
 
 
 class TransformModuleTest( unittest.TestCase ):
-    #class TransformModuleTest( object ):
-
-    #def assertEqual(self, x,x2):
-    #    print x,x2
 
     def test_scale__alpha( self ):
         """ see if set_alpha information is kept.
@@ -109,7 +105,6 @@ class TransformModuleTest( unittest.TestCase ):
         s3 = s.copy()
         self.assertEqual(s.get_alpha(),s3.get_alpha())
         self.assertEqual(s.get_alpha(),s2.get_alpha())
-
 
     def test_scale__destination( self ):
         """ see if the destination surface can be passed in to use.
@@ -135,7 +130,6 @@ class TransformModuleTest( unittest.TestCase ):
 
             # the wrong size surface is past in.  Should raise an error.
             self.assertRaises(ValueError, pygame.transform.smoothscale, s, (33,64), s3)
-
 
     def test_threshold__honors_third_surface(self):
         # __doc__ for threshold as of Tue 07/15/2008
@@ -200,7 +194,6 @@ class TransformModuleTest( unittest.TestCase ):
             search_surf=third_surface,
         )
         self.assertEqual(w*h, pixels_within_threshold)
-
 
     def test_threshold_dest_surf_not_change(self):
         """ the pixels within the threshold.
@@ -358,15 +351,23 @@ class TransformModuleTest( unittest.TestCase ):
             search_surf=search_surf)
 
         # surf, dest_surf, and search_surf should all be the same size.
-        # TODO: FIXME: need to check surface sizes are the same.
-        if 0:
-            different_sized_surf = pygame.Surface((22, 33), pygame.SRCALPHA, 32)
-            self.assertRaises(TypeError, pygame.transform.threshold,
-                dest_surf,
-                surf,
-                search_color=None,
-                set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,
-                search_surf=different_sized_surf)
+        # Check surface sizes are the same size.
+        different_sized_surf = pygame.Surface((22, 33), pygame.SRCALPHA, 32)
+        self.assertRaises(TypeError, pygame.transform.threshold,
+            different_sized_surf,
+            surf,
+            search_color=None,
+            set_color=None,
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,
+            search_surf=search_surf)
+
+        self.assertRaises(TypeError, pygame.transform.threshold,
+            dest_surf,
+            surf,
+            search_color=None,
+            set_color=None,
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,
+            search_surf=different_sized_surf)
 
         # We look to see if colors in search_surf are in surf.
         num_threshold_pixels = pygame.transform.threshold(
@@ -380,8 +381,6 @@ class TransformModuleTest( unittest.TestCase ):
         num_pixels_within = 2
         self.assertEqual(num_threshold_pixels, num_pixels_within)
 
-        #TODO: check out if dest_surf is modified correctly.
-
         dest_surf.fill(original_color)
         num_threshold_pixels = pygame.transform.threshold(
             dest_surf,
@@ -393,10 +392,6 @@ class TransformModuleTest( unittest.TestCase ):
             inverse_set=True)
 
         self.assertEqual(num_threshold_pixels, 2)
-
-        #TODO: check out if dest_surf is modified correctly.
-
-
 
     def test_threshold_inverse_set(self):
         """ changes the pixels within the threshold, and not outside.
@@ -444,8 +439,6 @@ class TransformModuleTest( unittest.TestCase ):
         # other pixels should be the same as they were before.
         # We just check one other pixel, not all of them.
         self.assertEqual(dest_surf.get_at((2, 2)), original_color)
-
-
 
 #XXX
     def test_threshold_non_src_alpha(self):

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -686,15 +686,16 @@ class TransformModuleTest( unittest.TestCase ):
         if 1:
             # only one pixel should not be changed.
             s1.fill((40, 40, 40))
-            s2.fill((255, 255, 255))
-            s1.set_at( (0,0), (170, 170, 170) )
+            s1.set_at((0, 0), (170, 170, 170))
+            THRESHOLD_BEHAVIOR_COUNT = 0
+
             num_threshold_pixels = threshold(
                 dest_surf=None,
                 surf=s1,
                 search_color=(30, 30, 30),
                 threshold=(11, 11, 11),
                 set_color=None,
-                set_behavior=0)
+                set_behavior=THRESHOLD_BEHAVIOR_COUNT)
 
             #num_threshold_pixels = threshold(s2, s1, (30,30,30))
             self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
@@ -708,26 +709,26 @@ class TransformModuleTest( unittest.TestCase ):
             s2.fill((255,255,255))
             s3.fill((255,255,255))
             s1.set_at( (0,0), (170, 170, 170) )
-            num_threshold_pixels = threshold(s3, s1, (254,254,254), (1,1,1),
-                                             (44,44,44,255), False)
+            num_threshold_pixels = threshold(None, s1, (254,254,254), (1,1,1),
+                                             None, THRESHOLD_BEHAVIOR_COUNT)
             self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
 
 
             # compare the two surfaces.  Should be all but one matching.
-            num_threshold_pixels = threshold(s3, s1, None, (1,1,1),
-                                             (44,44,44,255), False, s2)
+            num_threshold_pixels = threshold(None, s1, None, (1,1,1),
+                                             None, THRESHOLD_BEHAVIOR_COUNT, s2)
             self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
 
 
             # within (0,0,0) threshold?  Should match no pixels.
-            num_threshold_pixels = threshold(s3, s1, (253,253,253), (0,0,0),
-                                             (44,44,44,255), False)
+            num_threshold_pixels = threshold(None, s1, (253,253,253), (0,0,0),
+                                             None, THRESHOLD_BEHAVIOR_COUNT)
             self.assertEqual(num_threshold_pixels, 0)
 
 
             # other surface within (0,0,0) threshold?  Should match no pixels.
-            num_threshold_pixels = threshold(s3, s1, None, (0,0,0),
-                                             (44,44,44,255), False, s2)
+            num_threshold_pixels = threshold(None, s1, None, (0,0,0),
+                                             None, THRESHOLD_BEHAVIOR_COUNT, s2)
             self.assertEqual(num_threshold_pixels, 0)
 
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -257,6 +257,45 @@ class TransformModuleTest( unittest.TestCase ):
             self.assertEqual(dest_surface.get_at(pt), change_color)
 
 
+    def test_threshold_inverse_set(self):
+        """ changes the pixels within the threshold, and outside.
+        """
+        _surf = pygame.Surface((32, 32), pygame.SRCALPHA, 32)
+
+        dest_surf = _surf                  # surface we are changing.
+        surf = _surf                       # surface we are looking at
+        search_color = (55, 55, 55, 255)   # color we are searching for.
+        threshold = (0, 0, 0, 0)           # within this distance from search_color.
+        set_color = (5, 5, 5, 255)         # color we set.
+        set_behavior = 1                   # pixels in dest_surface will be changed to color.
+        search_surf = None                 # we are not comparing colors against a second surface.
+        inverse_set = True                 # pixels within threshold are changed to 'set_color'
+
+        # fill the surface with colors we are not looking for.
+        surf.fill((10, 10, 10, 255))
+        # set 2 pixels to the color we are searching for.
+        surf.set_at((0, 0), set_color)
+        surf.set_at((12, 5), set_color)
+
+        num_threshold_pixels = pygame.transform.threshold(
+            surf,
+            dest_surf,
+            search_color,
+            threshold,
+            set_color,
+            set_behavior,
+            search_surf,
+            inverse_set)
+
+        self.assertEqual(num_threshold_pixels, 2)
+        # only two pixels changed to diff_color.
+        self.assertEqual(surface.get_at((0, 0)), set_color)
+        self.assertEqual(surface.get_at((12, 5)), set_color)
+
+        # other pixels should be the same as they were before.
+        self.assertEqual(surface.get_at((2, 2)), (10, 10, 10, 255))
+
+
 
 #XXX
     def test_threshold_non_src_alpha(self):

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -200,7 +200,6 @@ class TransformModuleTest( unittest.TestCase ):
         self.assertEqual(w*h, pixels_within_threshold)
 
 
-
     def test_threshold_dest_surf_not_change(self):
         """ the pixels within the threshold.
 
@@ -223,12 +222,9 @@ class TransformModuleTest( unittest.TestCase ):
         search_surf.fill(threshold_color)
         dest_surf.fill(original_dest_color)
 
-        dest_rect = dest_surf.get_rect()
-
         # set_behavior=1, set dest_surface from set_color.
         # all within threshold of third_surface, so no color is set.
 
-        print('test_threshold_dest_surf_not_change')
         THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR = 1
         pixels_within_threshold = pygame.transform.threshold(
             dest_surf=dest_surf,
@@ -256,29 +252,43 @@ class TransformModuleTest( unittest.TestCase ):
             self.assertEqual(dest_surf.get_at(pt), original_dest_color)
 
 
+    def test_threshold_dest_surf_all_changed(self):
+        """ Lowering the threshold, expecting changed surface
+        """
 
-        ################################################################
-        # Lowering the threshold, expecting changed surface
+        (w, h) = size = (32, 32)
+        threshold = (20, 20, 20, 20)
+        original_color = (25, 25, 25, 25)
+        original_dest_color = (65, 65, 65, 55)
+        threshold_color = (10, 10, 10, 10)
+        set_color = (255, 10, 10, 10)
+
+        surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+        dest_surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+        search_surf = pygame.Surface(size, pygame.SRCALPHA, 32)
+
+        surf.fill(original_color)
+        search_surf.fill(threshold_color)
+        dest_surf.fill(original_dest_color)
+
+        THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR = 1
         pixels_within_threshold = pygame.transform.threshold (
             dest_surf,
             surf,
             search_color=None,
             set_color=set_color,
-            set_behavior=1,
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR,
             search_surf=search_surf,
         )
 
-        # Return, of pixels within threshold is correct
         self.assertEqual(0, pixels_within_threshold)
 
-        # Size of dest surface is correct
         dest_rect = dest_surf.get_rect()
         dest_size = dest_rect.size
         self.assertEqual(size, dest_size)
 
         # The color is the set_color specified for every pixel As all
         # pixels are not within threshold
-
         for pt in test_utils.rect_area_pts(dest_rect):
             self.assertEqual(dest_surf.get_at(pt), set_color)
 
@@ -401,7 +411,7 @@ class TransformModuleTest( unittest.TestCase ):
 
 
     def test_threshold_inverse_set(self):
-        """ changes the pixels within the threshold, and outside.
+        """ changes the pixels within the threshold, and not outside.
         """
         surf_size = (32, 32)
         _dest_surf = pygame.Surface(surf_size, pygame.SRCALPHA, 32)
@@ -412,15 +422,10 @@ class TransformModuleTest( unittest.TestCase ):
         search_color = (55, 55, 55, 255)   # color we are searching for.
         threshold = (0, 0, 0, 0)           # within this distance from search_color.
         set_color = (5, 5, 5, 255)         # color we set.
-        set_behavior = 1                   # pixels in dest_surface will be changed to color.
-        search_surf = None                 # we are not comparing colors against a second surface.
         inverse_set = 1                    # pixels within threshold are changed to 'set_color'
 
 
         original_color = (10, 10, 10, 255)
-        # raise ValueError('asdf')
-
-        # fill the surface with colors we are not looking for.
         surf.fill(original_color)
         # set 2 pixels to the color we are searching for.
         surf.set_at((0, 0), search_color)
@@ -433,15 +438,15 @@ class TransformModuleTest( unittest.TestCase ):
 
 
         print("test_threshold_inverse_set")
+        THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR = 1
         num_threshold_pixels = pygame.transform.threshold(
             dest_surf,
             surf,
-            search_color,
-            threshold,
-            set_color,
-            set_behavior,
-            search_surf,
-            inverse_set)
+            search_color=search_color,
+            threshold=threshold,
+            set_color=set_color,
+            set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_COLOR,
+            inverse_set=1)
 
         # 32x32 -> 1024. 1022 are within the threshold. 2 are not.
         num_pixels_within = (32 * 32) - 2

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -371,8 +371,8 @@ class TransformModuleTest( unittest.TestCase ):
 
         # We look to see if colors in search_surf are in surf.
         num_threshold_pixels = pygame.transform.threshold(
-            dest_surf,
-            surf,
+            dest_surf=dest_surf,
+            surf=surf,
             search_color=None,
             set_color=None,
             set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF,

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -208,7 +208,6 @@ class TransformModuleTest( unittest.TestCase ):
         All pixels not within threshold are changed to set_color.
         So there should be none changed in this test.
         """
-
         (w, h) = size = (32, 32)
         threshold = (20, 20, 20, 20)
         original_color = (25, 25, 25, 25)
@@ -253,7 +252,6 @@ class TransformModuleTest( unittest.TestCase ):
             self.assertNotEqual(dest_surf.get_at(pt), set_color)
             self.assertEqual(dest_surf.get_at(pt), original_dest_color)
 
-
     def test_threshold_dest_surf_all_changed(self):
         """ Lowering the threshold, expecting changed surface
         """
@@ -294,7 +292,6 @@ class TransformModuleTest( unittest.TestCase ):
         for pt in test_utils.rect_area_pts(dest_rect):
             self.assertEqual(dest_surf.get_at(pt), set_color)
 
-
     def test_threshold_count(self):
         """ counts the colors, and not changes them.
         """
@@ -323,26 +320,13 @@ class TransformModuleTest( unittest.TestCase ):
             search_color,
             set_behavior=THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF)
 
-        #TODO: FIXME: segfaults.
-        if 0:
-            THRESHOLD_BEHAVIOR_COUNT = 0
-            num_threshold_pixels = pygame.transform.threshold(
-                None,
-                surf,
-                search_color,
-                set_behavior=THRESHOLD_BEHAVIOR_COUNT)
-
-
-            # # 32x32 -> 1024. 1022 are within the threshold. 2 are not.
-            num_pixels_within = (32 * 32) - 2
-            self.assertEqual(num_threshold_pixels, num_pixels_within)
-
-
-
-        # # no pixels changed.
-        # self.assertEqual(dest_surf.get_at((0, 0)), original_color)
-        # self.assertEqual(dest_surf.get_at((12, 5)), original_color)
-        # self.assertEqual(dest_surf.get_at((2, 2)), original_color)
+        THRESHOLD_BEHAVIOR_COUNT = 0
+        num_threshold_pixels = pygame.transform.threshold(
+            dest_surf=None,
+            surf=surf,
+            search_color=search_color,
+            set_behavior=THRESHOLD_BEHAVIOR_COUNT)
+        self.assertEqual(num_threshold_pixels, 2)
 
     def test_threshold_search_surf(self):
         surf_size = (32, 32)

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -260,26 +260,39 @@ class TransformModuleTest( unittest.TestCase ):
     def test_threshold_inverse_set(self):
         """ changes the pixels within the threshold, and outside.
         """
-        _surf = pygame.Surface((32, 32), pygame.SRCALPHA, 32)
+        surf_size = (32, 32)
+        _dest_surf = pygame.Surface(surf_size, pygame.SRCALPHA, 32)
+        _surf = pygame.Surface(surf_size, pygame.SRCALPHA, 32)
 
-        dest_surf = _surf                  # surface we are changing.
+        dest_surf = _dest_surf             # surface we are changing.
         surf = _surf                       # surface we are looking at
         search_color = (55, 55, 55, 255)   # color we are searching for.
         threshold = (0, 0, 0, 0)           # within this distance from search_color.
         set_color = (5, 5, 5, 255)         # color we set.
         set_behavior = 1                   # pixels in dest_surface will be changed to color.
         search_surf = None                 # we are not comparing colors against a second surface.
-        inverse_set = True                 # pixels within threshold are changed to 'set_color'
+        inverse_set = 1                    # pixels within threshold are changed to 'set_color'
+
+
+        original_color = (10, 10, 10, 255)
+        # raise ValueError('asdf')
 
         # fill the surface with colors we are not looking for.
-        surf.fill((10, 10, 10, 255))
+        surf.fill(original_color)
         # set 2 pixels to the color we are searching for.
-        surf.set_at((0, 0), set_color)
-        surf.set_at((12, 5), set_color)
+        surf.set_at((0, 0), search_color)
+        surf.set_at((12, 5), search_color)
 
+        dest_surf.fill(original_color)
+        # set 2 pixels to the color we are searching for.
+        dest_surf.set_at((0, 0), search_color)
+        dest_surf.set_at((12, 5), search_color)
+
+
+        print("test_threshold_inverse_set")
         num_threshold_pixels = pygame.transform.threshold(
-            surf,
             dest_surf,
+            surf,
             search_color,
             threshold,
             set_color,
@@ -287,13 +300,16 @@ class TransformModuleTest( unittest.TestCase ):
             search_surf,
             inverse_set)
 
-        self.assertEqual(num_threshold_pixels, 2)
+        # 32x32 -> 1024. 1022 are within the threshold. 2 are not.
+        num_pixels_within = (32 * 32) - 2
+        self.assertEqual(num_threshold_pixels, num_pixels_within)
         # only two pixels changed to diff_color.
-        self.assertEqual(surface.get_at((0, 0)), set_color)
-        self.assertEqual(surface.get_at((12, 5)), set_color)
+        self.assertEqual(dest_surf.get_at((0, 0)), set_color)
+        self.assertEqual(dest_surf.get_at((12, 5)), set_color)
 
         # other pixels should be the same as they were before.
-        self.assertEqual(surface.get_at((2, 2)), (10, 10, 10, 255))
+        # We just check one other pixel, not all of them.
+        self.assertEqual(dest_surf.get_at((2, 2)), original_color)
 
 
 


### PR DESCRIPTION
"Threshold does not take keyword arguments"
https://www.reddit.com/r/pygame/comments/80zyqg/threshold_does_not_take_keyword_arguments/

Identifies a couple of problems:
- [x] no test for inverse argument.
- [x] argument names are super confusing and the documentation could be better.
- [x] no test for keyword arguments.
- [x] keyword arguments aren't supported.
- [x] Using the 'inverse' argument with the last surface argument set to None is not possible.
- [x] lots of invalid argument combinations were possible.
- [x] unit tests made more readable (using kwargs).
- [x] new documentation.

