### PR TITLE
More Test cleanup

### DIFF
--- a/test/base_test.py
+++ b/test/base_test.py
@@ -207,32 +207,22 @@ class BaseModuleTest(unittest.TestCase):
 
     if pygame.HAVE_NEWBUF:
         from pygame.tests.test_utils import buftools
-        def test_newbuf(self):
-            self.NEWBUF_test_newbuf()
-        def test_PgDict_AsBuffer_PyBUF_flags(self):
-            self.NEWBUF_test_PgDict_AsBuffer_PyBUF_flags()
-        def test_PgObject_AsBuffer_PyBUF_flags(self):
-            self.NEWBUF_test_PgObject_AsBuffer_PyBUF_flags()
-        def test_bad_format(self):
-            self.NEWBUF_test_bad_format()
 
     def NEWBUF_assertSame(self, proxy, exp):
         buftools = self.buftools
         Importer = buftools.Importer
         self.assertEqual(proxy.length, exp.len)
         imp = Importer(proxy, buftools.PyBUF_RECORDS_RO)
-        try:
-            self.assertEqual(imp.readonly, exp.readonly)
-            self.assertEqual(imp.format, exp.format)
-            self.assertEqual(imp.itemsize, exp.itemsize)
-            self.assertEqual(imp.ndim, exp.ndim)
-            self.assertEqual(imp.shape, exp.shape)
-            self.assertEqual(imp.strides, exp.strides)
-            self.assertTrue(imp.suboffsets is None)
-        finally:
-            imp = None
+        self.assertEqual(imp.readonly, exp.readonly)
+        self.assertEqual(imp.format, exp.format)
+        self.assertEqual(imp.itemsize, exp.itemsize)
+        self.assertEqual(imp.ndim, exp.ndim)
+        self.assertEqual(imp.shape, exp.shape)
+        self.assertEqual(imp.strides, exp.strides)
+        self.assertTrue(imp.suboffsets is None)
 
-    def NEWBUF_test_newbuf(self):
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf(self):
         from pygame.bufferproxy import BufferProxy
 
         Exporter = self.buftools.Exporter
@@ -250,7 +240,8 @@ class BaseModuleTest(unittest.TestCase):
             v = BufferProxy(o)
             self.NEWBUF_assertSame(v, o)
 
-    def NEWBUF_test_bad_format(self):
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_bad_format(self):
         from pygame.bufferproxy import BufferProxy
         from pygame.newbuffer import BufferMixin
         from ctypes import create_string_buffer, addressof
@@ -266,7 +257,8 @@ class BaseModuleTest(unittest.TestCase):
             b = BufferProxy(exp)
             self.assertRaises(ValueError, Importer, b, PyBUF_FORMAT)
 
-    def NEWBUF_test_PgDict_AsBuffer_PyBUF_flags(self):
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_PgDict_AsBuffer_PyBUF_flags(self):
         from pygame.bufferproxy import BufferProxy
 
         is_lil_endian = pygame.get_sdl_byteorder() == pygame.LIL_ENDIAN
@@ -364,10 +356,9 @@ class BaseModuleTest(unittest.TestCase):
         self.assertEqual(b.buf, 1000000)
         self.assertRaises(BufferError, Importer, a, buftools.PyBUF_FULL)
 
-    def NEWBUF_test_PgObject_AsBuffer_PyBUF_flags(self):
+    @unittest.skipIf(IS_PYPY or (not pygame.HAVE_NEWBUF), 'newbuf with ctypes')
+    def test_PgObject_AsBuffer_PyBUF_flags(self):
         from pygame.bufferproxy import BufferProxy
-        if IS_PYPY:
-            return
         import ctypes
 
         is_lil_endian = pygame.get_sdl_byteorder() == pygame.LIL_ENDIAN

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -81,14 +81,11 @@ class BaseModuleTest(unittest.TestCase):
 
     def assertSame(self, proxy, obj):
         self.assertEqual(proxy.length, obj.size)
-        d = proxy.__array_interface__
-        try:
-            self.assertEqual(d['typestr'], obj.typestr)
-            self.assertEqual(d['shape'], obj.shape)
-            self.assertEqual(d['strides'], obj.strides)
-            self.assertEqual(d['data'], obj.data)
-        finally:
-            d = None
+        iface = proxy.__array_interface__
+        self.assertEqual(iface['typestr'], obj.typestr)
+        self.assertEqual(iface['shape'], obj.shape)
+        self.assertEqual(iface['strides'], obj.strides)
+        self.assertEqual(iface['data'], obj.data)
 
     def test_PgObject_GetBuffer_array_interface(self):
         from pygame.bufferproxy import BufferProxy

