### PR TITLE
Midi tests : add, refactor, cleanup

### DIFF
--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -72,6 +72,9 @@ class MidiInputTest(MidiTestBase):
             self.assertEqual(read, [])
             # TODO fake some  incoming data
 
+    def todo_test_close(self):
+        pass
+
 
 class MidiOutputTest(MidiTestBase):
 
@@ -132,6 +135,7 @@ class MidiOutputTest(MidiTestBase):
         if m_id != -1:
             out = pygame.midi.Output(m_id)
             out.note_on(5, 30, 0)
+            out.note_on(5, 42, 10)
             with self.assertRaises(ValueError) as cm:
                 out.note_on(5, 30, 25)
             self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
@@ -139,14 +143,30 @@ class MidiOutputTest(MidiTestBase):
                 out.note_on(5, 30, -1)
             self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
 
-    def todo_test_set_instrument(self):
+    def test_set_instrument(self):
 
         # __doc__ (as of 2009-05-19) for pygame.midi.Output.set_instrument:
 
           # Select an instrument, with a value between 0 and 127.
           # Output.set_instrument(instrument_id, channel = 0)
 
-        self.fail()
+        m_id = pygame.midi.get_default_output_id()
+        if m_id != -1:
+            out = pygame.midi.Output(m_id)
+            out.set_instrument(5)
+            out.set_instrument(42, channel=2)
+            with self.assertRaises(ValueError) as cm:
+                out.set_instrument(-6)
+            self.assertEqual(cm.exception.message, "Undefined instrument id: -6")
+            with self.assertRaises(ValueError) as cm:
+                out.set_instrument(156)
+            self.assertEqual(cm.exception.message, "Undefined instrument id: 156")
+            with self.assertRaises(ValueError) as cm:
+                out.set_instrument(5, -1)
+            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            with self.assertRaises(ValueError) as cm:
+                out.set_instrument(5, 16)
+            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
 
     def test_write(self):
 
@@ -229,6 +249,16 @@ class MidiOutputTest(MidiTestBase):
           #                    [0xF0,0x7D,0x10,0x11,0x12,0x13,0xF7])
 
         self.fail()
+
+    def todo_test_pitch_bend(self):
+        pass
+        # FIXME : pitch_bend in the code, but not in documentation
+
+    def todo_test_close(self):
+        pass
+
+    def todo_test_abort(self):
+        pass
 
 
 class MidiModuleTest(MidiTestBase):

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -9,8 +9,6 @@ import pygame.compat
 from pygame.locals import *
 
 
-
-
 class MidiInputTest(unittest.TestCase):
 
     def setUp(self):
@@ -496,7 +494,7 @@ class MidiModuleTest(unittest.TestCase):
         pygame.midi.init()
         pygame.midi.init()
 
-    def todo_test_midis2events(self):
+    def test_midis2events(self):
 
         # __doc__ (as of 2009-05-19) for pygame.midi.midis2events:
 
@@ -505,7 +503,22 @@ class MidiModuleTest(unittest.TestCase):
           #
           # Takes a sequence of midi events and returns list of pygame events.
 
-        self.fail()
+        midi_data = ([[0xc0, 0, 1, 2], 20000],
+                     [[0x90, 60, 100, 'blablabla'], 20000]
+                    )
+        events = pygame.midi.midis2events(midi_data, 2)
+        self.assertEqual(len(events), 2)
+
+        for eve in events:
+            print(eve, type(eve))
+            # pygame.event.Event is a function, but ...
+            self.assertEqual(eve.__class__.__name__, 'Event')
+            self.assertEqual(eve.vice_id, 2)
+            # FIXME I don't know what we want for the Event.timestamp
+            # For now it accepts  it accepts int as is:
+            self.assertIsInstance(eve.timestamp, int)
+            self.assertEqual(eve.timestamp, 20000)
+        self.assertEqual(events[1].data3, 'blablabla')
 
     def test_quit(self):
 

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -259,15 +259,33 @@ class MidiOutputTest(unittest.TestCase):
 
         self.fail()
 
-    def todo_test_pitch_bend(self):
-        pass
+    def test_pitch_bend(self):
         # FIXME : pitch_bend in the code, but not in documentation
+        if not self.midi_output:
+           self.skipTest('No midi device')
 
-    def todo_test_close(self):
-        pass
+        out = self.midi_output
+        with self.assertRaises(ValueError) as cm:
+            out.pitch_bend(5, channel=-1)
+        self.assertEqual(str(cm.exception), "Channel not between 0 and 15.")
+        with self.assertRaises(ValueError) as cm:
+            out.pitch_bend(5, channel=16)
+        with self.assertRaises(ValueError) as cm:
+            out.pitch_bend(-10001, 1)
+        self.assertEqual(str(cm.exception), "Pitch bend value must be between "
+                                            "-8192 and +8191, not -10001.")
+        with self.assertRaises(ValueError) as cm:
+            out.pitch_bend(10665, 2)
 
