### PR TITLE
transform.scale does not crash for zero sized surfaces.

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -547,7 +547,7 @@ surf_scale (PyObject* self, PyObject* arg)
         return RAISE (PyExc_ValueError,
                       "Source and destination surfaces need the same format.");
 
-    if (width && height)
+    if ((width && height) && (surf->w && surf->h))
     {
         SDL_LockSurface (newsurf);
         pgSurface_Lock (surfobj);

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1308,10 +1308,6 @@ class SurfaceTypeTest(unittest.TestCase):
         surf.scroll(dx=-3, dy=-3)
         self.failUnlessEqual(surf.get_at((0, 0)), spot_color)
 
-    def test_zero_surface_transform(self):
-        tmp_surface = pygame.transform.scale(pygame.Surface((128, 128)), (0, 0))
-        tmp_surface = pygame.transform.scale(tmp_surface, (128, 128))
-
 class SurfaceSubtypeTest (unittest.TestCase):
     """Issue #280: Methods that return a new Surface preserve subclasses"""
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -131,6 +131,12 @@ class TransformModuleTest( unittest.TestCase ):
             # the wrong size surface is past in.  Should raise an error.
             self.assertRaises(ValueError, pygame.transform.smoothscale, s, (33,64), s3)
 
+    def test_scale__zero_surface_transform(self):
+        tmp_surface = pygame.transform.scale(pygame.Surface((128, 128)), (0, 0))
+        self.assertEqual(tmp_surface.get_size(), (0, 0))
+        tmp_surface = pygame.transform.scale(tmp_surface, (128, 128))
+        self.assertEqual(tmp_surface.get_size(), (128, 128))
+
     def test_threshold__honors_third_surface(self):
         # __doc__ for threshold as of Tue 07/15/2008
 


### PR DESCRIPTION
Thanks for the unit test @augusto2112 

- This fixes https://github.com/pygame/pygame/issues/411
- I made a mistake in the issue description for 411, as the transform.scale test should have been put into test/transform_test.py So I moved the test in there.