### PR TITLE
Remove "if 1:" pattern in tests

### DIFF
--- a/test/display_test.py
+++ b/test/display_test.py
@@ -19,30 +19,29 @@ class DisplayModuleTest( unittest.TestCase ):
             "|Tags:display|"
         """
 
-        if 1:
-            pygame.init()
-            screen = pygame.display.set_mode((100,100))
-            screen.fill((55,55,55))
+        pygame.init()
+        screen = pygame.display.set_mode((100,100))
+        screen.fill((55,55,55))
 
-            r1 = pygame.Rect(0,0,100,100)
-            pygame.display.update(r1)
+        r1 = pygame.Rect(0,0,100,100)
+        pygame.display.update(r1)
 
-            r2 = pygame.Rect(-10,0,100,100)
-            pygame.display.update(r2)
+        r2 = pygame.Rect(-10,0,100,100)
+        pygame.display.update(r2)
 
-            r3 = pygame.Rect(-10,0,-100,-100)
-            pygame.display.update(r3)
+        r3 = pygame.Rect(-10,0,-100,-100)
+        pygame.display.update(r3)
 
-            # NOTE: if I don't call pygame.quit there is a segfault.  hrmm.
-            pygame.quit()
-            #  I think it's because unittest runs stuff in threads
-            # here's a stack trace...
-            
-            # NOTE to author of above:
-            #   unittest doesn't run tests in threads    
-            #   segfault was probably caused by another tests need 
-            #   for a "clean slate"
-            
+        # NOTE: if I don't call pygame.quit there is a segfault.  hrmm.
+        pygame.quit()
+        #  I think it's because unittest runs stuff in threads
+        # here's a stack trace...
+        
+        # NOTE to author of above:
+        #   unittest doesn't run tests in threads    
+        #   segfault was probably caused by another tests need 
+        #   for a "clean slate"
+        
             """
     #0  0x08103b7c in PyFrame_New ()
     #1  0x080bd666 in PyEval_EvalCodeEx ()

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -42,7 +42,7 @@ class DisplayModuleTest( unittest.TestCase ):
         #   segfault was probably caused by another tests need 
         #   for a "clean slate"
         
-            """
+        """
     #0  0x08103b7c in PyFrame_New ()
     #1  0x080bd666 in PyEval_EvalCodeEx ()
     #2  0x08105202 in PyFunction_SetClosure ()
@@ -55,7 +55,7 @@ class DisplayModuleTest( unittest.TestCase ):
     #9  0xb7e04eb0 in __libc_start_main () from /lib/tls/libc.so.6
     #10 0x08054e31 in _start ()
 
-            """
+        """
 
     def todo_test_Info(self):
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -1,23 +1,24 @@
 import unittest
 import pygame, pygame.transform
 
-class DisplayModuleTest( unittest.TestCase ):
-    def test_update( self ):
+class DisplayModuleTest(unittest.TestCase):
+
+    def test_update(self):
         """ see if pygame.display.update takes rects with negative values.
             "|Tags:display|"
         """
 
         pygame.init()
-        screen = pygame.display.set_mode((100,100))
-        screen.fill((55,55,55))
+        screen = pygame.display.set_mode((100, 100))
+        screen.fill((55, 55, 55))
 
-        r1 = pygame.Rect(0,0,100,100)
+        r1 = pygame.Rect(0, 0, 100, 100)
         pygame.display.update(r1)
 
-        r2 = pygame.Rect(-10,0,100,100)
+        r2 = pygame.Rect(-10, 0, 100, 100)
         pygame.display.update(r2)
 
-        r3 = pygame.Rect(-10,0,-100,-100)
+        r3 = pygame.Rect(-10, 0, -100, -100)
         pygame.display.update(r3)
 
         # NOTE: if I don't call pygame.quit there is a segfault.  hrmm.

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -617,15 +617,4 @@ class MaskModuleTest(unittest.TestCase):
                 self.assertEqual(rects, [])
 
 if __name__ == '__main__':