-    def todo_test_abort(self):
-        pass
+    def test_close(self):
+        self.assertIsNotNone(self.midi_output._output)
+        self.midi_output.close()
+        self.assertIsNone(self.midi_output._output)
+
+    def test_abort(self):
+        self.assertEqual(self.midi_output._aborted, 0)
+        self.midi_output.abort()
+        self.assertEqual(self.midi_output._aborted, 1)
 
 
 class MidiModuleTest(MidiTestBase):

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -9,13 +9,35 @@ import pygame.compat
 from pygame.locals import *
 
 
-class MidiTest(unittest.TestCase):
+class MidiTestBase(unittest.TestCase):
+    """Base class for Midi tests."""
 
     def setUp(self):
         pygame.midi.init()
 
     def tearDown(self):
         pygame.midi.quit()
+
+
+class MidiInputTest(MidiTestBase):
+
+    def test_Input(self):
+        """|tags: interactive|
+        """
+
+        i = pygame.midi.get_default_input_id()
+        if i != -1:
+            _inp = pygame.midi.Input(i)
+
+        # try feeding it an input id.
+        i = pygame.midi.get_default_output_id()
+
+        # can handle some invalid input too.
+        self.assertRaises(pygame.midi.MidiException, pygame.midi.Input, i)
+        self.assertRaises(pygame.midi.MidiException, pygame.midi.Input, 9009)
+        self.assertRaises(pygame.midi.MidiException, pygame.midi.Input, -1)
+        self.assertRaises(TypeError, pygame.midi.Input, "1234")
+        self.assertRaises(OverflowError, pygame.midi.Input, pow(2, 99))
 
     def todo_test_poll(self):
 
@@ -25,7 +47,6 @@ class MidiTest(unittest.TestCase):
           # Input.poll(): return Bool
           #
           # raises a MidiException on error.
-
         self.fail()
 
     def todo_test_read(self):
@@ -41,14 +62,25 @@ class MidiTest(unittest.TestCase):
 
         self.fail()
 
-    def test_MidiException(self):
 
-        def raiseit():
-            raise pygame.midi.MidiException('Hello Midi param')
+class MidiOutputTest(MidiTestBase):
 
-        with self.assertRaises(pygame.midi.MidiException) as cm:
-            raiseit()
-        self.assertEqual(cm.exception.parameter, 'Hello Midi param')
+    def test_Output(self):
+        """|tags: interactive|
+        """
+        i = pygame.midi.get_default_output_id()
+        if i != -1:
+            _out = pygame.midi.Output(i)
+
+        # try feeding it an input id.
+        i = pygame.midi.get_default_input_id()
+
+        # can handle some invalid input too.
+        self.assertRaises(pygame.midi.MidiException, pygame.midi.Output, i)
+        self.assertRaises(pygame.midi.MidiException, pygame.midi.Output, 9009)
+        self.assertRaises(pygame.midi.MidiException, pygame.midi.Output, -1)
+        self.assertRaises(TypeError, pygame.midi.Output,"1234")
+        self.assertRaises(OverflowError, pygame.midi.Output, pow(2,99))
 
     def test_note_off(self):
         """|tags: interactive|
@@ -157,45 +189,6 @@ class MidiTest(unittest.TestCase):
             out.write_short(0x80, 65, 100)
             out.write_short(0x90)
 
-    def test_Input(self):
-        """|tags: interactive|
-        """
-
-        i = pygame.midi.get_default_input_id()
-        if i != -1:
-            o = pygame.midi.Input(i)
-            del o
-
-        # try feeding it an input id.
-        i = pygame.midi.get_default_output_id()
-
-        # can handle some invalid input too.
-        self.assertRaises(pygame.midi.MidiException, pygame.midi.Input, i)
-        self.assertRaises(pygame.midi.MidiException, pygame.midi.Input, 9009)
-        self.assertRaises(pygame.midi.MidiException, pygame.midi.Input, -1)
-        self.assertRaises(TypeError, pygame.midi.Input,"1234")
-        self.assertRaises(OverflowError, pygame.midi.Input, pow(2,99))
-
-
-    def test_Output(self):
-        """|tags: interactive|
-        """
-        i = pygame.midi.get_default_output_id()
-        if i != -1:
-            o = pygame.midi.Output(i)
-            del o
-
-        # try feeding it an input id.
-        i = pygame.midi.get_default_input_id()
-
-        # can handle some invalid input too.
-        self.assertRaises(pygame.midi.MidiException, pygame.midi.Output, i)
-        self.assertRaises(pygame.midi.MidiException, pygame.midi.Output, 9009)
-        self.assertRaises(pygame.midi.MidiException, pygame.midi.Output, -1)
-        self.assertRaises(TypeError, pygame.midi.Output,"1234")
-        self.assertRaises(OverflowError, pygame.midi.Output, pow(2,99))
-
-
     def todo_test_write_sys_ex(self):
 
         # __doc__ (as of 2009-05-19) for pygame.midi.Output.write_sys_ex:
@@ -215,6 +208,17 @@ class MidiTest(unittest.TestCase):
 
         self.fail()
 
+
+class MidiModuleTest(MidiTestBase):
+
+    def test_MidiException(self):
+
+        def raiseit():
+            raise pygame.midi.MidiException('Hello Midi param')
+
+        with self.assertRaises(pygame.midi.MidiException) as cm:
+            raiseit()
+        self.assertEqual(cm.exception.parameter, 'Hello Midi param')
 
     def test_get_count(self):
         c = pygame.midi.get_count()

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -115,10 +115,10 @@ class MidiOutputTest(MidiTestBase):
             out.note_off(5, 30, 0)
             with self.assertRaises(ValueError) as cm:
                 out.note_off(5, 30, 25)
-            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            self.assertEqual(str(cm.exception), "Channel not between 0 and 15.")
             with self.assertRaises(ValueError) as cm:
                 out.note_off(5, 30, -1)
-            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            self.assertEqual(str(cm.exception), "Channel not between 0 and 15.")
 
     def test_note_on(self):
         """|tags: interactive|
