### PR TITLE
Mac Travis homebrew fix

### DIFF
--- a/.travis_osx.sh
+++ b/.travis_osx.sh
@@ -6,10 +6,10 @@ set -e
 # Travis overrides cd to do something with Ruby. Revert to the default.
 unset -f cd
 
-git clone https://github.com/MacPython/terryfy.git
+git clone https://github.com/illume/terryfy.git
 cd terryfy
 # Work with a specific commit
-git checkout 703737bd7be3a5d388146d5a95241ec2a17a4b2c
+#git checkout 703737bd7be3a5d388146d5a95241ec2a17a4b2c
 cd ..
 source terryfy/travis_tools.sh
 


### PR DESCRIPTION
Homebrew updated the pythons. Both python 2 and python 3 builds needed updating.

See:
- https://github.com/Homebrew/brew/pull/3877 
- Sent a PR to https://github.com/MacPython/terryfy/issues/16

cc @takluyver