### PR TITLE
Improve mac compile times on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: python
 cache:
   directories:
     - $HOME/.cache/pip
+    - $HOME/Library/Caches/Homebrew
     - /Library/Caches/Homebrew
-#     - $HOME/.ccache
-#     - $HOME/Library/Caches/pip
 
 matrix:
   include:
@@ -25,9 +24,11 @@ matrix:
       sudo: required
       python: 3.7
       dist: xenial
-    - os: linux
-      sudo: required
-      python: pypy
+
+    # pypy build is broken. The pypy on travis is really old.
+    # - os: linux
+    #   sudo: required
+    #   python: pypy
 
     # Should only need one OSX build because older builds can work on newer machines ok.
     #https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version


### PR DESCRIPTION
- Only recompile from source when doing tag and master builds. 
- It did take 22 minutes, and now it takes 8 minutes.
- retry failed brew installs. This also avoids an intermittent failure on the libpng build because it is installed from the prebuilt bottle.
- Disable the pypy build, because the pypy on travis is too old.