### PR TITLE
Cleanup some test methods & test/sndarray_test.py

### DIFF
--- a/test/compat_test.py
+++ b/test/compat_test.py
@@ -35,9 +35,9 @@ class CompatModuleTest(unittest.TestCase):
         self.failUnless(isinstance(compat.ord_(compat.bytes_(1)[0]), int))
         
     def test_bytes_(self):
-        self.failIf(compat.bytes_ is compat.unicode_)
+        self.assertFalse(compat.bytes_ is compat.unicode_)
         self.failUnless(hasattr(compat.bytes_, 'capitalize'))
-        self.failIf(hasattr(compat.bytes_, 'isdecimal'))
+        self.assertFalse(hasattr(compat.bytes_, 'isdecimal'))
         
     def test_unicode_(self):
         self.failUnless(hasattr(compat.unicode_(), 'isdecimal'))
@@ -55,7 +55,7 @@ class CompatModuleTest(unittest.TestCase):
             self.failUnlessEqual(str(e), msg)
 
     def test_xrange_(self):
-        self.failIf(isinstance(compat.xrange_(2), list))
+        self.assertFalse(isinstance(compat.xrange_(2), list))
         
     def test_unichr_(self):
         ordval = 86

--- a/test/compat_test.py
+++ b/test/compat_test.py
@@ -18,18 +18,18 @@ class CompatModuleTest(unittest.TestCase):
     def test_as_unicode(self):
         r = r'Bo\u00F6tes'
         ords = [ord('B'), ord('o'), 0xF6, ord('t'), ord('e'), ord('s')]
-        self.failUnlessEqual(len(r), 11)
+        self.assertEqual(len(r), 11)
         u = compat.as_unicode(r)
         self.failUnless(isinstance(u, compat.unicode_))
-        self.failUnlessEqual([ord(c) for c in u], ords)
+        self.assertEqual([ord(c) for c in u], ords)
 
     def test_as_bytes(self):
         ords = [0, 1, 0x7F, 0x80, 0xC3, 0x20, 0xC3, 0xB6, 0xFF]
         s = ''.join([chr(i) for i in ords])
-        self.failUnlessEqual(len(s), len(ords))
+        self.assertEqual(len(s), len(ords))
         b = compat.as_bytes(s)
         self.failUnless(isinstance(b, compat.bytes_))
-        self.failUnlessEqual([compat.ord_(i) for i in b], ords)
+        self.assertEqual([compat.ord_(i) for i in b], ords)
 
     def test_ord_(self):
         self.failUnless(isinstance(compat.ord_(compat.bytes_(1)[0]), int))
@@ -52,7 +52,7 @@ class CompatModuleTest(unittest.TestCase):
         except TypeError:
             e = compat.geterror()
             self.failUnless(isinstance(e, TypeError))
-            self.failUnlessEqual(str(e), msg)
+            self.assertEqual(str(e), msg)
 
     def test_xrange_(self):
         self.assertFalse(isinstance(compat.xrange_(2), list))
@@ -61,21 +61,21 @@ class CompatModuleTest(unittest.TestCase):
         ordval = 86
         c = compat.unichr_(ordval)
         self.failUnless(isinstance(c, compat.unicode_))
-        self.failUnlessEqual(ord(c), ordval)
+        self.assertEqual(ord(c), ordval)
 
     def test_get_BytesIO(self):
         BytesIO = compat.get_BytesIO()
         b1 = compat.as_bytes("\x00\xffabc")
         b2 = BytesIO(b1).read()
         self.failUnless(isinstance(b2, compat.bytes_))
-        self.failUnlessEqual(b2, b1)
+        self.assertEqual(b2, b1)
 
     def test_get_StringIO(self):
         StringIO = compat.get_StringIO()
         b1 = "abcde"
         b2 = StringIO(b1).read()
         self.failUnless(isinstance(b2, str))
-        self.failUnlessEqual(b2, b1)
+        self.assertEqual(b2, b1)
     
     def test_raw_input_(self):
         StringIO = compat.get_StringIO()