@@ -138,10 +138,10 @@ class MidiOutputTest(MidiTestBase):
             out.note_on(5, 42, 10)
             with self.assertRaises(ValueError) as cm:
                 out.note_on(5, 30, 25)
-            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            self.assertEqual(str(cm.exception), "Channel not between 0 and 15.")
             with self.assertRaises(ValueError) as cm:
                 out.note_on(5, 30, -1)
-            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            self.assertEqual(str(cm.exception), "Channel not between 0 and 15.")
 
     def test_set_instrument(self):
 
@@ -196,11 +196,11 @@ class MidiOutputTest(MidiTestBase):
         with self.assertRaises(TypeError) as cm:
             out.write('Non sens ?')
         error_msg = "unsupported operand type(s) for &: 'str' and 'int'"
-        self.assertEqual(cm.exception.message, error_msg)
+        self.assertEqual(str(cm.exception), error_msg)
 
         with self.assertRaises(TypeError) as cm:
             out.write(["Hey what's that?"])
-        self.assertEqual(cm.exception.message, error_msg)
+        self.assertEqual(str(cm.exception), error_msg)
 
     def test_write_short(self):
         """|tags: interactive|

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -110,6 +110,12 @@ class MidiOutputTest(MidiTestBase):
             out = pygame.midi.Output(m_id)
             out.note_on(5, 30, 0)
             out.note_off(5, 30, 0)
+            with self.assertRaises(ValueError) as cm:
+                out.note_off(5, 30, 25)
+            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            with self.assertRaises(ValueError) as cm:
+                out.note_off(5, 30, -1)
+            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
 
     def test_note_on(self):
         """|tags: interactive|
@@ -126,6 +132,12 @@ class MidiOutputTest(MidiTestBase):
         if m_id != -1:
             out = pygame.midi.Output(m_id)
             out.note_on(5, 30, 0)
+            with self.assertRaises(ValueError) as cm:
+                out.note_on(5, 30, 25)
+            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
+            with self.assertRaises(ValueError) as cm:
+                out.note_on(5, 30, -1)
+            self.assertEqual(cm.exception.message, "Channel not between 0 and 15.")
 
     def todo_test_set_instrument(self):
 

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -9,7 +9,13 @@ import pygame.compat
 from pygame.locals import *
 
 
-class MidiTest( unittest.TestCase ):
+class MidiTest(unittest.TestCase):
+
+    def setUp(self):
+        pygame.midi.init()
+
+    def tearDown(self):
+        pygame.midi.quit()
 
     def todo_test_poll(self):
 
@@ -143,13 +149,13 @@ class MidiTest( unittest.TestCase ):
 
         i = pygame.midi.get_default_output_id()
         if i != -1:
-            o = pygame.midi.Output(i)
+            out = pygame.midi.Output(i)
+            # program change
+            out.write_short(0xc0)
             # put a note on, then off.
