### PR TITLE
Cleanup Python < 2.7 references

### DIFF
--- a/buildconfig/msysio.py
+++ b/buildconfig/msysio.py
@@ -18,15 +18,6 @@ except NameError:
     raw_input = input
 
 # Exported functions
-__all__ = ['raw_input_', 'print_', 'is_msys']
-
-# 2.x/3.x compatibility stuff
-try:
-    raw_input
-except NameError:
-    raw_input = input
-
-# Exported functions
 def raw_input_(prompt=None):
     """Prompt for user input in an MSYS console friendly way"""
     if prompt is None:

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -281,12 +281,6 @@ typedef enum {
 /* macros used throughout the source */
 #define RAISE(x, y) (PyErr_SetString((x), (y)), (PyObject *)NULL)
 
-#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 3
-#define Py_RETURN_NONE return Py_INCREF(Py_None), Py_None
-#define Py_RETURN_TRUE return Py_INCREF(Py_True), Py_True
-#define Py_RETURN_FALSE return Py_INCREF(Py_False), Py_False
-#endif
-
 /* Py_ssize_t availability. */
 #if PY_VERSION_HEX < 0x02050000 && !defined(PY_SSIZE_T_MIN)
 typedef int Py_ssize_t;
@@ -806,36 +800,5 @@ extern void *PyGAME_C_API[PYGAMEAPI_TOTALSLOTS];
 #define PYGAME_EXPORT
 #endif
 
-#if defined(__SYMBIAN32__) && PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 2
-
-// These are missing from Python 2.2
-#ifndef Py_RETURN_NONE
-
-#define Py_RETURN_NONE return Py_INCREF(Py_None), Py_None
-#define Py_RETURN_TRUE return Py_INCREF(Py_True), Py_True
-#define Py_RETURN_FALSE return Py_INCREF(Py_False), Py_False
-
-#ifndef intrptr_t
-#define intptr_t int
-
-// No PySlice_GetIndicesEx on Py 2.2
-#define PySlice_GetIndicesEx(a, b, c, d, e, f) \
-    PySlice_GetIndices(a, b, c, d, e)
-
-#define PyBool_FromLong(x) Py_BuildValue("b", x)
-#endif
-
-// _symport_free and malloc are not exported in python.dll
-// See http://discussion.forum.nokia.com/forum/showthread.php?t=57874
-#undef PyObject_NEW
-#define PyObject_NEW PyObject_New
-#undef PyMem_MALLOC
-#define PyMem_MALLOC PyMem_Malloc
-#undef PyObject_DEL
-#define PyObject_DEL PyObject_Del
-
-#endif  // intptr_t
-
-#endif  // __SYMBIAN32__ Python 2.2.2
 
 #endif /* PYGAME_H */

--- a/src_py/compat.py
+++ b/src_py/compat.py
@@ -5,9 +5,9 @@ import sys
 
 __all__ = ['geterror', 'long_', 'xrange_', 'ord_', 'unichr_',
            'unicode_', 'raw_input_', 'as_bytes', 'as_unicode',
-           'bytes_', 'next_', 'imap_', 'PY_MAJOR_VERSION', 'PY_MINOR_VERSION']
+           'bytes_', 'imap_', 'PY_MAJOR_VERSION']
 
-PY_MAJOR_VERSION, PY_MINOR_VERSION = sys.version_info[0:2]
+PY_MAJOR_VERSION = sys.version_info[0]
 
 
 def geterror():
@@ -101,14 +101,3 @@ def filesystem_encode(u):
         fsencoding = 'utf-8'
     return u.encode(fsencoding, filesystem_errors)
 
-# Include a next compatible function for Python versions < 2.6
-if (PY_MAJOR_VERSION, PY_MINOR_VERSION) >= (2, 6):
-    next_ = next
-else:
-    def next_(i, *args):
-        try:
-            return i.next()
-        except StopIteration:
-            if args:
-                return args[0]
-            raise

--- a/test/README.TXT
+++ b/test/README.TXT
@@ -14,10 +14,7 @@ The test runner for PyGame was developed for these purposes:
 
 It does this by altering the behaviour of unittest at run time. As much as
 possible each individual module was left to be fully compatible with the