-    if 1:
-        unittest.main()
-    else:
-        mask_from_surface = maskFromSurface
-
-        surf = pygame.Surface((70,70), SRCALPHA, 32)
-        #surf = surf.convert_alpha()
-        surf.set_at((0,0), (255,255,255,0))
-        print (surf.get_at((0,0)))
-
-        print ("asdf")
-        print (surf)
+    unittest.main()

--- a/test/test_utils/async_sub.py
+++ b/test/test_utils/async_sub.py
@@ -267,26 +267,6 @@ class AsyncTest(unittest.TestCase):
         self.assert_( 'successfully terminated' in ret_code )
 
 ################################################################################
-
-def _example():
-    if sys.platform == 'win32':
-        shell, commands, tail = ('cmd', ('echo "hello"', 'echo "HELLO WORLD"'), '\r\n')
-    else:
-        shell, commands, tail = ('sh', ('ls', 'echo HELLO WORLD'), '\n')
-    
-    a = Popen(shell, stdin=PIPE, stdout=PIPE)
-    sys.stdout.write(a.read_async())
-    sys.stdout.write(" ")
-    for cmd in commands:
-        a.send_all(cmd + tail)
-        sys.stdout.write(a.read_async())
-        sys.stdout.write(" ")
-    a.send_all('exit' + tail)
-    print (a.read_async(e=0))
-    a.wait()
-
-################################################################################
     
 if __name__ == '__main__':
-    if 1: unittest.main()
-    else: _example()
+    unittest.main()

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -120,16 +120,15 @@ class TransformModuleTest( unittest.TestCase ):
         # the wrong size surface is past in.  Should raise an error.
         self.assertRaises(ValueError, pygame.transform.scale, s, (33,64), s3)
 
-        if 1:
-            s = pygame.Surface((32,32))
-            s2 = pygame.transform.smoothscale(s, (64,64))
-            s3 = s2.copy()
+        s = pygame.Surface((32,32))
+        s2 = pygame.transform.smoothscale(s, (64,64))
+        s3 = s2.copy()
 
-            s3 = pygame.transform.smoothscale(s, (64,64), s3)
-            pygame.transform.smoothscale(s, (64,64), s2)
+        s3 = pygame.transform.smoothscale(s, (64,64), s3)
+        pygame.transform.smoothscale(s, (64,64), s2)
 
-            # the wrong size surface is past in.  Should raise an error.
-            self.assertRaises(ValueError, pygame.transform.smoothscale, s, (33,64), s3)
+        # the wrong size surface is past in.  Should raise an error.
+        self.assertRaises(ValueError, pygame.transform.smoothscale, s, (33,64), s3)
 
     def test_scale__zero_surface_transform(self):
         tmp_surface = pygame.transform.scale(pygame.Surface((128, 128)), (0, 0))
@@ -619,7 +618,6 @@ class TransformModuleTest( unittest.TestCase ):
         s3 = pygame.Surface((1,1), SRCALPHA, 32)
         THRESHOLD_BEHAVIOR_FROM_SEARCH_SURF = 2
 
-        # if 1:
         #     # only one pixel should not be changed.
         #     s1.fill((40,40,40))
         #     s2.fill((255,255,255))
@@ -644,7 +642,6 @@ class TransformModuleTest( unittest.TestCase ):
         # # abs(40 - 255) < 100
         # #(abs(c1[0] - r) < tr)
 
-        # if 1:
         #     s1.fill((160,160,160))
         #     s2.fill((255,255,255))
         #     num_threshold_pixels = threshold(s2, s1, (255,255,255), (100,100,100), (0,0,0), True)
@@ -652,58 +649,51 @@ class TransformModuleTest( unittest.TestCase ):
         #     self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()))
 
 