-            o.write_short(0x90,65,100)
-            o.write_short(0x80,65,100)
-
-
-
+            out.write_short(0x90, 65, 100)
+            out.write_short(0x80, 65, 100)
+            out.write_short(0x90)
 
     def test_Input(self):
         """|tags: interactive|
@@ -210,12 +216,6 @@ class MidiTest( unittest.TestCase ):
         self.fail()
 
 
-    def tearDown(self):
-        pygame.midi.quit()
-
-    def setUp(self):
-        pygame.midi.init()
-
     def test_get_count(self):
         c = pygame.midi.get_count()
         self.assertIsInstance(c, int)
@@ -274,6 +274,8 @@ class MidiTest( unittest.TestCase ):
         # if there is a not None return make sure it is an int.
         self.assertIsInstance(c, int)
         self.assertTrue(c >= -1)
+        pygame.midi.quit()
+        self.assertRaises(RuntimeError, pygame.midi.get_default_output_id)
 
     def test_get_default_output_id(self):
 
@@ -327,6 +329,8 @@ class MidiTest( unittest.TestCase ):
         c = pygame.midi.get_default_output_id()
         self.assertIsInstance(c, int)
         self.assertTrue(c >= -1)
+        pygame.midi.quit()
+        self.assertRaises(RuntimeError, pygame.midi.get_default_output_id)
 
     def test_get_device_info(self):
 
@@ -350,10 +354,7 @@ class MidiTest( unittest.TestCase ):
         if an_in_id != -1:
             r = pygame.midi.get_device_info(an_in_id)
             # if r is None, it means that the id is out of range.
-            try:
-                interf, name, input, output, opened = r
-            except TypeError:
-                raise Exception(repr(r))
+            interf, name, input, output, opened = r
 
             self.assertEqual(output, 0)
             self.assertEqual(input, 1)
@@ -417,10 +418,10 @@ class MidiTest( unittest.TestCase ):
           # returns the current time in ms of the PortMidi timer
           # pygame.midi.time(): return time
 
-        t = pygame.midi.time()
-        self.assertIsInstance(c, int)
+        mtime = pygame.midi.time()
+        self.assertIsInstance(mtime, int)
         # should be close to 2-3... since the timer is just init'd.
-        self.assertTrue(0 <= t < 100)
+        self.assertTrue(0 <= mtime < 100)
 
 
 if __name__ == '__main__':

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -37,18 +37,12 @@ class MidiTest( unittest.TestCase ):
 
     def test_MidiException(self):
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.MidiException.message:
-
         def raiseit():
-            raise pygame.midi.MidiException(0)
+            raise pygame.midi.MidiException('Hello Midi param')
 
-        self.assertRaises(pygame.midi.MidiException, raiseit)
-        try:
-            raise pygame.midi.MidiException(0)
-        except pygame.midi.MidiException:
-            e = pygame.compat.geterror()
-            self.assertEqual(e.parameter, 0)
-
+        with self.assertRaises(pygame.midi.MidiException) as cm:
+            raiseit()
+        self.assertEqual(cm.exception.parameter, 'Hello Midi param')
 
     def test_note_off(self):
         """|tags: interactive|
@@ -62,16 +56,16 @@ class MidiTest( unittest.TestCase ):
           # Turn a note off in the output stream.  The note must already
           # be on for this to work correctly.
 
-        i = pygame.midi.get_default_output_id()
-        if i != -1:
-            o = pygame.midi.Output(i)
-            o.note_on(5, 30, 0)
-            o.note_off(5, 30, 0)
+
+        m_id = pygame.midi.get_default_output_id()
+        if m_id != -1:
+            out = pygame.midi.Output(m_id)
+            out.note_on(5, 30, 0)
+            out.note_off(5, 30, 0)
 
     def test_note_on(self):
         """|tags: interactive|
         """
-
         # __doc__ (as of 2009-05-19) for pygame.midi.Output.note_on:
 
           # turns a midi note on.  Note must be off.
@@ -80,12 +74,10 @@ class MidiTest( unittest.TestCase ):
           # Turn a note on in the output stream.  The note must already
           # be off for this to work correctly.
 
-
-        i = pygame.midi.get_default_output_id()
-        if i != -1:
-            o = pygame.midi.Output(i)
-            o.note_on(5, 30, 0)
-
+        m_id = pygame.midi.get_default_output_id()
+        if m_id != -1:
+            out = pygame.midi.Output(m_id)
+            out.note_on(5, 30, 0)
 
     def todo_test_set_instrument(self):
 
@@ -225,20 +217,9 @@ class MidiTest( unittest.TestCase ):
         pygame.midi.init()
 
     def test_get_count(self):
-
-        # __doc__ (as of 2009-05-19) for pygame.midi.get_count:
-
-          # gets the number of devices.
-          # pygame.midi.get_count(): return num_devices
-          #
-          #
-          # Device ids range from 0 to get_count() -1
-
         c = pygame.midi.get_count()
