### PR TITLE
Vector cleanup

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -18,13 +18,17 @@ In addition vec*vec will perform a scalar-product (a.k.a. dot-product). If you
 want to multiply every element from vector v with every element from vector w
 you can use the elementwise method: ``v.elementwise()`` ``\*`` w
 
-New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
-
+New in pygame 1.9.2pre.
+1.9.4 removed experimental notice.
+1.9.4 changed constructors to require 2, or 3 elements rather than assigning 0 default.
+1.9.4 allowed scalar construction like GLSL Vector2(2) == Vector2(2.0, 2.0)
 
 .. class:: Vector2
 
    | :sl:`a 2-Dimensional Vector`
    | :sg:`Vector2() -> Vector2`
+   | :sg:`Vector2(int) -> Vector2`
+   | :sg:`Vector2(float) -> Vector2`
    | :sg:`Vector2(Vector2) -> Vector2`
    | :sg:`Vector2(x, y) -> Vector2`
    | :sg:`Vector2((x, y)) -> Vector2`
@@ -47,9 +51,30 @@ New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
 
       .. ## Vector2.cross ##
 
+   .. method:: magnitude
+
+      | :sl:`returns the Euclidean magnitude of the vector.`
+      | :sg:`magnitude() -> float`
+
+      calculates the magnitude of the vector which follows from the
+      theorem: ``vec.magnitude()`` == ``math.sqrt(vec.x**2 + vec.y**2)``
+
+      .. ## Vector2.magnitude ##
+
+   .. method:: magnitude_squared
+
+      | :sl:`returns the squared magnitude of the vector.`
+      | :sg:`magnitude_squared() -> float`
+
+      calculates the magnitude of the vector which follows from the
+      theorem: ``vec.magnitude_squared()`` == vec.x**2 + vec.y**2 This
+      is faster than ``vec.magnitude()`` because it avoids the square root.
+
+      .. ## Vector2.magnitude_squared ##
+
    .. method:: length
 
-      | :sl:`returns the Euclidian length of the vector.`
+      | :sl:`returns the Euclidean length of the vector.`
       | :sg:`length() -> float`
 
       calculates the Euclidean length of the vector which follows from the
@@ -233,6 +258,8 @@ New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
 
    | :sl:`a 3-Dimensional Vector`
    | :sg:`Vector3() -> Vector3`
+   | :sg:`Vector3(int) -> Vector2`
+   | :sg:`Vector3(float) -> Vector2`
    | :sg:`Vector3(Vector3) -> Vector3`
    | :sg:`Vector3(x, y, z) -> Vector3`
    | :sg:`Vector3((x, y, z)) -> Vector3`
@@ -254,6 +281,28 @@ New in pygame 1.9.2pre. 1.9.4 removed experimental notice.
       calculates the cross-product.
 
       .. ## Vector3.cross ##
+
+   .. method:: magnitude
+
+      | :sl:`returns the Euclidean magnitude of the vector.`
+      | :sg:`magnitude() -> float`
+
+      calculates the magnitude of the vector which follows from the
+      theorem: ``vec.magnitude()`` == ``math.sqrt(vec.x**2 + vec.y**2 + vec.z**2)``
+
+      .. ## Vector3.magnitude ##
+
+   .. method:: magnitude_squared
+
+      | :sl:`returns the squared Euclidean magnitude of the vector.`
+      | :sg:`magnitude_squared() -> float`
+
+      calculates the magnitude of the vector which follows from the
+      theorem: ``vec.magnitude_squared()`` == vec.x**2 + vec.y**2 +
+      vec.z**2 This is faster than ``vec.magnitude()`` because it avoids the
+      square root.
+
+      .. ## Vector3.magnitude_squared ##
 
    .. method:: length
 

--- a/src/doc/math_doc.h
+++ b/src/doc/math_doc.h
@@ -1,13 +1,17 @@
 /* Auto generated file: with makeref.py .  Docs go in src/ *.doc . */
 #define DOC_PYGAMEMATH "pygame module for vector classes"
 
-#define DOC_PYGAMEMATHVECTOR2 "Vector2() -> Vector2\nVector2(Vector2) -> Vector2\nVector2(x, y) -> Vector2\nVector2((x, y)) -> Vector2\na 2-Dimensional Vector"
+#define DOC_PYGAMEMATHVECTOR2 "Vector2() -> Vector2\nVector2(int) -> Vector2\nVector2(float) -> Vector2\nVector2(Vector2) -> Vector2\nVector2(x, y) -> Vector2\nVector2((x, y)) -> Vector2\na 2-Dimensional Vector"
 
 #define DOC_VECTOR2DOT "dot(Vector2) -> float\ncalculates the dot- or scalar-product with the other vector"
 
 #define DOC_VECTOR2CROSS "cross(Vector2) -> float\ncalculates the cross- or vector-product"
 
