### PR TITLE
So virtualenv gets a focused window on Mac too.

### DIFF
--- a/lib/macosx.py
+++ b/lib/macosx.py
@@ -16,9 +16,7 @@ def Video_AutoInit():
                 default_icon_data = None
             except NotImplementedError:
                 default_icon_data = None
-
             sdlmain_osx.InstallNSApplication(default_icon_data)
-            sdlmain_osx.WMEnable()
         if (os.getcwd() == '/') and len(sys.argv) > 1:
             os.chdir(os.path.dirname(sys.argv[0]))
     return True

--- a/lib/macosx.py
+++ b/lib/macosx.py
@@ -1,31 +1,24 @@
-import os, sys
-
-try:
-    import MacOS
-except:
-    MacOS = None
-
+import platform
+import os
+import sys
 from pygame.pkgdata import getResource
-
 from pygame import sdlmain_osx
 
 __all__ = ['Video_AutoInit']
 
 def Video_AutoInit():
-    """This is a function that's called from the c extension code
-       just before the display module is initialized"""
-    if MacOS and not MacOS.WMAvailable():
-        if not sdlmain_osx.WMEnable():
-            raise ImportError("Can not access the window manager.  Use py2app or execute with the pythonw script.")
-    if not sdlmain_osx.RunningFromBundleWithNSApplication():
-        try:
-            default_icon_data = getResource('pygame_icon.tiff').read()
-        except IOError:
-            default_icon_data = None
-        except NotImplementedError:
-            default_icon_data = None
+    """Called from the base.c just before display module is initialized."""
+    if 'Darwin' in platform.platform():
+        if not sdlmain_osx.RunningFromBundleWithNSApplication():
+            try:
+                default_icon_data = getResource('pygame_icon.tiff').read()
+            except IOError:
+                default_icon_data = None
+            except NotImplementedError:
+                default_icon_data = None
 
-        sdlmain_osx.InstallNSApplication(default_icon_data)
-    if (os.getcwd() == '/') and len(sys.argv) > 1:
-        os.chdir(os.path.dirname(sys.argv[0]))
+            sdlmain_osx.InstallNSApplication(default_icon_data)
+            sdlmain_osx.WMEnable()
+        if (os.getcwd() == '/') and len(sys.argv) > 1:
+            os.chdir(os.path.dirname(sys.argv[0]))
     return True

--- a/src/sdlmain_osx.m
+++ b/src/sdlmain_osx.m
@@ -65,7 +65,7 @@ static NSString *getApplicationName(void)
     dict = (const NSDictionary *)CFBundleGetInfoDictionary(CFBundleGetMainBundle());
     if (dict)
         appName = [dict objectForKey: @"CFBundleName"];
-    
+
     if (![appName length])
         appName = [[NSProcessInfo processInfo] processName];
 
@@ -79,7 +79,7 @@ _WMEnable(PyObject* self)
     OSErr err;
     const char* nameString;
     NSString* nameNSString;
-    
+
     err = CPSGetCurrentProcess(&psn);
     if (err == 0)
     {
@@ -93,7 +93,7 @@ _WMEnable(PyObject* self)
         	err = CPSSetFrontProcess(&psn);
         	if (err != 0)
         	{
-            	return RAISE (PyExc_SDLError, "CPSSetFrontProcess failed");        		
+            	return RAISE (PyExc_SDLError, "CPSSetFrontProcess failed");
         	}
         }
         else
@@ -105,7 +105,7 @@ _WMEnable(PyObject* self)
     {
     	return RAISE (PyExc_SDLError, "CPSGetCurrentProcess failed");
     }
-    
+
     Py_RETURN_TRUE;
 }
 
@@ -174,10 +174,10 @@ static void setApplicationMenu(void)
     NSMenuItem *menuItem;
     NSString *title;
     NSString *appName;
-    
+
     appName = getApplicationName();
     appleMenu = [[NSMenu alloc] initWithTitle:@""];
-    
+
 
     title = [@"About " stringByAppendingString:appName];
     [appleMenu addItemWithTitle:title action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
@@ -197,7 +197,7 @@ static void setApplicationMenu(void)
     title = [@"Quit " stringByAppendingString:appName];
     [appleMenu addItemWithTitle:title action:@selector(terminate:) keyEquivalent:@"q"];
 
-    
+
     menuItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
     [menuItem setSubmenu:appleMenu];
     [[NSApp mainMenu] addItem:menuItem];
@@ -215,15 +215,15 @@ static void setupWindowMenu(void)
     NSMenuItem  *menuItem;
 
     windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
-    
+
     menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@"m"];
     [windowMenu addItem:menuItem];
     [menuItem release];
-    
+
     windowMenuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
     [windowMenuItem setSubmenu:windowMenu];
     [[NSApp mainMenu] addItem:windowMenuItem];
-    
+
     [NSApp setWindowsMenu:windowMenu];
 
     [windowMenu release];
@@ -241,16 +241,6 @@ _InstallNSApplication(PyObject* self, PyObject* arg)
 
     [SDLApplication sharedApplication];
 
-    if (PyArg_ParseTuple (arg, "|z#", &icon_data, &data_len))
-    {
-        NSData *image_data = [NSData dataWithBytes:icon_data length:data_len];
-	    NSImage *icon_img = [[NSImage alloc] initWithData:image_data];
-	    if (icon_img != NULL)
-	    {
-	    	[NSApp setApplicationIconImage:icon_img];
-	    }
-    }
-
     [NSApp setMainMenu:[[NSMenu alloc] init]];
     setApplicationMenu();
     setupWindowMenu();
@@ -264,7 +254,21 @@ _InstallNSApplication(PyObject* self, PyObject* arg)
     /* Create SDLApplicationDelegate and make it the app delegate */
     sdlApplicationDelegate = [[SDLApplicationDelegate alloc] init];
     [NSApp setDelegate:sdlApplicationDelegate];
-    
+
+    _WMEnable(NULL);
+
+    if (PyArg_ParseTuple (arg, "|z#", &icon_data, &data_len))
+    {
+        NSData *image_data = [NSData dataWithBytes:icon_data length:data_len];
+        NSImage *icon_img = [[NSImage alloc] initWithData:image_data];
+        if (icon_img != NULL)
+        {
+            printf("icon_img\n");
+            [NSApp setApplicationIconImage:icon_img];
+        }
+    }
+
+
 	Py_RETURN_TRUE;
 }
 


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/203

I tested in virtualenv homebrew python 3.6.4, and python2.7, and out of it.

It also seems to fix the icon issue (of the icon not being set, but the pygame one being used instead). The custom icon can be seen by running `python -m pygame.examples.aliens`.