-        self.assertEqual(type(c), type(1))
-        self.failUnless(c >= 0)
-
-
+        self.assertIsInstance(c, int)
+        self.assertTrue(c >= 0)
 
     def test_get_default_input_id(self):
 
@@ -291,10 +272,8 @@ class MidiTest( unittest.TestCase ):
 
         c = pygame.midi.get_default_input_id()
         # if there is a not None return make sure it is an int.
-        self.assertEqual(type(c), type(1))
-        self.failUnless(c >= 0 or c == -1)
-
-
+        self.assertIsInstance(c, int)
+        self.assertTrue(c >= -1)
 
     def test_get_default_output_id(self):
 
@@ -346,11 +325,8 @@ class MidiTest( unittest.TestCase ):
           #     (the input or output device with the lowest PmDeviceID).
 
         c = pygame.midi.get_default_output_id()
-        self.assertEqual(type(c), type(1))
-        self.failUnless(c >= 0 or c == -1)
-
-
-
+        self.assertIsInstance(c, int)
+        self.assertTrue(c >= -1)
 
     def test_get_device_info(self):
 
@@ -366,14 +342,9 @@ class MidiTest( unittest.TestCase ):
         an_id = pygame.midi.get_default_output_id()
         if an_id != -1:
             interf, name, input, output, opened = pygame.midi.get_device_info(an_id)
-            #print interf
-            #print name
-            #print input, output, opened
-
             self.assertEqual(output, 1)
             self.assertEqual(input, 0)
             self.assertEqual(opened, 0)
-
 
         an_in_id = pygame.midi.get_default_input_id()
         if an_in_id != -1:
@@ -387,11 +358,6 @@ class MidiTest( unittest.TestCase ):
             self.assertEqual(output, 0)
             self.assertEqual(input, 1)
             self.assertEqual(opened, 0)
-
-
-
-
-
 
     def test_init(self):
 
@@ -410,8 +376,6 @@ class MidiTest( unittest.TestCase ):
         pygame.midi.init()
         pygame.midi.init()
         pygame.midi.init()
-
-
 
     def todo_test_midis2events(self):
 
@@ -437,7 +401,7 @@ class MidiTest( unittest.TestCase ):
           # It is safe to call this function more than once.
 
 
-          # It is safe to call this more than once.
+         # It is safe to call this more than once.
         pygame.midi.quit()
         pygame.midi.init()
         pygame.midi.quit()
@@ -454,10 +418,9 @@ class MidiTest( unittest.TestCase ):
           # pygame.midi.time(): return time
 
         t = pygame.midi.time()
-        self.assertEqual(type(t), type(1))
+        self.assertIsInstance(c, int)
         # should be close to 2-3... since the timer is just init'd.
-        self.failUnless(t >= 0 and t < 100)
-
+        self.assertTrue(0 <= t < 100)
 
 
 if __name__ == '__main__':

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -270,10 +270,10 @@ class MidiTest(unittest.TestCase):
           # Note: in the current release, the default is simply the first device
           #     (the input or output device with the lowest PmDeviceID).
 
-        c = pygame.midi.get_default_input_id()
+        midin_id = pygame.midi.get_default_input_id()
         # if there is a not None return make sure it is an int.
-        self.assertIsInstance(c, int)
-        self.assertTrue(c >= -1)
+        self.assertIsInstance(midin_id, int)
+        self.assertTrue(midin_id >= -1)
         pygame.midi.quit()
         self.assertRaises(RuntimeError, pygame.midi.get_default_output_id)
 
@@ -359,6 +359,11 @@ class MidiTest(unittest.TestCase):
             self.assertEqual(output, 0)
             self.assertEqual(input, 1)
             self.assertEqual(opened, 0)
+        out_of_range = pygame.midi.get_count()
+        for num in range(out_of_range):
+            self.assertIsNotNone(pygame.midi.get_device_info(num))
+        info = pygame.midi.get_device_info(out_of_range)
+        self.assertIsNone(info)
 
     def test_init(self):
 

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -44,13 +44,6 @@ class MidiInputTest(unittest.TestCase):
 
     def test_poll(self):
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.Input.poll:
-
-          # returns true if there's data, or false if not.
-          # Input.poll(): return Bool
-          #
-          # raises a MidiException on error.
-
         if not self.midi_input:
            self.skipTest('No midi Input device')
 
@@ -63,15 +56,6 @@ class MidiInputTest(unittest.TestCase):
         self.midi_input = None
 
     def test_read(self):