-#define DOC_VECTOR2LENGTH "length() -> float\nreturns the Euclidian length of the vector."
+#define DOC_VECTOR2MAGNITUDE "magnitude() -> float\nreturns the Euclidean magnitude of the vector."
+
+#define DOC_VECTOR2MAGNITUDESQUARED "magnitude_squared() -> float\nreturns the squared magnitude of the vector."
+
+#define DOC_VECTOR2LENGTH "length() -> float\nreturns the Euclidean length of the vector."
 
 #define DOC_VECTOR2LENGTHSQUARED "length_squared() -> float\nreturns the squared Euclidean length of the vector."
 
@@ -43,11 +47,15 @@
 
 #define DOC_VECTOR2FROMPOLAR "from_polar((r, phi)) -> None\nSets x and y from a polar coordinates tuple."
 
-#define DOC_PYGAMEMATHVECTOR3 "Vector3() -> Vector3\nVector3(Vector3) -> Vector3\nVector3(x, y, z) -> Vector3\nVector3((x, y, z)) -> Vector3\na 3-Dimensional Vector"
+#define DOC_PYGAMEMATHVECTOR3 "Vector3() -> Vector3\nVector3(int) -> Vector2\nVector3(float) -> Vector2\nVector3(Vector3) -> Vector3\nVector3(x, y, z) -> Vector3\nVector3((x, y, z)) -> Vector3\na 3-Dimensional Vector"
 
 #define DOC_VECTOR3DOT "dot(Vector3) -> float\ncalculates the dot- or scalar-product with the other vector"
 
 #define DOC_VECTOR3CROSS "cross(Vector3) -> float\ncalculates the cross- or vector-product"
+
+#define DOC_VECTOR3MAGNITUDE "magnitude() -> float\nreturns the Euclidean magnitude of the vector."
+
+#define DOC_VECTOR3MAGNITUDESQUARED "magnitude_squared() -> float\nreturns the squared Euclidean magnitude of the vector."
 
 #define DOC_VECTOR3LENGTH "length() -> float\nreturns the Euclidean length of the vector."
 
@@ -112,6 +120,8 @@ pygame module for vector classes
 
 pygame.math.Vector2
  Vector2() -> Vector2
+ Vector2(int) -> Vector2
+ Vector2(float) -> Vector2
  Vector2(Vector2) -> Vector2
  Vector2(x, y) -> Vector2
  Vector2((x, y)) -> Vector2
@@ -125,9 +135,17 @@ pygame.math.Vector2.cross
  cross(Vector2) -> float
 calculates the cross- or vector-product
 
+pygame.math.Vector2.magnitude
+ magnitude() -> float
+returns the Euclidean magnitude of the vector.
+
+pygame.math.Vector2.magnitude_squared
+ magnitude_squared() -> float
+returns the squared magnitude of the vector.
+
 pygame.math.Vector2.length
  length() -> float
-returns the Euclidian length of the vector.
+returns the Euclidean length of the vector.
 
 pygame.math.Vector2.length_squared
  length_squared() -> float
@@ -199,6 +217,8 @@ Sets x and y from a polar coordinates tuple.
 
 pygame.math.Vector3
  Vector3() -> Vector3
+ Vector3(int) -> Vector2
+ Vector3(float) -> Vector2
  Vector3(Vector3) -> Vector3
  Vector3(x, y, z) -> Vector3
  Vector3((x, y, z)) -> Vector3
@@ -211,6 +231,14 @@ calculates the dot- or scalar-product with the other vector
 pygame.math.Vector3.cross
  cross(Vector3) -> float
 calculates the cross- or vector-product
+
+pygame.math.Vector3.magnitude
+ magnitude() -> float
+returns the Euclidean magnitude of the vector.
+
+pygame.math.Vector3.magnitude_squared
+ magnitude_squared() -> float
+returns the squared Euclidean magnitude of the vector.
 
 pygame.math.Vector3.length
  length() -> float

