### PR TITLE
dependency version into README & Cleanup SDL1.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,8 +126,6 @@ Credits
      Also a big thanks to Roger Dingledine and the crew at SEUL.ORG for our
      excellent hosting.
 
-
-
 Dependencies
 ============
 
@@ -139,6 +137,16 @@ Dependencies
      transform module has an embedded version of SDL_rotozoom for its
      own rotozoom function. The surfarray module requires the python
      numpy package for its multidimensional numeric arrays.
+     Dependency versions:
+
+     * Python >= 2.7
+     * SDL >= 1.2.15
+     * SDL_mixer >= 1.2.13
+     * SDL_image (version?)
+     * SDL_tff (version ?)
+     * SDL_gfx (optional, version?)
+     * NumPy >= 1.6.2 (optional)
+
 
 Contribute
 ==========

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -376,27 +376,7 @@ _init(int freq, int size, int stereo, int chunk)
             SDL_QuitSubSystem(SDL_INIT_AUDIO);
             return PyInt_FromLong(0);
         }
-#if MIX_MAJOR_VERSION >= 1 && MIX_MINOR_VERSION >= 2 && MIX_PATCHLEVEL >= 3
         Mix_ChannelFinished(endsound_callback);
-#endif
-
-        /* A bug in sdl_mixer where the stereo is reversed for 8 bit.
-           So we use this CPU hogging effect to reverse it for us.
-           Hopefully this bug is fixed in SDL_mixer 1.2.9
-        printf("MIX_MAJOR_VERSION :%d: MIX_MINOR_VERSION :%d: MIX_PATCHLEVEL
-        :%d: \n", MIX_MAJOR_VERSION, MIX_MINOR_VERSION, MIX_PATCHLEVEL);
-        */
-
-#if MIX_MAJOR_VERSION >= 1 && MIX_MINOR_VERSION >= 2 && MIX_PATCHLEVEL <= 8
-        if (fmt == AUDIO_U8) {
-            if (!Mix_SetReverseStereo(MIX_CHANNEL_POST, 1)) {
-                /* We do nothing... because might as well just let it go ahead.
-                 */
-                /* return RAISE (pgExc_SDLError, Mix_GetError());
-                 */
-            }
-        }
-#endif
 
         Mix_VolumeMusic(127);
     }
@@ -975,7 +955,6 @@ chan_set_volume(PyObject *self, PyObject *args)
         return NULL;
 
     MIXER_INIT_CHECK();
-#if MIX_MAJOR_VERSION >= 1 && MIX_MINOR_VERSION >= 2 && MIX_PATCHLEVEL >= 1
     if ((stereovolume <= -1.10f) && (stereovolume >= -1.12f)) {
         /* The normal volume will be used.  No panning.  so panning is
          * set to full.  this is incase it was set previously to
@@ -1004,10 +983,6 @@ chan_set_volume(PyObject *self, PyObject *args)
 
         volume = 1.0f;
     }
-#else
-    if (!((stereovolume <= -1.10f) && (stereovolume >= -1.12f)))
-        volume = (volume + stereovolume) * 0.5f;
-#endif
 
 #ifdef Py_DEBUG
     result =

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -32,27 +32,6 @@
 
 #include "mixer.h"
 
-#define ver(major_version, minor_version, patchlevel) \
-    (major_version * 10000 + minor_version * 100 + patchlevel)
-#define _version_ ver(MIX_MAJOR_VERSION, MIX_MINOR_VERSION, MIX_PATCHLEVEL)
-
-/* versions 1.2.4 and greater have positioned fade-in */
-#if _version_ >= ver(1, 2, 4)
-#define MIXMUSIC_HAVE_STARTPOSN 1
-#else
-#define MIXMUSIC_HAVE_STARTPOSN 0
-#endif
-
-/* versions 1.2.8 and greater have rwops */
-#if _version_ >= ver(1, 2, 8)
-#define MIXMUSIC_HAVE_RWOPS 1
-#else
-#define MIXMUSIC_HAVE_RWOPS 0
-#endif
-
-#undef ver
-#undef _version_
-
 static Mix_Music *current_music = NULL;
 static Mix_Music *queue_music = NULL;
 static int endmusic_event = SDL_NOEVENT;
@@ -118,18 +97,10 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
     music_pos = 0;
     music_pos_time = SDL_GetTicks();
 
-#if MIXMUSIC_HAVE_STARTPOSN
     Py_BEGIN_ALLOW_THREADS volume = Mix_VolumeMusic(-1);
     val = Mix_FadeInMusicPos(current_music, loops, 0, startpos);
     Mix_VolumeMusic(volume);
     Py_END_ALLOW_THREADS
-#else
-    if (startpos)
-        return RAISE(PyExc_NotImplementedError,
-                     "music start position requires SDL_mixer-1.2.4");
-    Py_BEGIN_ALLOW_THREADS val = Mix_PlayMusic(current_music, loops);
-    Py_END_ALLOW_THREADS
-#endif
         if (val == -1) return RAISE(pgExc_SDLError, SDL_GetError());
 
     Py_RETURN_NONE;
@@ -294,7 +265,6 @@ music_load(PyObject *self, PyObject *args)
     oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);
     if (oencoded == Py_None) {
         Py_DECREF(oencoded);
-#if MIXMUSIC_HAVE_RWOPS
         rw = pgRWopsFromFileObjectThreaded(obj);
         if (rw == NULL) {
             return NULL;
@@ -306,11 +276,6 @@ music_load(PyObject *self, PyObject *args)
             new_music = Mix_LoadMUS_RW(rw, SDL_TRUE);
 #endif /* IS_SDLv2 */
         Py_END_ALLOW_THREADS
-#else
-        return RAISE(PyExc_NotImplementedError,
-                     "music file-like-object support requires"
-                     " SDL_mixer-1.2.8");
-#endif
     }
     else if (oencoded != NULL) {
         name = Bytes_AS_STRING(oencoded);
@@ -358,7 +323,6 @@ music_queue(PyObject *self, PyObject *args)
     oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);
     if (oencoded == Py_None) {
         Py_DECREF(oencoded);
-#if MIXMUSIC_HAVE_RWOPS
         rw = pgRWopsFromFileObjectThreaded(obj);
         if (rw == NULL) {
             return NULL;
@@ -370,11 +334,6 @@ music_queue(PyObject *self, PyObject *args)
             queue_music = Mix_LoadMUS_RW(rw, SDL_TRUE);
 #endif /* IS_SDLv2 */
         Py_END_ALLOW_THREADS
-#else
-        return RAISE(PyExc_NotImplementedError,
-                     "music file-like-object support requires"
-                     " SDL_mixer-1.2.8");
-#endif
     }
     else if (oencoded != NULL) {
         name = Bytes_AS_STRING(oencoded);


### PR DESCRIPTION

Here are my best guesses for the dependency versions that I wrote into REAMDE.rst :  
* Python >= 2.7
* SDL >= 1.2.15 (last version; released 2012, https://en.wikipedia.org/wiki/Simple_DirectMedia_Layer)
* SDL_mixer >= 1.2.13 (last version; released 2012, see source code)
* NumPy >= 1.6.2 (just as example : of Debian Wheezy (old-old-stable), released 2013: 
   https://www.debian.org/releases/wheezy/, https://packages.debian.org/wheezy/python-numpy)
* SDL_image (version?)
* SDL_tff (version ?)
* SDL_gfx (optional, version?)

Then I cleaned up "mixer.c" and "music.c" ...

At merge, we can check one more point in check list #494 !