-standard unittest. At one point it was discovered that the run time patching of
-unittest was incompatible with the 2.4 version so a copy of the 2.5 version now
-is included in the pygame test  directory. The test directory was made a
-package.
+standard unittest.
 
 If an individual module is run, eg ``python test/color_test.py``, then it will
 run an unmodified version of unittest. ( unittest.main() )

--- a/test/test_utils/arrinter.py
+++ b/test/test_utils/arrinter.py
@@ -21,10 +21,6 @@ except NameError:
         c_ssize_t = c_longlong
 
 
-PY3 = 0
-if sys.version_info >= (3,):
-    PY3 = 1
-
 SIZEOF_VOID_P = sizeof(c_void_p)
 if SIZEOF_VOID_P <= sizeof(c_int):
     Py_intptr_t = c_int
@@ -69,7 +65,7 @@ else:
     PyCapsule_GetContext.restype = c_void_p
     PyCapsule_GetContext.argtypes = [py_object]
 
-if PY3:
+if sys.version_info >= (3,): # Python3
     PyCapsule_Destructor = CFUNCTYPE(None, py_object)
     PyCapsule_New = pythonapi.PyCapsule_New
     PyCapsule_New.restype = py_object

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -159,24 +159,16 @@ And now, my famous members
 --------------------------
 """
 
-# http://www.python.org/doc/2.2.3/whatsnew/node5.html
-from __future__ import generators
-
 __version__ = "$URL: http://pypng.googlecode.com/svn/trunk/code/png.py $ $Rev: 228 $"
 
-from pygame.compat import geterror, next_, imap_
+from pygame.compat import geterror, imap_
 from array import array
-try: # See :pyver:old
-    import itertools
-except:
-    pass
+import itertools
 import math
-# http://www.python.org/doc/2.4.4/lib/module-operator.html
 import operator
 import struct
 import sys
 import zlib
-# http://www.python.org/doc/2.4.4/lib/module-warnings.html
 import warnings
 
 
@@ -201,27 +193,16 @@ def group(s, n):
     return zip(*[iter(s)]*n)
 
 def isarray(x):
-    """Same as ``isinstance(x, array)`` except on Python 2.2, where it
-    always returns ``False``.  This helps PyPNG work on Python 2.2.
+    """Same as ``isinstance(x, array)``.
     """
+    return isinstance(x, array)
 
-    try:
-        return isinstance(x, array)
-    except:
-        return False
 
-try:  # see :pyver:old
-    array.tostring
-except:
-    def tostring(row):
-        l = len(row)
-        return struct.pack('%dB' % l, *row)
-else:
-    def tostring(row):
-        """Convert row of bytes to string.  Expects `row` to be an
-        ``array``.
-        """
-        return row.tostring()
+def tostring(row):
+    """Convert row of bytes to string.  Expects `row` to be an
+    ``array``.
+    """
+    return row.tostring()
 
 # Conditionally convert to bytes.  Works on Python 2 and Python 3.
 try:
@@ -765,7 +746,7 @@ class Writer:
         # :todo: Certain exceptions in the call to ``.next()`` or the
         # following try would indicate no row data supplied.
         # Should catch.
-        i,row = next_(enumrows)
+        i, row = next(enumrows)
         try:
             # If this fails...
             extend(row)
@@ -1210,7 +1191,7 @@ def from_array(a, mode=None, info={}):
     # first row, which requires that we take a copy of its iterator.
     # We may also need the first row to derive width and bitdepth.
     a,t = itertools.tee(a)
-    row = next_(t)
+    row = next(t)
     del t
     try:
         row[0][0]

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -71,11 +71,6 @@ For help, type ``import png; help(png)`` in your python interpreter.
 
 A good place to start is the :class:`Reader` and :class:`Writer` classes.
 