-
-        # __doc__ (as of 2009-05-19) for pygame.midi.Input.read:
-
-          # reads num_events midi events from the buffer.
-          # Input.read(num_events): return midi_event_list
-          #
-          # Reads from the Input buffer and gives back midi events.
-          # [[[status,data1,data2,data3],timestamp],
-          #  [[status,data1,data2,data3],timestamp],...]
 
         if not self.midi_input:
            self.skipTest('No midi Input device')
@@ -130,14 +114,6 @@ class MidiOutputTest(unittest.TestCase):
         """|tags: interactive|
         """
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.Output.note_off:
-
-          # turns a midi note off.  Note must be on.
-          # Output.note_off(note, velocity=None, channel = 0)
-          #
-          # Turn a note off in the output stream.  The note must already
-          # be on for this to work correctly.
-
         if self.midi_output:
             out = self.midi_output
             out.note_on(5, 30, 0)
@@ -152,13 +128,6 @@ class MidiOutputTest(unittest.TestCase):
     def test_note_on(self):
         """|tags: interactive|
         """
-        # __doc__ (as of 2009-05-19) for pygame.midi.Output.note_on:
-
-          # turns a midi note on.  Note must be off.
-          # Output.note_on(note, velocity=None, channel = 0)
-          #
-          # Turn a note on in the output stream.  The note must already
-          # be off for this to work correctly.
 
         if self.midi_output:
             out = self.midi_output
@@ -172,11 +141,6 @@ class MidiOutputTest(unittest.TestCase):
             self.assertEqual(str(cm.exception), "Channel not between 0 and 15.")
 
     def test_set_instrument(self):
-
-        # __doc__ (as of 2009-05-19) for pygame.midi.Output.set_instrument:
-
-          # Select an instrument, with a value between 0 and 127.
-          # Output.set_instrument(instrument_id, channel = 0)
 
         if not self.midi_output:
            self.skipTest('No midi device')
@@ -231,22 +195,6 @@ class MidiOutputTest(unittest.TestCase):
     def test_write_short(self):
         """|tags: interactive|
         """
-        # __doc__ (as of 2009-05-19) for pygame.midi.Output.write_short:
-
-          # write_short(status <, data1><, data2>)
-          # Output.write_short(status)
-          # Output.write_short(status, data1 = 0, data2 = 0)
-          #
-          # output MIDI information of 3 bytes or less.
-          # data fields are optional
-          # status byte could be:
-          #      0xc0 = program change
-          #      0x90 = note on
-          #      etc.
-          #      data bytes are optional and assumed 0 if omitted
-          # example: note 65 on with velocity 100
-          #      write_short(0x90,65,100)
-
         if not self.midi_output:
            self.skipTest('No midi device')
 
@@ -323,53 +271,6 @@ class MidiModuleTest(unittest.TestCase):
 
     def test_get_default_input_id(self):
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.get_default_input_device_id:
-
-          # gets the device number of the default input device.
-          # pygame.midi.get_default_input_device_id(): return default_id
-          #
-          #
-          # Return the default device ID or -1 if there are no devices.
-          # The result can be passed to the Input()/Ouput() class.
-          #
-          # On the PC, the user can specify a default device by
-          # setting an environment variable. For example, to use device #1.
-          #
-          #     set PM_RECOMMENDED_INPUT_DEVICE=1
-          #
-          # The user should first determine the available device ID by using
-          # the supplied application "testin" or "testout".
-          #
-          # In general, the registry is a better place for this kind of info,
-          # and with USB devices that can come and go, using integers is not
-          # very reliable for device identification. Under Windows, if
-          # PM_RECOMMENDED_OUTPUT_DEVICE (or PM_RECOMMENDED_INPUT_DEVICE) is
-          # *NOT* found in the environment, then the default device is obtained
-          # by looking for a string in the registry under:
-          #     HKEY_LOCAL_MACHINE/SOFTWARE/PortMidi/Recommended_Input_Device
-          # and HKEY_LOCAL_MACHINE/SOFTWARE/PortMidi/Recommended_Output_Device
-          # for a string. The number of the first device with a substring that
-          # matches the string exactly is returned. For example, if the string
-          # in the registry is "USB", and device 1 is named
-          # "In USB MidiSport 1x1", then that will be the default
-          # input because it contains the string "USB".
-          #
-          # In addition to the name, get_device_info() returns "interf", which
-          # is the interface name. (The "interface" is the underlying software
-          #     system or API used by PortMidi to access devices. Examples are
-          #     MMSystem, DirectX (not implemented), ALSA, OSS (not implemented), etc.)
-          #     At present, the only Win32 interface is "MMSystem", the only Linux
-          #     interface is "ALSA", and the only Max OS X interface is "CoreMIDI".
-          # To specify both the interface and the device name in the registry,
-          # separate the two with a comma and a space, e.g.:
-          #     MMSystem, In USB MidiSport 1x1
-          # In this case, the string before the comma must be a substring of
-          # the "interf" string, and the string after the space must be a
-          # substring of the "name" name string in order to match the device.
-          #
-          # Note: in the current release, the default is simply the first device
-          #     (the input or output device with the lowest PmDeviceID).
-
         midin_id = pygame.midi.get_default_input_id()
         # if there is a not None return make sure it is an int.
         self.assertIsInstance(midin_id, int)
