### PR TITLE
Test cleanup n+1 : yet another test cleanup branch

### DIFF
--- a/test/font_test.py
+++ b/test/font_test.py
@@ -38,20 +38,20 @@ class FontModuleTest( unittest.TestCase ):
         # Can only check that a font object is returned.
         fonts = pygame_font.get_fonts()
         o = pygame_font.SysFont(fonts[0], 20)
-        self.failUnless(isinstance(o, pygame_font.FontType))
+        self.assertTrue(isinstance(o, pygame_font.FontType))
         o = pygame_font.SysFont(fonts[0], 20, italic=True)
-        self.failUnless(isinstance(o, pygame_font.FontType))
+        self.assertTrue(isinstance(o, pygame_font.FontType))
         o = pygame_font.SysFont(fonts[0], 20, bold=True)
-        self.failUnless(isinstance(o, pygame_font.FontType))
+        self.assertTrue(isinstance(o, pygame_font.FontType))
         o = pygame_font.SysFont('thisisnotafont', 20)
-        self.failUnless(isinstance(o, pygame_font.FontType))
+        self.assertTrue(isinstance(o, pygame_font.FontType))
 
     def test_get_default_font(self):
         self.assertEqual(pygame_font.get_default_font(), 'freesansbold.ttf')
 
     def test_get_fonts_returns_something(self):
         fnts = pygame_font.get_fonts()
-        self.failUnless(fnts)
+        self.assertTrue(fnts)
 
     # to test if some files exist...
     #def XXtest_has_file_osx_10_5_sdk(self):
@@ -79,12 +79,12 @@ class FontModuleTest( unittest.TestCase ):
         for name in fnts:
             # note, on ubuntu 2.6 they are all unicode strings.
 
-            self.failUnless(isinstance(name, name_types), name)
-            self.failUnless(name.islower(), name)
-            self.failUnless(name.isalnum(), name)
+            self.assertTrue(isinstance(name, name_types), name)
+            self.assertTrue(name.islower(), name)
+            self.assertTrue(name.isalnum(), name)
 
     def test_get_init(self):
-        self.failUnless(pygame_font.get_init())
+        self.assertTrue(pygame_font.get_init())
         pygame_font.quit()
         self.assertFalse(pygame_font.get_init())
 
@@ -99,7 +99,7 @@ class FontModuleTest( unittest.TestCase ):
         for font in fonts:
             path = pygame_font.match_font(font)
             self.assertFalse(path is None)
-            self.failUnless(os.path.isabs(path))
+            self.assertTrue(os.path.isabs(path))
 
     def test_match_font_bold(self):
         fonts = pygame_font.get_fonts()
@@ -125,13 +125,13 @@ class FontModuleTest( unittest.TestCase ):
         fonts = pygame_font.get_fonts()
 
         # Check for not found.
-        self.failUnless(pygame_font.match_font('thisisnotafont') is None)
+        self.assertTrue(pygame_font.match_font('thisisnotafont') is None)
 
         # Check comma separated list.
         names = ','.join(['thisisnotafont', fonts[-1], 'anothernonfont'])
         self.assertFalse(pygame_font.match_font(names) is None)
         names = ','.join(['thisisnotafont1', 'thisisnotafont2', 'thisisnotafont3'])
-        self.failUnless(pygame_font.match_font(names) is None)
+        self.assertTrue(pygame_font.match_font(names) is None)
 
     def test_quit(self):
         pygame_font.quit()
@@ -198,34 +198,34 @@ class FontTypeTest( unittest.TestCase ):
         # Ckecking ascent would need a custom test font to do properly.
         f = pygame_font.Font(None, 20)
         ascent = f.get_ascent()
-        self.failUnless(isinstance(ascent, int))
-        self.failUnless(ascent > 0)
+        self.assertTrue(isinstance(ascent, int))
+        self.assertTrue(ascent > 0)
         s = f.render("X", False, (255, 255, 255))
-        self.failUnless(s.get_size()[1] > ascent)
+        self.assertTrue(s.get_size()[1] > ascent)
 
     def test_get_descent(self):
         # Ckecking descent would need a custom test font to do properly.
         f = pygame_font.Font(None, 20)
         descent = f.get_descent()
-        self.failUnless(isinstance(descent, int))
-        self.failUnless(descent < 0)
+        self.assertTrue(isinstance(descent, int))
+        self.assertTrue(descent < 0)
 
     def test_get_height(self):
         # Ckecking height would need a custom test font to do properly.
         f = pygame_font.Font(None, 20)
         height = f.get_height()
-        self.failUnless(isinstance(height, int))
-        self.failUnless(height > 0)
+        self.assertTrue(isinstance(height, int))
+        self.assertTrue(height > 0)
         s = f.render("X", False, (255, 255, 255))
-        self.failUnless(s.get_size()[1] == height)
+        self.assertTrue(s.get_size()[1] == height)
 
     def test_get_linesize(self):
         # Ckecking linesize would need a custom test font to do properly.
         # Questions: How do linesize, height and descent relate?
         f = pygame_font.Font(None, 20)
         linesize = f.get_linesize()
-        self.failUnless(isinstance(linesize, int))
-        self.failUnless(linesize > 0)
+        self.assertTrue(isinstance(linesize, int))
+        self.assertTrue(linesize > 0)
 
     def test_metrics(self):
         # Ensure bytes decoding works correctly. Can only compare results
@@ -302,7 +302,7 @@ class FontTypeTest( unittest.TestCase ):
         # at least can assert the encodings differ.
         su = f.render(as_unicode("."), False, [0, 0, 0], [255, 255, 255])
         sb = f.render(as_bytes("."), False, [0, 0, 0], [255, 255, 255])
-        self.assert_(equal_images(su, sb))
+        self.assertTrue(equal_images(su, sb))
         u = as_unicode(r"\u212A")
         b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
         sb = f.render(b, False, [0, 0, 0], [255, 255, 255])
@@ -311,7 +311,7 @@ class FontTypeTest( unittest.TestCase ):
         except pygame.error:
             pass
         else:
-            self.assert_(not equal_images(su, sb))
+            self.assertFalse(equal_images(su, sb))
 
         # If the font module is SDL_ttf based, then it can only supports  UCS-2;
         # it will raise an exception for an out-of-range UCS-4 code point.
@@ -331,7 +331,7 @@ class FontTypeTest( unittest.TestCase ):
         f = pygame_font.Font(None, 20)
         self.assertFalse(f.get_bold())
         f.set_bold(True)
-        self.failUnless(f.get_bold())
+        self.assertTrue(f.get_bold())
         f.set_bold(False)
         self.assertFalse(f.get_bold())
 
@@ -339,7 +339,7 @@ class FontTypeTest( unittest.TestCase ):
         f = pygame_font.Font(None, 20)
         self.assertFalse(f.get_italic())
         f.set_italic(True)
-        self.failUnless(f.get_italic())
+        self.assertTrue(f.get_italic())
         f.set_italic(False)
         self.assertFalse(f.get_italic())
 
@@ -347,7 +347,7 @@ class FontTypeTest( unittest.TestCase ):
         f = pygame_font.Font(None, 20)
         self.assertFalse(f.get_underline())
         f.set_underline(True)
-        self.failUnless(f.get_underline())
+        self.assertTrue(f.get_underline())
         f.set_underline(False)
         self.assertFalse(f.get_underline())
 
@@ -492,22 +492,22 @@ class VisualTests( unittest.TestCase ):
                     return False
 
     def test_bold(self):
-        self.failUnless(self.query(bold=True))
+        self.assertTrue(self.query(bold=True))
 
     def test_italic(self):
-        self.failUnless(self.query(italic=True))
+        self.assertTrue(self.query(italic=True))
 
     def test_underline(self):
-        self.failUnless(self.query(underline=True))
+        self.assertTrue(self.query(underline=True))
 
     def test_antialiase(self):
-        self.failUnless(self.query(antialiase=True))
+        self.assertTrue(self.query(antialiase=True))
 
     def test_bold_antialiase(self):
-        self.failUnless(self.query(bold=True, antialiase=True))
+        self.assertTrue(self.query(bold=True, antialiase=True))
 
     def test_italic_underline(self):
-        self.failUnless(self.query(italic=True, underline=True))
+        self.assertTrue(self.query(italic=True, underline=True))
 
 
 if __name__ == '__main__':

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import unittest
+import platform
 
 import pygame
 from pygame import font as pygame_font  # So font can be replaced with ftfont
@@ -21,11 +22,12 @@ def equal_images(s1, s2):
     return True
 
 
-import platform
 IS_PYPY = 'PyPy' == platform.python_implementation()
+
 
 @unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
 class FontModuleTest( unittest.TestCase ):
+
     def setUp(self):
         pygame_font.init()
 
@@ -51,7 +53,6 @@ class FontModuleTest( unittest.TestCase ):
         fnts = pygame_font.get_fonts()
         self.failUnless(fnts)
 
-
     # to test if some files exist...
     #def XXtest_has_file_osx_10_5_sdk(self):
     #    import os
@@ -63,17 +64,10 @@ class FontModuleTest( unittest.TestCase ):
     #    f = "/Developer/SDKs/MacOSX10.4u.sdk/usr/X11R6/include/ft2build.h"
     #    self.assertEqual(os.path.exists(f), True)
 
-
-
-
-
     def test_get_fonts(self):
         fnts = pygame_font.get_fonts()
 
-        if not fnts:
-            raise Exception(repr(fnts))
-
-        self.failUnless(fnts)
+        self.assertTrue(fnts, msg=repr(fnts))
 
         if (PY_MAJOR_VERSION >= 3):
             # For Python 3.x, names will always be unicode strings.
@@ -108,7 +102,6 @@ class FontModuleTest( unittest.TestCase ):
             self.failUnless(os.path.isabs(path))
 
     def test_match_font_bold(self):
-
         fonts = pygame_font.get_fonts()
 
         # Look for a bold font.
@@ -119,7 +112,6 @@ class FontModuleTest( unittest.TestCase ):
             self.fail()
 
     def test_match_font_italic(self):
-
         fonts = pygame_font.get_fonts()
 
         # Look for an italic font.
@@ -129,9 +121,7 @@ class FontModuleTest( unittest.TestCase ):
         else:
             self.fail()
 
-
     def test_match_font_comma_separated(self):
-
         fonts = pygame_font.get_fonts()
 
         # Check for not found.
@@ -143,23 +133,18 @@ class FontModuleTest( unittest.TestCase ):
         names = ','.join(['thisisnotafont1', 'thisisnotafont2', 'thisisnotafont3'])
         self.failUnless(pygame_font.match_font(names) is None)
 
-
-
     def test_quit(self):
         pygame_font.quit()
 
 
-
-
-
 @unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
 class FontTest(unittest.TestCase):
+
     def setUp(self):
         pygame_font.init()
 
     def tearDown(self):
         pygame_font.quit()
-
 
     def test_render_args(self):
         screen = pygame.display.set_mode((600, 400))
@@ -200,12 +185,9 @@ class FontTest(unittest.TestCase):
 
 
 
-
-
-
-
 @unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
 class FontTypeTest( unittest.TestCase ):
+
     def setUp(self):
         pygame_font.init()
 
@@ -259,7 +241,7 @@ class FontTypeTest( unittest.TestCase ):
         b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
         bm = f.metrics(b)
         self.assert_(len(bm) == 2)
-        try:
+        try:  # FIXME why do we do this try/except ?
             um = f.metrics(u)
         except pygame.error:
             pass
@@ -292,9 +274,6 @@ class FontTypeTest( unittest.TestCase ):
         self.fail()
 
     def test_render(self):
-        """
-        """
-
         f = pygame_font.Font(None, 20)
         s = f.render("foo", True, [0, 0, 0], [255, 255, 255])
         s = f.render("xxx", True, [0, 0, 0], [255, 255, 255])
@@ -327,7 +306,7 @@ class FontTypeTest( unittest.TestCase ):
         u = as_unicode(r"\u212A")
         b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
         sb = f.render(b, False, [0, 0, 0], [255, 255, 255])
-        try:
+        try:  # FIXME why do we do this try/except ?
             su = f.render(u, False, [0, 0, 0], [255, 255, 255])
         except pygame.error:
             pass
@@ -347,50 +326,6 @@ class FontTypeTest( unittest.TestCase ):
         self.assertRaises(ValueError, f.render, b, 0, [0, 0, 0])
         u = as_unicode("ab\x00cd")
         self.assertRaises(ValueError, f.render, b, 0, [0, 0, 0])
-
-        # __doc__ (as of 2008-08-02) for pygame_font.Font.render:
-
-          # Font.render(text, antialias, color, background=None): return Surface
-          # draw text on a new Surface
-          #
-          # This creates a new Surface with the specified text rendered on it.
-          # Pygame provides no way to directly draw text on an existing Surface:
-          # instead you must use Font.render() to create an image (Surface) of
-          # the text, then blit this image onto another Surface.
-          #
-          # The text can only be a single line: newline characters are not
-          # rendered. The antialias argument is a boolean: if true the
-          # characters will have smooth edges. The color argument is the color
-          # of the text [e.g.: (0,0,255) for blue]. The optional background
-          # argument is a color to use for the text background. If no background
-          # is passed the area outside the text will be transparent.
-          #
-          # The Surface returned will be of the dimensions required to hold the
-          # text. (the same as those returned by Font.size()). If an empty
-          # string is passed for the text, a blank surface will be returned that
-          # is one pixel wide and the height of the font.
-          #
-          # Depending on the type of background and antialiasing used, this
-          # returns different types of Surfaces. For performance reasons, it is
-          # good to know what type of image will be used. If antialiasing is not
-          # used, the return image will always be an 8bit image with a two color
-          # palette. If the background is transparent a colorkey will be set.
-          # Antialiased images are rendered to 24-bit RGB images. If the
-          # background is transparent a pixel alpha will be included.
-          #
-          # Optimization: if you know that the final destination for the text
-          # (on the screen) will always have a solid background, and the text is
-          # antialiased, you can improve performance by specifying the
-          # background color. This will cause the resulting image to maintain
-          # transparency information by colorkey rather than (much less
-          # efficient) alpha values.
-          #
-          # If you render '\n' a unknown char will be rendered.  Usually a
-          # rectangle. Instead you need to handle new lines yourself.
-          #
-          # Font rendering is not thread safe: only a single thread can render
-          # text any time.
-
 
     def test_set_bold(self):
         f = pygame_font.Font(None, 20)
@@ -429,7 +364,7 @@ class FontTypeTest( unittest.TestCase ):
         text = as_unicode(r"\u212A")
         btext = text.encode("UTF-16")[2:] # Keep the byte order consistent.
         bsize = f.size(btext)
-        try:
+        try:  # FIXME why do we do this try/except ?
             size = f.size(text)
         except pygame.error:
             pass
@@ -475,7 +410,7 @@ class FontTypeTest( unittest.TestCase ):
         font_path = os.path.join(os.path.split(pygame.__file__)[0],
                                  pygame_font.get_default_font())
         filesystem_encoding = sys.getfilesystemencoding()
-        try:
+        try:  # FIXME why do we do this try/except ?
             font_path = font_path.decode(filesystem_encoding,
                                          filesystem_errors)
         except AttributeError:
@@ -487,6 +422,7 @@ class FontTypeTest( unittest.TestCase ):
 
 @unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
 class VisualTests( unittest.TestCase ):
+
     __tags__ = ['interactive']
 
     screen = None

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -105,21 +105,16 @@ class FontModuleTest( unittest.TestCase ):
         fonts = pygame_font.get_fonts()
 
         # Look for a bold font.
-        for font in fonts:
-            if pygame_font.match_font(font, bold=True) is not None:
-                break
-        else:
-            self.fail()
+        self.assertTrue(any(pygame_font.match_font(font, bold=True)
+                            for font in fonts))
+
 
     def test_match_font_italic(self):
         fonts = pygame_font.get_fonts()
 
         # Look for an italic font.
-        for font in fonts:
-            if pygame_font.match_font(font, italic=True) is not None:
-                break
-        else:
-            self.fail()
+        self.assertTrue(any(pygame_font.match_font(font, italic=True)
+                            for font in fonts))
 
     def test_match_font_comma_separated(self):
         fonts = pygame_font.get_fonts()

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -24,179 +24,179 @@ def equal_images(s1, s2):
 import platform
 IS_PYPY = 'PyPy' == platform.python_implementation()
 
