### PR TITLE
Surface.blits

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -121,6 +121,22 @@
 
       .. ## Surface.blit ##
 
+   .. method:: blits
+
+      | :sl:`draw many images onto another`
+      | :sg:`blit((source, dest), ...)) -> (Rect, ...)`
+      | :sg:`blit((source, dest, area), ...)) -> (Rect, ...)`
+      | :sg:`blit((source, dest, area, special_flags), ...)) -> (Rect, ...)`
+
+      Draws many surfaces onto this Surface. It takes a sequence as input,
+      with each of the elements corresponding to the ones of ``Surface.blit()``.
+      It needs at minimum a sequence of (source, dest).
+
+      New in pygame 1.9.4.
+
+      .. ## Surface.blits ##
+
+
    .. method:: convert
 
       | :sl:`change the pixel format of an image`
@@ -795,7 +811,7 @@
       | :sg:`get_view(<kind>='2') -> BufferProxy`
 
       Return an object which exports a surface's internal pixel buffer as
-      a C level array struct, Python level array interface or a C level 
+      a C level array struct, Python level array interface or a C level
       buffer interface. The pixel buffer is writeable. The new buffer protocol
       is supported for Python 2.6 and up in CPython. The old buffer protocol
       is also supported for Python 2.x. The old buffer data is in one segment
@@ -809,10 +825,10 @@
       '0' returns a contiguous unstructured bytes view. No surface shape
       information is given. A ValueError is raised if the surface's pixels
       are discontinuous.
-      
+
       '1' returns a (surface-width * surface-height) array of continuous
       pixels. A ValueError is raised if the surface pixels are discontinuous.
-      
+
       '2' returns a (surface-width, surface-height) array of raw pixels.
       The pixels are surface-bytesize-d unsigned integers. The pixel format is
       surface specific. The 3 byte unsigned integers of 24 bit surfaces are

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -124,13 +124,21 @@
    .. method:: blits
 
       | :sl:`draw many images onto another`
-      | :sg:`blit((source, dest), ...)) -> (Rect, ...)`
-      | :sg:`blit((source, dest, area), ...)) -> (Rect, ...)`
-      | :sg:`blit((source, dest, area, special_flags), ...)) -> (Rect, ...)`
+      | :sg:`blits(blit_sequence=(source, dest), ...), doreturn=1) -> (Rect, ...)`
+      | :sg:`blits((source, dest, area), ...)) -> (Rect, ...)`
+      | :sg:`blits((source, dest, area, special_flags), ...)) -> (Rect, ...)`
 
       Draws many surfaces onto this Surface. It takes a sequence as input,
       with each of the elements corresponding to the ones of ``Surface.blit()``.
       It needs at minimum a sequence of (source, dest).
+
+      :param blit_sequence: a sequence of surfaces, and arguments to blit them.
+       They correspond to the ``Surface.blit()`` arguments.
+
+      :param doreturn: if true, we return otherwise return None.
+
+      :returns: a list of rects of the areas changed.
+       If doreturn is false, returns None.
 
       New in pygame 1.9.4.
 

--- a/src/doc/surface_doc.h
+++ b/src/doc/surface_doc.h
@@ -3,7 +3,7 @@
 
 #define DOC_SURFACEBLIT "blit(source, dest, area=None, special_flags = 0) -> Rect\ndraw one image onto another"
 
-#define DOC_SURFACEBLITS "blit((source, dest), ...)) -> (Rect, ...)\nblit((source, dest, area), ...)) -> (Rect, ...)\nblit((source, dest, area, special_flags), ...)) -> (Rect, ...)\ndraw many images onto another"
+#define DOC_SURFACEBLITS "blits(blit_sequence=(source, dest), ...), doreturn=1) -> (Rect, ...)\nblits((source, dest, area), ...)) -> (Rect, ...)\nblits((source, dest, area, special_flags), ...)) -> (Rect, ...)\ndraw many images onto another"
 
 #define DOC_SURFACECONVERT "convert(Surface) -> Surface\nconvert(depth, flags=0) -> Surface\nconvert(masks, flags=0) -> Surface\nconvert() -> Surface\nchange the pixel format of an image"
 