--- a/test/bufferproxy_test.py
+++ b/test/bufferproxy_test.py
@@ -245,15 +245,11 @@ class BufferProxyTest(unittest.TestCase):
         self.assertEqual(r[:2], '*<')
         self.assertEqual(r[-2:], '>*')
 
-    if pygame.HAVE_NEWBUF:
-        def test_newbuf(self):
-            self.NEWBUF_test_newbuf()
-        from pygame.tests.test_utils import buftools
-
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
     def NEWBUF_test_newbuf(self):
         from ctypes import string_at
 
-        buftools = self.buftools
+        from pygame.tests.test_utils import buftools
         Exporter = buftools.Exporter
         Importer = buftools.Importer
         exp = Exporter((10,), 'B', readonly=True)

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -1,11 +1,13 @@
 import unittest
 import math
 import operator
+import platform
 
 import pygame
 from pygame.compat import long_
 
 
+IS_PYPY = 'PyPy' == platform.python_implementation()
 ################################### CONSTANTS ##################################
 
 rgba_vals = [0, 1, 62, 63, 126, 127, 255]
@@ -833,7 +835,6 @@ class ColorTypeTest (unittest.TestCase):
         # TODO: test against statically defined verified _correct_ values
         # assert corrected.r == 125 etc.
 
-
     def test_pickle(self):
         import pickle
         c1 = pygame.Color(1,2,3,4)
@@ -845,11 +846,8 @@ class ColorTypeTest (unittest.TestCase):
 ################################################################################
 # only available if ctypes module is also available
 
+    @unittest.skipIf(IS_PYPY, 'PyPy has no ctypes')
     def test_arraystruct(self):
-        import platform
-        IS_PYPY = 'PyPy' == platform.python_implementation()
-        if IS_PYPY:
-            return
 
         import pygame.tests.test_utils.arrinter as ai
         import ctypes as ct
@@ -872,14 +870,10 @@ class ColorTypeTest (unittest.TestCase):
             for j in range(i):
                 self.assertEqual(data[j], c[j])
 
-    if pygame.HAVE_NEWBUF:
-        def test_newbuf(self):
-            self.NEWBUF_test_newbuf()
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf(self):
         from pygame.tests.test_utils import buftools
-
-    def NEWBUF_test_newbuf(self):
         from ctypes import cast, POINTER, c_uint8
-        buftools = self.buftools
 
         class ColorImporter(buftools.Importer):
             def __init__(self, color, flags):
@@ -954,13 +948,9 @@ class ColorTypeTest (unittest.TestCase):
         self.assertRaises(BufferError, ColorImporter,
                           c, buftools.PyBUF_WRITABLE)
 
-    try:
-        import ctypes
-    except ImportError:
-        del test_arraystruct
-
 
 class SubclassTest(unittest.TestCase):
+
     class MyColor(pygame.Color):
         def __init__ (self, *args, **kwds):
             super(SubclassTest.MyColor, self).__init__ (*args, **kwds)

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1043,13 +1043,10 @@ class FreeTypeFontTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, setattr, f, 'fgcolor', None)
 
-    if pygame.HAVE_NEWBUF:
-        def test_newbuf(self):
-            self.NEWBUF_test_newbuf()
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf(self):
         from pygame.tests.test_utils import buftools