-if not IS_PYPY: #TODO: pypy skip known failure.
+@unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
+class FontModuleTest( unittest.TestCase ):
+    def setUp(self):
+        pygame_font.init()
 
-    class FontModuleTest( unittest.TestCase ):
-        def setUp(self):
-            pygame_font.init()
+    def tearDown(self):
+        pygame_font.quit()
 
-        def tearDown(self):
-            pygame_font.quit()
+    def test_SysFont(self):
+        # Can only check that a font object is returned.
+        fonts = pygame_font.get_fonts()
+        o = pygame_font.SysFont(fonts[0], 20)
+        self.failUnless(isinstance(o, pygame_font.FontType))
+        o = pygame_font.SysFont(fonts[0], 20, italic=True)
+        self.failUnless(isinstance(o, pygame_font.FontType))
+        o = pygame_font.SysFont(fonts[0], 20, bold=True)
+        self.failUnless(isinstance(o, pygame_font.FontType))
+        o = pygame_font.SysFont('thisisnotafont', 20)
+        self.failUnless(isinstance(o, pygame_font.FontType))
 
-        def test_SysFont(self):
-            # Can only check that a font object is returned.
-            fonts = pygame_font.get_fonts()
-            o = pygame_font.SysFont(fonts[0], 20)
-            self.failUnless(isinstance(o, pygame_font.FontType))
-            o = pygame_font.SysFont(fonts[0], 20, italic=True)
-            self.failUnless(isinstance(o, pygame_font.FontType))
-            o = pygame_font.SysFont(fonts[0], 20, bold=True)
-            self.failUnless(isinstance(o, pygame_font.FontType))
-            o = pygame_font.SysFont('thisisnotafont', 20)
-            self.failUnless(isinstance(o, pygame_font.FontType))
+    def test_get_default_font(self):
+        self.assertEqual(pygame_font.get_default_font(), 'freesansbold.ttf')
 
-        def test_get_default_font(self):
-            self.assertEqual(pygame_font.get_default_font(), 'freesansbold.ttf')
-
-        def test_get_fonts_returns_something(self):
-            fnts = pygame_font.get_fonts()
-            self.failUnless(fnts)
-
-
-        # to test if some files exist...
-        #def XXtest_has_file_osx_10_5_sdk(self):
-        #    import os
-        #    f = "/Developer/SDKs/MacOSX10.5.sdk/usr/X11/include/ft2build.h"
-        #    self.assertEqual(os.path.exists(f), True)
-
-        #def XXtest_has_file_osx_10_4_sdk(self):
-        #    import os
-        #    f = "/Developer/SDKs/MacOSX10.4u.sdk/usr/X11R6/include/ft2build.h"
-        #    self.assertEqual(os.path.exists(f), True)
+    def test_get_fonts_returns_something(self):
+        fnts = pygame_font.get_fonts()
+        self.failUnless(fnts)
 
 
+    # to test if some files exist...
+    #def XXtest_has_file_osx_10_5_sdk(self):
+    #    import os
+    #    f = "/Developer/SDKs/MacOSX10.5.sdk/usr/X11/include/ft2build.h"
+    #    self.assertEqual(os.path.exists(f), True)
 
-
-
-        def test_get_fonts(self):
-            fnts = pygame_font.get_fonts()
-
-            if not fnts:
-                raise Exception(repr(fnts))
-
-            self.failUnless(fnts)
-
-            if (PY_MAJOR_VERSION >= 3):
-                # For Python 3.x, names will always be unicode strings.
-                name_types = (str,)
-            else:
-                # For Python 2.x, names may be either unicode or ascii strings.
-                name_types = (str, unicode)
-
-            for name in fnts:
-                # note, on ubuntu 2.6 they are all unicode strings.
-
-                self.failUnless(isinstance(name, name_types), name)
-                self.failUnless(name.islower(), name)
-                self.failUnless(name.isalnum(), name)
-
-        def test_get_init(self):
-            self.failUnless(pygame_font.get_init())
-            pygame_font.quit()
-            self.assertFalse(pygame_font.get_init())
-
-        def test_init(self):
-            pygame_font.init()
-
-        def test_match_font_all_exist(self):
-            fonts = pygame_font.get_fonts()
-
-            # Ensure all listed fonts are in fact available, and the returned file
-            # name is a full path.
-            for font in fonts:
-                path = pygame_font.match_font(font)
-                self.assertFalse(path is None)
-                self.failUnless(os.path.isabs(path))
-
-        def test_match_font_bold(self):
-
-            fonts = pygame_font.get_fonts()
-
-            # Look for a bold font.
-            for font in fonts:
-                if pygame_font.match_font(font, bold=True) is not None:
-                    break
-            else:
-                self.fail()
-
-        def test_match_font_italic(self):
-
-            fonts = pygame_font.get_fonts()
-
-            # Look for an italic font.
-            for font in fonts:
-                if pygame_font.match_font(font, italic=True) is not None:
-                    break
-            else:
-                self.fail()
-
-
-        def test_match_font_comma_separated(self):
-
-            fonts = pygame_font.get_fonts()
-
-            # Check for not found.
-            self.failUnless(pygame_font.match_font('thisisnotafont') is None)
-
-            # Check comma separated list.
-            names = ','.join(['thisisnotafont', fonts[-1], 'anothernonfont'])
-            self.assertFalse(pygame_font.match_font(names) is None)
-            names = ','.join(['thisisnotafont1', 'thisisnotafont2', 'thisisnotafont3'])
-            self.failUnless(pygame_font.match_font(names) is None)
-
-
-
-        def test_quit(self):
-            pygame_font.quit()
+    #def XXtest_has_file_osx_10_4_sdk(self):
+    #    import os
+    #    f = "/Developer/SDKs/MacOSX10.4u.sdk/usr/X11R6/include/ft2build.h"
+    #    self.assertEqual(os.path.exists(f), True)
 
 
 
 
 
-    class FontTest(unittest.TestCase):
-        def setUp(self):
-            pygame_font.init()
+    def test_get_fonts(self):
+        fnts = pygame_font.get_fonts()
 
-        def tearDown(self):
-            pygame_font.quit()
+        if not fnts:
+            raise Exception(repr(fnts))
+
+        self.failUnless(fnts)
+
+        if (PY_MAJOR_VERSION >= 3):
+            # For Python 3.x, names will always be unicode strings.
+            name_types = (str,)
+        else:
+            # For Python 2.x, names may be either unicode or ascii strings.
+            name_types = (str, unicode)
+
+        for name in fnts:
+            # note, on ubuntu 2.6 they are all unicode strings.
+
+            self.failUnless(isinstance(name, name_types), name)
+            self.failUnless(name.islower(), name)
+            self.failUnless(name.isalnum(), name)
+
+    def test_get_init(self):
+        self.failUnless(pygame_font.get_init())
+        pygame_font.quit()
+        self.assertFalse(pygame_font.get_init())
+
+    def test_init(self):
+        pygame_font.init()
+
+    def test_match_font_all_exist(self):
+        fonts = pygame_font.get_fonts()
+
+        # Ensure all listed fonts are in fact available, and the returned file
+        # name is a full path.
+        for font in fonts:
+            path = pygame_font.match_font(font)
+            self.assertFalse(path is None)
+            self.failUnless(os.path.isabs(path))
+
+    def test_match_font_bold(self):
+
+        fonts = pygame_font.get_fonts()
+
+        # Look for a bold font.
+        for font in fonts:
+            if pygame_font.match_font(font, bold=True) is not None:
+                break
+        else:
+            self.fail()
+
+    def test_match_font_italic(self):
+
+        fonts = pygame_font.get_fonts()
+
+        # Look for an italic font.
+        for font in fonts:
+            if pygame_font.match_font(font, italic=True) is not None:
+                break
+        else:
+            self.fail()
 
 
-        def test_render_args(self):
-            screen = pygame.display.set_mode((600, 400))
-            rect = screen.get_rect()
-            f = pygame_font.Font(None, 20)
+    def test_match_font_comma_separated(self):
+
+        fonts = pygame_font.get_fonts()
+
+        # Check for not found.
+        self.failUnless(pygame_font.match_font('thisisnotafont') is None)
+
+        # Check comma separated list.
+        names = ','.join(['thisisnotafont', fonts[-1], 'anothernonfont'])
+        self.assertFalse(pygame_font.match_font(names) is None)
+        names = ','.join(['thisisnotafont1', 'thisisnotafont2', 'thisisnotafont3'])
+        self.failUnless(pygame_font.match_font(names) is None)
+
+
+
+    def test_quit(self):
+        pygame_font.quit()
+
+
+
+
+
+@unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
+class FontTest(unittest.TestCase):
+    def setUp(self):
+        pygame_font.init()
+
+    def tearDown(self):
+        pygame_font.quit()
+
+
+    def test_render_args(self):
+        screen = pygame.display.set_mode((600, 400))
+        rect = screen.get_rect()
+        f = pygame_font.Font(None, 20)
+        screen.fill((10, 10, 10))
+        font_surface = f.render("   bar", True, (0, 0, 0), (255, 255, 255))
+        font_rect = font_surface.get_rect()
+        font_rect.topleft = rect.topleft
+        self.assertTrue(font_surface)
+        screen.blit(font_surface, font_rect, font_rect)
+        pygame.display.update()
+        self.assertEqual(tuple(screen.get_at((0,0)))[:3], (255, 255, 255))
+        self.assertEqual(tuple(screen.get_at(font_rect.topleft))[:3], (255, 255, 255))
+
+        # If we don't have a real display, don't do this test.
+        # Transparent background doesn't seem to work without a read video card.
+        if os.environ.get('SDL_VIDEODRIVER') != 'dummy':
             screen.fill((10, 10, 10))
-            font_surface = f.render("   bar", True, (0, 0, 0), (255, 255, 255))
+            font_surface = f.render("   bar", True, (0, 0, 0), None)
             font_rect = font_surface.get_rect()
             font_rect.topleft = rect.topleft
             self.assertTrue(font_surface)
             screen.blit(font_surface, font_rect, font_rect)
             pygame.display.update()
-            self.assertEqual(tuple(screen.get_at((0,0)))[:3], (255, 255, 255))
-            self.assertEqual(tuple(screen.get_at(font_rect.topleft))[:3], (255, 255, 255))
+            self.assertEqual(tuple(screen.get_at((0,0)))[:3], (10, 10, 10))
+            self.assertEqual(tuple(screen.get_at(font_rect.topleft))[:3], (10, 10, 10))
 
-            # If we don't have a real display, don't do this test.
-            # Transparent background doesn't seem to work without a read video card.
-            if os.environ.get('SDL_VIDEODRIVER') != 'dummy':
-                screen.fill((10, 10, 10))
-                font_surface = f.render("   bar", True, (0, 0, 0), None)
-                font_rect = font_surface.get_rect()
-                font_rect.topleft = rect.topleft
-                self.assertTrue(font_surface)
-                screen.blit(font_surface, font_rect, font_rect)
-                pygame.display.update()
-                self.assertEqual(tuple(screen.get_at((0,0)))[:3], (10, 10, 10))
-                self.assertEqual(tuple(screen.get_at(font_rect.topleft))[:3], (10, 10, 10))
-
-                screen.fill((10, 10, 10))
-                font_surface = f.render("   bar", True, (0, 0, 0))
-                font_rect = font_surface.get_rect()
-                font_rect.topleft = rect.topleft
-                self.assertTrue(font_surface)
-                screen.blit(font_surface, font_rect, font_rect)
-                pygame.display.update(rect)
-                self.assertEqual(tuple(screen.get_at((0,0)))[:3], (10, 10, 10))
-                self.assertEqual(tuple(screen.get_at(font_rect.topleft))[:3], (10, 10, 10))
+            screen.fill((10, 10, 10))
+            font_surface = f.render("   bar", True, (0, 0, 0))
+            font_rect = font_surface.get_rect()
+            font_rect.topleft = rect.topleft
+            self.assertTrue(font_surface)
+            screen.blit(font_surface, font_rect, font_rect)
+            pygame.display.update(rect)
+            self.assertEqual(tuple(screen.get_at((0,0)))[:3], (10, 10, 10))
+            self.assertEqual(tuple(screen.get_at(font_rect.topleft))[:3], (10, 10, 10))
 
 
 
@@ -204,371 +204,374 @@ if not IS_PYPY: #TODO: pypy skip known failure.
 
 
 
-    class FontTypeTest( unittest.TestCase ):
-        def setUp(self):
-            pygame_font.init()
+@unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
+class FontTypeTest( unittest.TestCase ):
+    def setUp(self):
+        pygame_font.init()
 
-        def tearDown(self):
-            pygame_font.quit()
+    def tearDown(self):
+        pygame_font.quit()
 
-        def test_get_ascent(self):
-            # Ckecking ascent would need a custom test font to do properly.
-            f = pygame_font.Font(None, 20)
-            ascent = f.get_ascent()
-            self.failUnless(isinstance(ascent, int))
-            self.failUnless(ascent > 0)
-            s = f.render("X", False, (255, 255, 255))
-            self.failUnless(s.get_size()[1] > ascent)
+    def test_get_ascent(self):
+        # Ckecking ascent would need a custom test font to do properly.
+        f = pygame_font.Font(None, 20)
+        ascent = f.get_ascent()
+        self.failUnless(isinstance(ascent, int))
+        self.failUnless(ascent > 0)
+        s = f.render("X", False, (255, 255, 255))
+        self.failUnless(s.get_size()[1] > ascent)
 
-        def test_get_descent(self):
-            # Ckecking descent would need a custom test font to do properly.
-            f = pygame_font.Font(None, 20)
-            descent = f.get_descent()
-            self.failUnless(isinstance(descent, int))
-            self.failUnless(descent < 0)
+    def test_get_descent(self):
+        # Ckecking descent would need a custom test font to do properly.
+        f = pygame_font.Font(None, 20)
+        descent = f.get_descent()
+        self.failUnless(isinstance(descent, int))
+        self.failUnless(descent < 0)
 
-        def test_get_height(self):
-            # Ckecking height would need a custom test font to do properly.
-            f = pygame_font.Font(None, 20)
-            height = f.get_height()
-            self.failUnless(isinstance(height, int))
-            self.failUnless(height > 0)
-            s = f.render("X", False, (255, 255, 255))
-            self.failUnless(s.get_size()[1] == height)
+    def test_get_height(self):
+        # Ckecking height would need a custom test font to do properly.
+        f = pygame_font.Font(None, 20)
+        height = f.get_height()
+        self.failUnless(isinstance(height, int))
+        self.failUnless(height > 0)
+        s = f.render("X", False, (255, 255, 255))
+        self.failUnless(s.get_size()[1] == height)
 
-        def test_get_linesize(self):
-            # Ckecking linesize would need a custom test font to do properly.
-            # Questions: How do linesize, height and descent relate?
-            f = pygame_font.Font(None, 20)
-            linesize = f.get_linesize()
-            self.failUnless(isinstance(linesize, int))
-            self.failUnless(linesize > 0)
+    def test_get_linesize(self):
+        # Ckecking linesize would need a custom test font to do properly.
+        # Questions: How do linesize, height and descent relate?
+        f = pygame_font.Font(None, 20)
+        linesize = f.get_linesize()
+        self.failUnless(isinstance(linesize, int))
+        self.failUnless(linesize > 0)
 
-        def test_metrics(self):
-            # Ensure bytes decoding works correctly. Can only compare results
-            # with unicode for now.
-            f = pygame_font.Font(None, 20)
-            um = f.metrics(as_unicode("."))
-            bm = f.metrics(as_bytes("."))
+    def test_metrics(self):
+        # Ensure bytes decoding works correctly. Can only compare results
+        # with unicode for now.
+        f = pygame_font.Font(None, 20)
+        um = f.metrics(as_unicode("."))
+        bm = f.metrics(as_bytes("."))
+        self.assert_(len(um) == 1)
+        self.assert_(len(bm) == 1)
+        self.assert_(um[0] is not None)
+        self.assert_(um == bm)
+        u = as_unicode(r"\u212A")
+        b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
+        bm = f.metrics(b)
+        self.assert_(len(bm) == 2)
+        try:
+            um = f.metrics(u)
+        except pygame.error:
+            pass
+        else:
             self.assert_(len(um) == 1)
