### PR TITLE
Updated docker vagrant install instructions for manylinux build.

### DIFF
--- a/config_darwin.py
+++ b/config_darwin.py
@@ -98,6 +98,25 @@ class DependencyPython:
         else:
             print (self.name + '        '[len(self.name):] + ': not found')
 
+def find_freetype():
+    """ modern freetype uses pkg-config. However, some older systems don't have that.
+    """
+    pkg_config = DependencyProg(
+        'FREETYPE', 'FREETYPE_CONFIG', 'pkg-config freetype2', '2.0',
+        ['freetype2'], '--modversion'
+    )
+    if pkg_config.found:
+        return pkg_config
+
+    #DependencyProg('FREETYPE', 'FREETYPE_CONFIG', '/usr/X11R6/bin/freetype-config', '2.0',
+    freetype_config = DependencyProg(
+        'FREETYPE', 'FREETYPE_CONFIG', 'freetype-config', '2.0', ['freetype'], '--ftversion'
+    )
+    if freetype_config.found:
+        return freetype_config
+    return pkg_config
+
+
 DEPS = [
     [DependencyProg('SDL', 'SDL_CONFIG', 'sdl-config', '1.2', ['sdl']),
          FrameworkDependency('SDL', 'SDL.h', 'libSDL', 'SDL')],
@@ -112,11 +131,7 @@ DEPS = [
     Dependency('PNG', 'png.h', 'libpng', ['png']),
     Dependency('JPEG', 'jpeglib.h', 'libjpeg', ['jpeg']),
     Dependency('PORTMIDI', 'portmidi.h', 'libportmidi', ['portmidi']),
-    #DependencyProg('FREETYPE', 'FREETYPE_CONFIG', '/usr/X11R6/bin/freetype-config', '2.0',
-    # DependencyProg('FREETYPE', 'FREETYPE_CONFIG', 'freetype-config', '2.0',
-    #                ['freetype'], '--ftversion'),
-    DependencyProg('FREETYPE', 'FREETYPE_CONFIG', 'pkg-config freetype2', '2.0',
-                   ['freetype2'], '--modversion'),
+    find_freetype(),
     # Scrap is included in sdlmain_osx, there is nothing to look at.
     # Dependency('SCRAP', '','',[]),
 ]

--- a/config_unix.py
+++ b/config_unix.py
@@ -175,6 +175,25 @@ def main():
 
     porttime_dep = get_porttime_dep()
 
+
+    def find_freetype():
+        """ modern freetype uses pkg-config. However, some older systems don't have that.
+        """
+        pkg_config = DependencyProg(
+            'FREETYPE', 'FREETYPE_CONFIG', 'pkg-config freetype2', '2.0',
+            ['freetype2'], '--modversion'
+        )
+        if pkg_config.found:
+            return pkg_config
+
+        freetype_config = DependencyProg(
+            'FREETYPE', 'FREETYPE_CONFIG', 'freetype-config', '2.0',
+            ['freetype'], '--ftversion'
+        )
+        if freetype_config.found:
+            return freetype_config
+        return pkg_config
+
     DEPS = [
         DependencyProg('SDL', 'SDL_CONFIG', 'sdl-config', '1.2', ['sdl']),
         Dependency('FONT', 'SDL_ttf.h', 'libSDL_ttf.so', ['SDL_ttf']),
@@ -185,10 +204,7 @@ def main():
         Dependency('SCRAP', '', 'libX11', ['X11']),
         Dependency('PORTMIDI', 'portmidi.h', 'libportmidi.so', ['portmidi']),
         porttime_dep,
-        # DependencyProg('FREETYPE', 'FREETYPE_CONFIG', 'freetype-config', '2.0',
-        #                ['freetype'], '--ftversion'),
-        DependencyProg('FREETYPE', 'FREETYPE_CONFIG', 'pkg-config freetype2', '2.0',
-                       ['freetype2'], '--modversion'),
+        find_freetype(),
         #Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL_gfx.so', ['SDL_gfx']),
     ]
     if not DEPS[0].found:

--- a/manylinux-build/README.rst
+++ b/manylinux-build/README.rst
@@ -54,23 +54,28 @@ mac, windows or linux boxes.
 These aren't meant to be copypasta'd in. Perhaps these can be worked into a script later::
 
     # You should be in the base of the pygame repo when you run all this.
+    $ pwd
+    /home/jblogs/pygame
 
     # Download many megabytes of ubuntu.
+    mkdir vagrant.xenial64
+    cd vagrant.xenial64
     vagrant init ubuntu/xenial64
+
+    # edit your Vagrantfile to add /vagrant_pygame synced folder.
+    # You pygame folder is next to your vagrant
+    config.vm.synced_folder "../pygame", "/vagrant_pygame"
+
+    # now start vagrant.
     vagrant up
     vagrant ssh
 
     # now we are on the vagrant ubuntu host
     # We set up docker following these instructions for ubuntu-xenial
-    # https://docs.docker.com/engine/installation/linux/ubuntulinux/
-    sudo apt-get install apt-transport-https ca-certificates
-    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    vi /etc/apt/sources.list.d/docker.list
-    sudo vi /etc/apt/sources.list.d/docker.list
+    # https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce-1
     sudo apt-get update
-    sudo apt-get purge lxc-docker
-    apt-cache policy docker-engine
-    sudo apt-get install docker-engine
+    sudo apt-get remove docker docker-engine docker.io
+    sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
 
     # Now edit /etc/hosts so it has a first line with the hostname ubuntu-xenial in it.
     # Otherwise docker does not start.
@@ -78,8 +83,20 @@ These aren't meant to be copypasta'd in. Perhaps these can be worked into a scri
     # makes a /etc/hosts.bak in case something breaks.
     sudo sed -i".bak" '/127.0.0.1 localhost/s/$/ ubuntu-xenial/' /etc/hosts
 
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+    sudo apt-get update
+
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+    sudo apt-get install docker-ce
+
+    # check that it runs.
+    sudo docker run hello-world
+
+
     # We should have been in our python package clone root directory before we ran vagrant ssh
-    cd /vagrant
+    cd /vagrant_pygame
 
     # We need to be able to run docker as the ubuntu user.
     sudo usermod -aG docker ubuntu
@@ -95,7 +112,7 @@ These aren't meant to be copypasta'd in. Perhaps these can be worked into a scri
     sudo service docker start
 
 
-    cd /vagrant/manylinux-build
+    cd /vagrant_pygame/manylinux-build
 
     # To make the base docker images and push them to docker hub do these commands.
     # Note, these have already been built, so only needed if rebuilding dependencies.

--- a/manylinux-build/build-wheels.sh
+++ b/manylinux-build/build-wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -x
 
-SUPPORTED_PYTHONS="cp27-cp27mu cp34-cp34m cp35-cp35m cp36-cp36m"
+SUPPORTED_PYTHONS="cp27-cp27mu cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m"
 
 export PORTMIDI_INC_PORTTIME=1
 


### PR DESCRIPTION
Updating instructions for manylinux build as I go. So far docker instructions changed since last year.
- [x] freetype pkg-config does not work, fallback to freetype-config.
- [x] update docker install instructions on vagrant.
- [x] upgrade manylinux to have python3.7 (cp37-cp37m)

re: https://github.com/pygame/pygame/issues/390