@@ -115,9 +115,9 @@ pygame.Surface.blit
 draw one image onto another
 
 pygame.Surface.blits
- blit((source, dest), ...)) -> (Rect, ...)
- blit((source, dest, area), ...)) -> (Rect, ...)
- blit((source, dest, area, special_flags), ...)) -> (Rect, ...)
+ blits(blit_sequence=(source, dest), ...), doreturn=1) -> (Rect, ...)
+ blits((source, dest, area), ...)) -> (Rect, ...)
+ blits((source, dest, area, special_flags), ...)) -> (Rect, ...)
 draw many images onto another
 
 pygame.Surface.convert

--- a/src/doc/surface_doc.h
+++ b/src/doc/surface_doc.h
@@ -3,6 +3,8 @@
 
 #define DOC_SURFACEBLIT "blit(source, dest, area=None, special_flags = 0) -> Rect\ndraw one image onto another"
 
+#define DOC_SURFACEBLITS "blit((source, dest), ...)) -> (Rect, ...)\nblit((source, dest, area), ...)) -> (Rect, ...)\nblit((source, dest, area, special_flags), ...)) -> (Rect, ...)\ndraw many images onto another"
+
 #define DOC_SURFACECONVERT "convert(Surface) -> Surface\nconvert(depth, flags=0) -> Surface\nconvert(masks, flags=0) -> Surface\nconvert() -> Surface\nchange the pixel format of an image"
 
 #define DOC_SURFACECONVERTALPHA "convert_alpha(Surface) -> Surface\nconvert_alpha() -> Surface\nchange the pixel format of an image including per pixel alphas"
@@ -111,6 +113,12 @@ pygame object for representing images
 pygame.Surface.blit
  blit(source, dest, area=None, special_flags = 0) -> Rect
 draw one image onto another
+
+pygame.Surface.blits
+ blit((source, dest), ...)) -> (Rect, ...)
+ blit((source, dest, area), ...)) -> (Rect, ...)
+ blit((source, dest, area, special_flags), ...)) -> (Rect, ...)
+draw many images onto another
 
 pygame.Surface.convert
  convert(Surface) -> Surface

--- a/src/surface.c
+++ b/src/surface.c
@@ -92,6 +92,7 @@ static PyObject *surf_convert_alpha (PyObject *self, PyObject *args);
 static PyObject *surf_set_clip (PyObject *self, PyObject *args);
 static PyObject *surf_get_clip (PyObject *self);
 static PyObject *surf_blit (PyObject *self, PyObject *args, PyObject *keywds);
+static PyObject *surf_blits (PyObject *self, PyObject *args, PyObject *keywds);
 static PyObject *surf_fill (PyObject *self, PyObject *args, PyObject *keywds);
 static PyObject *surf_scroll (PyObject *self,
                               PyObject *args, PyObject *keywds);
@@ -190,6 +191,8 @@ static struct PyMethodDef surface_methods[] = {
       DOC_SURFACEFILL },
     { "blit", (PyCFunction) surf_blit, METH_VARARGS | METH_KEYWORDS,
       DOC_SURFACEBLIT },
+    { "blits", (PyCFunction) surf_blits, METH_VARARGS | METH_KEYWORDS,
+      DOC_SURFACEBLITS },
 
     { "scroll", (PyCFunction) surf_scroll, METH_VARARGS | METH_KEYWORDS,
       DOC_SURFACESCROLL },
@@ -1591,6 +1594,212 @@ surf_blit (PyObject *self, PyObject *args, PyObject *keywds)
 
     return PyRect_New (&dest_rect);
 }