@@ -379,53 +280,6 @@ class MidiModuleTest(unittest.TestCase):
 
     def test_get_default_output_id(self):
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.get_default_output_device_id:
-
-          # get the device number of the default output device.
-          # pygame.midi.get_default_output_device_id(): return default_id
-          #
-          #
-          # Return the default device ID or -1 if there are no devices.
-          # The result can be passed to the Input()/Ouput() class.
-          #
-          # On the PC, the user can specify a default device by
-          # setting an environment variable. For example, to use device #1.
-          #
-          #     set PM_RECOMMENDED_OUTPUT_DEVICE=1
-          #
-          # The user should first determine the available device ID by using
-          # the supplied application "testin" or "testout".
-          #
-          # In general, the registry is a better place for this kind of info,
-          # and with USB devices that can come and go, using integers is not
-          # very reliable for device identification. Under Windows, if
-          # PM_RECOMMENDED_OUTPUT_DEVICE (or PM_RECOMMENDED_INPUT_DEVICE) is
-          # *NOT* found in the environment, then the default device is obtained
-          # by looking for a string in the registry under:
-          #     HKEY_LOCAL_MACHINE/SOFTWARE/PortMidi/Recommended_Input_Device
-          # and HKEY_LOCAL_MACHINE/SOFTWARE/PortMidi/Recommended_Output_Device
-          # for a string. The number of the first device with a substring that
-          # matches the string exactly is returned. For example, if the string
-          # in the registry is "USB", and device 1 is named
-          # "In USB MidiSport 1x1", then that will be the default
-          # input because it contains the string "USB".
-          #
-          # In addition to the name, get_device_info() returns "interf", which
-          # is the interface name. (The "interface" is the underlying software
-          #     system or API used by PortMidi to access devices. Examples are
-          #     MMSystem, DirectX (not implemented), ALSA, OSS (not implemented), etc.)
-          #     At present, the only Win32 interface is "MMSystem", the only Linux
-          #     interface is "ALSA", and the only Max OS X interface is "CoreMIDI".
-          # To specify both the interface and the device name in the registry,
-          # separate the two with a comma and a space, e.g.:
-          #     MMSystem, In USB MidiSport 1x1
-          # In this case, the string before the comma must be a substring of
-          # the "interf" string, and the string after the space must be a
-          # substring of the "name" name string in order to match the device.
-          #
-          # Note: in the current release, the default is simply the first device
-          #     (the input or output device with the lowest PmDeviceID).
-
         c = pygame.midi.get_default_output_id()
         self.assertIsInstance(c, int)
         self.assertTrue(c >= -1)
@@ -433,15 +287,6 @@ class MidiModuleTest(unittest.TestCase):
         self.assertRaises(RuntimeError, pygame.midi.get_default_output_id)
 
     def test_get_device_info(self):
-
-        # __doc__ (as of 2009-05-19) for pygame.midi.get_device_info:
-
-          # returns (interf, name, input, output, opened)
-          # pygame.midi.get_device_info(an_id): return (interf, name, input,
-          # output, opened)
-          #
-          #
-          # If the id is out of range, the function returns None.
 
         an_id = pygame.midi.get_default_output_id()
         if an_id != -1:
@@ -467,14 +312,6 @@ class MidiModuleTest(unittest.TestCase):
 
     def test_init(self):
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.init:
-
-          # initialize the midi module
-          # pygame.midi.init(): return None
-          #
-          # Call the initialisation function before using the midi module.
-          #
-          # It is safe to call this more than once.
         pygame.midi.quit()
         self.assertRaises(RuntimeError, pygame.midi.get_count)
         # initialising many times should be fine.
@@ -484,13 +321,6 @@ class MidiModuleTest(unittest.TestCase):
         pygame.midi.init()
 
     def test_midis2events(self):