-            self.assert_(len(bm) == 1)
-            self.assert_(um[0] is not None)
-            self.assert_(um == bm)
-            u = as_unicode(r"\u212A")
-            b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
-            bm = f.metrics(b)
-            self.assert_(len(bm) == 2)
-            try:
-                um = f.metrics(u)
-            except pygame.error:
-                pass
-            else:
-                self.assert_(len(um) == 1)
-                self.assert_(bm[0] != um[0])
-                self.assert_(bm[1] != um[0])
+            self.assert_(bm[0] != um[0])
+            self.assert_(bm[1] != um[0])
 
-            if UCS_4:
-                u = as_unicode(r"\U00013000")
-                bm = f.metrics(u)
-                self.assert_(len(bm) == 1 and bm[0] is None)
+        if UCS_4:
+            u = as_unicode(r"\U00013000")
+            bm = f.metrics(u)
+            self.assert_(len(bm) == 1 and bm[0] is None)
 
-            return # unfinished
-            # The documentation is useless here. How large a list?
-            # How do list positions relate to character codes?
-            # What about unicode characters?
+        return # unfinished
+        # The documentation is useless here. How large a list?
+        # How do list positions relate to character codes?
+        # What about unicode characters?
 
-            # __doc__ (as of 2008-08-02) for pygame_font.Font.metrics:
+        # __doc__ (as of 2008-08-02) for pygame_font.Font.metrics:
 
-              # Font.metrics(text): return list
-              # Gets the metrics for each character in the pased string.
-              #
-              # The list contains tuples for each character, which contain the
-              # minimum X offset, the maximum X offset, the minimum Y offset, the
-              # maximum Y offset and the advance offset (bearing plus width) of the
-              # character. [(minx, maxx, miny, maxy, advance), (minx, maxx, miny,
-              # maxy, advance), ...]
+          # Font.metrics(text): return list
+          # Gets the metrics for each character in the pased string.
+          #
+          # The list contains tuples for each character, which contain the
+          # minimum X offset, the maximum X offset, the minimum Y offset, the
+          # maximum Y offset and the advance offset (bearing plus width) of the
+          # character. [(minx, maxx, miny, maxy, advance), (minx, maxx, miny,
+          # maxy, advance), ...]
 
-            self.fail()
+        self.fail()
 
-        def test_render(self):
-            """
-            """
+    def test_render(self):
+        """
+        """
 
-            f = pygame_font.Font(None, 20)
-            s = f.render("foo", True, [0, 0, 0], [255, 255, 255])
-            s = f.render("xxx", True, [0, 0, 0], [255, 255, 255])
-            s = f.render("", True, [0, 0, 0], [255, 255, 255])
-            s = f.render("foo", False, [0, 0, 0], [255, 255, 255])
-            s = f.render("xxx", False, [0, 0, 0], [255, 255, 255])
-            s = f.render("xxx", False, [0, 0, 0])
-            s = f.render("   ", False, [0, 0, 0])
-            s = f.render("   ", False, [0, 0, 0], [255, 255, 255])
-            # null text should be 1 pixel wide.
-            s = f.render("", False, [0, 0, 0], [255, 255, 255])
-            self.assertEqual(s.get_size()[0], 1)
-            # None text should be 1 pixel wide.
-            s = f.render(None, False, [0, 0, 0], [255, 255, 255])
-            self.assertEqual(s.get_size()[0], 1)
-            # Non-text should raise a TypeError.
-            self.assertRaises(TypeError, f.render,
-                              [], False, [0, 0, 0], [255, 255, 255])
-            self.assertRaises(TypeError, f.render,
-                              1, False, [0, 0, 0], [255, 255, 255])
-            # is background transparent for antialiasing?
-            s = f.render(".", True, [255, 255, 255])
-            self.assertEqual(s.get_at((0, 0))[3], 0)
-            # is Unicode and bytes encoding correct?
-            # Cannot really test if the correct characters are rendered, but
-            # at least can assert the encodings differ.
-            su = f.render(as_unicode("."), False, [0, 0, 0], [255, 255, 255])
-            sb = f.render(as_bytes("."), False, [0, 0, 0], [255, 255, 255])
-            self.assert_(equal_images(su, sb))
-            u = as_unicode(r"\u212A")
-            b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
-            sb = f.render(b, False, [0, 0, 0], [255, 255, 255])
-            try:
-                su = f.render(u, False, [0, 0, 0], [255, 255, 255])
-            except pygame.error:
-                pass
-            else:
-                self.assert_(not equal_images(su, sb))
+        f = pygame_font.Font(None, 20)
+        s = f.render("foo", True, [0, 0, 0], [255, 255, 255])
+        s = f.render("xxx", True, [0, 0, 0], [255, 255, 255])
+        s = f.render("", True, [0, 0, 0], [255, 255, 255])
+        s = f.render("foo", False, [0, 0, 0], [255, 255, 255])
+        s = f.render("xxx", False, [0, 0, 0], [255, 255, 255])
+        s = f.render("xxx", False, [0, 0, 0])
+        s = f.render("   ", False, [0, 0, 0])
+        s = f.render("   ", False, [0, 0, 0], [255, 255, 255])
+        # null text should be 1 pixel wide.
+        s = f.render("", False, [0, 0, 0], [255, 255, 255])
+        self.assertEqual(s.get_size()[0], 1)
+        # None text should be 1 pixel wide.
+        s = f.render(None, False, [0, 0, 0], [255, 255, 255])
+        self.assertEqual(s.get_size()[0], 1)
+        # Non-text should raise a TypeError.
+        self.assertRaises(TypeError, f.render,
+                          [], False, [0, 0, 0], [255, 255, 255])
+        self.assertRaises(TypeError, f.render,
+                          1, False, [0, 0, 0], [255, 255, 255])
+        # is background transparent for antialiasing?
+        s = f.render(".", True, [255, 255, 255])
+        self.assertEqual(s.get_at((0, 0))[3], 0)
+        # is Unicode and bytes encoding correct?
+        # Cannot really test if the correct characters are rendered, but
+        # at least can assert the encodings differ.
+        su = f.render(as_unicode("."), False, [0, 0, 0], [255, 255, 255])
+        sb = f.render(as_bytes("."), False, [0, 0, 0], [255, 255, 255])
+        self.assert_(equal_images(su, sb))
+        u = as_unicode(r"\u212A")
+        b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
+        sb = f.render(b, False, [0, 0, 0], [255, 255, 255])
+        try:
+            su = f.render(u, False, [0, 0, 0], [255, 255, 255])
+        except pygame.error:
+            pass
+        else:
+            self.assert_(not equal_images(su, sb))
 
-            # If the font module is SDL_ttf based, then it can only supports  UCS-2;
-            # it will raise an exception for an out-of-range UCS-4 code point.
-            if UCS_4 and not hasattr(f, 'ucs4'):
-                ucs_2 = as_unicode(r"\uFFEE")
-                s = f.render(ucs_2, False, [0, 0, 0], [255, 255, 255])
-                ucs_4 = as_unicode(r"\U00010000")
-                self.assertRaises(UnicodeError, f.render,
-                                  ucs_4, False, [0, 0, 0], [255, 255, 255])
+        # If the font module is SDL_ttf based, then it can only supports  UCS-2;
+        # it will raise an exception for an out-of-range UCS-4 code point.
+        if UCS_4 and not hasattr(f, 'ucs4'):
+            ucs_2 = as_unicode(r"\uFFEE")
+            s = f.render(ucs_2, False, [0, 0, 0], [255, 255, 255])
+            ucs_4 = as_unicode(r"\U00010000")
+            self.assertRaises(UnicodeError, f.render,
+                              ucs_4, False, [0, 0, 0], [255, 255, 255])
 
-            b = as_bytes("ab\x00cd")
-            self.assertRaises(ValueError, f.render, b, 0, [0, 0, 0])
-            u = as_unicode("ab\x00cd")
-            self.assertRaises(ValueError, f.render, b, 0, [0, 0, 0])
+        b = as_bytes("ab\x00cd")
+        self.assertRaises(ValueError, f.render, b, 0, [0, 0, 0])
+        u = as_unicode("ab\x00cd")
+        self.assertRaises(ValueError, f.render, b, 0, [0, 0, 0])
 
-            # __doc__ (as of 2008-08-02) for pygame_font.Font.render:
+        # __doc__ (as of 2008-08-02) for pygame_font.Font.render:
 
-              # Font.render(text, antialias, color, background=None): return Surface
-              # draw text on a new Surface
-              #
-              # This creates a new Surface with the specified text rendered on it.
-              # Pygame provides no way to directly draw text on an existing Surface:
-              # instead you must use Font.render() to create an image (Surface) of
-              # the text, then blit this image onto another Surface.
-              #
-              # The text can only be a single line: newline characters are not
-              # rendered. The antialias argument is a boolean: if true the
-              # characters will have smooth edges. The color argument is the color
-              # of the text [e.g.: (0,0,255) for blue]. The optional background
-              # argument is a color to use for the text background. If no background
-              # is passed the area outside the text will be transparent.
-              #
-              # The Surface returned will be of the dimensions required to hold the
-              # text. (the same as those returned by Font.size()). If an empty
-              # string is passed for the text, a blank surface will be returned that
-              # is one pixel wide and the height of the font.
-              #
-              # Depending on the type of background and antialiasing used, this
-              # returns different types of Surfaces. For performance reasons, it is
-              # good to know what type of image will be used. If antialiasing is not
-              # used, the return image will always be an 8bit image with a two color
-              # palette. If the background is transparent a colorkey will be set.
-              # Antialiased images are rendered to 24-bit RGB images. If the
-              # background is transparent a pixel alpha will be included.
-              #
-              # Optimization: if you know that the final destination for the text
-              # (on the screen) will always have a solid background, and the text is
-              # antialiased, you can improve performance by specifying the
-              # background color. This will cause the resulting image to maintain
-              # transparency information by colorkey rather than (much less
-              # efficient) alpha values.
-              #
-              # If you render '\n' a unknown char will be rendered.  Usually a
-              # rectangle. Instead you need to handle new lines yourself.
-              #
-              # Font rendering is not thread safe: only a single thread can render
-              # text any time.
+          # Font.render(text, antialias, color, background=None): return Surface
+          # draw text on a new Surface
+          #
+          # This creates a new Surface with the specified text rendered on it.
+          # Pygame provides no way to directly draw text on an existing Surface:
+          # instead you must use Font.render() to create an image (Surface) of
+          # the text, then blit this image onto another Surface.
+          #
+          # The text can only be a single line: newline characters are not
+          # rendered. The antialias argument is a boolean: if true the
+          # characters will have smooth edges. The color argument is the color
+          # of the text [e.g.: (0,0,255) for blue]. The optional background
+          # argument is a color to use for the text background. If no background
+          # is passed the area outside the text will be transparent.
+          #
+          # The Surface returned will be of the dimensions required to hold the
+          # text. (the same as those returned by Font.size()). If an empty
+          # string is passed for the text, a blank surface will be returned that
+          # is one pixel wide and the height of the font.
+          #
+          # Depending on the type of background and antialiasing used, this
+          # returns different types of Surfaces. For performance reasons, it is
+          # good to know what type of image will be used. If antialiasing is not
+          # used, the return image will always be an 8bit image with a two color
+          # palette. If the background is transparent a colorkey will be set.
+          # Antialiased images are rendered to 24-bit RGB images. If the
+          # background is transparent a pixel alpha will be included.
+          #
+          # Optimization: if you know that the final destination for the text
+          # (on the screen) will always have a solid background, and the text is
+          # antialiased, you can improve performance by specifying the
+          # background color. This will cause the resulting image to maintain
+          # transparency information by colorkey rather than (much less
+          # efficient) alpha values.
+          #
+          # If you render '\n' a unknown char will be rendered.  Usually a
+          # rectangle. Instead you need to handle new lines yourself.
+          #
+          # Font rendering is not thread safe: only a single thread can render
+          # text any time.
 
 
-        def test_set_bold(self):
-            f = pygame_font.Font(None, 20)
-            self.assertFalse(f.get_bold())
-            f.set_bold(True)
-            self.failUnless(f.get_bold())
-            f.set_bold(False)
-            self.assertFalse(f.get_bold())
+    def test_set_bold(self):
+        f = pygame_font.Font(None, 20)
+        self.assertFalse(f.get_bold())
+        f.set_bold(True)
+        self.failUnless(f.get_bold())
+        f.set_bold(False)
+        self.assertFalse(f.get_bold())
 
-        def test_set_italic(self):
-            f = pygame_font.Font(None, 20)
-            self.assertFalse(f.get_italic())
-            f.set_italic(True)
-            self.failUnless(f.get_italic())
-            f.set_italic(False)
-            self.assertFalse(f.get_italic())
+    def test_set_italic(self):
+        f = pygame_font.Font(None, 20)
+        self.assertFalse(f.get_italic())
+        f.set_italic(True)
+        self.failUnless(f.get_italic())
+        f.set_italic(False)
+        self.assertFalse(f.get_italic())
 
-        def test_set_underline(self):
-            f = pygame_font.Font(None, 20)
-            self.assertFalse(f.get_underline())
-            f.set_underline(True)
-            self.failUnless(f.get_underline())
-            f.set_underline(False)
-            self.assertFalse(f.get_underline())
+    def test_set_underline(self):
+        f = pygame_font.Font(None, 20)
+        self.assertFalse(f.get_underline())
+        f.set_underline(True)
+        self.failUnless(f.get_underline())
+        f.set_underline(False)
+        self.assertFalse(f.get_underline())
 
-        def test_size(self):
-            f = pygame_font.Font(None, 20)
-            text = as_unicode("Xg")
+    def test_size(self):
+        f = pygame_font.Font(None, 20)
+        text = as_unicode("Xg")
+        size = f.size(text)
+        w, h = size
+        self.assert_(isinstance(w, int) and isinstance(h, int))
+        s = f.render(text, False, (255, 255, 255))
+        self.assert_(size == s.get_size())
+        btext = text.encode("ascii")
+        self.assert_(f.size(btext) == size)
+        text = as_unicode(r"\u212A")
+        btext = text.encode("UTF-16")[2:] # Keep the byte order consistent.
+        bsize = f.size(btext)
+        try:
             size = f.size(text)
-            w, h = size
-            self.assert_(isinstance(w, int) and isinstance(h, int))
-            s = f.render(text, False, (255, 255, 255))
-            self.assert_(size == s.get_size())
-            btext = text.encode("ascii")
-            self.assert_(f.size(btext) == size)
-            text = as_unicode(r"\u212A")
-            btext = text.encode("UTF-16")[2:] # Keep the byte order consistent.
-            bsize = f.size(btext)
-            try:
-                size = f.size(text)
-            except pygame.error:
-                pass
-            else:
-                self.assert_(size != bsize)
+        except pygame.error:
+            pass
+        else:
+            self.assert_(size != bsize)
 
-        def test_font_file_not_found(self):
-            # A per BUG reported by Bo Jangeborg on pygame-user mailing list,
-            # http://www.mail-archive.com/pygame-users@seul.org/msg11675.html
+    def test_font_file_not_found(self):
+        # A per BUG reported by Bo Jangeborg on pygame-user mailing list,
+        # http://www.mail-archive.com/pygame-users@seul.org/msg11675.html
 
-            pygame_font.init()
-            self.assertRaises(IOError,
-                              pygame_font.Font,
-                              'some-fictional-font.ttf', 20)
+        pygame_font.init()
+        self.assertRaises(IOError,
+                          pygame_font.Font,
+                          'some-fictional-font.ttf', 20)
 
-        def test_load_from_file(self):
-            font_name = pygame_font.get_default_font()
-            font_path = os.path.join(os.path.split(pygame.__file__)[0],
-                                     pygame_font.get_default_font())
-            f = pygame_font.Font(font_path, 20)
+    def test_load_from_file(self):
+        font_name = pygame_font.get_default_font()
+        font_path = os.path.join(os.path.split(pygame.__file__)[0],
+                                 pygame_font.get_default_font())
+        f = pygame_font.Font(font_path, 20)
 