+
+
+#define BLITS_ERR_SEQUENCE 1
+#define BLITS_ERR_DISPLAY_SURF_QUIT 2
+#define BLITS_ERR_SEQUENCE_SURF 3
+#define BLITS_ERR_NO_OPENGL_SURF 4
+#define BLITS_ERR_INVALID_DESTINATION 5
+#define BLITS_ERR_INVALID_RECT_STYLE 6
+#define BLITS_ERR_MUST_ASSIGN_NUMERIC 7
+#define BLITS_ERR_BLIT_FAIL 8
+
+
+static PyObject*
+surf_blits (PyObject *self, PyObject *args, PyObject *keywds)
+{
+    SDL_Surface *src, *dest = PySurface_AsSurface (self);
+    GAME_Rect *src_rect, temp;
+    PyObject *srcobject = NULL, *argpos = NULL, *argrect = NULL;
+    int dx, dy, result;
+    SDL_Rect dest_rect, sdlsrc_rect;
+    int sx, sy;
+    int the_args = 0;
+
+
+    PyObject *blitsequence = NULL;
+    PyObject *iterator = NULL;
+    PyObject *item = NULL;
+    PyObject *special_flags = NULL;
+    PyObject* ret = NULL;
+    PyObject* retrect = NULL;
+    int itemlength;
+    int doreturn = 1;
+    int bliterrornum = 0;
+    static char *kwids[] = {"blit_sequence", "doreturn", NULL};
+    if (!PyArg_ParseTupleAndKeywords (args, keywds, "O|i", kwids,
+                                      &blitsequence, &doreturn))
+        return NULL;
+
+    if (doreturn) {
+        ret = PyList_New(0);
+        if (!ret)
+            return NULL;
+    }
+    if (!PySequence_Check(blitsequence)) {
+        bliterrornum = BLITS_ERR_SEQUENCE;
+        goto bliterror;
+    }
+    iterator = PyObject_GetIter(blitsequence);
+    if (!iterator) {
+        return NULL;
+    }
+
+    while ((item = PyIter_Next(iterator))) {
+        if (PySequence_Check (item)) {
+            itemlength = PySequence_Length (item);
+            if (itemlength > 4 || itemlength < 2) {
+                bliterrornum = BLITS_ERR_SEQUENCE;
+                goto bliterror;
+            }
+        } else {
+            bliterrornum = BLITS_ERR_SEQUENCE;
+            goto bliterror;
+        }
+        bliterrornum = 0;
+        srcobject = NULL;
+        argpos = NULL;
+        argrect = NULL;
+        special_flags = NULL;
+        the_args = 0;
+        if (itemlength >= 2) {
+            /* (Surface, dest) */
+            srcobject = PySequence_GetItem (item, 0);
+            argpos = PySequence_GetItem (item, 1);
+        }
+        if (itemlength == 3) {
+            /* (Surface, dest, area) */
+            argrect = PySequence_GetItem (item, 3);
+        }
+        if (itemlength == 4) {
+            /* (Surface, dest, area, special_flags) */
+            special_flags = PySequence_GetItem (item, 4);
+        }
+        Py_DECREF(item);
+
+
+        src = PySurface_AsSurface (srcobject);
+        if (!dest) {
+            bliterrornum = BLITS_ERR_DISPLAY_SURF_QUIT;
+            goto bliterror;
+        }
+        if (!src) {
+            bliterrornum = BLITS_ERR_SEQUENCE_SURF;
+            goto bliterror;
+        }
+
+        if (dest->flags & SDL_OPENGL &&
+            !(dest->flags & (SDL_OPENGLBLIT & ~SDL_OPENGL))) {
+            bliterrornum = BLITS_ERR_NO_OPENGL_SURF;
+            goto bliterror;
+        }
+
+        if ((src_rect = GameRect_FromObject (argpos, &temp))) {
+            dx = src_rect->x;
+            dy = src_rect->y;
+        }
+        else if (TwoIntsFromObj (argpos, &sx, &sy)) {
+            dx = sx;
+            dy = sy;
+        } else {
+            bliterrornum = BLITS_ERR_INVALID_DESTINATION;
+            goto bliterror;
+        }
+        if (argrect && argrect != Py_None) {
+            if (!(src_rect = GameRect_FromObject (argrect, &temp))) {
+                bliterrornum = BLITS_ERR_INVALID_RECT_STYLE;
+                goto bliterror;
+            }
+        }
+        else {
+            temp.x = temp.y = 0;
+            temp.w = src->w;
+            temp.h = src->h;
+            src_rect = &temp;
+        }
+
+        dest_rect.x = (short) dx;
+        dest_rect.y = (short) dy;
+        dest_rect.w = (unsigned short) src_rect->w;
+        dest_rect.h = (unsigned short) src_rect->h;
+        sdlsrc_rect.x = (short) src_rect->x;
+        sdlsrc_rect.y = (short) src_rect->y;
+        sdlsrc_rect.w = (unsigned short) src_rect->w;
+        sdlsrc_rect.h = (unsigned short) src_rect->h;
+
+        if (special_flags) {
+            if (!IntFromObj (special_flags, &the_args)) {
+                bliterrornum = BLITS_ERR_MUST_ASSIGN_NUMERIC;
+                goto bliterror;
+            }
+        }
+
+        Py_DECREF(srcobject);
+        Py_DECREF(argpos);
+        Py_XDECREF(argrect);
+        Py_XDECREF(special_flags);
+
+        result = PySurface_Blit(self, srcobject, &dest_rect, &sdlsrc_rect,
+                                the_args);
+        if (result != 0) {
+            bliterrornum = BLITS_ERR_BLIT_FAIL;
+            goto bliterror;
+        }
+
+        if (doreturn) {
+            retrect = NULL;
+            retrect = PyRect_New(&dest_rect);
+            PyList_Append(ret, retrect);
+            Py_DECREF(retrect);
+        }
+    }
+
+    Py_DECREF(iterator);
+
+    if (doreturn) {
+        return ret;
+    } else {
+        Py_RETURN_NONE;
+    }
+
+
+bliterror:
+    Py_XDECREF(srcobject);
+    Py_XDECREF(argpos);
+    Py_XDECREF(argrect);
+    Py_XDECREF(special_flags);
+    Py_XDECREF(iterator);
+    Py_XDECREF(item);
+
+    switch (bliterrornum)
+    {
+    case BLITS_ERR_SEQUENCE:
+        return RAISE (PyExc_ValueError, "blit_sequence should be iterator of (Surface, dest)");
+    case BLITS_ERR_DISPLAY_SURF_QUIT:
+        return RAISE (PyExc_SDLError, "display Surface quit");
+    case BLITS_ERR_SEQUENCE_SURF:
+        return RAISE (PyExc_TypeError, "First element of blit_list needs to be Surface.");
+    case BLITS_ERR_NO_OPENGL_SURF:
+        return RAISE (PyExc_SDLError,
+                      "Cannot blit to OPENGL Surfaces (OPENGLBLIT is ok)");
+    case BLITS_ERR_INVALID_DESTINATION:
+        return RAISE (PyExc_TypeError, "invalid destination position for blit");
+    case BLITS_ERR_INVALID_RECT_STYLE:
+        return RAISE (PyExc_TypeError, "Invalid rectstyle argument");
+    case BLITS_ERR_MUST_ASSIGN_NUMERIC:
+        return RAISE (PyExc_TypeError, "Must assign numeric values");
+    case BLITS_ERR_BLIT_FAIL:
+        return RAISE (PyExc_TypeError, "Blit failed");
+    default:
+        return RAISE (PyExc_TypeError, "Unknown error");
+    }
+}
+
+
+
+
+
 
 static PyObject*
 surf_scroll (PyObject *self, PyObject *args, PyObject *keywds)