-
-        # __doc__ (as of 2009-05-19) for pygame.midi.midis2events:
-
-          # converts midi events to pygame events
-          # pygame.midi.midis2events(midis, device_id): return [Event, ...]
-          #
-          # Takes a sequence of midi events and returns list of pygame events.
 
         midi_data = ([[0xc0, 0, 1, 2], 20000],
                      [[0x90, 60, 100, 'blablabla'], 20000]
@@ -511,17 +341,6 @@ class MidiModuleTest(unittest.TestCase):
 
     def test_quit(self):
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.quit:
-
-          # uninitialize the midi module
-          # pygame.midi.quit(): return None
-          #
-          #
-          # Called automatically atexit if you don't call it.
-          #
-          # It is safe to call this function more than once.
-
-
          # It is safe to call this more than once.
         pygame.midi.quit()
         pygame.midi.init()
@@ -532,11 +351,6 @@ class MidiModuleTest(unittest.TestCase):
         pygame.midi.quit()
 
     def test_time(self):
-
-        # __doc__ (as of 2009-05-19) for pygame.midi.time:
-
-          # returns the current time in ms of the PortMidi timer
-          # pygame.midi.time(): return time
 
         mtime = pygame.midi.time()
         self.assertIsInstance(mtime, int)

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -258,24 +258,13 @@ class MidiOutputTest(unittest.TestCase):
         out.write_short(0x80, 65, 100)
         out.write_short(0x90)
 
-    def todo_test_write_sys_ex(self):
+    def test_write_sys_ex(self):
+        if not self.midi_output:
+           self.skipTest('No midi device')
 
-        # __doc__ (as of 2009-05-19) for pygame.midi.Output.write_sys_ex:
-
-          # writes a timestamped system-exclusive midi message.
-          # Output.write_sys_ex(when, msg)
-          #
-          # write_sys_ex(<timestamp>,<msg>)
-          #
-          # msg - can be a *list* or a *string*
-          # example:
-          #   (assuming o is an onput MIDI stream)
-          #     o.write_sys_ex(0,'\xF0\x7D\x10\x11\x12\x13\xF7')
-          #   is equivalent to
-          #     o.write_sys_ex(pygame.midi.Time,
-          #                    [0xF0,0x7D,0x10,0x11,0x12,0x13,0xF7])
-
-        self.fail()
+        out = self.midi_output
+        out.write_sys_ex(pygame.midi.time(),
+                         [0xF0, 0x7D, 0x10, 0x11, 0x12, 0x13, 0xF7])
 
     def test_pitch_bend(self):
         # FIXME : pitch_bend in the code, but not in documentation

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -39,7 +39,7 @@ class MidiInputTest(MidiTestBase):
         self.assertRaises(TypeError, pygame.midi.Input, "1234")
         self.assertRaises(OverflowError, pygame.midi.Input, pow(2, 99))
 
-    def todo_test_poll(self):
+    def test_poll(self):
 
         # __doc__ (as of 2009-05-19) for pygame.midi.Input.poll:
 
@@ -47,9 +47,15 @@ class MidiInputTest(MidiTestBase):
           # Input.poll(): return Bool
           #
           # raises a MidiException on error.
-        self.fail()
+        in_id = pygame.midi.get_default_input_id()
+        if in_id != -1:
+            midi_in = pygame.midi.Input(in_id)
+            self.assertFalse(midi_in.poll())
+            # TODO fake some incoming data
+            pygame.midi.quit()
+            self.assertRaises(RuntimeError, midi_in.poll)
 
-    def todo_test_read(self):
+    def test_read(self):
 
         # __doc__ (as of 2009-05-19) for pygame.midi.Input.read:
 
@@ -59,8 +65,12 @@ class MidiInputTest(MidiTestBase):
           # Reads from the Input buffer and gives back midi events.
           # [[[status,data1,data2,data3],timestamp],
           #  [[status,data1,data2,data3],timestamp],...]
-
-        self.fail()
+        in_id = pygame.midi.get_default_input_id()
+        if in_id != -1:
+            midi_in = pygame.midi.Input(in_id)
+            read = midi_in.read(5)
+            self.assertEqual(read, [])
+            # TODO fake some  incoming data
 
 
 class MidiOutputTest(MidiTestBase):


### PR DESCRIPTION
Hi, many new tests for midi: 

* the PR is a bit noisy, since I created two more test case classes **MidiInputTest** and **MidiOutputTest**, moving code around
* add a lot of tests (no more `def todo_test_sth` left)
* tried to get rid of the `Exception: b"PortMidi: Invalid MIDI message Data'"` messages during test run with *setUp* and *tearDown* (worked only partially)
* cleanup using **Python >= 2.7**
* also, I removed the `__doc__ as of 2009 ...` docstrings (noisy last commit to be possibly reverted)

I do not understand so much midi, and specially not understanding `midi.midis2events`  ...

Note: I also tested `pg.midi.Output.pitch_bend` while going through source code, but it is not mentionned in https://www.pygame.org/docs/ref/midi.html ; ommitted or intended ?