-        def test_load_from_file_obj(self):
-            font_name = pygame_font.get_default_font()
-            font_path = os.path.join(os.path.split(pygame.__file__)[0],
-                                     pygame_font.get_default_font())
-            f = open(font_path, "rb")
-            font = pygame_font.Font(f, 20)
+    def test_load_from_file_obj(self):
+        font_name = pygame_font.get_default_font()
+        font_path = os.path.join(os.path.split(pygame.__file__)[0],
+                                 pygame_font.get_default_font())
+        f = open(font_path, "rb")
+        font = pygame_font.Font(f, 20)
 
-        def test_load_default_font_filename(self):
-            # In font_init, a special case is when the filename argument is
-            # identical to the default font file name.
-            f = pygame_font.Font(pygame_font.get_default_font(), 20)
+    def test_load_default_font_filename(self):
+        # In font_init, a special case is when the filename argument is
+        # identical to the default font file name.
+        f = pygame_font.Font(pygame_font.get_default_font(), 20)
 
-        def test_load_from_file_unicode(self):
-            base_dir = os.path.dirname(pygame.__file__)
-            font_path = os.path.join(base_dir, pygame_font.get_default_font())
-            if os.path.sep == '\\':
-                font_path = font_path.replace('\\', '\\\\')
-            ufont_path = as_unicode(font_path)
-            f = pygame_font.Font(ufont_path, 20)
+    def test_load_from_file_unicode(self):
+        base_dir = os.path.dirname(pygame.__file__)
+        font_path = os.path.join(base_dir, pygame_font.get_default_font())
+        if os.path.sep == '\\':
+            font_path = font_path.replace('\\', '\\\\')
+        ufont_path = as_unicode(font_path)
+        f = pygame_font.Font(ufont_path, 20)
 
-        def test_load_from_file_bytes(self):
-            font_path = os.path.join(os.path.split(pygame.__file__)[0],
-                                     pygame_font.get_default_font())
-            filesystem_encoding = sys.getfilesystemencoding()
-            try:
-                font_path = font_path.decode(filesystem_encoding,
-                                             filesystem_errors)
-            except AttributeError:
-                pass
-            bfont_path = font_path.encode(filesystem_encoding,
-                                          filesystem_errors)
-            f = pygame_font.Font(bfont_path, 20)
+    def test_load_from_file_bytes(self):
+        font_path = os.path.join(os.path.split(pygame.__file__)[0],
+                                 pygame_font.get_default_font())
+        filesystem_encoding = sys.getfilesystemencoding()
+        try:
+            font_path = font_path.decode(filesystem_encoding,
+                                         filesystem_errors)
+        except AttributeError:
+            pass
+        bfont_path = font_path.encode(filesystem_encoding,
+                                      filesystem_errors)
+        f = pygame_font.Font(bfont_path, 20)
 
-    class VisualTests( unittest.TestCase ):
-        __tags__ = ['interactive']
 
-        screen = None
-        aborted = False
+@unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
+class VisualTests( unittest.TestCase ):
+    __tags__ = ['interactive']
 
-        def setUp(self):
-            if self.screen is None:
-                pygame.init()
-                self.screen = pygame.display.set_mode((600, 200))
-                self.screen.fill((255, 255, 255))
-                pygame.display.flip()
-                self.f = pygame_font.Font(None, 32)
+    screen = None
+    aborted = False
 
-        def abort(self):
-            if self.screen is not None:
-                pygame.quit()
-            self.aborted = True
-
-        def query(self,
-                  bold=False, italic=False, underline=False, antialiase=False):
-            if self.aborted:
-                return False
-            spacing = 10
-            offset = 20
-            y = spacing
-            f = self.f
-            screen = self.screen
-            screen.fill((255, 255, 255))
+    def setUp(self):
+        if self.screen is None:
+            pygame.init()
+            self.screen = pygame.display.set_mode((600, 200))
+            self.screen.fill((255, 255, 255))
             pygame.display.flip()
-            if not (bold or italic or underline or antialiase):
-                text = "normal"
-            else:
-                modes = []
-                if bold:
-                    modes.append("bold")
-                if italic:
-                    modes.append("italic")
-                if underline:
-                    modes.append("underlined")
-                if antialiase:
-                    modes.append("antialiased")
-                text = "%s (y/n):" % ('-'.join(modes),)
-            f.set_bold(bold)
-            f.set_italic(italic)
-            f.set_underline(underline)
-            s = f.render(text, antialiase, (0, 0, 0))
-            screen.blit(s, (offset, y))
-            y += s.get_size()[1] + spacing
-            f.set_bold(False)
-            f.set_italic(False)
-            f.set_underline(False)
-            s = f.render("(some comparison text)", False, (0, 0, 0))
-            screen.blit(s, (offset, y))
-            pygame.display.flip()
-            while 1:
-                for evt in pygame.event.get():
-                    if evt.type == pygame.KEYDOWN:
-                        if evt.key == pygame.K_ESCAPE:
-                            self.abort()
-                            return False
-                        if evt.key == pygame.K_y:
-                            return True
-                        if evt.key == pygame.K_n:
-                            return False
-                    if evt.type == pygame.QUIT:
+            self.f = pygame_font.Font(None, 32)
+
+    def abort(self):
+        if self.screen is not None:
+            pygame.quit()
+        self.aborted = True
+
+    def query(self,
+              bold=False, italic=False, underline=False, antialiase=False):
+        if self.aborted:
+            return False
+        spacing = 10
+        offset = 20
+        y = spacing
+        f = self.f
+        screen = self.screen
+        screen.fill((255, 255, 255))
+        pygame.display.flip()
+        if not (bold or italic or underline or antialiase):
+            text = "normal"
+        else:
+            modes = []
+            if bold:
+                modes.append("bold")
+            if italic:
+                modes.append("italic")
+            if underline:
+                modes.append("underlined")
+            if antialiase:
+                modes.append("antialiased")
+            text = "%s (y/n):" % ('-'.join(modes),)
+        f.set_bold(bold)
+        f.set_italic(italic)
+        f.set_underline(underline)
+        s = f.render(text, antialiase, (0, 0, 0))
+        screen.blit(s, (offset, y))
+        y += s.get_size()[1] + spacing
+        f.set_bold(False)
+        f.set_italic(False)
+        f.set_underline(False)
+        s = f.render("(some comparison text)", False, (0, 0, 0))
+        screen.blit(s, (offset, y))
+        pygame.display.flip()
+        while 1:
+            for evt in pygame.event.get():
+                if evt.type == pygame.KEYDOWN:
+                    if evt.key == pygame.K_ESCAPE:
                         self.abort()
                         return False
+                    if evt.key == pygame.K_y:
+                        return True
+                    if evt.key == pygame.K_n:
+                        return False
+                if evt.type == pygame.QUIT:
+                    self.abort()
+                    return False
 
-        def test_bold(self):
-            self.failUnless(self.query(bold=True))
+    def test_bold(self):
+        self.failUnless(self.query(bold=True))
 
-        def test_italic(self):
-            self.failUnless(self.query(italic=True))
+    def test_italic(self):
+        self.failUnless(self.query(italic=True))
 
-        def test_underline(self):
-            self.failUnless(self.query(underline=True))
+    def test_underline(self):
+        self.failUnless(self.query(underline=True))
 
-        def test_antialiase(self):
-            self.failUnless(self.query(antialiase=True))
+    def test_antialiase(self):
+        self.failUnless(self.query(antialiase=True))
 
-        def test_bold_antialiase(self):
-            self.failUnless(self.query(bold=True, antialiase=True))
+    def test_bold_antialiase(self):
+        self.failUnless(self.query(bold=True, antialiase=True))
 
-        def test_italic_underline(self):
-            self.failUnless(self.query(italic=True, underline=True))
+    def test_italic_underline(self):
+        self.failUnless(self.query(italic=True, underline=True))
 
 
 if __name__ == '__main__':

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -1,40 +1,35 @@
 # -*- coding: utf-8 -*-
-
+import sys
 import unittest
 import math
 from time import clock
-from random import random
-import gc
 import platform
 
 import pygame.math
 from pygame.math import Vector2, Vector3
 
 IS_PYPY = 'PyPy' == platform.python_implementation()
+PY3 = sys.version_info.major == 3
 
 
 class Vector2TypeTest(unittest.TestCase):
+
     def setUp(self):
         pygame.math.enable_swizzling()
-#        gc.collect()
         self.zeroVec = Vector2()
         self.e1 = Vector2(1, 0)
         self.e2 = Vector2(0, 1)
-#        self.t1 = (random(), random())
         self.t1 = (1.2, 3.4)
         self.l1 = list(self.t1)
         self.v1 = Vector2(self.t1)
-#        self.t2 = (random(), random())
         self.t2 = (5.6, 7.8)
         self.l2 = list(self.t2)
         self.v2 = Vector2(self.t2)
-#        self.s1 = random()
-#        self.s2 = random()
         self.s1 = 5.6
         self.s2 = 7.8
+
     def tearDown(self):
         pygame.math.enable_swizzling()
-
 
     def testConstructionDefault(self):
         v = Vector2()
@@ -91,7 +86,6 @@ class Vector2TypeTest(unittest.TestCase):
             v = Vector2()
             v.x = "spam"
         self.assertRaises(TypeError, assign_nonfloat)
-
 
     def testSequence(self):
         v = Vector2(1.2, 3.4)
@@ -273,13 +267,10 @@ class Vector2TypeTest(unittest.TestCase):
 
     def testIter(self):
         it = self.v1.__iter__()
-        # support py2.x and 3.x
-        if hasattr(it, "next"):
-            next_ = it.next
-        elif hasattr(it, "__next__"):
+        if PY3:
             next_ = it.__next__
         else:
-            self.fail("Iterator has neither a 'next' nor a '__next__' method.")
+            next_ = it.next
         self.assertEqual(next_(), self.v1[0])
         self.assertEqual(next_(), self.v1[1])
         self.assertRaises(StopIteration, lambda : next_())
@@ -444,8 +435,8 @@ class Vector2TypeTest(unittest.TestCase):
                          self.v2.distance_squared_to(self.v1))
 
     def test_swizzle(self):
-        self.assertEqual(hasattr(pygame.math, "enable_swizzling"), True)
-        self.assertEqual(hasattr(pygame.math, "disable_swizzling"), True)
+        self.assertTrue(hasattr(pygame.math, "enable_swizzling"))
+        self.assertTrue(hasattr(pygame.math, "disable_swizzling"))
         # swizzling not disabled by default
         pygame.math.disable_swizzling()
         self.assertRaises(AttributeError, lambda : self.v1.yx)
@@ -736,26 +727,19 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertEqual(v, self.e1)
 
 
-
-
-
 class Vector3TypeTest(unittest.TestCase):
+
     def setUp(self):
-#        gc.collect()
         self.zeroVec = Vector3()
         self.e1 = Vector3(1, 0, 0)
         self.e2 = Vector3(0, 1, 0)
         self.e3 = Vector3(0, 0, 1)
-#        self.t1 = (random(), random())
         self.t1 = (1.2, 3.4, 9.6)
         self.l1 = list(self.t1)
         self.v1 = Vector3(self.t1)
-#        self.t2 = (random(), random())
         self.t2 = (5.6, 7.8, 2.1)
         self.l2 = list(self.t2)
         self.v2 = Vector3(self.t2)
-#        self.s1 = random()
-#        self.s2 = random()
         self.s1 = 5.6
         self.s2 = 7.8
 
@@ -1039,13 +1023,10 @@ class Vector3TypeTest(unittest.TestCase):
 
     def testIter(self):
         it = self.v1.__iter__()
-        # support py2.x and 3.x
-        if hasattr(it, "next"):
-            next_ = it.next
-        elif hasattr(it, "__next__"):
+        if PY3:
             next_ = it.__next__
         else:
-            self.fail("Iterator has neither a 'next' nor a '__next__' method.")
+            next_ = it.next
         self.assertEqual(next_(), self.v1[0])
         self.assertEqual(next_(), self.v1[1])
         self.assertEqual(next_(), self.v1[2])
@@ -1349,8 +1330,8 @@ class Vector3TypeTest(unittest.TestCase):
                          self.v2.distance_squared_to(self.v1))
 
     def test_swizzle(self):
-        self.assertEqual(hasattr(pygame.math, "enable_swizzling"), True)
-        self.assertEqual(hasattr(pygame.math, "disable_swizzling"), True)
+        self.assertTrue(hasattr(pygame.math, "enable_swizzling"))
+        self.assertTrue(hasattr(pygame.math, "disable_swizzling"))
         # swizzling enabled by default
         pygame.math.disable_swizzling()
         self.assertRaises(AttributeError, lambda : self.v1.yx)
@@ -1367,6 +1348,9 @@ class Vector3TypeTest(unittest.TestCase):
         self.v1.yz = self.t2[:2]
         self.assertEqual(self.v1, (self.t2[1], self.t2[0], self.t2[1]))
         self.assertEqual(type(self.v1), Vector3)
+
+    @unittest.skipIf(IS_PYPY, "known pypy failure")
+    def test_invalid_swizzle(self):
         def invalidSwizzleX():
             Vector3().xx = (1, 2)
         def invalidSwizzleY():
@@ -1375,7 +1359,6 @@ class Vector3TypeTest(unittest.TestCase):
             Vector3().zz = (1, 2)
         def invalidSwizzleW():
             Vector3().ww = (1, 2)
-        if IS_PYPY: return #TODO: known pypy failure.
         self.assertRaises(AttributeError, invalidSwizzleX)
         self.assertRaises(AttributeError, invalidSwizzleY)
         self.assertRaises(AttributeError, invalidSwizzleZ)
@@ -1593,8 +1576,6 @@ class Vector3TypeTest(unittest.TestCase):
         v3 = Vector3(1, 2, 3)
         self.assertEqual(pickle.loads(pickle.dumps(v2)), v2)
         self.assertEqual(pickle.loads(pickle.dumps(v3)), v3)
-
-
 
 
 if __name__ == '__main__':

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import unittest
+import platform
 import time
 
 from pygame.tests.test_utils import example_path
@@ -8,6 +9,8 @@ import pygame
 from pygame import mixer
 from pygame.compat import unicode_, as_bytes, bytes_
 
+
+IS_PYPY = 'PyPy' == platform.python_implementation()
 
 ################################### CONSTANTS ##################################
 
@@ -473,14 +476,10 @@ class MixerModuleTest(unittest.TestCase):
         finally:
             mixer.quit()
 
+    @unittest.skipIf(IS_PYPY, 'pypy skip')
     def test_get_raw_more(self):
         """ test the array interface a bit better.
         """
-        import platform
-        IS_PYPY = 'PyPy' == platform.python_implementation()
-
-        if IS_PYPY:
-            return
         from ctypes import pythonapi, c_void_p, py_object
 
         try:

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1005,13 +1005,14 @@ class PixelArrayTypeTest (unittest.TestCase, TestMixin):
         self.assertEqual(repr (ar),
                          type (ar).__name__ + "([\n  [42, 42, 42]]\n)")
 
-class PixelArrayArrayInterfaceTest (unittest.TestCase, TestMixin):
+
+class PixelArrayArrayInterfaceTest(unittest.TestCase, TestMixin):
+
+    @unittest.skipIf(IS_PYPY, 'skipping for PyPy (why?)')
     def test_basic (self):
         # Check unchanging fields.
         sf = pygame.Surface ((2, 2), 0, 32)
         ar = pygame.PixelArray (sf)
-        if IS_PYPY:
-            return
 
         ai = arrinter.ArrayInterface (ar)
         self.assertEqual (ai.two, 2)
@@ -1019,9 +1020,8 @@ class PixelArrayArrayInterfaceTest (unittest.TestCase, TestMixin):
         self.assertEqual (ai.nd, 2)
         self.assertEqual (ai.data, ar._pixels_address)
 
-    def test_shape (self):
-        if IS_PYPY:
-            return
+    @unittest.skipIf(IS_PYPY, 'skipping for PyPy (why?)')
+    def test_shape(self):
 
         for shape in [[4, 16], [5, 13]]:
             w, h = shape
