### PR TITLE
Update unit tests draw.ellipse, add unit tests draw.(aa)line(s)

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1,8 +1,13 @@
 import unittest
-from pygame.tests import test_utils
+
 import pygame
 from pygame import draw
 from pygame.locals import SRCALPHA
+
+if is_pygame_pkg:
+    from pygame.tests import test_utils
+else:
+    from test import test_utils
 
 
 def get_border_values(surface, width, height):
@@ -46,7 +51,7 @@ def lines_set_up():
     colors = [
             (0, 0, 0), (255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0),
             (255, 0, 255), (0, 255, 255), (255, 255, 255)]
-        
+
     # Create each possible surface type
     surface_default = pygame.display.set_mode((50, 50))
     surface_default_SRCALPHA = pygame.Surface((50, 50), SRCALPHA)
@@ -89,17 +94,17 @@ class DrawModuleTest(unittest.TestCase):
 
         self.assert_(drawn == rect)
 
-        #Should be colored where it's supposed to be
+        # Should be colored where it's supposed to be
         for pt in test_utils.rect_area_pts(rect):
             color_at_pt = self.surf.get_at(pt)
             self.assert_(color_at_pt == self.color)
 
-        #And not where it shouldn't
+        # And not where it shouldn't
         for pt in test_utils.rect_outer_bounds(rect):
             color_at_pt = self.surf.get_at(pt)
             self.assert_(color_at_pt != self.color)
 
-        #Issue #310: Cannot draw rectangles that are 1 pixel high
+        # Issue #310: Cannot draw rectangles that are 1 pixel high
         bgcolor = pygame.Color('black')
         self.surf.fill(bgcolor)
         hrect = pygame.Rect(1, 1, self.surf_w - 2, 1)
@@ -131,12 +136,12 @@ class DrawModuleTest(unittest.TestCase):
         drawn = draw.rect(self.surf, self.color, rect, 1)
         self.assert_(drawn == rect)
 
-        #Should be colored where it's supposed to be
+        # Should be colored where it's supposed to be
         for pt in test_utils.rect_perimeter_pts(drawn):
             color_at_pt = self.surf.get_at(pt)
             self.assert_(color_at_pt == self.color)
 
-        #And not where it shouldn't
+        # And not where it shouldn't
         for pt in test_utils.rect_outer_bounds(drawn):
             color_at_pt = self.surf.get_at(pt)
             self.assert_(color_at_pt != self.color)
@@ -148,20 +153,20 @@ class DrawModuleTest(unittest.TestCase):
           # pygame.draw.line(Surface, color, start_pos, end_pos, width=1): return Rect
           # draw a straight line segment
 
-        drawn = draw.line(self.surf, self.color, (1, 0), (200, 0)) #(l, t), (l, t)
+        # (l, t), (l, t)
+        drawn = draw.line(self.surf, self.color, (1, 0), (200, 0))
         self.assert_(drawn.right == 201,
-            "end point arg should be (or at least was) inclusive"
-        )
+                     "end point arg should be (or at least was) inclusive")
 
-        #Should be colored where it's supposed to be
+        # Should be colored where it's supposed to be
         for pt in test_utils.rect_area_pts(drawn):
             self.assert_(self.surf.get_at(pt) == self.color)
 
-        #And not where it shouldn't
+        # And not where it shouldn't
         for pt in test_utils.rect_outer_bounds(drawn):
             self.assert_(self.surf.get_at(pt) != self.color)
 
-        #Line width greater that 1
+        # Line width greater that 1
         line_width = 2
         offset = 5
         a = (offset, offset)
@@ -235,7 +240,7 @@ class DrawModuleTest(unittest.TestCase):
           #
 
         colors, surfaces = lines_set_up()
-        
+
         for surface in surfaces:
             for color in colors:
                 self.assertTrue(line_is_color(surface, color, "aaline"))
@@ -311,7 +316,7 @@ class DrawModuleTest(unittest.TestCase):
         left_top = [(0, 0), (1, 0), (0, 1), (1, 1)]
         sizes = [(5, 4)]
         color = (1, 13, 24, 255)
