### PR TITLE
Fixed freezing while playing music from file objects

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -400,6 +400,17 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
     Sint64 retval;
 #endif
 
+    if (helper->fileno != -1) {
+        if (!(offset == 0 &&
+             whence == SEEK_CUR)) /* being seek'd, not just tell'd */
+        {
+            if (lseek(helper->fileno, offset, whence) == -1) {
+                return -1;
+            }
+        }
+        return lseek(helper->fileno, 0, SEEK_CUR);
+    }
+
     if (!helper->seek || !helper->tell)
         return -1;
 
@@ -648,6 +659,17 @@ _pg_rw_seek_th(SDL_RWops *context, Sint64 offset, int whence)
     Sint64 retval;
 #endif /* IS_SDLv2 */
     PyGILState_STATE state;
+
+    if (helper->fileno != -1) {
+        if (!(offset == 0 &&
+             whence == SEEK_CUR)) /* being seek'd, not just tell'd */
+        {
+            if (lseek(helper->fileno, offset, whence) == -1) {
+                return -1;
+            }
+        }
+        return lseek(helper->fileno, 0, SEEK_CUR);
+    }
 
     if (!helper->seek || !helper->tell)
         return -1;

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -277,6 +277,8 @@ pgRWopsFromFileObject(PyObject *obj)
         return (SDL_RWops *)PyErr_NoMemory();
     }
     helper->fileno = PyObject_AsFileDescriptor(obj);
+    if (helper->fileno == -1)
+        PyErr_Clear();
     fetch_object_methods(helper, obj);
     rw->hidden.unknown.data1 = (void *)helper;
 #if IS_SDLv2
@@ -547,6 +549,8 @@ pgRWopsFromFileObjectThreaded(PyObject *obj)
         return (SDL_RWops *)PyErr_NoMemory();
     }
     helper->fileno = PyObject_AsFileDescriptor(obj);
+    if (helper->fileno == -1)
+        PyErr_Clear();
     fetch_object_methods(helper, obj);
     rw->hidden.unknown.data1 = (void *)helper;
 #if IS_SDLv2

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -403,14 +403,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
 #endif
 
     if (helper->fileno != -1) {
-        if (!(offset == 0 &&
-             whence == SEEK_CUR)) /* being seek'd, not just tell'd */
-        {
-            if (lseek(helper->fileno, offset, whence) == -1) {
-                return -1;
-            }
-        }
-        return lseek(helper->fileno, 0, SEEK_CUR);
+        return lseek(helper->fileno, offset, whence);
     }
 
     if (!helper->seek || !helper->tell)
@@ -665,14 +658,7 @@ _pg_rw_seek_th(SDL_RWops *context, Sint64 offset, int whence)
     PyGILState_STATE state;
 
     if (helper->fileno != -1) {
-        if (!(offset == 0 &&
-             whence == SEEK_CUR)) /* being seek'd, not just tell'd */
-        {
-            if (lseek(helper->fileno, offset, whence) == -1) {
-                return -1;
-            }
-        }
-        return lseek(helper->fileno, 0, SEEK_CUR);
+        return lseek(helper->fileno, offset, whence);
     }
 
     if (!helper->seek || !helper->tell)


### PR DESCRIPTION
#548

The problem is primarily `_pg_rw_read_th`. Calling fileobj.read() (and possibly Py_DECREF) makes Python switch to the other thread and often causes the other thread to wait forever to acquire the mixer mutex.

My solution was to store the file descriptor and use this instead of the Python method, if it's available. Are there any drawbacks to this?