@@ -84,7 +84,7 @@ class CompatModuleTest(unittest.TestCase):
         sys.stdin = StringIO(msg + '\n')
         try:
             s = compat.raw_input_()
-            self.failUnlessEqual(s, msg)
+            self.assertEqual(s, msg)
         finally:
             sys.stdin = tmp
 

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -257,13 +257,13 @@ class EventModuleTest(unittest.TestCase):
         d = pygame.event.Event(1, a=2)
 
         self.failUnless(a == a)
-        self.failIf(a != a)
+        self.assertFalse(a != a)
         self.failUnless(a == b)
-        self.failIf(a != b)
+        self.assertFalse(a != b)
         self.failUnless(a !=  c)
-        self.failIf(a == c)
+        self.assertFalse(a == c)
         self.failUnless(a != d)
-        self.failIf(a == d)
+        self.assertFalse(a == d)
 
     def todo_test_get_blocked(self):
 

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -102,7 +102,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
         def test_get_init(self):
             self.failUnless(pygame_font.get_init())
             pygame_font.quit()
-            self.failIf(pygame_font.get_init())
+            self.assertFalse(pygame_font.get_init())
 
         def test_init(self):
             pygame_font.init()
@@ -114,7 +114,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
             # name is a full path.
             for font in fonts:
                 path = pygame_font.match_font(font)
-                self.failIf(path is None)
+                self.assertFalse(path is None)
                 self.failUnless(os.path.isabs(path))
 
         def test_match_font_bold(self):
@@ -149,7 +149,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
 
             # Check comma separated list.
             names = ','.join(['thisisnotafont', fonts[-1], 'anothernonfont'])
-            self.failIf(pygame_font.match_font(names) is None)
+            self.assertFalse(pygame_font.match_font(names) is None)
             names = ','.join(['thisisnotafont1', 'thisisnotafont2', 'thisisnotafont3'])
             self.failUnless(pygame_font.match_font(names) is None)
 
@@ -402,27 +402,27 @@ if not IS_PYPY: #TODO: pypy skip known failure.
 
         def test_set_bold(self):
             f = pygame_font.Font(None, 20)
-            self.failIf(f.get_bold())
+            self.assertFalse(f.get_bold())
             f.set_bold(True)
             self.failUnless(f.get_bold())
             f.set_bold(False)
-            self.failIf(f.get_bold())
+            self.assertFalse(f.get_bold())
 
         def test_set_italic(self):
             f = pygame_font.Font(None, 20)
-            self.failIf(f.get_italic())
+            self.assertFalse(f.get_italic())
             f.set_italic(True)
             self.failUnless(f.get_italic())
             f.set_italic(False)
-            self.failIf(f.get_italic())
+            self.assertFalse(f.get_italic())
 
         def test_set_underline(self):
             f = pygame_font.Font(None, 20)
-            self.failIf(f.get_underline())
+            self.assertFalse(f.get_underline())
             f.set_underline(True)
             self.failUnless(f.get_underline())
             f.set_underline(False)
-            self.failIf(f.get_underline())
+            self.assertFalse(f.get_underline())
 
         def test_size(self):
             f = pygame_font.Font(None, 20)

--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -37,6 +37,7 @@ def intensity(c, i):
             g + ((255 - g) * (255 - i)) // 127,
             b + ((255 - b) * (255 - i)) // 127)
 
+
 class GfxdrawDefaultTest( unittest.TestCase ):
 
     is_started = False
@@ -66,7 +67,7 @@ class GfxdrawDefaultTest( unittest.TestCase ):
         fail_msg = ("%s != %s at %s, bitsize: %i, flags: %i, masks: %s" %
                     (sc, color, posn, surf.get_bitsize(), surf.get_flags(),
                      surf.get_masks()))
-        self.failIfEqual(sc, color, fail_msg)
+        self.assertNotEqual(sc, color, fail_msg)
 
     def setUp(self):
         Surface = pygame.Surface