--- a/src/surface.c
+++ b/src/surface.c
@@ -1596,7 +1596,7 @@ surf_blit (PyObject *self, PyObject *args, PyObject *keywds)
 }
 
 
-#define BLITS_ERR_SEQUENCE 1
+#define BLITS_ERR_SEQUENCE_REQUIRED 1
 #define BLITS_ERR_DISPLAY_SURF_QUIT 2
 #define BLITS_ERR_SEQUENCE_SURF 3
 #define BLITS_ERR_NO_OPENGL_SURF 4
@@ -1637,8 +1637,8 @@ surf_blits (PyObject *self, PyObject *args, PyObject *keywds)
         if (!ret)
             return NULL;
     }
-    if (!PySequence_Check(blitsequence)) {
-        bliterrornum = BLITS_ERR_SEQUENCE;
+    if (!PyIter_Check(blitsequence) && !PySequence_Check(blitsequence)) {
+        bliterrornum = BLITS_ERR_SEQUENCE_REQUIRED;
         goto bliterror;
     }
     iterator = PyObject_GetIter(blitsequence);
@@ -1647,14 +1647,14 @@ surf_blits (PyObject *self, PyObject *args, PyObject *keywds)
     }
 
     while ((item = PyIter_Next(iterator))) {
-        if (PySequence_Check (item)) {
-            itemlength = PySequence_Length (item);
+        if (PySequence_Check(item)) {
+            itemlength = PySequence_Length(item);
             if (itemlength > 4 || itemlength < 2) {
-                bliterrornum = BLITS_ERR_SEQUENCE;
+                bliterrornum = BLITS_ERR_SEQUENCE_REQUIRED;
                 goto bliterror;
             }
         } else {
-            bliterrornum = BLITS_ERR_SEQUENCE;
+            bliterrornum = BLITS_ERR_SEQUENCE_REQUIRED;
             goto bliterror;
         }
         bliterrornum = 0;
@@ -1665,21 +1665,21 @@ surf_blits (PyObject *self, PyObject *args, PyObject *keywds)
         the_args = 0;
         if (itemlength >= 2) {
             /* (Surface, dest) */
-            srcobject = PySequence_GetItem (item, 0);
-            argpos = PySequence_GetItem (item, 1);
+            srcobject = PySequence_GetItem(item, 0);
+            argpos = PySequence_GetItem(item, 1);
         }
         if (itemlength == 3) {
             /* (Surface, dest, area) */
-            argrect = PySequence_GetItem (item, 3);
+            argrect = PySequence_GetItem(item, 3);
         }
         if (itemlength == 4) {
             /* (Surface, dest, area, special_flags) */
-            special_flags = PySequence_GetItem (item, 4);
+            special_flags = PySequence_GetItem(item, 4);
         }
         Py_DECREF(item);
 
 
-        src = PySurface_AsSurface (srcobject);
+        src = PySurface_AsSurface(srcobject);
         if (!dest) {
             bliterrornum = BLITS_ERR_DISPLAY_SURF_QUIT;
             goto bliterror;
@@ -1774,7 +1774,7 @@ bliterror:
 
     switch (bliterrornum)
     {
-    case BLITS_ERR_SEQUENCE:
+    case BLITS_ERR_SEQUENCE_REQUIRED:
         return RAISE (PyExc_ValueError, "blit_sequence should be iterator of (Surface, dest)");
     case BLITS_ERR_DISPLAY_SURF_QUIT:
         return RAISE (PyExc_SDLError, "display Surface quit");

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -89,5 +89,32 @@ class BlitTest( unittest.TestCase ):
 
 
 
+    def test_blits(self):
+
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        dst.fill((230, 230, 230))
+
+        blit_list = []
+        for i in range(10):
+            dest = (i * 10, 0)
+            surf = pygame.Surface((10, 10), SRCALPHA, 32)
+            color = (i * 10, i * 10, i * 10)
+            surf.fill(color)
+            blit_list.append((surf, dest))
+
+        def blits(blit_list):
+            for surface, dest in blit_list:
+                dst.blit(surface, dest)
+
+        #dst.blits(blit_list)
+        blits(blit_list)
+
+        # check if we blit all the different colors in the correct spots.
+        for i in range(10):
+            color = (i * 10, i * 10, i * 10)
+            self.assertEqual(dst.get_at((i * 10, 0)), color)
+            self.assertEqual(dst.get_at(((i * 10) + 5, 5)), color)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -88,6 +88,16 @@ class BlitTest( unittest.TestCase ):
         self.assertEqual(s.get_at((0,0))[0], 0 )
 
 
+    def make_blit_list(self, num_surfs):
+
+        blit_list = []
+        for i in range(num_surfs):
+            dest = (i * 10, 0)
+            surf = pygame.Surface((10, 10), SRCALPHA, 32)
+            color = (i * 1, i * 1, i * 1)
+            surf.fill(color)
+            blit_list.append((surf, dest))
+        return blit_list
 
     def test_blits(self):
 
@@ -95,14 +105,7 @@ class BlitTest( unittest.TestCase ):
         PRINT_TIMING = 0
         dst = pygame.Surface((NUM_SURFS * 10, 10), SRCALPHA, 32)
         dst.fill((230, 230, 230))
-
-        blit_list = []
-        for i in range(NUM_SURFS):
-            dest = (i * 10, 0)
-            surf = pygame.Surface((10, 10), SRCALPHA, 32)
-            color = (i * 1, i * 1, i * 1)
-            surf.fill(color)
-            blit_list.append((surf, dest))
+        blit_list = self.make_blit_list(NUM_SURFS)
 
         def blits(blit_list):
             for surface, dest in blit_list:
@@ -136,8 +139,14 @@ class BlitTest( unittest.TestCase ):
         t1 = time()
         if PRINT_TIMING:
             print("Surface.blits doreturn=0: %s" % (t1-t0))
-
         self.assertEqual(results, None)
+
+
+        t0 = time()
+        results = dst.blits(((surf, dest) for surf, dest in blit_list))
+        t1 = time()
+        if PRINT_TIMING:
+            print("Surface.blits generator: %s" % (t1-t0))
 
 
     def test_blits_not_sequence(self):

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -91,14 +91,16 @@ class BlitTest( unittest.TestCase ):
 
     def test_blits(self):
 
-        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        NUM_SURFS = 255
+        PRINT_TIMING = 0
+        dst = pygame.Surface((NUM_SURFS * 10, 10), SRCALPHA, 32)
         dst.fill((230, 230, 230))
 
         blit_list = []
-        for i in range(10):
+        for i in range(NUM_SURFS):
             dest = (i * 10, 0)
             surf = pygame.Surface((10, 10), SRCALPHA, 32)
-            color = (i * 10, i * 10, i * 10)
+            color = (i * 1, i * 1, i * 1)
             surf.fill(color)
             blit_list.append((surf, dest))
 
@@ -106,14 +108,54 @@ class BlitTest( unittest.TestCase ):
             for surface, dest in blit_list:
                 dst.blit(surface, dest)
 
-        #dst.blits(blit_list)
-        blits(blit_list)
+        from time import time
+        t0 = time()
+        results = blits(blit_list)
+        t1 = time()
+        if PRINT_TIMING:
+            print("python blits: %s" % (t1-t0))
+
+        dst.fill((230, 230, 230))
+        t0 = time()
+        results = dst.blits(blit_list)
+        t1 = time()
+        if PRINT_TIMING:
+            print("Surface.blits :%s" % (t1-t0))
+
 
         # check if we blit all the different colors in the correct spots.
-        for i in range(10):
-            color = (i * 10, i * 10, i * 10)
+        for i in range(NUM_SURFS):
+            color = (i * 1, i * 1, i * 1)
             self.assertEqual(dst.get_at((i * 10, 0)), color)
             self.assertEqual(dst.get_at(((i * 10) + 5, 5)), color)
+
+        self.assertEqual(len(results), NUM_SURFS)
+
+        t0 = time()
+        results = dst.blits(blit_list, doreturn = 0)
+        t1 = time()
+        if PRINT_TIMING:
+            print("Surface.blits doreturn=0: %s" % (t1-t0))
+
+        self.assertEqual(results, None)
+
+
+    def test_blits_not_sequence(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(ValueError, dst.blits, None)
+
+    def test_blits_wrong_length(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(ValueError, dst.blits, [pygame.Surface((10, 10), SRCALPHA, 32)])
+
+    def test_blits_bad_surf_args(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(TypeError, dst.blits, [(None, None)])
+
+    def test_blits_bad_dest(self):
+        dst = pygame.Surface((100, 10), SRCALPHA, 32)
+        self.assertRaises(TypeError, dst.blits, [(pygame.Surface((10, 10), SRCALPHA, 32), None)])
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For drawing multiple surfaces at once. See subject: "blits proposal" on mailing list.

I made an initial implementation of Surface.blits(), focusing just on correctness, with no optimizations.

In the micro benchmark below it takes from 88% to 92% of the time for 255 surfaces
compared to using Surface.blit in python in a loop over the same list.

Considering blit is usually the slow part in most pygame apps, this is sort of nice.

Some benchmarking and other notes below.

---


1) Why not work on a faster implementation that saves the unwrapped objects?
This would allow you to save a list into a C object like:

```C
struct blitinfo {
 SDL_Surface dest;
 GAME_Rect *src_rect;
 GAME_Rect *area;
 int flags;
}
```

Then if you promise not to change the C list (ie, you are updating rects in place, and all your Surfaces are still there),
then it could avoid a lot of the unwrapping work.

However, I did a test where I commented out the blit call. So only the unwrapping and looping over the list is done.
And it seems that the python book keeping for these 255 10x10 surfaces is only 2.1%-3.3% of the total time taken.



2) Another optimization would be to avoid subsurface checks, and avoid a few other preparations for surfaces.
I tried this, and didn't see any noticeable improvement.

3) Currently neither SDL1 or SDL2 have a special batched blit, but there are proposals and implementations around.
Such as SDL_GPU.
This could see a bigger improvement on such backends where changing state is slow (OpenGL etc).




```python
import pygame
from pygame.locals import *
NUM_SURFS = 255
dst = pygame.Surface((NUM_SURFS * 10, 10), SRCALPHA, 32)
dst.fill((230, 230, 230))

blit_list = []
for i in range(NUM_SURFS):
    dest = (i * 10, 0)
    surf = pygame.Surface((10, 10), SRCALPHA, 32)
    color = (i * 1, i * 1, i * 1)
    surf.fill(color)
    blit_list.append((surf, dest))

def blits(blit_list):
    for surface, dest in blit_list:
        dst.blit(surface, dest)
```


```
In [17]: %timeit results = blits(blit_list)
774 µs ± 24.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [18]: %timeit results = dst.blits(blit_list)
717 µs ± 12.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [19]: %timeit results = dst.blits(blit_list, doreturn=0)
688 µs ± 14.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [20]: (100. / 774) * 717
Out[20]: 92.63565891472868

In [21]: (100. / 774) * 688
Out[21]: 88.88888888888889
```


If I comment out the actual blit call...

```
In [3]:  %timeit results = dst.blits(blit_list)
26.2 µs ± 695 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit results = dst.blits(blit_list, doreturn=0)
17.6 µs ± 314 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [5]: (100. / 774) * 26
Out[5]: 3.3591731266149867

In [6]: (100. / 774) * 17
Out[6]: 2.1963824289405682
```
