### PR TITLE
Added python 3.7 to appveyor and travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,20 @@ matrix:
   include:
     - os: linux
       sudo: required
+      dist: xenial
       python: 2.7
     - os: linux
       sudo: required
-      python: 3.4
-    - os: linux
-      sudo: required
+      dist: xenial
       python: 3.5
     - os: linux
       sudo: required
+      dist: xenial
       python: 3.6
     - os: linux
       sudo: required
-      python: 3.7-dev
+      python: 3.7
+      dist: xenial
     - os: linux
       sudo: required
       python: pypy
@@ -42,7 +43,6 @@ matrix:
       env:
         - PY_VERSION=2
         - MAKEFLAGS=-j8
-        # - MACOSX_DEPLOYMENT_TARGET=10.6
     # - os: osx
     #   osx_image: xcode7.3
     #   language: generic
@@ -72,7 +72,7 @@ before_install:
       sudo apt-get update
       sudo apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev \
         libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev \
-        libtiff4-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi \
+        libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi \
         xfonts-cyrillic fluid-soundfont-gm musescore-soundfont-gm
     fi
 install:

--- a/.travis_osx.sh
+++ b/.travis_osx.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Order the osx scripts are run.
+	# .travis_osx_before_install.sh
+	# .travis_osx.sh
+	# .travis_osx_install.sh
+	# .travis_osx_after_success.sh
+	# .travis_osx_rename_whl.py
+	# .travis_osx_upload_whl.py --no-config
+
 set -e
 
 # Work around https://github.com/travis-ci/travis-ci/issues/8703 :-@

--- a/.travis_osx_before_install.sh
+++ b/.travis_osx_before_install.sh
@@ -59,14 +59,17 @@ brew install fluid-synth
 brew install libmikmod ${UNIVERSAL_FLAG}
 brew install smpeg
 
-# seems portmidi added python in homebrew, which is broken with our travis python builds on mac.
-#brew install portmidi ${UNIVERSAL_FLAG}
-
-brew install https://gist.githubusercontent.com/illume/08f9d3ca872dc2b61d80f665602233fd/raw/0fbfd6657da24c419d23a6678b5715a18cd6560a/portmidi.rb
+# Because portmidi hates us... and installs python2, which messes homebrew up.
+# So we install portmidi from our own formula.
+brew tap pygame/portmidi
+brew install pygame/portmidi/portmidi ${UNIVERSAL_FLAG}
 
 brew install freetype ${UNIVERSAL_FLAG}
 brew install sdl_ttf ${UNIVERSAL_FLAG}
 brew install sdl_image ${UNIVERSAL_FLAG}
 brew install sdl_mixer ${UNIVERSAL_FLAG} --with-flac --with-fluid-synth --with-libmikmod --with-libvorbis --with-smpeg
+
+brew install https://gist.githubusercontent.com/illume/08f9d3ca872dc2b61d80f665602233fd/raw/0fbfd6657da24c419d23a6678b5715a18cd6560a/portmidi.rb
+
 
 echo "finished .travis_osx_before_install.sh"

--- a/.travis_osx_upload_whl.py
+++ b/.travis_osx_upload_whl.py
@@ -63,4 +63,7 @@ try:
 except:
     print('is twine installed?')
 finally:
-    os.unlink('pypirc')
+    try:
+        os.unlink('pypirc')
+    except:
+        print('issue unlinking pypirc file... probably ok?')

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,10 @@ environment:
       PYTHON_VERSION: "3.6.0"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python37\\python"
+      PYTHON_VERSION: "3.7.0"
+      PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Python27-x64\\python"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
@@ -45,6 +49,10 @@ environment:
 
     - PYTHON: "C:\\Python36-x64\\python"
       PYTHON_VERSION: "3.6.0"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python37-x64\\python"
+      PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
 
 init:

--- a/readme.html
+++ b/readme.html
@@ -339,7 +339,7 @@ involve compiling and installing all the pygame dependencies. Once
 that is done run the &quot;setup.py&quot; script which will attempt to
 auto-configure, build, and install pygame.</p>
 <p>Much more information about installing and compiling is available
-in the install.html file.</p>
+in the install.html file and at <a href="https://www.pygame.org/wiki/Compilation">https://www.pygame.org/wiki/Compilation</a></p>
 </blockquote>
 </div>
 <div class="section" id="help">

--- a/src/math.c
+++ b/src/math.c
@@ -899,12 +899,15 @@ vector_subscript (PyVector *self, PyObject *key)
 
 #if PY_VERSION_HEX >= 0x03020000
         if (PySlice_GetIndicesEx ((PyObject*)key,
-#else
-        if (PySlice_GetIndicesEx ((PySliceObject*)key,
-#endif
                  self->dim, &start, &stop, &step, &slicelength) < 0) {
             return NULL;
         }
+#else
+        if (PySlice_GetIndicesEx ((PySliceObject*)key,
+                 self->dim, &start, &stop, &step, &slicelength) < 0) {
+            return NULL;
+        }
+#endif
 
         if (slicelength <= 0) {
             return PyList_New(0);
@@ -962,12 +965,15 @@ vector_ass_subscript (PyVector *self, PyObject *key, PyObject *value)
 
 #if PY_VERSION_HEX >= 0x03020000
         if (PySlice_GetIndicesEx ((PyObject*)key,
-#else
-        if (PySlice_GetIndicesEx ((PySliceObject*)key,
-#endif
             self->dim, &start, &stop, &step, &slicelength) < 0) {
             return -1;
         }
+#else
+        if (PySlice_GetIndicesEx ((PySliceObject*)key,
+            self->dim, &start, &stop, &step, &slicelength) < 0) {
+            return -1;
+        }
+#endif
 
         if (step == 1)
             return vector_SetSlice(self, start, stop, value);


### PR DESCRIPTION
la la la

Updated the travis, and appveyor config to build 3.7. Fixed a little issue in math.c on windows with 3.7.
Travis with python 3.7 isn't supported properly yet? https://github.com/travis-ci/travis-ci/issues/9815

Also fixed an issue with portmidi on travis mac builds. Had to drop python3.4 travis build, as it is not supported by travis on the distro that 3.7 is supported on.