--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -60,7 +60,7 @@ class GfxdrawDefaultTest( unittest.TestCase ):
         fail_msg = ("%s != %s at %s, bitsize: %i, flags: %i, masks: %s" %
                     (sc, color, posn, surf.get_bitsize(), surf.get_flags(),
                      surf.get_masks()))
-        self.failUnlessEqual(sc, color, fail_msg)
+        self.assertEqual(sc, color, fail_msg)
 
     def check_not_at(self, surf, posn, color):
         sc = surf.get_at(posn)

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -90,7 +90,7 @@ class MixerModuleTest(unittest.TestCase):
         mixer.pre_init(0, 0, 0)       # Should reset to default values
         mixer.init()
         try:
-            self.failUnlessEqual(mixer.get_init(), (22050, -16, 2))
+            self.assertEqual(mixer.get_init(), (22050, -16, 2))
         finally:
             mixer.quit()
 
@@ -100,7 +100,7 @@ class MixerModuleTest(unittest.TestCase):
         mixer.pre_init(44100, 8, 1)  # None default values
         mixer.init(0, 0, 0)
         try:
-            self.failUnlessEqual(mixer.get_init(), (44100, 8, 1))
+            self.assertEqual(mixer.get_init(), (44100, 8, 1))
         finally:
             mixer.quit()
             mixer.pre_init(0, 0, 0, 0)

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -11,35 +11,22 @@ else:
     is_pygame_pkg = __name__.startswith('pygame.tests.')
 
 import unittest
+
+from numpy import int8, int16, uint8, uint16, array, alltrue
+
 import pygame
 from pygame.compat import as_bytes
-
 import pygame.sndarray
-from numpy import \
-     int8, int16, uint8, uint16, array, alltrue
-arraytype = "numpy"
 
 
 class SndarrayTest (unittest.TestCase):
-    if arraytype:
-        array_dtypes = {8: uint8, -8: int8, 16: uint16, -16: int16}
+    array_dtypes = {8: uint8, -8: int8, 16: uint16, -16: int16}
 
     def _assert_compatible(self, arr, size):
         dtype = self.array_dtypes[size]
-        if arraytype == 'numpy':
-            self.failUnlessEqual(arr.dtype, dtype)
-        else:
-            self.failUnlessEqual(arr.typecode(), dtype)
-
-    def test_import(self):
-        'does it import'
-        if not arraytype:
-            self.fail("no array package installed")
-        import pygame.sndarray
+        self.assertEqual(arr.dtype, dtype)
 
     def test_array(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         def check_array(size, channels, test_data):
             try:
@@ -74,18 +61,12 @@ class SndarrayTest (unittest.TestCase):
                              [0x7fff, 0], [0, 0x7fff]])
 
     def test_get_arraytype(self):
-        if not arraytype:
-            self.fail("no array package installed")
-
         self.failUnless((pygame.sndarray.get_arraytype() in
                          ['numpy']),
                         ("unknown array type %s" %
                          pygame.sndarray.get_arraytype()))
 
     def test_get_arraytypes(self):
-        if not arraytype:
-            self.fail("no array package installed")
-
         arraytypes = pygame.sndarray.get_arraytypes()
         self.failUnless('numpy' in arraytypes)
 