-
-    def NEWBUF_test_newbuf(self):
-        Exporter = self.buftools.Exporter
+        Exporter = buftools.Exporter
         font = self._TEST_FONTS['sans']
         srect = font.get_rect("Hi", size=12)
         for format in ['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q',

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -2,15 +2,16 @@ import os
 if os.environ.get('SDL_VIDEODRIVER') == 'dummy':
     __tags__ = ('ignore', 'subprocess_ignore')
 
+import unittest
 import sys
 import ctypes
 import weakref
 import gc
 import platform
+
 IS_PYPY = 'PyPy' == platform.python_implementation()
 
 
-import unittest
 try:
     from pygame.tests.test_utils import arrinter
 except NameError:
@@ -45,6 +46,7 @@ def surf_same_image(a, b):
     a_bytes = ctypes.string_at(a._pixels_address, a_sz)
     b_bytes = ctypes.string_at(b._pixels_address, b_sz)
     return a_bytes == b_bytes
+
 
 class FreeTypeFontTest(unittest.TestCase):
 
@@ -1069,18 +1071,14 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertEqual(ft.STYLE_NORMAL, font.style)
 
         # make sure we check for style type
-        try:    font.style = "None"
-        except TypeError: pass
-        else:   self.fail("Failed style assignement")
-
-        try:    font.style = None
-        except TypeError: pass
-        else:   self.fail("Failed style assignement")
+        with self.assertRaises(TypeError):
+            font.style = "None"
+        with self.assertRaises(TypeError):
+            font.style = None
 
         # make sure we only accept valid constants
-        try:    font.style = 112
-        except ValueError: pass
-        else:   self.fail("Failed style assignement")
+        with self.assertRaises(ValueError):
+            font.style = 112
 
         # make assure no assignements happened
         self.assertEqual(ft.STYLE_NORMAL, font.style)

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -243,8 +243,6 @@ class ImageModuleTest( unittest.TestCase ):
             finally:
                 #clean up the temp file, comment out to leave tmp file after run.
                 os.remove(temp_filename)
-                pass
-
 
     def test_save_colorkey(self):
         """ make sure the color key is not changed when saving.
@@ -261,7 +259,6 @@ class ImageModuleTest( unittest.TestCase ):
             s2 = pygame.image.load(temp_filename)
         finally:
             os.remove(temp_filename)
-
 
         colorkey2 = s.get_colorkey()
         # check that the pixel and the colorkey is correct.

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -341,12 +341,8 @@ class MixerModuleTest(unittest.TestCase):
         finally:
             mixer.quit()
 
-    if pygame.HAVE_NEWBUF:
-        def test_newbuf(self):
-            self.NEWBUF_test_newbuf()
-        from pygame.tests.test_utils import buftools
-
-    def NEWBUF_test_newbuf(self):
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf(self):
         mixer.init(22050, -16, 1)
         try:
             self.NEWBUF_export_check()
@@ -367,7 +363,7 @@ class MixerModuleTest(unittest.TestCase):
                    32: '=I', -32: '=i',  # 32 and 64 for future consideration
                    64: '=Q', -64: '=q'}
         format = formats[fmt]
-        buftools = self.buftools
+        from pygame.tests.test_utils import buftools
         Exporter = buftools.Exporter
         Importer = buftools.Importer
         is_lil_endian = pygame.get_sdl_byteorder() == pygame.LIL_ENDIAN

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1139,6 +1139,7 @@ class PixelArrayArrayInterfaceTest(unittest.TestCase, TestMixin):
 
 @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
 class PixelArrayNewBufferTest(unittest.TestCase, TestMixin):
+
     if pygame.HAVE_NEWBUF:
         from pygame.tests.test_utils import buftools
 

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1137,17 +1137,14 @@ class PixelArrayArrayInterfaceTest(unittest.TestCase, TestMixin):
             self.assert_surfaces_equal (sf3, sf2)
 
 
-class PixelArrayNewBufferTest (unittest.TestCase, TestMixin):
+@unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+class PixelArrayNewBufferTest(unittest.TestCase, TestMixin):
     if pygame.HAVE_NEWBUF:
-        def test_newbuf_2D (self):
-            self.NEWBUF_test_newbuf_2D ()
-        def test_newbuf_1D (self):
-            self.NEWBUF_test_newbuf_1D ()
         from pygame.tests.test_utils import buftools
 
     bitsize_to_format = {8: 'B', 16: '=H', 24: '3x', 32: '=I'}
 
-    def NEWBUF_test_newbuf_2D (self):
+    def test_newbuf_2D (self):
         buftools = self.buftools
         Importer = buftools.Importer
 
@@ -1295,7 +1292,7 @@ class PixelArrayNewBufferTest (unittest.TestCase, TestMixin):
         self.assertRaises (BufferError, Importer, ar,
                            buftools.PyBUF_ANY_CONTIGUOUS)
 
-    def NEWBUF_test_newbuf_1D (self):
+    def test_newbuf_1D(self):
         buftools = self.buftools
         Importer = buftools.Importer
 

--- a/test/pixelcopy_test.py
+++ b/test/pixelcopy_test.py
@@ -542,12 +542,11 @@ class PixelCopyTestWithArray(unittest.TestCase):
         del numpy
 
 
+@unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
 class PixelCopyTestWithArray(unittest.TestCase):
-    try:
+
+    if pygame.HAVE_NEWBUF:
         from pygame.tests.test_utils import buftools
-    except ImportError:
-        pass
-    else:
         class Array2D(buftools.Exporter):
             def __init__(self, initializer):
                 from ctypes import cast, POINTER, c_uint32
@@ -645,13 +644,6 @@ class PixelCopyTestWithArray(unittest.TestCase):
                        '1x', '2x', '3x', '5x', '6x', '7x', '9x']:
             exp = Exporter(shape, format=format)
             self.assertRaises(ValueError, array_to_surface, surface, exp)
-
-    if not pygame.HAVE_NEWBUF:
-        del test_surface_to_array_newbuf
-        del test_array_to_surface_newbuf
-        del test_map_array_newbuf
-        del test_make_surface_newbuf
-        del test_format_newbuf
 
 
 if __name__ == '__main__':

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1283,6 +1283,12 @@ class SurfaceTypeTest(unittest.TestCase):
 class SurfaceSubtypeTest(unittest.TestCase):
     """Issue #280: Methods that return a new Surface preserve subclasses"""
 
+    def setUp(self):
+        pygame.display.init()
+
+    def tearDown(self):
+        pygame.display.quit()
+
     class MySurface(pygame.Surface):
         def __init__(self, *args, **kwds):
             super(SurfaceSubtypeTest.MySurface, self).__init__(*args, **kwds)
@@ -1308,16 +1314,12 @@ class SurfaceSubtypeTest(unittest.TestCase):
         instances of the subclass. Non Surface fields are omitted, however.
         This includes instance attributes.
         """
-        pygame.display.init()
-        try:
-            ms1 = self.MySurface((32, 32), 0, 24)
-            ms2 = ms1.convert(24)
-            self.assertTrue(ms2 is not ms1)
-            self.assertTrue(isinstance(ms2, self.MySurface))
-            self.assertTrue(ms1.an_attribute)
-            self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
-        finally:
-            pygame.display.quit()
+        ms1 = self.MySurface((32, 32), 0, 24)
+        ms2 = ms1.convert(24)
+        self.assertTrue(ms2 is not ms1)
+        self.assertTrue(isinstance(ms2, self.MySurface))
+        self.assertTrue(ms1.an_attribute)
+        self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
 
     def test_convert_alpha(self):
         """Ensure method convert_alpha() preserves the surface's class
@@ -1326,18 +1328,14 @@ class SurfaceSubtypeTest(unittest.TestCase):
         return instances of the subclass. Non Surface fields are omitted,
         however. This includes instance attributes.
         """
-        pygame.display.init()
-        try:
-            pygame.display.set_mode((40, 40))
-            s = pygame.Surface((32, 32), pygame.SRCALPHA, 16)
-            ms1 = self.MySurface((32, 32), pygame.SRCALPHA, 32)
-            ms2 = ms1.convert_alpha(s)
-            self.assertTrue(ms2 is not ms1)
-            self.assertTrue(isinstance(ms2, self.MySurface))
-            self.assertTrue(ms1.an_attribute)
-            self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
-        finally:
-            pygame.display.quit()
+        pygame.display.set_mode((40, 40))
+        s = pygame.Surface((32, 32), pygame.SRCALPHA, 16)
+        ms1 = self.MySurface((32, 32), pygame.SRCALPHA, 32)
+        ms2 = ms1.convert_alpha(s)
+        self.assertTrue(ms2 is not ms1)
+        self.assertTrue(isinstance(ms2, self.MySurface))
+        self.assertTrue(ms1.an_attribute)
+        self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
 
     def test_subsurface(self):
         """Ensure method subsurface() preserves the surface's class
@@ -1353,7 +1351,7 @@ class SurfaceSubtypeTest(unittest.TestCase):
         self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
 
 
-class SurfaceGetBufferTest (unittest.TestCase):
+class SurfaceGetBufferTest(unittest.TestCase):
 
     # These tests requires ctypes. They are disabled if ctypes
     # is not installed.
@@ -1841,6 +1839,13 @@ class SurfaceGetBufferTest (unittest.TestCase):
 
 class SurfaceBlendTest(unittest.TestCase):
 
+    def setUp(self):
+        # Needed for 8 bits-per-pixel color palette surface tests.
+        pygame.init()
+
+    def tearDown(self):
+        pygame.quit()
+
     _test_palette = [(0, 0, 0, 255),
                      (10, 30, 60, 0),
                      (25, 75, 100, 128),
@@ -1886,13 +1891,6 @@ class SurfaceBlendTest(unittest.TestCase):
                                  (surf.get_at(posn),
                                   palette[i], surf.get_flags(),
                                   surf.get_bitsize(), posn, msg))
-
-    def setUp(self):
-        # Needed for 8 bits-per-pixel color palette surface tests.
-        pygame.init()
-
-    def tearDown(self):
-        pygame.quit()
 
     def test_blit_blend(self):
         sources = [self._make_src_surface(8),
@@ -2053,14 +2051,8 @@ class SurfaceBlendTest(unittest.TestCase):
         src.fill((1, 2, 3, 4))
         dst.fill((40, 30, 20, 10))
         subsrc = src.subsurface((2, 3, 4, 4))
-        try:
-            subdst = dst.subsurface((2, 3, 4, 4))
-            try:
-                subdst.blit(subsrc, (0, 0), special_flags=BLEND_RGBA_ADD)
-            finally:
-                del subdst
-        finally:
-            del subsrc
+        subdst = dst.subsurface((2, 3, 4, 4))
+        subdst.blit(subsrc, (0, 0), special_flags=BLEND_RGBA_ADD)
         tst.fill((40, 30, 20, 10))
         tst.fill((41, 32, 23, 14), (2, 3, 4, 4))
         for x in range(8):
@@ -2184,6 +2176,13 @@ class SurfaceSelfBlitTest(unittest.TestCase):
     This test case is in response to MotherHamster Bugzilla Bug 19.
     """
 
+    def setUp(self):
+        # Needed for 8 bits-per-pixel color palette surface tests.
+        pygame.init()
+
+    def tearDown(self):
+        pygame.quit()
+
     _test_palette = [(0, 0, 0, 255),
                     (255, 0, 0, 0),
                     (0, 255, 0, 255)]
@@ -2215,13 +2214,6 @@ class SurfaceSelfBlitTest(unittest.TestCase):
                                      ("%s != %s, bpp: %i" %
                                       (a.get_at((x, y)), b.get_at((x, y)),
                                        a.get_bitsize())))
-
-    def setUp(self):
-        # Needed for 8 bits-per-pixel color palette surface tests.
-        pygame.init()
-
-    def tearDown(self):
-        pygame.quit()
 
     def test_overlap_check(self):
         # Ensure overlapping blits are properly detected. There are two
@@ -2370,51 +2362,50 @@ class SurfaceSelfBlitTest(unittest.TestCase):
 
 class SurfaceFillTest(unittest.TestCase):
 
-    def test_fill(self):
+    def setUp(self):
         pygame.init()
-        try:
-            screen = pygame.display.set_mode((640, 480))
 
-            # Green and blue test pattern
-            screen.fill((0, 255, 0), (0, 0, 320, 240))
-            screen.fill((0, 255, 0), (320, 240, 320, 240))
-            screen.fill((0, 0, 255), (320, 0, 320, 240))
-            screen.fill((0, 0, 255), (0, 240, 320, 240))
+    def tearDown(self):
+        pygame.quit()
 
-            # Now apply a clip rect, such that only the left side of the
-            # screen should be effected by blit opperations.
-            screen.set_clip((0, 0, 320, 480))
+    def test_fill(self):
+        screen = pygame.display.set_mode((640, 480))
 
-            # Test fills with each special flag, and additionaly without any.
-            screen.fill((255, 0, 0, 127), (160, 0, 320, 30), 0)
-            screen.fill((255, 0, 0, 127), (160, 30, 320, 30), pygame.BLEND_ADD)
-            screen.fill((0, 127, 127, 127), (160, 60, 320, 30), pygame.BLEND_SUB)
-            screen.fill((0, 63, 63, 127), (160, 90, 320, 30), pygame.BLEND_MULT)
-            screen.fill((0, 127, 127, 127), (160, 120, 320, 30), pygame.BLEND_MIN)
-            screen.fill((127, 0, 0, 127), (160, 150, 320, 30), pygame.BLEND_MAX)
-            screen.fill((255, 0, 0, 127), (160, 180, 320, 30), pygame.BLEND_RGBA_ADD)
-            screen.fill((0, 127, 127, 127), (160, 210, 320, 30), pygame.BLEND_RGBA_SUB)
-            screen.fill((0, 63, 63, 127), (160, 240, 320, 30), pygame.BLEND_RGBA_MULT)
-            screen.fill((0, 127, 127, 127), (160, 270, 320, 30), pygame.BLEND_RGBA_MIN)
-            screen.fill((127, 0, 0, 127), (160, 300, 320, 30), pygame.BLEND_RGBA_MAX)
-            screen.fill((255, 0, 0, 127), (160, 330, 320, 30), pygame.BLEND_RGB_ADD)
-            screen.fill((0, 127, 127, 127), (160, 360, 320, 30), pygame.BLEND_RGB_SUB)
-            screen.fill((0, 63, 63, 127), (160, 390, 320, 30), pygame.BLEND_RGB_MULT)
-            screen.fill((0, 127, 127, 127), (160, 420, 320, 30), pygame.BLEND_RGB_MIN)
-            screen.fill((255, 0, 0, 127), (160, 450, 320, 30), pygame.BLEND_RGB_MAX)
+        # Green and blue test pattern
+        screen.fill((0, 255, 0), (0, 0, 320, 240))
+        screen.fill((0, 255, 0), (320, 240, 320, 240))
+        screen.fill((0, 0, 255), (320, 0, 320, 240))
+        screen.fill((0, 0, 255), (0, 240, 320, 240))
 
-            # Update the display so we can see the results
-            pygame.display.flip()
+        # Now apply a clip rect, such that only the left side of the
+        # screen should be effected by blit opperations.
+        screen.set_clip((0, 0, 320, 480))
 
-            # Compare colors on both sides of window
-            y = 5
-            while y < 480:
-                self.assertEquals(screen.get_at((10, y)),
-                        screen.get_at((330, 480 - y)))
-                y += 10
+        # Test fills with each special flag, and additionaly without any.
+        screen.fill((255, 0, 0, 127), (160, 0, 320, 30), 0)
+        screen.fill((255, 0, 0, 127), (160, 30, 320, 30), pygame.BLEND_ADD)
+        screen.fill((0, 127, 127, 127), (160, 60, 320, 30), pygame.BLEND_SUB)
+        screen.fill((0, 63, 63, 127), (160, 90, 320, 30), pygame.BLEND_MULT)
+        screen.fill((0, 127, 127, 127), (160, 120, 320, 30), pygame.BLEND_MIN)
+        screen.fill((127, 0, 0, 127), (160, 150, 320, 30), pygame.BLEND_MAX)
+        screen.fill((255, 0, 0, 127), (160, 180, 320, 30), pygame.BLEND_RGBA_ADD)
+        screen.fill((0, 127, 127, 127), (160, 210, 320, 30), pygame.BLEND_RGBA_SUB)
+        screen.fill((0, 63, 63, 127), (160, 240, 320, 30), pygame.BLEND_RGBA_MULT)
+        screen.fill((0, 127, 127, 127), (160, 270, 320, 30), pygame.BLEND_RGBA_MIN)
+        screen.fill((127, 0, 0, 127), (160, 300, 320, 30), pygame.BLEND_RGBA_MAX)
+        screen.fill((255, 0, 0, 127), (160, 330, 320, 30), pygame.BLEND_RGB_ADD)
+        screen.fill((0, 127, 127, 127), (160, 360, 320, 30), pygame.BLEND_RGB_SUB)
+        screen.fill((0, 63, 63, 127), (160, 390, 320, 30), pygame.BLEND_RGB_MULT)
+        screen.fill((0, 127, 127, 127), (160, 420, 320, 30), pygame.BLEND_RGB_MIN)
+        screen.fill((255, 0, 0, 127), (160, 450, 320, 30), pygame.BLEND_RGB_MAX)
 
-        finally:
-            pygame.quit()
+        # Update the display so we can see the results
+        pygame.display.flip()
+
+        # Compare colors on both sides of window
+        for y in range(5, 480,  10):
+            self.assertEqual(screen.get_at((10, y)), screen.get_at((330, 480 - y)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -492,17 +492,10 @@ class SurfaceTypeTest(unittest.TestCase):
         gc.collect()
         self.assertFalse(s.get_locked())
 
-    try:
-        pygame.bufferproxy.get_segcount
-    except AttributeError:
-        pass
-    else:
-        def test_get_buffer_oldbuf(self):
-            self.OLDBUF_get_buffer_oldbuf()
-        def test_get_view_oldbuf(self):
-            self.OLDBUF_get_view_oldbuf()
+    OLDBUF = hasattr(pygame.bufferproxy, 'get_segcount')
 
-    def OLDBUF_get_buffer_oldbuf(self):
+    @unittest.skipIf(not OLDBUF, 'old buffer not available')
+    def test_get_buffer_oldbuf(self):
         from pygame.bufferproxy import get_segcount, get_write_buffer
 
         s = pygame.Surface((2, 4), pygame.SRCALPHA, 32)
@@ -514,7 +507,8 @@ class SurfaceTypeTest(unittest.TestCase):
         self.assertEqual(segaddr, s._pixels_address)
         self.assertEqual(seglen, buflen)
 
-    def OLDBUF_get_view_oldbuf(self):
+    @unittest.skipIf(not OLDBUF, 'old buffer not available')
+    def test_get_view_oldbuf(self):
         from pygame.bufferproxy import get_segcount, get_write_buffer
 
         s = pygame.Surface((2, 4), pygame.SRCALPHA, 32)

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1543,23 +1543,9 @@ class SurfaceGetBufferTest (unittest.TestCase):
                 s = pygame.Surface((4, 2), 0, 32)
                 self._check_interface_rgba(s, plane)
 
-    if pygame.HAVE_NEWBUF:
-        def test_newbuf_PyBUF_flags_bytes(self):
-            self.NEWBUF_test_newbuf_PyBUF_flags_bytes()
-        def test_newbuf_PyBUF_flags_0D(self):
-            self.NEWBUF_test_newbuf_PyBUF_flags_0D()
-        def test_newbuf_PyBUF_flags_1D(self):
-            self.NEWBUF_test_newbuf_PyBUF_flags_1D()
-        def test_newbuf_PyBUF_flags_2D(self):
-            self.NEWBUF_test_newbuf_PyBUF_flags_2D()
-        def test_newbuf_PyBUF_flags_3D(self):
-            self.NEWBUF_test_newbuf_PyBUF_flags_3D()
-        def test_newbuf_PyBUF_flags_rgba(self):
-            self.NEWBUF_test_newbuf_PyBUF_flags_rgba()
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf_PyBUF_flags_bytes(self):
         from pygame.tests.test_utils import buftools
-
-    def NEWBUF_test_newbuf_PyBUF_flags_bytes(self):
-        buftools = self.buftools
         Importer = buftools.Importer
         s = pygame.Surface((10, 6), 0, 32)
         a = s.get_buffer()
@@ -1616,10 +1602,11 @@ class SurfaceGetBufferTest (unittest.TestCase):
         self.assertEqual(b.ndim, 1)
         self.assertEqual(b.strides, (1,))
 
-    def NEWBUF_test_newbuf_PyBUF_flags_0D(self):
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf_PyBUF_flags_0D(self):
         # This is the same handler as used by get_buffer(), so just
         # confirm that it succeeds for one case.
-        buftools = self.buftools
+        from pygame.tests.test_utils import buftools
         Importer = buftools.Importer
         s = pygame.Surface((10, 6), 0, 32)
         a = s.get_view('0')
@@ -1634,8 +1621,9 @@ class SurfaceGetBufferTest (unittest.TestCase):
         self.assertFalse(b.readonly)
         self.assertEqual(b.buf, s._pixels_address)
 
-    def NEWBUF_test_newbuf_PyBUF_flags_1D(self):
-        buftools = self.buftools
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf_PyBUF_flags_1D(self):
+        from pygame.tests.test_utils import buftools
         Importer = buftools.Importer
         s = pygame.Surface((10, 6), 0, 32)
         a = s.get_view('1')
@@ -1671,8 +1659,9 @@ class SurfaceGetBufferTest (unittest.TestCase):
         self.assertTrue(b.format is None)
         self.assertEqual(b.strides, (s.get_bytesize(),))
 
-    def NEWBUF_test_newbuf_PyBUF_flags_2D(self):
-        buftools = self.buftools
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf_PyBUF_flags_2D(self):
+        from pygame.tests.test_utils import buftools
         Importer = buftools.Importer
         s = pygame.Surface((10, 6), 0, 32)
         a = s.get_view('2')
@@ -1745,8 +1734,9 @@ class SurfaceGetBufferTest (unittest.TestCase):
         self.assertRaises(BufferError, Importer, a,
                           buftools.PyBUF_ANY_CONTIGUOUS)
 
-    def NEWBUF_test_newbuf_PyBUF_flags_3D(self):
-        buftools = self.buftools
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf_PyBUF_flags_3D(self):
+        from pygame.tests.test_utils import buftools
         Importer = buftools.Importer
         s = pygame.Surface((12, 6), 0, 24)
         rmask, gmask, bmask, amask = s.get_masks()
@@ -1797,10 +1787,11 @@ class SurfaceGetBufferTest (unittest.TestCase):
         self.assertRaises(BufferError, Importer, a,
                           buftools.PyBUF_ANY_CONTIGUOUS)
 
-    def NEWBUF_test_newbuf_PyBUF_flags_rgba(self):
+    @unittest.skipIf(not pygame.HAVE_NEWBUF, 'newbuf not implemented')
+    def test_newbuf_PyBUF_flags_rgba(self):
         # All color plane views are handled by the same routine,
         # so only one plane need be checked.
-        buftools = self.buftools
+        from pygame.tests.test_utils import buftools
         Importer = buftools.Importer
         s = pygame.Surface((12, 6), 0, 24)
         rmask, gmask, bmask, amask = s.get_masks()

--- a/test/test_utils/run_tests.py
+++ b/test/test_utils/run_tests.py
@@ -295,8 +295,9 @@ def run(*args, **kwds):
     meta['total_failures'] = n_failures
     results.update(meta_results)
 
-    if not option_usesubprocess:
-        assert total == untrusty_total
+    if not option_usesubprocess and total != untrusty_total:
+        raise AssertionError('Something went wrong in the Test Machinery:\n'
+                             'total: %d != untrusty_total: %d' % (total, untrusty_total))
 
     if not option_dump:
         print (combined)

--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -106,7 +106,7 @@ return (first 10 and last 10 lines):
 
 RAN_TESTS_DIV = (70 * "-") + "\nRan"
 
-DOTS = re.compile("^([FE.]*)$", re.MULTILINE)
+DOTS = re.compile("^([FE.sx]*)$", re.MULTILINE)
 
 def combine_results(all_results, t):
     """
@@ -148,15 +148,16 @@ def combine_results(all_results, t):
     total_tests = len(all_dots)
 
     combined = [all_dots]
-    if failures: combined += [''.join(failures).lstrip('\n')[:-1]]
+    if failures:
+        combined += [''.join(failures).lstrip('\n')[:-1]]
     combined += ["%s %s tests in %.3fs\n" % (RAN_TESTS_DIV, total_tests, t)]
 
-    if not failures: combined += ['OK\n']
-    else: combined += [
-        'FAILED (%s)\n' % ', '.join (
-            (total_fails  and ["failures=%s" % total_fails] or []) +
-            (total_errors and ["errors=%s"  % total_errors] or [])
-        )]
+    if failures:
+        infos = ((["failures=%s" % total_fails] if total_fails else []) +
+                 (["errors=%s"  % total_errors] if total_errors else []))
+        combined += ['FAILED (%s)\n' % ', '.join(infos)]
+    else:
+        combined += ['OK\n']
 
     return total_tests, '\n'.join(combined)
 


### PR DESCRIPTION
Some more test cleanups; it's an infinite job, but I want to believe ( that we might close #496 this year :) )

But this time, when I run all tests, I get  : 
```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "test/__main__.py", line 131, in <module>
    run_and_exit(*args, **kwds)
  File "/home/eea/src/pygame/test/test_utils/run_tests.py", line 339, in run_and_exit
    total, fails = run(*args, **kwargs)
  File "/home/eea/src/pygame/test/test_utils/run_tests.py", line 299, in run
    assert total == untrusty_total
AssertionError
```
which I don't understand. I checked the commit where I introduced it (917f3645), but I still do not understand ...

Other thing, many tests depend on `pygame.HAVE_NEWBUF`, but I could find no documentation on this variable, where and when it's introduced, and if it can be *false* ...