### PR TITLE
Appveyor pypy and pypy3 windows 32bit.

### DIFF
--- a/Setup.in
+++ b/Setup.in
@@ -19,7 +19,7 @@ PORTTIME = -lporttime
 FREETYPE = -lfreetype
 #--EndConfig
 
-DEBUG = 
+DEBUG =
 
 #the following modules are optional. you will want to compile
 #everything you can, but you can ignore ones you don't have
@@ -32,8 +32,8 @@ mixer_music src/music.c $(SDL) $(MIXER) $(DEBUG)
 scrap src/scrap.c $(SDL) $(SCRAP) $(DEBUG)
 pypm src/pypm.c $(SDL) $(PORTMIDI) $(PORTTIME) $(DEBUG)
 
-GFX = src/SDL_gfx/SDL_gfxPrimitives.c 
-#GFX = src/SDL_gfx/SDL_gfxBlitFunc.c src/SDL_gfx/SDL_gfxPrimitives.c 
+GFX = src/SDL_gfx/SDL_gfxPrimitives.c
+#GFX = src/SDL_gfx/SDL_gfxBlitFunc.c src/SDL_gfx/SDL_gfxPrimitives.c
 gfxdraw src/gfxdraw.c $(SDL) $(GFX) $(DEBUG)
 
 #optional freetype module (do not break in multiple lines

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,13 @@ environment:
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
       PYPY_VERSION: "pypy2-v5.10.0-win32"
-      PYPY_DOWNLOAD: "powershell appveyor\\download_pypy.ps1 -pypy_version pypy2-v5.10.0-win32"
+      PYPY_DOWNLOAD: "powershell appveyor\\download_pypy.ps1"
 
     - PYTHON: "pypy3.exe"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
       PYPY_VERSION: "pypy3-v5.10.1-win32"
-      PYPY_DOWNLOAD: "powershell appveyor\\download_pypy.ps1 -pypy_version pypy3-v5.10.1-win32"
+      PYPY_DOWNLOAD: "powershell appveyor\\download_pypy.ps1"
 
     - PYTHON: "C:\\Python27\\python"
       PYTHON_VERSION: "2.7.13"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,6 @@ build: off
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
-  - "%PYTHON% -m pygame.tests --exclude opengl"
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,13 @@ environment:
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
       PYPY_VERSION: "pypy2-v5.10.0-win32"
+      PYPY_DOWNLOAD: "powershell appveyor\\download_pypy.ps1 -pypy_version pypy2-v5.10.0-win32"
 
     - PYTHON: "pypy3.exe"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
       PYPY_VERSION: "pypy3-v5.10.1-win32"
+      PYPY_DOWNLOAD: "powershell appveyor\\download_pypy.ps1 -pypy_version pypy3-v5.10.1-win32"
 
     - PYTHON: "C:\\Python27\\python"
       PYTHON_VERSION: "2.7.13"
@@ -50,7 +52,7 @@ init:
 
 install:
   - "powershell appveyor\\install.ps1"
-  - "powershell appveyor\\download_pypy.ps1 -pypy_version %PYPY_VERSION%"
+  - "%PYPY_DOWNLOAD%"
   - "set HOME=%APPVEYOR_BUILD_FOLDER%"
   - "set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\\%PYPY_VERSION%"
   - "%PYTHON% -m ensurepip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,35 +11,37 @@ environment:
     SDL_AUDIODRIVER: "disk"
 
   matrix:
-    - PYTHON: "C:\\Python27"
+    - PYTHON: "pypy.exe"
+      PYTHON_VERSION: "2.7.13"
+      PYTHON_ARCH: "32"
+      PYPY_VERSION: "pypy2-v5.10.0-win32"
+
+    - PYTHON: "pypy3.exe"
+      PYTHON_VERSION: "2.7.13"
+      PYTHON_ARCH: "32"
+      PYPY_VERSION: "pypy3-v5.10.1-win32"
+
+    - PYTHON: "C:\\Python27\\python"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.4"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35\\python"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36\\python"
       PYTHON_VERSION: "3.6.0"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python27-x64\\python"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.4"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python35-x64\\python"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python36-x64\\python"
       PYTHON_VERSION: "3.6.0"
       PYTHON_ARCH: "64"
 
@@ -48,15 +50,18 @@ init:
 
 install:
   - "powershell appveyor\\install.ps1"
+  - "powershell appveyor\\download_pypy.ps1 -pypy_version %PYPY_VERSION%"
   - "set HOME=%APPVEYOR_BUILD_FOLDER%"