@@ -94,8 +75,6 @@ class SndarrayTest (unittest.TestCase):
                             "unknown array type %s" % atype)
 
     def test_make_sound(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         def check_sound(size, channels, test_data):
             try:
@@ -129,8 +108,6 @@ class SndarrayTest (unittest.TestCase):
                              [0x7fff, 0], [0, 0x7fff]])
 
     def test_samples(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         null_byte = as_bytes('\x00')
         def check_sample(size, channels, test_data):
@@ -172,14 +149,12 @@ class SndarrayTest (unittest.TestCase):
                              [0x7fff, 0], [0, 0x7fff]])
 
     def test_use_arraytype(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         def do_use_arraytype(atype):
             pygame.sndarray.use_arraytype(atype)
 
         pygame.sndarray.use_arraytype('numpy')
-        self.failUnlessEqual(pygame.sndarray.get_arraytype(), 'numpy')
+        self.assertEqual(pygame.sndarray.get_arraytype(), 'numpy')
 
         self.failUnlessRaises(ValueError, do_use_arraytype, 'not an option')
 

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -223,7 +223,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
                 surf.set_alpha(0)
                 arr = pygame.surfarray.array_alpha(surf)
                 if surf.get_masks()[3]:
-                    self.failIf(alltrue(arr == 255),
+                    self.assertFalse(alltrue(arr == 255),
                                 "bitsize: %i, flags: %i" %
                                 (surf.get_bitsize(), surf.get_flags()))
                 else:
@@ -520,14 +520,14 @@ if not IS_PYPY: #TODO: pypy skip known failure.
                        self._make_surface(32, srcalpha=True)]
 
             for surf in sources:
-                self.failIf(surf.get_locked())
+                self.assertFalse(surf.get_locked())
                 arr = pygame.surfarray.pixels2d(surf)
                 self.failUnless(surf.get_locked())
                 self._fill_array2d(arr, surf)
                 surf.unlock()
                 self.failUnless(surf.get_locked())
                 del arr
-                self.failIf(surf.get_locked())
+                self.assertFalse(surf.get_locked())
                 self.failUnlessEqual(surf.get_locks(), ())
                 self._assert_surface(surf)
 
@@ -544,14 +544,14 @@ if not IS_PYPY: #TODO: pypy skip known failure.
                        self._make_surface(32)]
 
             for surf in sources:
-                self.failIf(surf.get_locked())
+                self.assertFalse(surf.get_locked())
                 arr = pygame.surfarray.pixels3d(surf)
                 self.failUnless(surf.get_locked())
                 self._fill_array3d(arr)
                 surf.unlock()
                 self.failUnless(surf.get_locked())
                 del arr
-                self.failIf(surf.get_locked())
+                self.assertFalse(surf.get_locked())
                 self.failUnlessEqual(surf.get_locks(), ())
                 self._assert_surface(surf)
 
@@ -586,7 +586,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
 
             surf = self._make_src_surface(32, srcalpha=True, palette=palette)
 
-            self.failIf(surf.get_locked())
+            self.assertFalse(surf.get_locked())
             arr = pygame.surfarray.pixels_alpha(surf)
             self.failUnless(surf.get_locked())
             surf.unlock()
@@ -603,7 +603,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
                                      "posn: (%i, %i)" % (x, y))
 
             del arr
-            self.failIf(surf.get_locked())
+            self.assertFalse(surf.get_locked())
             self.failUnlessEqual(surf.get_locks(), ())
 
             # Check exceptions.
@@ -647,7 +647,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
             surf32a = self._make_src_surface(32, srcalpha=True, palette=palette)
 
             for surf in [surf24, surf32, surf32a]:
-                self.failIf(surf.get_locked())
+                self.assertFalse(surf.get_locked())
                 arr = pixels_rgb(surf)
                 self.failUnless(surf.get_locked())
                 surf.unlock()
@@ -657,7 +657,7 @@ if not IS_PYPY: #TODO: pypy skip known failure.
                     self.failUnlessEqual(arr[x, y], plane[i])
 
                 del arr
-                self.failIf(surf.get_locked())
+                self.assertFalse(surf.get_locked())
                 self.failUnlessEqual(surf.get_locks(), ())
 
             # Check exceptions.


### PR DESCRIPTION
Hello,

here some first cleanup branch on tests : 

* replace all occurences of `failIf` with `assertFalse`
* replace some deprecated `failUnlessEqual` with standard `assertEqual`
* rm obsolete `if not arraytype ...` in **test/sndarray_test.py** & rm a test on import

I first fancied, I could cleanup all tests methods, but that would be way to noisy.
2 tests of **gfxdraw_test.py** fail, they fail also on master, right ?

Once merged, we can check the *test/sndarray_test.py* in #496 