--- a/src/math.c
+++ b/src/math.c
@@ -2681,6 +2681,12 @@ static PyMethodDef vector3_methods[] = {
     {"length_squared", (PyCFunction)vector_length_squared, METH_NOARGS,
      DOC_VECTOR3LENGTHSQUARED
     },
+    {"magnitude", (PyCFunction)vector_length, METH_NOARGS,
+     DOC_VECTOR3MAGNIDUDE
+    },
+    {"magnitude_squared", (PyCFunction)vector_length_squared, METH_NOARGS,
+     DOC_VECTOR3MAGNIDUDESQUARED
+    },
     {"rotate", (PyCFunction)vector3_rotate, METH_VARARGS,
      DOC_VECTOR3ROTATE
     },

--- a/src/math.c
+++ b/src/math.c
@@ -1783,7 +1783,10 @@ static int
 vector2_init(PyVector *self, PyObject *args, PyObject *kwds)
 {
     PyObject *xOrSequence=NULL, *y=NULL;
-    if (!PyArg_ParseTuple (args, "|OO:Vector2", &xOrSequence, &y))
+    static char *kwlist[] = {"x", "y", NULL};
+
+    if (! PyArg_ParseTupleAndKeywords(args, kwds, "|OO:Vector2", kwlist,
+                                      &xOrSequence, &y))
         return -1;
 
     if (xOrSequence) {
@@ -2197,15 +2200,11 @@ static int
 vector3_init(PyVector *self, PyObject *args, PyObject *kwds)
 {
     PyObject *xOrSequence=NULL, *y=NULL, *z=NULL;
-    // static char *kwlist[] = {"x", "y", "z", NULL};
+    static char *kwlist[] = {"x", "y", "z", NULL};
 
-    // if (! PyArg_ParseTupleAndKeywords(args, kwds, "|OOO:Vector3", kwlist,
-    //                                   &xOrSequence, &y, &z))
-    //     return -1;
-
-    if (!PyArg_ParseTuple (args, "|OOO:Vector3", &xOrSequence, &y, &z))
+    if (! PyArg_ParseTupleAndKeywords(args, kwds, "|OOO:Vector3", kwlist,
+                                      &xOrSequence, &y, &z))
         return -1;
-
 
     if (xOrSequence) {
         if (RealNumber_Check(xOrSequence)) {

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -54,6 +54,16 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(v.x, 1.)
         self.assertEqual(v.y, 1.)
 
+    def testConstructionScalarKeywords(self):
+        v = Vector2(x=1)
+        self.assertEqual(v.x, 1.)
+        self.assertEqual(v.y, 1.)
+
+    def testConstructionKeywords(self):
+        v = Vector2(x=1, y=2)
+        self.assertEqual(v.x, 1.)
+        self.assertEqual(v.y, 2.)
+
     def testConstructionXY(self):
         v = Vector2(1.2, 3.4)
         self.assertEqual(v.x, 1.2)
@@ -793,9 +803,25 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(v.y, 1.)
         self.assertEqual(v.z, 1.)
 
+    def testConstructionScalarKeywords(self):
+        v = Vector3(x=1)
+        self.assertEqual(v.x, 1.)
+        self.assertEqual(v.y, 1.)
+        self.assertEqual(v.z, 1.)
+
+    def testConstructionKeywords(self):
+        v = Vector3(x=1, y=2, z=3)
+        self.assertEqual(v.x, 1.)
+        self.assertEqual(v.y, 2.)
+        self.assertEqual(v.z, 3.)
+
     def testConstructionMissing(self):
         def assign_missing_value():
             v = Vector3(1, 2)
+        self.assertRaises(ValueError, assign_missing_value)
+
+        def assign_missing_value():
+            v = Vector3(x=1, y=2)
         self.assertRaises(ValueError, assign_missing_value)
 
     def testAttributAccess(self):

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -796,7 +796,7 @@ class Vector3TypeTest(unittest.TestCase):
     def testConstructionMissing(self):
         def assign_missing_value():
             v = Vector3(1, 2)
-        self.assertRaises(TypeError, assign_missing_value)
+        self.assertRaises(ValueError, assign_missing_value)
 
     def testAttributAccess(self):
         tmp = self.v1.x
@@ -1075,7 +1075,7 @@ class Vector3TypeTest(unittest.TestCase):
                          Vector3(0, 1, 0))
 
     def test_rotate_ip(self):
-        v = Vector3(1, 0)
+        v = Vector3(1, 0, 0)
         axis = Vector3(0, 1, 0)
         self.assertEqual(v.rotate_ip(90, axis), None)
         self.assertEqual(v.x, 0)

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -49,6 +49,11 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(v.x, 0.)
         self.assertEqual(v.y, 0.)
 
+    def testConstructionScalar(self):
+        v = Vector2(1)
+        self.assertEqual(v.x, 1.)
+        self.assertEqual(v.y, 1.)
+
     def testConstructionXY(self):
         v = Vector2(1.2, 3.4)
         self.assertEqual(v.x, 1.2)
@@ -758,7 +763,6 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(v.y, 0.)
         self.assertEqual(v.z, 0.)
 
-
     def testConstructionXYZ(self):
         v = Vector3(1.2, 3.4, 9.6)
         self.assertEqual(v.x, 1.2)
@@ -782,6 +786,17 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(v.x, 1.2)
         self.assertEqual(v.y, 3.4)
         self.assertEqual(v.z, -9.6)
+
+    def testConstructionScalar(self):
+        v = Vector3(1)
+        self.assertEqual(v.x, 1.)
+        self.assertEqual(v.y, 1.)
+        self.assertEqual(v.z, 1.)
+
+    def testConstructionMissing(self):
+        def assign_missing_value():
+            v = Vector3(1, 2)
+        self.assertRaises(TypeError, assign_missing_value)
 
     def testAttributAccess(self):
         tmp = self.v1.x


### PR DESCRIPTION
Some changes from the mailing list discussion.

- Tests and fixes for keyword arguments with pygame.math.Vector
- Tests for Vector2, and Vector3 scalar constructors like GLSL.
- missing an element is an error now, no zero default. Vector(1, 2) fails.
- Added magnitude to Vector types, which is an alias for length.