-Requires Python 2.3.  Limited support is available for Python 2.2, but
-not everything works.  Best with Python 2.4 and higher.  Installation is
-trivial, but see the ``README.txt`` file (with the source distribution)
-for details.
-
 This file can also be used as a command-line utility to convert
 `Netpbm <http://netpbm.sourceforge.net/>`_ PNM files to PNG, and the reverse conversion from PNG to
 PNM. The interface is similar to that of the ``pnmtopng`` program from
@@ -2203,100 +2198,6 @@ class Reader:
         return width,height,convert(),meta
 
 
-# === Legacy Version Support ===
-
-# :pyver:old:  PyPNG works on Python versions 2.3 and 2.2, but not
-# without some awkward problems.  Really PyPNG works on Python 2.4 (and
-# above); it works on Pythons 2.3 and 2.2 by virtue of fixing up
-# problems here.  It's a bit ugly (which is why it's hidden down here).
-#
-# Generally the strategy is one of pretending that we're running on
-# Python 2.4 (or above), and patching up the library support on earlier
-# versions so that it looks enough like Python 2.4.  When it comes to
-# Python 2.2 there is one thing we cannot patch: extended slices
-# http://www.python.org/doc/2.3/whatsnew/section-slices.html.
-# Instead we simply declare that features that are implemented using
-# extended slices will not work on Python 2.2.
-#
-# In order to work on Python 2.3 we fix up a recurring annoyance involving
-# the array type.  In Python 2.3 an array cannot be initialised with an
-# array, and it cannot be extended with a list (or other sequence).
-# Both of those are repeated issues in the code.  Whilst I would not
-# normally tolerate this sort of behaviour, here we "shim" a replacement
-# for array into place (and hope no-ones notices).  You never read this.
-#
-# In an amusing case of warty hacks on top of warty hacks... the array
-# shimming we try and do only works on Python 2.3 and above (you can't
-# subclass array.array in Python 2.2).  So to get it working on Python
-# 2.2 we go for something much simpler and (probably) way slower.
-try:
-    array('B').extend([])
-    array('B', array('B'))
-except:
-    # Expect to get here on Python 2.3
-    try:
-        class _array_shim(array):
-            true_array = array
-            def __new__(cls, typecode, init=None):
-                super_new = super(_array_shim, cls).__new__
-                it = super_new(cls, typecode)
-                if init is None:
-                    return it
-                it.extend(init)
-                return it
-            def extend(self, extension):
-                super_extend = super(_array_shim, self).extend
-                if isinstance(extension, self.true_array):
-                    return super_extend(extension)
-                if not isinstance(extension, (list, str)):
-                    # Convert to list.  Allows iterators to work.
-                    extension = list(extension)
-                return super_extend(self.true_array(self.typecode, extension))
-        array = _array_shim
-    except:
-        # Expect to get here on Python 2.2
-        def array(typecode, init=()):
-            if type(init) == str:
-                return map(ord, init)
-            return list(init)
-
-# Further hacks to get it limping along on Python 2.2
-try:
-    enumerate
-except:
-    def enumerate(seq):
-        i=0
-        for x in seq:
-            yield i,x
-            i += 1
-
-try:
-    reversed
-except:
-    def reversed(l):
-        l = list(l)
-        l.reverse()
-        for x in l:
-            yield x
-
-try:
-    itertools
-except:
-    class _dummy_itertools:
-        pass
-    itertools = _dummy_itertools()
-    def _itertools_imap(f, seq):
-        for x in seq:
-            yield f(x)
-    itertools.imap = _itertools_imap
-    def _itertools_chain(*iterables):
-        for it in iterables:
-            for element in it:
-                yield element
-    itertools.chain = _itertools_chain
-
-
-
 # === Internal Test Support ===
 
 # This section comprises the tests that are internally validated (as
@@ -2318,7 +2219,6 @@ try:
 except:
     from StringIO import StringIO as BytesIO
 import tempfile
-# http://www.python.org/doc/2.4.4/lib/module-unittest.html
 import unittest
 
 


### PR DESCRIPTION
Remove old code and comments for Python 2.2, 2.3, 2.5 ...

Since PR requests 504 & 509 implies we drop  Python < 2.7 , it should be fine, isn't it?