@@ -1041,9 +1041,8 @@ class PixelArrayArrayInterfaceTest (unittest.TestCase, TestMixin):
             ai_shape = [ai2.shape[i] for i in range(ai2.nd)]
             self.assertEqual (ai_shape, [w, h2])
 
+    @unittest.skipIf(IS_PYPY, 'skipping for PyPy (why?)')
     def test_itemsize (self):
-        if IS_PYPY:
-            return
         for bytes_per_pixel in range(1, 5):
             bits_per_pixel = 8 * bytes_per_pixel
             sf = pygame.Surface ((2, 2), 0, bits_per_pixel)
@@ -1051,9 +1050,8 @@ class PixelArrayArrayInterfaceTest (unittest.TestCase, TestMixin):
             ai = arrinter.ArrayInterface (ar)
             self.assertEqual (ai.itemsize, bytes_per_pixel)
 
+    @unittest.skipIf(IS_PYPY, 'skipping for PyPy (why?)')
     def test_flags (self):
-        if IS_PYPY:
-            return
         aim = arrinter
         common_flags = (aim.PAI_NOTSWAPPED | aim.PAI_WRITEABLE |
                         aim.PAI_ALIGNED)

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -19,6 +19,16 @@ IS_PYPY = 'PyPy' == platform.python_implementation()
 @unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
 class SurfarrayModuleTest (unittest.TestCase):
 
+    def setUp(self):
+        # Needed for 8 bits-per-pixel color palette surface tests.
+        pygame.init()
+
+        # Makes sure the same array package is used each time.
+        pygame.surfarray.use_arraytype(arraytype)
+
+    def tearDown(self):
+        pygame.quit()
+
     pixels2d = {8: True, 16: True, 24: False, 32: True}
     pixels3d = {8: False, 16: False, 24: True, 32: True}
     array2d = {8: True, 16: True, 24: True, 32: True}
@@ -95,20 +105,7 @@ class SurfarrayModuleTest (unittest.TestCase):
     def _make_array2d(self, dtype):
         return zeros(self.surf_size, dtype)
 