-  - "%PYTHON%/python -m pip install -U pip"  # Upgrade pip
-  - "%WITH_COMPILER% %PYTHON%/python config.py -auto"
-  - "%WITH_COMPILER% %PYTHON%/python setup.py build"
-  - "%WITH_COMPILER% %PYTHON%/python setup.py -setuptools %DISTRIBUTIONS%"
+  - "set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\\%PYPY_VERSION%"
+  - "%PYTHON% -m ensurepip"
+  - "%PYTHON% -m pip install -U wheel pip"
+  - "%WITH_COMPILER% %PYTHON% config.py -auto"
+  - "%WITH_COMPILER% %PYTHON% setup.py build"
+  - "%WITH_COMPILER% %PYTHON% setup.py -setuptools %DISTRIBUTIONS%"
   - ps: "ls dist"
 
   # Install the wheel to test it
-  - "%PYTHON%/python -m pip install --ignore-installed --pre --no-index --find-links dist/ pygame"
+  - "%PYTHON% -m pip install --ignore-installed --pre --no-index --find-links dist/ pygame"
 
 # Appveyor's build step is specific to .NET projects, so we build in the
 # install step instead.
@@ -65,12 +70,12 @@ build: off
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
-  - "%PYTHON%/python -m pygame.tests --exclude opengl"
+  - "%PYTHON% -m pygame.tests --exclude opengl"
 
   # Move back to the project folder
   - "cd .."
 
 artifacts:
-  - path: dist\*
+  - path: 'dist\*'
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,6 +72,7 @@ build: off
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
+  - "%PYTHON% -m pygame.tests --exclude opengl"
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,6 @@ build: off
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
-  - "%PYTHON% -m pygame.tests --exclude opengl"
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ build: off
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
-
+  - "%PYTHON% -m pygame.tests --exclude opengl"
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ build: off
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
+  - "%PYTHON% -m pygame.tests --exclude opengl"
 
   # Move back to the project folder
   - "cd .."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,6 +73,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
+
   # Move back to the project folder
   - "cd .."
 

