### PR TITLE
video4linux header for linux only. freebsd no have.

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -39,9 +39,8 @@
     /* on freebsd there is no asm/types */
     #ifdef linux
         #include <asm/types.h>          /* for videodev2.h */
+        #include <linux/videodev2.h>
     #endif
-
-    #include <linux/videodev2.h>
 #elif defined(__APPLE__)
     #include <AvailabilityMacros.h>
     /* We support OSX 10.6 and below. */


### PR DESCRIPTION
I don't have freebsd to test this... but apparently there is no video4linux header on there. Was there once one? The comment in the file seems to suggest so. A bit of searching I can't find it.

For https://github.com/pygame/pygame/issues/473