-    def setUp(self):
-        # Needed for 8 bits-per-pixel color palette surface tests.
-        pygame.init()
-
-        # Makes sure the same array package is used each time.
-        if arraytype:
-            pygame.surfarray.use_arraytype(arraytype)
-
-    def tearDown(self):
-        pygame.quit()
-
     def test_array2d(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         sources = [self._make_src_surface(8),
                    self._make_src_surface(16),
@@ -140,8 +137,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                                       surf.get_bitsize()))
 
     def test_array3d(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         sources = [self._make_src_surface(16),
                    self._make_src_surface(16, srcalpha=True),
@@ -165,8 +160,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                                  posn))
 
     def test_array_alpha(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         palette = [(0, 0, 0, 0),
                    (10, 50, 100, 255),
@@ -222,8 +215,6 @@ class SurfarrayModuleTest (unittest.TestCase):
             surf.set_alpha(blanket_alpha)
 
     def test_array_colorkey(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         palette = [(0, 0, 0, 0),
                    (10, 50, 100, 255),
@@ -258,8 +249,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                                            surf.get_bitsize())))
 
     def test_blit_array(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         # bug 24 at http://pygame.motherhamster.org/bugzilla/
         if 'numpy' in pygame.surfarray.get_arraytypes():
@@ -419,17 +408,12 @@ class SurfarrayModuleTest (unittest.TestCase):
                                          int(rint(farr[x, y])))
 
     def test_get_arraytype(self):
-        if not arraytype:
-            self.fail("no array package installed")
-
         self.failUnless((pygame.surfarray.get_arraytype() in
                          ['numpy']),
                         ("unknown array type %s" %
                          pygame.surfarray.get_arraytype()))
 
     def test_get_arraytypes(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         arraytypes = pygame.surfarray.get_arraytypes()
         self.failUnless('numpy' in arraytypes)
@@ -439,8 +423,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                             "unknown array type %s" % atype)
 
     def test_make_surface(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         # How does one properly test this with 2d arrays. It makes no sense
         # since the pixel format is not entirely dependent on element size.
@@ -475,8 +457,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                                          int(rint(farr[x, y])))
 
     def test_map_array(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         arr3d = self._make_src_array3d(uint8)
         targets = [self._make_surface(8),
@@ -501,8 +481,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                           self._make_array2d(uint8))
 
     def test_pixels2d(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         sources = [self._make_surface(8),
                    self._make_surface(16, srcalpha=True),
@@ -526,8 +504,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                           self._make_surface(24))
 
     def test_pixels3d(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         sources = [self._make_surface(24),
                    self._make_surface(32)]
@@ -563,8 +539,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                           self._make_surface(16))
 
     def test_pixels_alpha(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         palette = [(0, 0, 0, 0),
                    (127, 127, 127, 0),
@@ -620,8 +594,6 @@ class SurfarrayModuleTest (unittest.TestCase):
 
     def _test_pixels_rgb(self, operation, mask_posn):
         method_name = "pixels_" + operation
-        if not arraytype:
-            self.fail("no array package installed")
 
         pixels_rgb = getattr(pygame.surfarray, method_name)
         palette = [(0, 0, 0, 255),
@@ -659,8 +631,6 @@ class SurfarrayModuleTest (unittest.TestCase):
                               self._make_surface(bitsize, srcalpha))
 
     def test_use_arraytype(self):
-        if not arraytype:
-            self.fail("no array package installed")
 
         def do_use_arraytype(atype):
             pygame.surfarray.use_arraytype(atype)
@@ -670,9 +640,6 @@ class SurfarrayModuleTest (unittest.TestCase):
         self.assertRaises(ValueError, do_use_arraytype, 'not an option')
 
     def test_surf_lock (self):
-        if not arraytype:
-            self.fail("no array package installed")
-
         sf = pygame.Surface ((5, 5), 0, 32)
         for atype in pygame.surfarray.get_arraytypes ():
             pygame.surfarray.use_arraytype (atype)
@@ -691,7 +658,4 @@ class SurfarrayModuleTest (unittest.TestCase):
 
 
 if __name__ == '__main__':
-    if not arraytype:
-        print ("No array package is installed. Cannot run unit tests.")
-    else:
-        unittest.main()
+    unittest.main()

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -1,693 +1,693 @@
 
 import unittest
-import pygame
-from pygame.locals import *
+import platform
 
-
-import pygame.surfarray
 from numpy import \
     uint8, uint16, uint32, uint64, zeros, \
     float32, float64, alltrue, rint, arange
+
+import pygame
+from pygame.locals import *
+
+import pygame.surfarray
 arraytype = 'numpy'
 
 
-
-import platform
 IS_PYPY = 'PyPy' == platform.python_implementation()
 
-if not IS_PYPY: #TODO: pypy skip known failure.
 
-    class SurfarrayModuleTest (unittest.TestCase):
+@unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
+class SurfarrayModuleTest (unittest.TestCase):
 
-        pixels2d = {8: True, 16: True, 24: False, 32: True}
-        pixels3d = {8: False, 16: False, 24: True, 32: True}
-        array2d = {8: True, 16: True, 24: True, 32: True}
-        array3d = {8: False, 16: False, 24: True, 32: True}
+    pixels2d = {8: True, 16: True, 24: False, 32: True}
+    pixels3d = {8: False, 16: False, 24: True, 32: True}
+    array2d = {8: True, 16: True, 24: True, 32: True}
+    array3d = {8: False, 16: False, 24: True, 32: True}
 
-        test_palette = [(0, 0, 0, 255),
-                        (10, 30, 60, 255),
-                        (25, 75, 100, 255),
-                        (100, 150, 200, 255),
-                        (0, 100, 200, 255)]
-        surf_size = (10, 12)
-        test_points = [((0, 0), 1), ((4, 5), 1), ((9, 0), 2),
-                       ((5, 5), 2), ((0, 11), 3), ((4, 6), 3),
-                       ((9, 11), 4), ((5, 6), 4)]
+    test_palette = [(0, 0, 0, 255),
+                    (10, 30, 60, 255),
+                    (25, 75, 100, 255),
+                    (100, 150, 200, 255),
+                    (0, 100, 200, 255)]
+    surf_size = (10, 12)
+    test_points = [((0, 0), 1), ((4, 5), 1), ((9, 0), 2),
+                   ((5, 5), 2), ((0, 11), 3), ((4, 6), 3),
+                   ((9, 11), 4), ((5, 6), 4)]
 
-        def _make_surface(self, bitsize, srcalpha=False, palette=None):
-            if palette is None:
-                palette = self.test_palette
-            flags = 0
-            if srcalpha:
-                flags |= SRCALPHA
-            surf = pygame.Surface(self.surf_size, flags, bitsize)
-            if bitsize == 8:
-                surf.set_palette([c[:3] for c in palette])
-            return surf
+    def _make_surface(self, bitsize, srcalpha=False, palette=None):
+        if palette is None:
+            palette = self.test_palette
+        flags = 0
+        if srcalpha:
+            flags |= SRCALPHA
+        surf = pygame.Surface(self.surf_size, flags, bitsize)
+        if bitsize == 8:
+            surf.set_palette([c[:3] for c in palette])
+        return surf
 
-        def _fill_surface(self, surf, palette=None):
-            if palette is None:
-                palette = self.test_palette
-            surf.fill(palette[1], (0, 0, 5, 6))
-            surf.fill(palette[2], (5, 0, 5, 6))
-            surf.fill(palette[3], (0, 6, 5, 6))
-            surf.fill(palette[4], (5, 6, 5, 6))
+    def _fill_surface(self, surf, palette=None):
+        if palette is None:
+            palette = self.test_palette
+        surf.fill(palette[1], (0, 0, 5, 6))
+        surf.fill(palette[2], (5, 0, 5, 6))
+        surf.fill(palette[3], (0, 6, 5, 6))
+        surf.fill(palette[4], (5, 6, 5, 6))
 
-        def _make_src_surface(self, bitsize, srcalpha=False, palette=None):
-            surf = self._make_surface(bitsize, srcalpha, palette)
-            self._fill_surface(surf, palette)
-            return surf
+    def _make_src_surface(self, bitsize, srcalpha=False, palette=None):
+        surf = self._make_surface(bitsize, srcalpha, palette)
+        self._fill_surface(surf, palette)
+        return surf
 
-        def _assert_surface(self, surf, palette=None, msg=""):
-            if palette is None:
-                palette = self.test_palette
-            if surf.get_bitsize() == 16:
-                palette = [surf.unmap_rgb(surf.map_rgb(c)) for c in palette]
+    def _assert_surface(self, surf, palette=None, msg=""):
+        if palette is None:
+            palette = self.test_palette
+        if surf.get_bitsize() == 16:
+            palette = [surf.unmap_rgb(surf.map_rgb(c)) for c in palette]
+        for posn, i in self.test_points:
+            self.assertEqual(surf.get_at(posn), palette[i],
+                                 "%s != %s: flags: %i, bpp: %i, posn: %s%s" %
+                                 (surf.get_at(posn),
+                                  palette[i], surf.get_flags(),
+                                  surf.get_bitsize(), posn, msg))
+
+    def _make_array3d(self, dtype):
+        return zeros((self.surf_size[0], self.surf_size[1], 3), dtype)
+
+    def _fill_array2d(self, arr, surf):
+        palette = self.test_palette
+        arr[:5,:6] = surf.map_rgb(palette[1])
+        arr[5:,:6] = surf.map_rgb(palette[2])
+        arr[:5,6:] = surf.map_rgb(palette[3])
+        arr[5:,6:] = surf.map_rgb(palette[4])
+
+    def _fill_array3d(self, arr):
+        palette = self.test_palette
+        arr[:5,:6] = palette[1][:3]
+        arr[5:,:6] = palette[2][:3]
+        arr[:5,6:] = palette[3][:3]
+        arr[5:,6:] = palette[4][:3]
+
+    def _make_src_array3d(self, dtype):
+        arr = self._make_array3d(dtype)
+        self._fill_array3d(arr)
+        return arr
+
+    def _make_array2d(self, dtype):
+        return zeros(self.surf_size, dtype)
+
+    def setUp(self):
+        # Needed for 8 bits-per-pixel color palette surface tests.
+        pygame.init()
+
+        # Makes sure the same array package is used each time.
+        if arraytype:
+            pygame.surfarray.use_arraytype(arraytype)
+
+    def tearDown(self):
+        pygame.quit()
+
+    def test_array2d(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        sources = [self._make_src_surface(8),
+                   self._make_src_surface(16),
+                   self._make_src_surface(16, srcalpha=True),
+                   self._make_src_surface(24),
+                   self._make_src_surface(32),
+                   self._make_src_surface(32, srcalpha=True)]
+        palette = self.test_palette
+        alpha_color = (0, 0, 0, 128)
+
+        for surf in sources:
+            arr = pygame.surfarray.array2d(surf)
             for posn, i in self.test_points:
-                self.assertEqual(surf.get_at(posn), palette[i],
-                                     "%s != %s: flags: %i, bpp: %i, posn: %s%s" %
-                                     (surf.get_at(posn),
-                                      palette[i], surf.get_flags(),
-                                      surf.get_bitsize(), posn, msg))
+                self.assertEqual(arr[posn], surf.get_at_mapped(posn),
+                                     "%s != %s: flags: %i, bpp: %i, posn: %s" %
+                                     (arr[posn],
+                                      surf.get_at_mapped(posn),
+                                      surf.get_flags(), surf.get_bitsize(),
+                                      posn))
 
-        def _make_array3d(self, dtype):
-            return zeros((self.surf_size[0], self.surf_size[1], 3), dtype)
-
-        def _fill_array2d(self, arr, surf):
-            palette = self.test_palette
-            arr[:5,:6] = surf.map_rgb(palette[1])
-            arr[5:,:6] = surf.map_rgb(palette[2])
-            arr[:5,6:] = surf.map_rgb(palette[3])
-            arr[5:,6:] = surf.map_rgb(palette[4])
-
-        def _fill_array3d(self, arr):
-            palette = self.test_palette
-            arr[:5,:6] = palette[1][:3]
-            arr[5:,:6] = palette[2][:3]
-            arr[:5,6:] = palette[3][:3]
-            arr[5:,6:] = palette[4][:3]
-
-        def _make_src_array3d(self, dtype):
-            arr = self._make_array3d(dtype)
-            self._fill_array3d(arr)
-            return arr
-
-        def _make_array2d(self, dtype):
-            return zeros(self.surf_size, dtype)
-
-        def setUp(self):
-            # Needed for 8 bits-per-pixel color palette surface tests.
-            pygame.init()
-
-            # Makes sure the same array package is used each time.
-            if arraytype:
-                pygame.surfarray.use_arraytype(arraytype)
-
-        def tearDown(self):
-            pygame.quit()
-
-        def test_array2d(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            sources = [self._make_src_surface(8),
-                       self._make_src_surface(16),
-                       self._make_src_surface(16, srcalpha=True),
-                       self._make_src_surface(24),
-                       self._make_src_surface(32),
-                       self._make_src_surface(32, srcalpha=True)]
-            palette = self.test_palette
-            alpha_color = (0, 0, 0, 128)
-
-            for surf in sources:
+            if surf.get_masks()[3]:
+                surf.fill(alpha_color)
                 arr = pygame.surfarray.array2d(surf)
-                for posn, i in self.test_points:
-                    self.assertEqual(arr[posn], surf.get_at_mapped(posn),
-                                         "%s != %s: flags: %i, bpp: %i, posn: %s" %
-                                         (arr[posn],
-                                          surf.get_at_mapped(posn),
-                                          surf.get_flags(), surf.get_bitsize(),
-                                          posn))
+                posn = (0, 0)
+                self.assertEqual(arr[posn], surf.get_at_mapped(posn),
+                                     "%s != %s: bpp: %i" %
+                                     (arr[posn],
+                                      surf.get_at_mapped(posn),
+                                      surf.get_bitsize()))
 
-                if surf.get_masks()[3]:
-                    surf.fill(alpha_color)
-                    arr = pygame.surfarray.array2d(surf)
-                    posn = (0, 0)
-                    self.assertEqual(arr[posn], surf.get_at_mapped(posn),
-                                         "%s != %s: bpp: %i" %
-                                         (arr[posn],
-                                          surf.get_at_mapped(posn),
-                                          surf.get_bitsize()))
+    def test_array3d(self):
+        if not arraytype:
+            self.fail("no array package installed")
 
-        def test_array3d(self):
-            if not arraytype:
-                self.fail("no array package installed")
+        sources = [self._make_src_surface(16),
+                   self._make_src_surface(16, srcalpha=True),
+                   self._make_src_surface(24),
+                   self._make_src_surface(32),
+                   self._make_src_surface(32, srcalpha=True)]
+        palette = self.test_palette
 
-            sources = [self._make_src_surface(16),
-                       self._make_src_surface(16, srcalpha=True),
-                       self._make_src_surface(24),
-                       self._make_src_surface(32),
-                       self._make_src_surface(32, srcalpha=True)]
-            palette = self.test_palette
+        for surf in sources:
+            arr = pygame.surfarray.array3d(surf)
+            def same_color(ac, sc):
+                return (ac[0] == sc[0] and
+                        ac[1] == sc[1] and
+                        ac[2] == sc[2])
+            for posn, i in self.test_points:
+                self.failUnless(same_color(arr[posn], surf.get_at(posn)),
+                                "%s != %s: flags: %i, bpp: %i, posn: %s" %
+                                (tuple(arr[posn]),
+                                 surf.get_at(posn),
+                                 surf.get_flags(), surf.get_bitsize(),
+                                 posn))
 
-            for surf in sources:
-                arr = pygame.surfarray.array3d(surf)
-                def same_color(ac, sc):
-                    return (ac[0] == sc[0] and
-                            ac[1] == sc[1] and
-                            ac[2] == sc[2])
-                for posn, i in self.test_points:
-                    self.failUnless(same_color(arr[posn], surf.get_at(posn)),
-                                    "%s != %s: flags: %i, bpp: %i, posn: %s" %
-                                    (tuple(arr[posn]),
-                                     surf.get_at(posn),
-                                     surf.get_flags(), surf.get_bitsize(),
-                                     posn))
+    def test_array_alpha(self):
+        if not arraytype:
+            self.fail("no array package installed")
 
-        def test_array_alpha(self):
-            if not arraytype:
-                self.fail("no array package installed")
+        palette = [(0, 0, 0, 0),
+                   (10, 50, 100, 255),
+                   (60, 120, 240, 130),
+                   (64, 128, 255, 0),
+                   (255, 128, 0, 65)]
+        targets = [self._make_src_surface(8, palette=palette),
+                   self._make_src_surface(16, palette=palette),
+                   self._make_src_surface(16, palette=palette, srcalpha=True),
+                   self._make_src_surface(24, palette=palette),
+                   self._make_src_surface(32, palette=palette),
+                   self._make_src_surface(32, palette=palette, srcalpha=True)]
 
-            palette = [(0, 0, 0, 0),
-                       (10, 50, 100, 255),
-                       (60, 120, 240, 130),
-                       (64, 128, 255, 0),
-                       (255, 128, 0, 65)]
-            targets = [self._make_src_surface(8, palette=palette),
-                       self._make_src_surface(16, palette=palette),
-                       self._make_src_surface(16, palette=palette, srcalpha=True),
-                       self._make_src_surface(24, palette=palette),
-                       self._make_src_surface(32, palette=palette),
-                       self._make_src_surface(32, palette=palette, srcalpha=True)]
+        for surf in targets:
+            p = palette
+            if surf.get_bitsize() == 16:
+                p = [surf.unmap_rgb(surf.map_rgb(c)) for c in p]
+            arr = pygame.surfarray.array_alpha(surf)
+            if surf.get_masks()[3]:
+                for (x, y), i in self.test_points:
+                    self.assertEqual(arr[x, y], p[i][3],
+                                         ("%i != %i, posn: (%i, %i), "
+                                          "bitsize: %i" %
+                                          (arr[x, y], p[i][3],
+                                           x, y,
+                                           surf.get_bitsize())))
+            else:
+                self.failUnless(alltrue(arr == 255))
 
-            for surf in targets:
-                p = palette
-                if surf.get_bitsize() == 16:
-                    p = [surf.unmap_rgb(surf.map_rgb(c)) for c in p]
-                arr = pygame.surfarray.array_alpha(surf)
-                if surf.get_masks()[3]:
-                    for (x, y), i in self.test_points:
-                        self.assertEqual(arr[x, y], p[i][3],
-                                             ("%i != %i, posn: (%i, %i), "
-                                              "bitsize: %i" %
-                                              (arr[x, y], p[i][3],
-                                               x, y,
-                                               surf.get_bitsize())))
-                else:
-                    self.failUnless(alltrue(arr == 255))
+        # No per-pixel alpha when blanket alpha is None.
+        for surf in targets:
+            blacket_alpha = surf.get_alpha()
+            surf.set_alpha(None)
+            arr = pygame.surfarray.array_alpha(surf)
+            self.failUnless(alltrue(arr == 255),
+                            "bitsize: %i, flags: %i" %
+                            (surf.get_bitsize(), surf.get_flags()))
+            surf.set_alpha(blacket_alpha)
 
-            # No per-pixel alpha when blanket alpha is None.
-            for surf in targets:
-                blacket_alpha = surf.get_alpha()
-                surf.set_alpha(None)
-                arr = pygame.surfarray.array_alpha(surf)
+        # Bug for per-pixel alpha surface when blanket alpha 0.
+        for surf in targets:
+            blanket_alpha = surf.get_alpha()
+            surf.set_alpha(0)
+            arr = pygame.surfarray.array_alpha(surf)
+            if surf.get_masks()[3]:
+                self.assertFalse(alltrue(arr == 255),
+                            "bitsize: %i, flags: %i" %
+                            (surf.get_bitsize(), surf.get_flags()))
+            else:
                 self.failUnless(alltrue(arr == 255),
                                 "bitsize: %i, flags: %i" %
                                 (surf.get_bitsize(), surf.get_flags()))
-                surf.set_alpha(blacket_alpha)
+            surf.set_alpha(blanket_alpha)
 
-            # Bug for per-pixel alpha surface when blanket alpha 0.
-            for surf in targets:
-                blanket_alpha = surf.get_alpha()
-                surf.set_alpha(0)
-                arr = pygame.surfarray.array_alpha(surf)
-                if surf.get_masks()[3]:
-                    self.assertFalse(alltrue(arr == 255),
-                                "bitsize: %i, flags: %i" %
-                                (surf.get_bitsize(), surf.get_flags()))
-                else:
-                    self.failUnless(alltrue(arr == 255),
-                                    "bitsize: %i, flags: %i" %
-                                    (surf.get_bitsize(), surf.get_flags()))
-                surf.set_alpha(blanket_alpha)
+    def test_array_colorkey(self):
+        if not arraytype:
+            self.fail("no array package installed")
 
-        def test_array_colorkey(self):
-            if not arraytype:
-                self.fail("no array package installed")
+        palette = [(0, 0, 0, 0),
+                   (10, 50, 100, 255),
+                   (60, 120, 240, 130),
+                   (64, 128, 255, 0),
+                   (255, 128, 0, 65)]
+        targets = [self._make_src_surface(8, palette=palette),
+                   self._make_src_surface(16, palette=palette),
+                   self._make_src_surface(16, palette=palette, srcalpha=True),
+                   self._make_src_surface(24, palette=palette),
+                   self._make_src_surface(32, palette=palette),
+                   self._make_src_surface(32, palette=palette, srcalpha=True)]
 
-            palette = [(0, 0, 0, 0),
-                       (10, 50, 100, 255),
-                       (60, 120, 240, 130),
-                       (64, 128, 255, 0),
-                       (255, 128, 0, 65)]
-            targets = [self._make_src_surface(8, palette=palette),
-                       self._make_src_surface(16, palette=palette),
-                       self._make_src_surface(16, palette=palette, srcalpha=True),
-                       self._make_src_surface(24, palette=palette),
-                       self._make_src_surface(32, palette=palette),
-                       self._make_src_surface(32, palette=palette, srcalpha=True)]
-
-            for surf in targets:
-                p = palette
-                if surf.get_bitsize() == 16:
-                    p = [surf.unmap_rgb(surf.map_rgb(c)) for c in p]
-                surf.set_colorkey(None)
+        for surf in targets:
+            p = palette
+            if surf.get_bitsize() == 16:
+                p = [surf.unmap_rgb(surf.map_rgb(c)) for c in p]
+            surf.set_colorkey(None)
+            arr = pygame.surfarray.array_colorkey(surf)
+            self.failUnless(alltrue(arr == 255))
+            for i in range(1, len(palette)):
+                surf.set_colorkey(p[i])
+                alphas = [255] * len(p)
+                alphas[i] = 0
                 arr = pygame.surfarray.array_colorkey(surf)
-                self.failUnless(alltrue(arr == 255))
-                for i in range(1, len(palette)):
-                    surf.set_colorkey(p[i])
-                    alphas = [255] * len(p)
-                    alphas[i] = 0
-                    arr = pygame.surfarray.array_colorkey(surf)
-                    for (x, y), j in self.test_points:
-                        self.assertEqual(arr[x, y], alphas[j],
-                                             ("%i != %i, posn: (%i, %i), "
-                                              "bitsize: %i" %
-                                              (arr[x, y], alphas[j],
-                                               x, y,
-                                               surf.get_bitsize())))
+                for (x, y), j in self.test_points:
+                    self.assertEqual(arr[x, y], alphas[j],
+                                         ("%i != %i, posn: (%i, %i), "
+                                          "bitsize: %i" %
+                                          (arr[x, y], alphas[j],
+                                           x, y,
+                                           surf.get_bitsize())))
 
-        def test_blit_array(self):
-            if not arraytype:
-                self.fail("no array package installed")
+    def test_blit_array(self):
+        if not arraytype:
+            self.fail("no array package installed")
 
-            # bug 24 at http://pygame.motherhamster.org/bugzilla/
-            if 'numpy' in pygame.surfarray.get_arraytypes():
-                prev = pygame.surfarray.get_arraytype()
-                # This would raise exception:
-                #  File "[...]\pygame\_numpysurfarray.py", line 381, in blit_array
-                #    (array[:,:,1::3] >> losses[1] << shifts[1]) | \
-                # TypeError: unsupported operand type(s) for >>: 'float' and 'int'
-                pygame.surfarray.use_arraytype('numpy')
-                s = pygame.Surface((10,10), 0, 24)
-                a = pygame.surfarray.array3d(s)
-                pygame.surfarray.blit_array(s, a)
-                prev = pygame.surfarray.use_arraytype(prev)
+        # bug 24 at http://pygame.motherhamster.org/bugzilla/
+        if 'numpy' in pygame.surfarray.get_arraytypes():
+            prev = pygame.surfarray.get_arraytype()
+            # This would raise exception:
+            #  File "[...]\pygame\_numpysurfarray.py", line 381, in blit_array
+            #    (array[:,:,1::3] >> losses[1] << shifts[1]) | \
+            # TypeError: unsupported operand type(s) for >>: 'float' and 'int'
+            pygame.surfarray.use_arraytype('numpy')
+            s = pygame.Surface((10,10), 0, 24)
+            a = pygame.surfarray.array3d(s)
+            pygame.surfarray.blit_array(s, a)
+            prev = pygame.surfarray.use_arraytype(prev)
 
-            # target surfaces
-            targets = [self._make_surface(8),
-                       self._make_surface(16),
-                       self._make_surface(16, srcalpha=True),
-                       self._make_surface(24),
-                       self._make_surface(32),
-                       self._make_surface(32, srcalpha=True),
-                       ]
+        # target surfaces
+        targets = [self._make_surface(8),
+                   self._make_surface(16),
+                   self._make_surface(16, srcalpha=True),
+                   self._make_surface(24),
+                   self._make_surface(32),
+                   self._make_surface(32, srcalpha=True),
+                   ]
 
-            # source arrays
-            arrays3d = []
-            dtypes = [(8, uint8), (16, uint16), (32, uint32)]
-            try:
-                dtypes.append((64, uint64))
-            except NameError:
-                pass
-            arrays3d = [(self._make_src_array3d(dtype), None)
-                        for __, dtype in dtypes]
-            for bitsize in [8, 16, 24, 32]:
-                palette = None
-                if bitsize == 16:
-                    s = pygame.Surface((1,1), 0, 16)
-                    palette = [s.unmap_rgb(s.map_rgb(c))
-                               for c in self.test_palette]
-                if self.pixels3d[bitsize]:
-                    surf = self._make_src_surface(bitsize)
-                    arr = pygame.surfarray.pixels3d(surf)
-                    arrays3d.append((arr, palette))
-                if self.array3d[bitsize]:
-                    surf = self._make_src_surface(bitsize)
-                    arr = pygame.surfarray.array3d(surf)
-                    arrays3d.append((arr, palette))
-                    for sz, dtype in dtypes:
-                        arrays3d.append((arr.astype(dtype), palette))
-
-            # tests on arrays
-            def do_blit(surf, arr):
-                pygame.surfarray.blit_array(surf, arr)
-
-            for surf in targets:
-                bitsize = surf.get_bitsize()
-                for arr, palette in arrays3d:
-                    surf.fill((0, 0, 0, 0))
-                    if bitsize == 8:
-                        self.assertRaises(ValueError, do_blit, surf, arr)
-                    else:
-                        pygame.surfarray.blit_array(surf, arr)
-                        self._assert_surface(surf, palette)
-
-                if self.pixels2d[bitsize]:
-                    surf.fill((0, 0, 0, 0))
-                    s = self._make_src_surface(bitsize, surf.get_flags() & SRCALPHA)
-                    arr = pygame.surfarray.pixels2d(s)
-                    pygame.surfarray.blit_array(surf, arr)
-                    self._assert_surface(surf)
-
-                if self.array2d[bitsize]:
-                    s = self._make_src_surface(bitsize, surf.get_flags() & SRCALPHA)
-                    arr = pygame.surfarray.array2d(s)
-                    for sz, dtype in dtypes:
-                        surf.fill((0, 0, 0, 0))
-                        if sz >= bitsize:
-                            pygame.surfarray.blit_array(surf, arr.astype(dtype))
-                            self._assert_surface(surf)
-                        else:
-                            self.assertRaises(ValueError, do_blit,
-                                              surf, self._make_array2d(dtype))
-
-            # Check alpha for 2D arrays
-            surf = self._make_surface(16, srcalpha=True)
-            arr = zeros(surf.get_size(), uint16)
-            arr[...] = surf.map_rgb((0, 128, 255, 64))
-            color = surf.unmap_rgb(arr[0, 0])
-            pygame.surfarray.blit_array(surf, arr)
-            self.assertEqual(surf.get_at((5, 5)), color)
-
-            surf = self._make_surface(32, srcalpha=True)
-            arr = zeros(surf.get_size(), uint32)
-            color = (0, 111, 255, 63)
-            arr[...] = surf.map_rgb(color)
-            pygame.surfarray.blit_array(surf, arr)
-            self.assertEqual(surf.get_at((5, 5)), color)
-
-            # Check shifts
-            arr3d = self._make_src_array3d(uint8)
-
-            shift_tests = [(16,
-                            [12, 0, 8, 4],
-                            [0xf000, 0xf, 0xf00, 0xf0]),
-                           (24,
-                            [16, 0, 8, 0],
-                            [0xff0000, 0xff, 0xff00, 0]),
-                           (32,
-                            [0, 16, 24, 8],
-                            [0xff, 0xff0000, 0xff000000, 0xff00])]
-
-            for bitsize, shifts, masks in shift_tests:
-                surf = self._make_surface(bitsize, srcalpha=(shifts[3] != 0))
-                palette = None
-                if bitsize == 16:
-                    palette = [surf.unmap_rgb(surf.map_rgb(c))
-                               for c in self.test_palette]
-                surf.set_shifts(shifts)
-                surf.set_masks(masks)
-                pygame.surfarray.blit_array(surf, arr3d)
-                self._assert_surface(surf, palette)
-
-            # Invalid arrays
-            surf = pygame.Surface((1,1), 0, 32)
-            t = 'abcd'
-            self.assertRaises(ValueError, do_blit, surf, t)
-
-            surf_size = self.surf_size
-            surf = pygame.Surface(surf_size, 0, 32)
-            arr = zeros([surf_size[0], surf_size[1] + 1, 3], uint32)
-            self.assertRaises(ValueError, do_blit, surf, arr)
-            arr = zeros([surf_size[0] + 1, surf_size[1], 3], uint32)
-            self.assertRaises(ValueError, do_blit, surf, arr)
-
-            surf = pygame.Surface((1, 4), 0, 32)
-            arr = zeros((4,), uint32)
-            self.assertRaises(ValueError, do_blit, surf, arr)
-            arr.shape = (1, 1, 1, 4)
-            self.assertRaises(ValueError, do_blit, surf, arr)
-
-            # Issue #81: round from float to int
-            try:
-                rint
-            except NameError:
-                pass
-            else:
-                surf = pygame.Surface((10, 10), pygame.SRCALPHA, 32)
-                w, h = surf.get_size()
-                length = w * h
-                for dtype in [float32, float64]:
-                    surf.fill((255, 255, 255, 0))
-                    farr = arange(0, length, dtype=dtype)
-                    farr.shape = w, h
-                    pygame.surfarray.blit_array(surf, farr)
-                    for x in range(w):
-                        for y in range(h):
-                            self.assertEqual(surf.get_at_mapped((x, y)),
-                                             int(rint(farr[x, y])))
-
-        def test_get_arraytype(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            self.failUnless((pygame.surfarray.get_arraytype() in
-                             ['numpy']),
-                            ("unknown array type %s" %
-                             pygame.surfarray.get_arraytype()))
-
-        def test_get_arraytypes(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            arraytypes = pygame.surfarray.get_arraytypes()
-            self.failUnless('numpy' in arraytypes)
-
-            for atype in arraytypes:
-                self.failUnless(atype in ['numpy'],
-                                "unknown array type %s" % atype)
-
-        def test_make_surface(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            # How does one properly test this with 2d arrays. It makes no sense
-            # since the pixel format is not entirely dependent on element size.
-            # Just make sure the surface pixel size is at least as large as the
-            # array element size I guess.
-            #
-            for bitsize, dtype in [(8, uint8), (16, uint16), (24, uint32)]:
-    ## Even this simple assertion fails for 2d arrays. Where's the problem?
-    ##            surf = pygame.surfarray.make_surface(self._make_array2d(dtype))
-    ##            self.failUnless(surf.get_bitsize() >= bitsize,
-    ##                            "not %i >= %i)" % (surf.get_bitsize(), bitsize))
-    ##
-                surf = pygame.surfarray.make_surface(self._make_src_array3d(dtype))
-                self._assert_surface(surf)
-
-            # Issue #81: round from float to int
-            try:
-                rint
-            except NameError:
-                pass
-            else:
-                w = 9
-                h = 11
-                length = w * h
-                for dtype in [float32, float64]:
-                    farr = arange(0, length, dtype=dtype)
-                    farr.shape = w, h
-                    surf = pygame.surfarray.make_surface(farr)
-                    for x in range(w):
-                        for y in range(h):
-                            self.assertEqual(surf.get_at_mapped((x, y)),
-                                             int(rint(farr[x, y])))
-
-        def test_map_array(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            arr3d = self._make_src_array3d(uint8)
-            targets = [self._make_surface(8),
-                       self._make_surface(16),
-                       self._make_surface(16, srcalpha=True),
-                       self._make_surface(24),
-                       self._make_surface(32),
-                       self._make_surface(32, srcalpha=True)]
-            palette = self.test_palette
-
-            for surf in targets:
-                arr2d = pygame.surfarray.map_array(surf, arr3d)
-                for posn, i in self.test_points:
-                    self.assertEqual(arr2d[posn], surf.map_rgb(palette[i]),
-                                         "%i != %i, bitsize: %i, flags: %i" %
-                                         (arr2d[posn], surf.map_rgb(palette[i]),
-                                          surf.get_bitsize(), surf.get_flags()))
-
-            # Exception checks
-            self.assertRaises(ValueError, pygame.surfarray.map_array,
-                              self._make_surface(32),
-                              self._make_array2d(uint8))
-
-        def test_pixels2d(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            sources = [self._make_surface(8),
-                       self._make_surface(16, srcalpha=True),
-                       self._make_surface(32, srcalpha=True)]
-
-            for surf in sources:
-                self.assertFalse(surf.get_locked())
-                arr = pygame.surfarray.pixels2d(surf)
-                self.failUnless(surf.get_locked())
-                self._fill_array2d(arr, surf)
-                surf.unlock()
-                self.failUnless(surf.get_locked())
-                del arr
-                self.assertFalse(surf.get_locked())
-                self.assertEqual(surf.get_locks(), ())
-                self._assert_surface(surf)
-
-            # Error checks
-            self.assertRaises(ValueError,
-                              pygame.surfarray.pixels2d,
-                              self._make_surface(24))
-
-        def test_pixels3d(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            sources = [self._make_surface(24),
-                       self._make_surface(32)]
-
-            for surf in sources:
-                self.assertFalse(surf.get_locked())
+        # source arrays
+        arrays3d = []
+        dtypes = [(8, uint8), (16, uint16), (32, uint32)]
+        try:
+            dtypes.append((64, uint64))
+        except NameError:
+            pass
+        arrays3d = [(self._make_src_array3d(dtype), None)
+                    for __, dtype in dtypes]
+        for bitsize in [8, 16, 24, 32]:
+            palette = None
+            if bitsize == 16:
+                s = pygame.Surface((1,1), 0, 16)
+                palette = [s.unmap_rgb(s.map_rgb(c))
+                           for c in self.test_palette]
+            if self.pixels3d[bitsize]:
+                surf = self._make_src_surface(bitsize)
                 arr = pygame.surfarray.pixels3d(surf)
-                self.failUnless(surf.get_locked())
-                self._fill_array3d(arr)
-                surf.unlock()
-                self.failUnless(surf.get_locked())
-                del arr
-                self.assertFalse(surf.get_locked())
-                self.assertEqual(surf.get_locks(), ())
+                arrays3d.append((arr, palette))
+            if self.array3d[bitsize]:
+                surf = self._make_src_surface(bitsize)
+                arr = pygame.surfarray.array3d(surf)
+                arrays3d.append((arr, palette))
+                for sz, dtype in dtypes:
+                    arrays3d.append((arr.astype(dtype), palette))
+
+        # tests on arrays
+        def do_blit(surf, arr):
+            pygame.surfarray.blit_array(surf, arr)
+
+        for surf in targets:
+            bitsize = surf.get_bitsize()
+            for arr, palette in arrays3d:
+                surf.fill((0, 0, 0, 0))
+                if bitsize == 8:
+                    self.assertRaises(ValueError, do_blit, surf, arr)
+                else:
+                    pygame.surfarray.blit_array(surf, arr)
+                    self._assert_surface(surf, palette)
+
+            if self.pixels2d[bitsize]:
+                surf.fill((0, 0, 0, 0))
+                s = self._make_src_surface(bitsize, surf.get_flags() & SRCALPHA)
+                arr = pygame.surfarray.pixels2d(s)
+                pygame.surfarray.blit_array(surf, arr)
                 self._assert_surface(surf)
 
-            # Alpha check
-            color = (1, 2, 3, 0)
-            surf = self._make_surface(32, srcalpha=True)
-            arr = pygame.surfarray.pixels3d(surf)
-            arr[0,0] = color[:3]
-            self.assertEqual(surf.get_at((0, 0)), color)
+            if self.array2d[bitsize]:
+                s = self._make_src_surface(bitsize, surf.get_flags() & SRCALPHA)
+                arr = pygame.surfarray.array2d(s)
+                for sz, dtype in dtypes:
+                    surf.fill((0, 0, 0, 0))
+                    if sz >= bitsize:
+                        pygame.surfarray.blit_array(surf, arr.astype(dtype))
+                        self._assert_surface(surf)
+                    else:
+                        self.assertRaises(ValueError, do_blit,
+                                          surf, self._make_array2d(dtype))
 
-            # Error checks
-            def do_pixels3d(surf):
-                pygame.surfarray.pixels3d(surf)
+        # Check alpha for 2D arrays
+        surf = self._make_surface(16, srcalpha=True)
+        arr = zeros(surf.get_size(), uint16)
+        arr[...] = surf.map_rgb((0, 128, 255, 64))
+        color = surf.unmap_rgb(arr[0, 0])
+        pygame.surfarray.blit_array(surf, arr)
+        self.assertEqual(surf.get_at((5, 5)), color)
 
-            self.assertRaises(ValueError,
-                              do_pixels3d,
-                              self._make_surface(8))
-            self.assertRaises(ValueError,
-                              do_pixels3d,
-                              self._make_surface(16))
+        surf = self._make_surface(32, srcalpha=True)
+        arr = zeros(surf.get_size(), uint32)
+        color = (0, 111, 255, 63)
+        arr[...] = surf.map_rgb(color)
+        pygame.surfarray.blit_array(surf, arr)
+        self.assertEqual(surf.get_at((5, 5)), color)
 
-        def test_pixels_alpha(self):
-            if not arraytype:
-                self.fail("no array package installed")
+        # Check shifts
+        arr3d = self._make_src_array3d(uint8)
 
-            palette = [(0, 0, 0, 0),
-                       (127, 127, 127, 0),
-                       (127, 127, 127, 85),
-                       (127, 127, 127, 170),
-                       (127, 127, 127, 255)]
-            alphas = [0, 45, 86, 99, 180]
+        shift_tests = [(16,
+                        [12, 0, 8, 4],
+                        [0xf000, 0xf, 0xf00, 0xf0]),
+                       (24,
+                        [16, 0, 8, 0],
+                        [0xff0000, 0xff, 0xff00, 0]),
+                       (32,
+                        [0, 16, 24, 8],
+                        [0xff, 0xff0000, 0xff000000, 0xff00])]
 
-            surf = self._make_src_surface(32, srcalpha=True, palette=palette)
+        for bitsize, shifts, masks in shift_tests:
+            surf = self._make_surface(bitsize, srcalpha=(shifts[3] != 0))
+            palette = None
+            if bitsize == 16:
+                palette = [surf.unmap_rgb(surf.map_rgb(c))
+                           for c in self.test_palette]
+            surf.set_shifts(shifts)
+            surf.set_masks(masks)
+            pygame.surfarray.blit_array(surf, arr3d)
+            self._assert_surface(surf, palette)
 
+        # Invalid arrays
+        surf = pygame.Surface((1,1), 0, 32)
+        t = 'abcd'
+        self.assertRaises(ValueError, do_blit, surf, t)
+
+        surf_size = self.surf_size
+        surf = pygame.Surface(surf_size, 0, 32)
+        arr = zeros([surf_size[0], surf_size[1] + 1, 3], uint32)
+        self.assertRaises(ValueError, do_blit, surf, arr)
+        arr = zeros([surf_size[0] + 1, surf_size[1], 3], uint32)
+        self.assertRaises(ValueError, do_blit, surf, arr)
+
+        surf = pygame.Surface((1, 4), 0, 32)
+        arr = zeros((4,), uint32)
+        self.assertRaises(ValueError, do_blit, surf, arr)
+        arr.shape = (1, 1, 1, 4)
+        self.assertRaises(ValueError, do_blit, surf, arr)
+
+        # Issue #81: round from float to int
+        try:
+            rint
+        except NameError:
+            pass
+        else:
+            surf = pygame.Surface((10, 10), pygame.SRCALPHA, 32)
+            w, h = surf.get_size()
+            length = w * h
+            for dtype in [float32, float64]:
+                surf.fill((255, 255, 255, 0))
+                farr = arange(0, length, dtype=dtype)
+                farr.shape = w, h
+                pygame.surfarray.blit_array(surf, farr)
+                for x in range(w):
+                    for y in range(h):
+                        self.assertEqual(surf.get_at_mapped((x, y)),
+                                         int(rint(farr[x, y])))
+
+    def test_get_arraytype(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        self.failUnless((pygame.surfarray.get_arraytype() in
+                         ['numpy']),
+                        ("unknown array type %s" %
+                         pygame.surfarray.get_arraytype()))
+
+    def test_get_arraytypes(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        arraytypes = pygame.surfarray.get_arraytypes()
+        self.failUnless('numpy' in arraytypes)
+
+        for atype in arraytypes:
+            self.failUnless(atype in ['numpy'],
+                            "unknown array type %s" % atype)
+
+    def test_make_surface(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        # How does one properly test this with 2d arrays. It makes no sense
+        # since the pixel format is not entirely dependent on element size.
+        # Just make sure the surface pixel size is at least as large as the
+        # array element size I guess.
+        #
+        for bitsize, dtype in [(8, uint8), (16, uint16), (24, uint32)]:
+## Even this simple assertion fails for 2d arrays. Where's the problem?
+##            surf = pygame.surfarray.make_surface(self._make_array2d(dtype))
+##            self.failUnless(surf.get_bitsize() >= bitsize,
+##                            "not %i >= %i)" % (surf.get_bitsize(), bitsize))
+##
+            surf = pygame.surfarray.make_surface(self._make_src_array3d(dtype))
+            self._assert_surface(surf)
+
+        # Issue #81: round from float to int
+        try:
+            rint
+        except NameError:
+            pass
+        else:
+            w = 9
+            h = 11
+            length = w * h
+            for dtype in [float32, float64]:
+                farr = arange(0, length, dtype=dtype)
+                farr.shape = w, h
+                surf = pygame.surfarray.make_surface(farr)
+                for x in range(w):
+                    for y in range(h):
+                        self.assertEqual(surf.get_at_mapped((x, y)),
+                                         int(rint(farr[x, y])))
+
+    def test_map_array(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        arr3d = self._make_src_array3d(uint8)
+        targets = [self._make_surface(8),
+                   self._make_surface(16),
+                   self._make_surface(16, srcalpha=True),
+                   self._make_surface(24),
+                   self._make_surface(32),
+                   self._make_surface(32, srcalpha=True)]
+        palette = self.test_palette
+
+        for surf in targets:
+            arr2d = pygame.surfarray.map_array(surf, arr3d)
+            for posn, i in self.test_points:
+                self.assertEqual(arr2d[posn], surf.map_rgb(palette[i]),
+                                     "%i != %i, bitsize: %i, flags: %i" %
+                                     (arr2d[posn], surf.map_rgb(palette[i]),
+                                      surf.get_bitsize(), surf.get_flags()))
+
+        # Exception checks
+        self.assertRaises(ValueError, pygame.surfarray.map_array,
+                          self._make_surface(32),
+                          self._make_array2d(uint8))
+
+    def test_pixels2d(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        sources = [self._make_surface(8),
+                   self._make_surface(16, srcalpha=True),
+                   self._make_surface(32, srcalpha=True)]
+
+        for surf in sources:
             self.assertFalse(surf.get_locked())
-            arr = pygame.surfarray.pixels_alpha(surf)
+            arr = pygame.surfarray.pixels2d(surf)
+            self.failUnless(surf.get_locked())
+            self._fill_array2d(arr, surf)
+            surf.unlock()
+            self.failUnless(surf.get_locked())
+            del arr
+            self.assertFalse(surf.get_locked())
+            self.assertEqual(surf.get_locks(), ())
+            self._assert_surface(surf)
+
+        # Error checks
+        self.assertRaises(ValueError,
+                          pygame.surfarray.pixels2d,
+                          self._make_surface(24))
+
+    def test_pixels3d(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        sources = [self._make_surface(24),
+                   self._make_surface(32)]
+
+        for surf in sources:
+            self.assertFalse(surf.get_locked())
+            arr = pygame.surfarray.pixels3d(surf)
+            self.failUnless(surf.get_locked())
+            self._fill_array3d(arr)
+            surf.unlock()
+            self.failUnless(surf.get_locked())
+            del arr
+            self.assertFalse(surf.get_locked())
+            self.assertEqual(surf.get_locks(), ())
+            self._assert_surface(surf)
+
+        # Alpha check
+        color = (1, 2, 3, 0)
+        surf = self._make_surface(32, srcalpha=True)
+        arr = pygame.surfarray.pixels3d(surf)
+        arr[0,0] = color[:3]
+        self.assertEqual(surf.get_at((0, 0)), color)
+
+        # Error checks
+        def do_pixels3d(surf):
+            pygame.surfarray.pixels3d(surf)
+
+        self.assertRaises(ValueError,
+                          do_pixels3d,
+                          self._make_surface(8))
+        self.assertRaises(ValueError,
+                          do_pixels3d,
+                          self._make_surface(16))
+
+    def test_pixels_alpha(self):
+        if not arraytype:
+            self.fail("no array package installed")
+
+        palette = [(0, 0, 0, 0),
+                   (127, 127, 127, 0),
+                   (127, 127, 127, 85),
+                   (127, 127, 127, 170),
+                   (127, 127, 127, 255)]
+        alphas = [0, 45, 86, 99, 180]
+
+        surf = self._make_src_surface(32, srcalpha=True, palette=palette)
+
+        self.assertFalse(surf.get_locked())
+        arr = pygame.surfarray.pixels_alpha(surf)
+        self.failUnless(surf.get_locked())
+        surf.unlock()
+        self.failUnless(surf.get_locked())
+
+        for (x, y), i in self.test_points:
+            self.assertEqual(arr[x, y], palette[i][3])
+
+        for (x, y), i in self.test_points:
+            alpha = alphas[i]
+            arr[x, y] = alpha
+            color = (127, 127, 127, alpha)
+            self.assertEqual(surf.get_at((x, y)), color,
+                                 "posn: (%i, %i)" % (x, y))
+
+        del arr
+        self.assertFalse(surf.get_locked())
+        self.assertEqual(surf.get_locks(), ())
+
+        # Check exceptions.
+        def do_pixels_alpha(surf):
+            pygame.surfarray.pixels_alpha(surf)
+
+        targets = [(8, False),
+                   (16, False),
+                   (16, True),
+                   (24, False),
+                   (32, False)]
+
+        for bitsize, srcalpha in targets:
+            self.assertRaises(ValueError, do_pixels_alpha,
+                              self._make_surface(bitsize, srcalpha))
+
+    def test_pixels_red(self):
+        self._test_pixels_rgb('red', 0)
+
+    def test_pixels_green(self):
+        self._test_pixels_rgb('green', 1)
+
+    def test_pixels_blue(self):
+        self._test_pixels_rgb('blue', 2)
+
+    def _test_pixels_rgb(self, operation, mask_posn):
+        method_name = "pixels_" + operation
+        if not arraytype:
+            self.fail("no array package installed")
+
+        pixels_rgb = getattr(pygame.surfarray, method_name)
+        palette = [(0, 0, 0, 255),
+                   (5, 13, 23, 255),
+                   (29, 31, 37, 255),
+                   (131, 157, 167, 255),
+                   (179, 191, 251, 255)]
+        plane = [c[mask_posn] for c in palette]
+
+        surf24 = self._make_src_surface(24, srcalpha=False, palette=palette)
+        surf32 = self._make_src_surface(32, srcalpha=False, palette=palette)
+        surf32a = self._make_src_surface(32, srcalpha=True, palette=palette)
+
+        for surf in [surf24, surf32, surf32a]:
+            self.assertFalse(surf.get_locked())
+            arr = pixels_rgb(surf)
             self.failUnless(surf.get_locked())
             surf.unlock()
             self.failUnless(surf.get_locked())
 
             for (x, y), i in self.test_points:
-                self.assertEqual(arr[x, y], palette[i][3])
-
-            for (x, y), i in self.test_points:
-                alpha = alphas[i]
-                arr[x, y] = alpha
-                color = (127, 127, 127, alpha)
-                self.assertEqual(surf.get_at((x, y)), color,
-                                     "posn: (%i, %i)" % (x, y))
+                self.assertEqual(arr[x, y], plane[i])
 
             del arr
             self.assertFalse(surf.get_locked())
             self.assertEqual(surf.get_locks(), ())
 
-            # Check exceptions.
-            def do_pixels_alpha(surf):
-                pygame.surfarray.pixels_alpha(surf)
+        # Check exceptions.
+        targets = [(8, False),
+                   (16, False),
+                   (16, True)]
 
-            targets = [(8, False),
-                       (16, False),
-                       (16, True),
-                       (24, False),
-                       (32, False)]
+        for bitsize, srcalpha in targets:
+            self.assertRaises(ValueError, pixels_rgb,
+                              self._make_surface(bitsize, srcalpha))
 
-            for bitsize, srcalpha in targets:
-                self.assertRaises(ValueError, do_pixels_alpha,
-                                  self._make_surface(bitsize, srcalpha))
+    def test_use_arraytype(self):
+        if not arraytype:
+            self.fail("no array package installed")
 
-        def test_pixels_red(self):
-            self._test_pixels_rgb('red', 0)
+        def do_use_arraytype(atype):
+            pygame.surfarray.use_arraytype(atype)
 
-        def test_pixels_green(self):
-            self._test_pixels_rgb('green', 1)
+        pygame.surfarray.use_arraytype('numpy')
+        self.assertEqual(pygame.surfarray.get_arraytype(), 'numpy')
+        self.assertRaises(ValueError, do_use_arraytype, 'not an option')
 
-        def test_pixels_blue(self):
-            self._test_pixels_rgb('blue', 2)
+    def test_surf_lock (self):
+        if not arraytype:
+            self.fail("no array package installed")
 
-        def _test_pixels_rgb(self, operation, mask_posn):
-            method_name = "pixels_" + operation
-            if not arraytype:
-                self.fail("no array package installed")
+        sf = pygame.Surface ((5, 5), 0, 32)
+        for atype in pygame.surfarray.get_arraytypes ():
+            pygame.surfarray.use_arraytype (atype)
 
-            pixels_rgb = getattr(pygame.surfarray, method_name)
-            palette = [(0, 0, 0, 255),
-                       (5, 13, 23, 255),
-                       (29, 31, 37, 255),
-                       (131, 157, 167, 255),
-                       (179, 191, 251, 255)]
-            plane = [c[mask_posn] for c in palette]
+            ar = pygame.surfarray.pixels2d (sf)
+            self.assertEquals (sf.get_locked (), True)
 
-            surf24 = self._make_src_surface(24, srcalpha=False, palette=palette)
-            surf32 = self._make_src_surface(32, srcalpha=False, palette=palette)
-            surf32a = self._make_src_surface(32, srcalpha=True, palette=palette)
+            sf.unlock ()
+            self.assertEquals (sf.get_locked (), True)
 
-            for surf in [surf24, surf32, surf32a]:
-                self.assertFalse(surf.get_locked())
-                arr = pixels_rgb(surf)
-                self.failUnless(surf.get_locked())
-                surf.unlock()
-                self.failUnless(surf.get_locked())
+            del ar
+            self.assertEquals (sf.get_locked (), False)
+            self.assertEquals (sf.get_locks (), ())
 
-                for (x, y), i in self.test_points:
-                    self.assertEqual(arr[x, y], plane[i])
-
-                del arr
-                self.assertFalse(surf.get_locked())
-                self.assertEqual(surf.get_locks(), ())
-
-            # Check exceptions.
-            targets = [(8, False),
-                       (16, False),
-                       (16, True)]
-
-            for bitsize, srcalpha in targets:
-                self.assertRaises(ValueError, pixels_rgb,
-                                  self._make_surface(bitsize, srcalpha))
-
-        def test_use_arraytype(self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            def do_use_arraytype(atype):
-                pygame.surfarray.use_arraytype(atype)
-
-            pygame.surfarray.use_arraytype('numpy')
-            self.assertEqual(pygame.surfarray.get_arraytype(), 'numpy')
-            self.assertRaises(ValueError, do_use_arraytype, 'not an option')
-
-        def test_surf_lock (self):
-            if not arraytype:
-                self.fail("no array package installed")
-
-            sf = pygame.Surface ((5, 5), 0, 32)
-            for atype in pygame.surfarray.get_arraytypes ():
-                pygame.surfarray.use_arraytype (atype)
-
-                ar = pygame.surfarray.pixels2d (sf)
-                self.assertEquals (sf.get_locked (), True)
-
-                sf.unlock ()
-                self.assertEquals (sf.get_locked (), True)
-
-                del ar
-                self.assertEquals (sf.get_locked (), False)
-                self.assertEquals (sf.get_locks (), ())
-
-            #print ("test_surf_lock - end")
+        #print ("test_surf_lock - end")
 
 
 if __name__ == '__main__':

--- a/test/surflock_test.py
+++ b/test/surflock_test.py
@@ -6,140 +6,138 @@ import pygame
 
 IS_PYPY = 'PyPy' == platform.python_implementation()
 
-if not IS_PYPY: #TODO: pypy skip known failure.
+@unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
+class SurfaceLockTest(unittest.TestCase):
 
+    def test_lock(self):
+        sf = pygame.Surface((5, 5))
 
-    class SurfaceLockTest(unittest.TestCase):
+        sf.lock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (sf,))
 
-        def test_lock(self):
-            sf = pygame.Surface((5, 5))
+        sf.lock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (sf, sf))
 
-            sf.lock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (sf,))
+        sf.unlock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (sf,))
 
-            sf.lock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (sf, sf))
+        sf.unlock()
+        self.assertEqual(sf.get_locked(), False)
+        self.assertEqual(sf.get_locks(), ())
 
-            sf.unlock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (sf,))
+    def test_subsurface_lock(self):
+        sf = pygame.Surface((5, 5))
+        subsf = sf.subsurface((1, 1, 2, 2))
+        sf2 = pygame.Surface((5, 5))
 
-            sf.unlock()
-            self.assertEqual(sf.get_locked(), False)
-            self.assertEqual(sf.get_locks(), ())
+        # Simple blits, nothing should happen here.
+        sf2.blit(subsf, (0, 0))
+        sf2.blit(sf, (0, 0))
 
-        def test_subsurface_lock(self):
-            sf = pygame.Surface((5, 5))
-            subsf = sf.subsurface((1, 1, 2, 2))
-            sf2 = pygame.Surface((5, 5))
+        # Test blitting on self:
+        self.assertRaises(pygame.error, sf.blit, subsf, (0, 0))
+        #self.assertRaises(pygame.error, subsf.blit, sf, (0, 0))
+        # ^ Fails although it should not in my opinion. If I cannot
+        # blit the subsurface to the surface, it should not be allowed
+        # the other way around as well.
 
-            # Simple blits, nothing should happen here.
-            sf2.blit(subsf, (0, 0))
-            sf2.blit(sf, (0, 0))
+        # Test additional locks.
+        sf.lock()
+        sf2.blit(subsf, (0, 0))
+        self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
 
-            # Test blitting on self:
-            self.assertRaises(pygame.error, sf.blit, subsf, (0, 0))
-            #self.assertRaises(pygame.error, subsf.blit, sf, (0, 0))
-            # ^ Fails although it should not in my opinion. If I cannot
-            # blit the subsurface to the surface, it should not be allowed
-            # the other way around as well.
+        subsf.lock()
+        self.assertRaises(pygame.error, sf2.blit, subsf, (0, 0))
+        self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
 
-            # Test additional locks.
-            sf.lock()
-            sf2.blit(subsf, (0, 0))
-            self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
+        # sf and subsf are now explicitly locked. Unlock sf, so we can
+        # (assume) to blit it.
+        # It will fail though as the subsurface still has a lock around,
+        # which is okay and correct behaviour.
+        sf.unlock()
+        self.assertRaises(pygame.error, sf2.blit, subsf, (0, 0))
+        self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
 
-            subsf.lock()
-            self.assertRaises(pygame.error, sf2.blit, subsf, (0, 0))
-            self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
+        # Run a second unlock on the surface. This should ideally have
+        # no effect as the subsurface is the locking reason!
+        sf.unlock()
+        self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
+        self.assertRaises(pygame.error, sf2.blit, subsf, (0, 0))
+        subsf.unlock()
 
-            # sf and subsf are now explicitly locked. Unlock sf, so we can
-            # (assume) to blit it.
-            # It will fail though as the subsurface still has a lock around,
-            # which is okay and correct behaviour.
-            sf.unlock()
-            self.assertRaises(pygame.error, sf2.blit, subsf, (0, 0))
-            self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
+        sf.lock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (sf,))
+        self.assertEqual(subsf.get_locked(), False)
+        self.assertEqual(subsf.get_locks(), ())
 
-            # Run a second unlock on the surface. This should ideally have
-            # no effect as the subsurface is the locking reason!
-            sf.unlock()
-            self.assertRaises(pygame.error, sf2.blit, sf, (0, 0))
-            self.assertRaises(pygame.error, sf2.blit, subsf, (0, 0))
-            subsf.unlock()
+        subsf.lock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (sf, subsf))
+        self.assertEqual(subsf.get_locked(), True)
+        self.assertEqual(subsf.get_locks(), (subsf,))
 
-            sf.lock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (sf,))
-            self.assertEqual(subsf.get_locked(), False)
-            self.assertEqual(subsf.get_locks(), ())
+        sf.unlock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (subsf,))
+        self.assertEqual(subsf.get_locked(), True)
+        self.assertEqual(subsf.get_locks(), (subsf,))
 
-            subsf.lock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (sf, subsf))
-            self.assertEqual(subsf.get_locked(), True)
-            self.assertEqual(subsf.get_locks(), (subsf,))
+        subsf.unlock()
+        self.assertEqual(sf.get_locked(), False)
+        self.assertEqual(sf.get_locks(), ())
+        self.assertEqual(subsf.get_locked(), False)
+        self.assertEqual(subsf.get_locks(), ())
 
-            sf.unlock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (subsf,))
-            self.assertEqual(subsf.get_locked(), True)
-            self.assertEqual(subsf.get_locks(), (subsf,))
+        subsf.lock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (subsf,))
+        self.assertEqual(subsf.get_locked(), True)
+        self.assertEqual(subsf.get_locks(), (subsf,))
 
-            subsf.unlock()
-            self.assertEqual(sf.get_locked(), False)
-            self.assertEqual(sf.get_locks(), ())
-            self.assertEqual(subsf.get_locked(), False)
-            self.assertEqual(subsf.get_locks(), ())
+        subsf.lock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (subsf, subsf))
+        self.assertEqual(subsf.get_locked(), True)
+        self.assertEqual(subsf.get_locks(), (subsf, subsf))
 
-            subsf.lock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (subsf,))
-            self.assertEqual(subsf.get_locked(), True)
-            self.assertEqual(subsf.get_locks(), (subsf,))
+    def test_pxarray_ref(self):
+        sf = pygame.Surface((5, 5))
+        ar = pygame.PixelArray(sf)
+        ar2 = pygame.PixelArray(sf)
 
-            subsf.lock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (subsf, subsf))
-            self.assertEqual(subsf.get_locked(), True)
-            self.assertEqual(subsf.get_locks(), (subsf, subsf))
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (ar, ar2))
 
-        def test_pxarray_ref(self):
-            sf = pygame.Surface((5, 5))
-            ar = pygame.PixelArray(sf)
-            ar2 = pygame.PixelArray(sf)
+        del ar
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (ar2,))
 
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (ar, ar2))
+        ar = ar2[:]
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (ar2,))
 
-            del ar
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (ar2,))
+        del ar
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(len(sf.get_locks()), 1)
 
-            ar = ar2[:]
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (ar2,))
+    def test_buffer(self):
+        sf = pygame.Surface((5, 5))
+        buf = sf.get_buffer()
 
-            del ar
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(len(sf.get_locks()), 1)
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (buf,))
 
-        def test_buffer(self):
-            sf = pygame.Surface((5, 5))
-            buf = sf.get_buffer()
+        sf.unlock()
+        self.assertEqual(sf.get_locked(), True)
+        self.assertEqual(sf.get_locks(), (buf,))
 
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (buf,))
-
-            sf.unlock()
-            self.assertEqual(sf.get_locked(), True)
-            self.assertEqual(sf.get_locks(), (buf,))
-
-            del buf
-            self.assertEqual(sf.get_locked(), False)
-            self.assertEqual(sf.get_locks(), ())
+        del buf
+        self.assertEqual(sf.get_locked(), False)
+        self.assertEqual(sf.get_locks(), ())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

* use `@unittest.skipIf(` instead of indentation or **return** to skip for PYPY
* PEP8 cleanup
* replace some more method aliases