### PR TITLE
Set resolution

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -682,7 +682,7 @@ pg_set_resolution(PyObject *self, PyObject *arg)
     int w = 0;
     int h = 0;
 
-    if (!PyArg_ParseTuple(arg, "|(ii)ii", &w, &h))
+    if (!PyArg_ParseTuple(arg, "|(ii)", &w, &h))
         return NULL;
 
     if (w < 0 || h < 0)
@@ -764,17 +764,11 @@ pg_set_resolution(PyObject *self, PyObject *arg)
     int depth = 0;
     int hasbuf;
 
-    if (!PyArg_ParseTuple(arg, "|(ii)ii", &w, &h, &depth))
+    if (!PyArg_ParseTuple(arg, "|(ii)i", &w, &h, &depth))
         return NULL;
 
     if (w < 0 || h < 0)
         return RAISE(pgExc_SDLError, "Cannot set negative sized display mode");
-
-    /*
-    if (depth == 0) {
-        return RAISE(pgExc_SDLError, "Cannot set depth 0");
-    }
-    */
 
     if (w == 0 || h == 0) {
         SDL_version versioninfo;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -756,15 +756,13 @@ pg_flip(PyObject *self)
 static PyObject *
 pg_set_resolution(PyObject *self, PyObject *arg)
 {
-    SDL_Surface *surf;
 
-    int flags = SDL_SWSURFACE;
     int w = 0;
     int h = 0;
-    int depth = 0;
-    int hasbuf;
 
-    if (!PyArg_ParseTuple(arg, "|(ii)i", &w, &h, &depth))
+    SDL_Surface *currSurf = SDL_GetVideoSurface();
+
+    if (!PyArg_ParseTuple(arg, "|(ii)", &w, &h))
         return NULL;
 
     if (w < 0 || h < 0)
@@ -787,31 +785,11 @@ pg_set_resolution(PyObject *self, PyObject *arg)
             return NULL;
     }
 
-    if (flags & SDL_OPENGL) {
-        if (flags & SDL_DOUBLEBUF) {
-            flags &= ~SDL_DOUBLEBUF;
-            SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-        }
-        else
-            SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 0);
+    int currDepth = 0;
 
-        surf = SDL_SetVideoMode(w, h, depth, flags);
-        if (!surf)
-            return RAISE(pgExc_SDLError, SDL_GetError());
-
-        SDL_GL_GetAttribute(SDL_GL_DOUBLEBUFFER, &hasbuf);
-        if (hasbuf)
-            surf->flags |= SDL_DOUBLEBUF;
-    }
-    else {
-        if (!depth)
-            flags |= SDL_ANYFORMAT;
-        Py_BEGIN_ALLOW_THREADS;
-        surf = SDL_SetVideoMode(w, h, depth, flags);
-        Py_END_ALLOW_THREADS;
-        if (!surf)
-            return RAISE(pgExc_SDLError, SDL_GetError());
-    }
+    SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, currDepth);
+    
+    SDL_SetVideoMode(w, h, currDepth, currSurf->flags);
 
     /*probably won't do much, but can't hurt, and might help*/
     SDL_PumpEvents();

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -785,11 +785,7 @@ pg_set_resolution(PyObject *self, PyObject *arg)
             return NULL;
     }
 
-    int currDepth = 0;
-
-    SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, currDepth);
-    
-    SDL_SetVideoMode(w, h, currDepth, currSurf->flags);
+    SDL_SetVideoMode(w, h, currSurf->format->BitsPerPixel, currSurf->flags);
 
     /*probably won't do much, but can't hurt, and might help*/
     SDL_PumpEvents();


### PR DESCRIPTION
couldn't find an option to change resolution, with this code it's possible to change the resolution by calling ```pygame.display.set_resolution((x, y))```, it preserves the old depth and flags.

tested with:
```
import pygame
import random

pygame.init()
screen = pygame.display.set_mode((640, 480))
clock = pygame.time.Clock()
done = False

screen.fill((255, 255, 255))
pygame.display.flip()

green = (0,255,0)

print(pygame.get_sdl_version())

while not done:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            done = True
        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
            done = True
        if event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
            pygame.display.set_resolution((random.randint(32, 512), random.randint(32, 512)))

    screen.fill((255, 255, 255))

    pygame.draw.circle(screen, green, (screen.get_width() / 2, screen.get_height() / 2), min(screen.get_width() , screen.get_height()) / 2, 5)

    pygame.display.flip()

    clock.tick(60)
```

works fine on ```macOS Mojave``` and ```Ubuntu 18.04``` with SDL