+        # only one pixel should not be changed.
+        s1.fill((40, 40, 40))
+        s1.set_at((0, 0), (170, 170, 170))
+        THRESHOLD_BEHAVIOR_COUNT = 0
+
+        num_threshold_pixels = threshold(
+            dest_surf=None,
+            surf=s1,
+            search_color=(30, 30, 30),
+            threshold=(11, 11, 11),
+            set_color=None,
+            set_behavior=THRESHOLD_BEHAVIOR_COUNT)
+
+        #num_threshold_pixels = threshold(s2, s1, (30,30,30))
+        self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
 
 
-        if 1:
-            # only one pixel should not be changed.
-            s1.fill((40, 40, 40))
-            s1.set_at((0, 0), (170, 170, 170))
-            THRESHOLD_BEHAVIOR_COUNT = 0
+        # test end markers.  0, and 255
 
-            num_threshold_pixels = threshold(
-                dest_surf=None,
-                surf=s1,
-                search_color=(30, 30, 30),
-                threshold=(11, 11, 11),
-                set_color=None,
-                set_behavior=THRESHOLD_BEHAVIOR_COUNT)
-
-            #num_threshold_pixels = threshold(s2, s1, (30,30,30))
-            self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
+        # the pixels are different by 1.
+        s1.fill((254,254,254))
+        s2.fill((255,255,255))
+        s3.fill((255,255,255))
+        s1.set_at( (0,0), (170, 170, 170) )
+        num_threshold_pixels = threshold(None, s1, (254,254,254), (1,1,1),
+                                         None, THRESHOLD_BEHAVIOR_COUNT)
+        self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
 
 
-        if 1:
-            # test end markers.  0, and 255
-
-            # the pixels are different by 1.
-            s1.fill((254,254,254))
-            s2.fill((255,255,255))
-            s3.fill((255,255,255))
-            s1.set_at( (0,0), (170, 170, 170) )
-            num_threshold_pixels = threshold(None, s1, (254,254,254), (1,1,1),
-                                             None, THRESHOLD_BEHAVIOR_COUNT)
-            self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
+        # compare the two surfaces.  Should be all but one matching.
+        num_threshold_pixels = threshold(None, s1, None, (1,1,1),
+                                         None, THRESHOLD_BEHAVIOR_COUNT, s2)
+        self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
 
 
-            # compare the two surfaces.  Should be all but one matching.
-            num_threshold_pixels = threshold(None, s1, None, (1,1,1),
-                                             None, THRESHOLD_BEHAVIOR_COUNT, s2)
-            self.assertEqual(num_threshold_pixels, (s1.get_height() * s1.get_width()) -1)
+        # within (0,0,0) threshold?  Should match no pixels.
+        num_threshold_pixels = threshold(None, s1, (253,253,253), (0,0,0),
+                                         None, THRESHOLD_BEHAVIOR_COUNT)
+        self.assertEqual(num_threshold_pixels, 0)
 
 
-            # within (0,0,0) threshold?  Should match no pixels.
-            num_threshold_pixels = threshold(None, s1, (253,253,253), (0,0,0),
-                                             None, THRESHOLD_BEHAVIOR_COUNT)
-            self.assertEqual(num_threshold_pixels, 0)
-
-
-            # other surface within (0,0,0) threshold?  Should match no pixels.
-            num_threshold_pixels = threshold(None, s1, None, (0,0,0),
-                                             None, THRESHOLD_BEHAVIOR_COUNT, s2)
-            self.assertEqual(num_threshold_pixels, 0)
-
-
-
+        # other surface within (0,0,0) threshold?  Should match no pixels.
+        num_threshold_pixels = threshold(None, s1, None, (0,0,0),
+                                         None, THRESHOLD_BEHAVIOR_COUNT, s2)
+        self.assertEqual(num_threshold_pixels, 0)
 
     def test_laplacian(self):
         """


### PR DESCRIPTION

* remove many "`if 1:` in test 
* remove two unreachable code in the **else**-part of `if 1:` (not sure what the meaning of this other code was, so maybe we want to do something with it , but differently ?)
* Some PEP8 wsp cleanup in *display_test.py*
* The "`if 1:`" in *run_tests__tests/* seem to make sense as intended dummy-code, so I left them