-    
+
         def get_border_values(surface, width, height):
             """
             Returns a list containing lists with the values of the surface's
@@ -333,7 +338,7 @@ class DrawModuleTest(unittest.TestCase):
             surface = pygame.Surface((width, height))
 
             draw.ellipse(
-                surface, color, (0, 0, height, width), border_width)            
+                surface, color, (0, 0, height, width), border_width)
 
             # For each of the four borders check if it contains the color
             borders = get_border_values(surface, width, height)

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -136,7 +136,7 @@ class DrawLineTest(unittest.TestCase):
 
             draw_line(surface, color, (0, 0), (width - 1, 0))
 
-            colors = [surface.get_at((width, 0)) for width in range(width)]
+            colors = [surface.get_at((x, 0)) for x in range(width)]
 
             return len(colors) == colors.count(color)
 
@@ -162,14 +162,14 @@ class DrawLineTest(unittest.TestCase):
             draw_lines(surface, color, True, points)
 
             borders = get_border_values(surface, width, height)
-            return [color in border for border in borders]
+            return [all(c == color for c in border) for border in borders]
 
         for draw_lines in [draw.lines, draw.aalines]:
             colors, surfaces = lines_set_up()
             for surface in surfaces:
                 for color in colors:
                     in_border = lines_are_color(surface, color, draw_lines)
-                    self.assertTrue(in_border.count(True) == 4)
+                    self.assertTrue(all(in_border))
 
     def test_lines_gaps(self):
         """|tags: ignore|
@@ -192,13 +192,13 @@ class DrawLineTest(unittest.TestCase):
             draw_lines(surface, color, True, points)
 
             borders = get_border_values(surface, width, height)
-            return [len(border) == border.count(color) for border in borders]
+            return [all(c == color for c in border) for border in borders]
 
         for draw_lines in [draw.lines, draw.aalines]:
             _, surfaces = lines_set_up()
             for surface in surfaces:
-                have_gaps = lines_have_gaps(surface, draw_lines)
-                self.assertTrue(have_gaps.count(True) == 4)
+                no_gaps = lines_have_gaps(surface, draw_lines)
+                self.assertTrue(all(no_gaps))
 
 
 class DrawModuleTest(unittest.TestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -9,8 +9,7 @@ from pygame.tests import test_utils
 
 
 def get_border_values(surface, width, height):
-    """
-    Returns a list containing lists with the values of the surface's
+    """Returns a list containing lists with the values of the surface's
     borders.
     """
     border_top = [surface.get_at((x, 0)) for x in range(width)]
@@ -28,30 +27,19 @@ class DrawEllipseTest(unittest.TestCase):
     Class for testing ellipse().
     """
     def test_ellipse(self):
-        """ |tags: ignore|
+        """|tags: ignore|
+
         Draws ellipses of differing sizes on surfaces of differing sizes and
         checks to see if the number of sides touching the border of the surface
         is correct.
         """
-        # __doc__ (as of 2008-08-02) for pygame.draw.ellipse:
-
-          # pygame.draw.ellipse(Surface, color, Rect, width=0): return Rect
-          # draw a round shape inside a rectangle
-          # 
-          # Draws an elliptical shape on the Surface. The given rectangle is the
-          # area that the circle will fill. The width argument is the thickness
-          # to draw the outer edge. If width is zero then the ellipse will be
-          # filled.
-          # 
 
         left_top = [(0, 0), (1, 0), (0, 1), (1, 1)]
         sizes = [(4, 4), (5, 4), (4, 5), (5, 5)]
         color = (1, 13, 24, 255)
 
         def same_size(width, height, border_width):
-            """
-            Test for ellipses with the same size as the surface.
-            """
+            """Test for ellipses with the same size as the surface."""
             surface = pygame.Surface((width, height))
 
             draw.ellipse(
@@ -63,9 +51,7 @@ class DrawEllipseTest(unittest.TestCase):
                 self.assertTrue(color in border)
 
         def not_same_size(width, height, border_width, left, top):
-            """
-            Test for ellipses that aren't the same size as the surface.
-            """
+            """Test for ellipses that aren't the same size as the surface."""
             surface = pygame.Surface((width, height))
 
             draw.ellipse(surface, color, (left, top, width - 1, height - 1),
@@ -85,225 +71,134 @@ class DrawEllipseTest(unittest.TestCase):
                     not_same_size(width, height, border_width, left, top)
 
 
-def lines_are_color(surface, color, line_type="lines"):
-    """
-    Draws (aa)lines around the border of the given surface and checks if all
-    borders of the surface only contain the given color.
-    """
-    width = surface.get_width()
-    height = surface.get_height()
-    points = [(0, 0), (width - 1, 0), (width - 1, height - 1), (0, height - 1)]
-
-    if line_type == "aalines":
-        draw.aalines(surface, color, True, points)
-    else:
-        draw.lines(surface, color, True, points)
-
-    borders = get_border_values(surface, width, height)
-    return [color in border for border in borders]
-
-
 def lines_set_up():
-    """
-    Returns the colors and surfaces needed in the tests for draw.line,
+    """Returns the colors and surfaces needed in the tests for draw.line,
     draw.aaline, draw.lines and draw.aalines.
     """
     colors = [
             (0, 0, 0), (255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0),
             (255, 0, 255), (0, 255, 255), (255, 255, 255)]
 
-    # Create each possible surface type
-    surface_default = pygame.display.set_mode((50, 50))
-    surface_default_SRCALPHA = pygame.Surface((50, 50), SRCALPHA)
-    surface_alpha = surface_default.convert_alpha()
-    surface_alpha_SRCALPHA = surface_default_SRCALPHA.convert_alpha()
+    sizes = [(49, 49), (50, 50)]
+    depths = [16, 32]
+    surfaces = []
+    for size in sizes:
+        for depth in depths:
+            # Create each possible surface type
+            surface_default = pygame.display.set_mode(size, 0, depth)
+            surface_default_SRCALPHA = pygame.Surface(size, SRCALPHA, depth)
+            surface_alpha = surface_default.convert_alpha()
+            surface_alpha_SRCALPHA = surface_default_SRCALPHA.convert_alpha()
 
-    surfaces = [surface_default, surface_alpha, surface_alpha_SRCALPHA,
-                surface_alpha_SRCALPHA]
+            surfaces.extend([surface_default, surface_alpha,
+                             surface_alpha_SRCALPHA, surface_alpha_SRCALPHA])
 
     return colors, surfaces
 
 
-def line_is_color(surface, color, line_type="line"):
-    """
-    Returns True if the line is drawn with the correct color on the
-    given surface.
-    """
-    if line_type == "aaline":
-        draw.aaline(surface, color, (0, 0), (1, 0))
-    else:
-        draw.line(surface, color, (0, 0), (1, 0))
-
-    return surface.get_at((0, 0)) == color
-
-
-def line_has_gaps(surface, line_type="line"):
-    """
-    Returns True if the line drawn on the surface contains gaps.
-    """
-    width = surface.get_width()
-    color = (255, 255, 255)
-
-    if line_type == "aaline":
-        draw.aaline(surface, color, (0, 0), (width - 1, 0))
-    else:
-        draw.line(surface, color, (0, 0), (width - 1, 0))
-
-    colors = [surface.get_at((width, 0)) for width in range(width)]
-
-    return len(colors) == colors.count(color)
-
-
-def lines_have_gaps(surface, line_type="lines"):
-    """
-    Draws (aa)lines around the border of the given surface and checks if all
-    borders of the surface contain any gaps.
-    """
-    width = surface.get_width()
-    height = surface.get_height()
-    color = (255, 255, 255)
-    points = [(0, 0), (width - 1, 0), (width - 1, height - 1), (0, height - 1)]
-
-    if line_type == "aalines":
-        draw.aalines(surface, color, True, points)
-    else:
-        draw.lines(surface, color, True, points)
-
-    borders = get_border_values(surface, width, height)
-    return [len(border) == border.count(color) for border in borders]
-
-
 class DrawLineTest(unittest.TestCase):
+    """Class for testing line(), aaline(), lines() and aalines().
     """
-    Class for testing line(), aaline(), lines() and aalines().
-    """
-    # __doc__ (as of 2008-06-25) for pygame.draw.line:
-
-      # pygame.draw.line(Surface, color, start_pos, end_pos, width=1): return Rect
-      # draw a straight line segment
-
-    # __doc__ (as of 2008-08-02) for pygame.draw.aaline:
-
-      # pygame.draw.aaline(Surface, color, startpos, endpos, blend=1): return Rect
-      # draw fine antialiased lines
-      # 
-      # Draws an anti-aliased line on a surface. This will respect the
-      # clipping rectangle. A bounding box of the affected area is returned
-      # returned as a rectangle. If blend is true, the shades will be be
-      # blended with existing pixel shades instead of overwriting them. This
-      # function accepts floating point values for the end points.
-
-    # __doc__ (as of 2008-08-02) for pygame.draw.lines:
-
-      # pygame.draw.lines(Surface, color, closed, pointlist, width=1): return Rect
-      # draw multiple contiguous line segments
-      # 
-      # Draw a sequence of lines on a Surface. The pointlist argument is a
-      # series of points that are connected by a line. If the closed
-      # argument is true an additional line segment is drawn between the
-      # first and last points.
-      # 
-      # This does not draw any endcaps or miter joints. Lines with sharp
-      # corners and wide line widths can have improper looking corners.
-
-    # __doc__ (as of 2008-08-02) for pygame.draw.aalines:
-
-      # pygame.draw.aalines(Surface, color, closed, pointlist, blend=1): return Rect
-      # 
-      # Draws a sequence on a surface. You must pass at least two points in
-      # the sequence of points. The closed argument is a simple boolean and
-      # if true, a line will be draw between the first and last points. The
-      # boolean blend argument set to true will blend the shades with
-      # existing shades instead of overwriting them. This function accepts
-      # floating point values for the end points.
 
     def test_line_color(self):
-        """
+        """|tags: ignore|
+
         Checks if the line drawn with line_is_color() is the correct color.
         """
 
-        colors, surfaces = lines_set_up()
+        def line_is_color(surface, color, draw_line):
+            """
+            Returns True if draw_line is drawn with the correct color on the
+            given surface.
+            """
+            draw_line(surface, color, (0, 0), (1, 0))
+            return surface.get_at((0, 0)) == color
 
-        for surface in surfaces:
-            for color in colors:
-                self.assertTrue(line_is_color(surface, color))
+        for draw_line in [draw.line, draw.aaline]:
+            colors, surfaces = lines_set_up()
+            for surface in surfaces:
+                for color in colors:
+                    self.assertTrue(line_is_color(surface, color, draw_line))
 
     def test_line_gaps(self):
-        """
-        Checks if the line drawn with line_has_gaps() contains any gaps.
-        """
-        sizes = [(49, 49), (50, 50)]
-        for size in sizes:
-            surface = pygame.Surface(size)
-            self.assertTrue(line_has_gaps(surface))
+        """|tags: ignore|
 
-    def test_aaline_color(self):
-        """ |tags: ignore|
-        Checks if the aaline drawn with line_is_color() is the correct color.
-        """
-        colors, surfaces = lines_set_up()
+        Tests if the line drawn with line_has_gaps() contains any gaps.
 
-        for surface in surfaces:
-            for color in colors:
-                self.assertTrue(line_is_color(surface, color, "aaline"))
-
-    def test_aaline_gaps(self):
-        """ |tags: ignore|
-        Checks if the aaline drawn with line_has_gaps() contains any gaps.
+        See: #512
         """
-        sizes = [(49, 49), (50, 50)]
-        for size in sizes:
-            surface = pygame.Surface(size)
-            self.assertTrue(line_has_gaps(surface, "aaline"))
+
+        def line_has_gaps(surface, draw_line):
+            """Returns True if the line drawn on the surface contains gaps.
+            """
+            width = surface.get_width()
+            color = (255, 255, 255)
+
+            draw_line(surface, color, (0, 0), (width - 1, 0))
+
+            colors = [surface.get_at((width, 0)) for width in range(width)]
+
+            return len(colors) == colors.count(color)
+
+        for draw_line in [draw.line, draw.aaline]:
+            _, surfaces = lines_set_up()
+            for surface in surfaces:
+                self.assertTrue(line_has_gaps(surface, draw_line))
 
     def test_lines_color(self):
-        """
-        Checks if the lines drawn with lines_are_color() are the correct color.
-        """
-        colors, surfaces = lines_set_up()
+        """|tags: ignore|
 
-        for surface in surfaces:
-            for color in colors:
-                in_border = lines_are_color(surface, color)
-                self.assertTrue(in_border.count(True) == 4)
+        Tests if the lines drawn with lines_are_color() are the correct color.
+        """
+        def lines_are_color(surface, color, draw_lines):
+            """Draws (aa)lines around the border of the given surface and
+            checks if all borders of the surface only contain the given color.
+            """
+            width = surface.get_width()
+            height = surface.get_height()
+            points = [(0, 0), (width - 1, 0), (width - 1, height - 1),
+                      (0, height - 1)]
+
+            draw_lines(surface, color, True, points)
+
+            borders = get_border_values(surface, width, height)
+            return [color in border for border in borders]
+
+        for draw_lines in [draw.lines, draw.aalines]:
+            colors, surfaces = lines_set_up()
+            for surface in surfaces:
+                for color in colors:
+                    in_border = lines_are_color(surface, color, draw_lines)
+                    self.assertTrue(in_border.count(True) == 4)
 
     def test_lines_gaps(self):
+        """|tags: ignore|
+
+        Tests if the lines drawn with lines_have_gaps() contain any gaps.
+
+        See: #512
         """
-        Checks if the lines drawn with lines_have_gaps() contain any gaps.
-        """
-        colors, surfaces = lines_set_up()
 
-        sizes = [(49, 49), (50, 50)]
-        for size in sizes:
-            surface = pygame.Surface(size)
-            have_gaps = lines_have_gaps(surface)
-            self.assertTrue(have_gaps.count(True) == 4)
+        def lines_have_gaps(surface, draw_lines):
+            """Draws (aa)lines around the border of the given surface and
+            checks if all borders of the surface contain any gaps.
+            """
+            width = surface.get_width()
+            height = surface.get_height()
+            color = (255, 255, 255)
+            points = [(0, 0), (width - 1, 0), (width - 1, height - 1),
+                      (0, height - 1)]
 
-    def test_aalines_color(self):
-        """ |tags: ignore|
-        Checks if the aalines drawn with lines_are_color() are the correct
-        color.
-        """
-        colors, surfaces = lines_set_up()
+            draw_lines(surface, color, True, points)
 
-        for surface in surfaces:
-            for color in colors:
-                in_border = lines_are_color(surface, color, "aalines")
-                self.assertTrue(in_border.count(True) == 4)
+            borders = get_border_values(surface, width, height)
+            return [len(border) == border.count(color) for border in borders]
 
-    def test_aalines_gaps(self):
-        """ |tags: ignore|
-        Checks if the lines drawn with lines_have_gaps() contain any gaps.
-        """
-        colors, surfaces = lines_set_up()
-
-        sizes = [(49, 49), (50, 50)]
-        for size in sizes:
-            surface = pygame.Surface(size)
-            have_gaps = lines_have_gaps(surface, "aalines")
-            self.assertTrue(have_gaps.count(True) == 4)
-
-################################################################################
+        for draw_lines in [draw.lines, draw.aalines]:
+            _, surfaces = lines_set_up()
+            for surface in surfaces:
+                have_gaps = lines_have_gaps(surface, draw_lines)
+                self.assertTrue(have_gaps.count(True) == 4)
 
 
 class DrawModuleTest(unittest.TestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -257,48 +257,61 @@ class DrawModuleTest(unittest.TestCase):
           # filled.
           #
 
-        sizes = [(4, 4), (5, 4), (4, 5), (5, 5)]
+        left_top = [(0, 0), (1, 0), (0, 1), (1, 1)]
+        sizes = [(5, 4)]
         color = (1, 13, 24, 255)
+<<<<<<< HEAD
+=======
+    
+        def get_border_values(surface, width, height):
+            """
+            Returns a list containing lists with the values of the surface's
+            borders.
+            """
+            border_top = [surface.get_at((x, 0)) for x in range(width)]
+            border_left = [surface.get_at((0, y)) for y in range(height)]
+            border_right = [
+                surface.get_at((width - 1, y)) for y in range(height)]
+            border_bottom = [
+                surface.get_at((x, height - 1)) for x in range(width)]
+
+            return [border_top, border_left, border_right, border_bottom]
+
+        def same_size(width, height, border_width):
+            """
+            Test for ellipses with the same size as the surface.
+            """
+            surface = pygame.Surface((width, height))
+
+            draw.ellipse(
+                surface, color, (0, 0, height, width), border_width)            
+
+            # For each of the four borders check if it contains the color
+            borders = get_border_values(surface, width, height)
+            for border in borders:
+                self.assertTrue(color in border)
+
+        def not_same_size(width, height, border_width, left, top):
+            """
+            Test for ellipses that aren't the same size as the surface.
+            """
+            surface = pygame.Surface((width, height))
+
+            draw.ellipse(surface, color, (left, top, width - 1, height - 1),
+                         border_width)
+
+            borders = get_border_values(surface, width, height)
+
+            # Check if two sides of the ellipse are touching the surface's border
+            sides_touching = [color in border for border in borders].count(True)
+            self.assertEqual(sides_touching, 2)
+>>>>>>> Update test_ellipse for ellipses not same size surface
 
         for width, height in sizes:
             for border_width in (0, 1):
-                surface = pygame.Surface((width, height))
-
-                draw.ellipse(
-                    surface, color, (0, 0, height, width), border_width)
-
-                # Get all positions of the surface's borders
-                border_top = []
-                border_left = []
-                border_right = []
-                border_bottom = []
-                for x in range(width):
-                    for y in range(height):
-                        try:
-                            surface.get_at((x, y - 1))
-                        except IndexError:
-                            border_top.append((x, y))
-
-                        try:
-                            surface.get_at((x - 1, y))
-                        except IndexError:
-                            border_left.append((x, y))
-
-                        try:
-                            surface.get_at((x + 1, y))
-                        except IndexError:
-                            border_right.append((x, y))
-
-                        try:
-                            surface.get_at((x, y + 1))
-                        except IndexError:
-                            border_bottom.append((x, y))
-
-                # For each of the four borders check if it contains the color
-                borders = [border_top, border_left, border_right, border_bottom]
-                for border in borders:
-                    colors = [surface.get_at(position) for position in border]
-                    self.assertTrue(color in colors)
+                same_size(width, height, border_width)
+                for left, top in left_top:
+                    not_same_size(width, height, border_width, left, top)
 
     def todo_test_lines(self):
 


### PR DESCRIPTION
This pull request contains the following:

### Ellipse

I updated the draw.ellipse unit test so that it now also includes a test that checks if at least two sides of an ellipse, that has a width and height that is 1 pixel smaller than the surface, is touching the surface's border.

It also cleans up the code slightly, including a better way of retrieving the border's values and adds reusability in the form of additional functions.

See: #233

### Lines

It also adds unit tests for draw.aaline, draw.line, draw.aalines and draw.lines.

For draw.aaline and draw.line it now draws a line of differing colours on all types of surfaces and checks if the colour stays the same at position (0, 0). There is also a test that checks if the line contains any gaps, as I noticed aaline(s) sometimes does (or is not drawn at all when close to a surface's border).

The same is done for draw.aalines and draw.lines, except these tests draw a line around the border of the given surface then check if all pixels are of the given colour, or if they contain gaps.

See: #395