--- a/appveyor/download_pypy.ps1
+++ b/appveyor/download_pypy.ps1
@@ -1,0 +1,37 @@
+// TODO: a better powershell dev would:
+//         - make this function reusable.
+//         - add sha or even md5 checksum verification.
+function DownloadPyPy($which_pypy) {
+    $webclient = New-Object System.Net.WebClient
+
+    $which_pypy_zip = $which_pypy + ".zip"
+    $download_url = "https://bitbucket.org/pypy/pypy/downloads/" + $which_pypy + ".zip"
+
+    $filepath = "$env:appveyor_build_folder\" + $which_pypy + ".zip"
+
+    Write-Host "Downloading" $filepath "from" $download_url
+    $retry_attempts = 3
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($download_url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   Write-Host "File saved at" $filepath
+
+   & 7z x $which_pypy_zip
+   $env:path = "$env:appveyor_build_folder\$which_pypy;$env:path"
+}
+
+
+function main ($pypy_version) {
+    Write-Host "pypy_version" $pypy_version
+	if ($pypy_version) {
+	    DownloadPyPy $pypy_version
+	}
+}
+
+main $pypy_version

--- a/appveyor/download_pypy.ps1
+++ b/appveyor/download_pypy.ps1
@@ -1,3 +1,6 @@
+// For downloading pypy or pypy3.
+// powershell appveyor\\download_pypy.ps1 -pypy_version pypy2-v5.10.0-win32
+//
 // TODO: a better powershell dev would:
 //         - make this function reusable.
 //         - add sha or even md5 checksum verification.

--- a/appveyor/download_pypy.ps1
+++ b/appveyor/download_pypy.ps1
@@ -31,7 +31,8 @@ function DownloadPyPy($which_pypy) {
 
 
 function main ($pypy_version) {
-   DownloadPyPy $pypy_version
+   DownloadPyPy "pypy2-v5.10.0-win32"
+   & DownloadPyPy "pypy3-v5.10.1-win32"
 }
 
 main $pypy_version

--- a/appveyor/download_pypy.ps1
+++ b/appveyor/download_pypy.ps1
@@ -31,10 +31,7 @@ function DownloadPyPy($which_pypy) {
 
 
 function main ($pypy_version) {
-    Write-Host "pypy_version" $pypy_version
-	if ($pypy_version) {
-	    DownloadPyPy $pypy_version
-	}
+   DownloadPyPy $pypy_version
 }
 
 main $pypy_version

--- a/appveyor/download_pypy.ps1
+++ b/appveyor/download_pypy.ps1
@@ -1,9 +1,9 @@
-// For downloading pypy or pypy3.
-// powershell appveyor\\download_pypy.ps1 -pypy_version pypy2-v5.10.0-win32
-//
-// TODO: a better powershell dev would:
-//         - make this function reusable.
-//         - add sha or even md5 checksum verification.
+# For downloading pypy or pypy3.
+#   powershell appveyor\\download_pypy.ps1 -pypy_version pypy2-v5.10.0-win32
+#
+# TODO: a better powershell dev would:
+#         - make this function reusable.
+#         - add sha or even md5 checksum verification.
 function DownloadPyPy($which_pypy) {
     $webclient = New-Object System.Net.WebClient
 

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,7 +1,5 @@
-function InstallPackage ($python_home, $pkg) {
-    $pip_path = $python_home + "/Scripts/pip.exe"
-    & $pip_path install $pkg
-}
+// For downloading windows prebuilt dependencies.
+//   powershell appveyor\install.ps1
 
 function DownloadPrebuilt () {
     $webclient = New-Object System.Net.WebClient
@@ -40,39 +38,9 @@ function DownloadPrebuilt () {
    & 7z x $prebuilt_zip
 }
 
-// TODO: a better powershell dev would make this function reusable.
-//       add sha or even md5 checksum verification.
-function DownloadPyPy($which_pypy) {
-    $webclient = New-Object System.Net.WebClient
-
-    $which_pypy_zip = $which_pypy + ".zip"
-    $download_url = "https://bitbucket.org/pypy/pypy/downloads/" + $which_pypy + ".zip"
-
-    $filepath = "$env:appveyor_build_folder\" + $which_pypy + ".zip"
-
-    Write-Host "Downloading" $filepath "from" $download_url
-    $retry_attempts = 3
-    for($i=0; $i -lt $retry_attempts; $i++){
-        try {
-            $webclient.DownloadFile($download_url, $filepath)
-            break
-        }
-        Catch [Exception]{
-            Start-Sleep 1
-        }
-   }
-   Write-Host "File saved at" $filepath
-
-   & 7z x $which_pypy_zip
-   $env:path = "$env:appveyor_build_folder\$which_pypy;$env:path"
-}
-
 
 function main () {
-    DownloadPyPy "pypy2-v5.10.0-win32"
-    & DownloadPyPy "pypy3-v5.10.1-win32"
-    & InstallPackage $env:PYTHON wheel
-    & DownloadPrebuilt
+    DownloadPrebuilt
 }
 
 main

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,5 +1,5 @@
-// For downloading windows prebuilt dependencies.
-//   powershell appveyor\install.ps1
+# For downloading windows prebuilt dependencies.
+#   powershell appveyor\install.ps1
 
 function DownloadPrebuilt () {
     $webclient = New-Object System.Net.WebClient

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -40,9 +40,38 @@ function DownloadPrebuilt () {
    & 7z x $prebuilt_zip
 }
 
+// TODO: a better powershell dev would make this function reusable.
+//       add sha or even md5 checksum verification.
+function DownloadPyPy($which_pypy) {
+    $webclient = New-Object System.Net.WebClient
+
+    $which_pypy_zip = $which_pypy + ".zip"
+    $download_url = "https://bitbucket.org/pypy/pypy/downloads/" + $which_pypy + ".zip"
+
+    $filepath = "$env:appveyor_build_folder\" + $which_pypy + ".zip"
+
+    Write-Host "Downloading" $filepath "from" $download_url
+    $retry_attempts = 3
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($download_url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   Write-Host "File saved at" $filepath
+
+   & 7z x $which_pypy_zip
+   $env:path = "$env:appveyor_build_folder\$which_pypy;$env:path"
+}
+
 
 function main () {
-    InstallPackage $env:PYTHON wheel
+    DownloadPyPy "pypy2-v5.10.0-win32"
+    & DownloadPyPy "pypy3-v5.10.1-win32"
+    & InstallPackage $env:PYTHON wheel
     & DownloadPrebuilt
 }
 

--- a/config_win.py
+++ b/config_win.py
@@ -44,7 +44,7 @@ class Dependency(object):
         self.libs = libs
         self.found = False
         self.cflags = ''
-                 
+
     def hunt(self):
         parent = os.path.abspath('..')
         for p in huntpaths:
@@ -104,7 +104,7 @@ class DependencyPython(object):
         self.ver = '0'
         self.module = module
         self.header = header
- 
+
     def configure(self):
         self.found = True
         if self.module:
@@ -168,7 +168,7 @@ class DependencyWin(object):
         self.libs = []
         self.found = True
         self.cflags = cflags
-        
+
     def configure(self):
         pass
 
@@ -186,7 +186,7 @@ class DependencyGroup(object):
 
     def add_win(self, name, cflags):
         self.dependencies.append(DependencyWin(name, cflags))
-                                 
+
     def add_dll(self, dll_regex, lib=None, wildcards=None, libs=None, link_lib=None):
         link = None
         if link_lib is not None:
@@ -233,6 +233,10 @@ for d in get_definitions():
 
 def setup_prebuilt(prebuilt_dir):
     setup = open('Setup', 'w')
+    is_pypy = '__pypy__' in sys.builtin_module_names
+    import platform
+    is_python3 = platform.python_version().startswith('3')
+
     try:
         try:
             setup_win_in = open(os.path.join(prebuilt_dir, 'Setup_Win.in'))
@@ -245,6 +249,9 @@ def setup_prebuilt(prebuilt_dir):
         try:
             do_copy = True
             for line in setup_in:
+                if is_pypy and is_python3:
+                    if line.startswith('_freetype'):
+                        continue
                 if line.startswith('#--StartConfig'):
                     do_copy = False
                     setup.write(setup_win_in.read())
@@ -281,7 +288,7 @@ def main():
             raise SystemExit()
 
     global DEPS
-    
+
     DEPS.configure()
     return list(DEPS)
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -30,6 +30,9 @@ import os
 # Choose Windows display driver
 if os.name == 'nt':
 
+    #pypy does not find the dlls, so we add package folder to PATH.
+    pygame_dir = os.path.split(__file__)[0]
+    os.environ['PATH'] = os.environ['PATH'] + ';' + pygame_dir
     # Respect existing SDL_VIDEODRIVER setting if it has been set
     if 'SDL_VIDEODRIVER' not in os.environ:
 

--- a/src/base.c
+++ b/src/base.c
@@ -1200,8 +1200,8 @@ _arraystruct_as_buffer (Py_buffer* view_p, PyObject* cobj,
                         PyArrayInterface* inter_p, int flags)
 {
     ViewInternals* internal_p;
-    ssize_t sz = (sizeof (ViewInternals) +
-                  (2 * inter_p->nd - 1) * sizeof (Py_ssize_t));
+    Py_ssize_t sz = (sizeof (ViewInternals) +
+                    (2 * inter_p->nd - 1) * sizeof (Py_ssize_t));
     int readonly = inter_p->flags & PAI_WRITEABLE ? 0 : 1;
     Py_ssize_t i;
 
@@ -1574,7 +1574,7 @@ _pyvalues_as_buffer(Py_buffer* view_p, int flags,
 {
     Py_ssize_t ndim = PyTuple_GET_SIZE (pyshape);
     ViewInternals* internal_p;
-    ssize_t sz;
+    Py_ssize_t sz;
     int i;
 
     assert (ndim > 0);

--- a/src/freetype/ft_unicode.c
+++ b/src/freetype/ft_unicode.c
@@ -30,7 +30,7 @@
 #include "ft_wrap.h"
 
 #define SIZEOF_PGFT_STRING(len) \
-    (sizeof(PGFT_String) + (ssize_t)(len) * sizeof(PGFT_char))
+    (sizeof(PGFT_String) + (Py_ssize_t)(len) * sizeof(PGFT_char))
 
 static const PGFT_char UNICODE_HSA_START = 0xD800;
 static const PGFT_char UNICODE_HSA_END = 0xDBFF;

--- a/src/freetype/ft_wrap.h
+++ b/src/freetype/ft_wrap.h
@@ -73,7 +73,7 @@ typedef FT_UInt GlyphIndex_t;
 /**********************************************************
  * Internal data structures
  **********************************************************/
- 
+
 /* FreeTypeInstance: the global freetype 2 library state.
  *
  * Instances of this struct are created by _PGFT_Init, and
@@ -85,7 +85,7 @@ typedef FT_UInt GlyphIndex_t;
  * zero.
  */
 typedef struct freetypeinstance_ {
-    ssize_t ref_count;
+    Py_ssize_t ref_count;
 
     /* Internal */
     FT_Library library;


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/423

This downloads and tests pypy.exe and pypy3.exe and if successful uploads the .whl files to appveyor.

- ssize_t type from posix isn't in pypy like in cpython.
- pypy does not find pygame dlls like cpython. Add PATH env var.
- Download pypy and pypy3 to test with.

No 64bit, since pypy doesn't support that yet on windows.