### PR TITLE
Raise TypeError on invalid point arguments (fix #521)

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -249,11 +249,17 @@ aalines(PyObject *self, PyObject *arg)
         return RAISE(PyExc_ValueError,
                      "points argument must contain more than 1 points");
 
+    for(loop = 0; loop < length; ++loop) {
+        item = PySequence_GetItem(points, loop);
+        result = pg_TwoIntsFromObj(item, &x, &y);
+        Py_DECREF(item);
+        if(!result)
+            return RAISE(PyExc_TypeError, "all points must be number pairs");
+    }
+
     item = PySequence_GetItem(points, 0);
     result = pg_TwoFloatsFromObj(item, &x, &y);
     Py_DECREF(item);
-    if (!result)
-        return RAISE(PyExc_TypeError, "points must be number pairs");
 
     startx = pts[0] = x;
     starty = pts[1] = y;
@@ -268,8 +274,6 @@ aalines(PyObject *self, PyObject *arg)
         item = PySequence_GetItem(points, loop);
         result = pg_TwoFloatsFromObj(item, &x, &y);
         Py_DECREF(item);
-        if (!result)
-            continue; /*note, we silently skip over bad points :[ */
         ++drawn;
         pts[0] = startx;
         pts[1] = starty;
@@ -342,11 +346,17 @@ lines(PyObject *self, PyObject *arg)
         return RAISE(PyExc_ValueError,
                      "points argument must contain more than 1 points");
 
+    for(loop = 0; loop < length; ++loop) {
+        item = PySequence_GetItem(points, loop);
+        result = pg_TwoIntsFromObj(item, &x, &y);
+        Py_DECREF(item);
+        if(!result)
+            return RAISE(PyExc_TypeError, "all points must be number pairs");
+    }
+
     item = PySequence_GetItem(points, 0);
     result = pg_TwoIntsFromObj(item, &x, &y);
     Py_DECREF(item);
-    if (!result)
-        return RAISE(PyExc_TypeError, "points must be number pairs");
 
     startx = pts[0] = left = right = x;
     starty = pts[1] = top = bottom = y;
@@ -362,8 +372,6 @@ lines(PyObject *self, PyObject *arg)
         item = PySequence_GetItem(points, loop);
         result = pg_TwoIntsFromObj(item, &x, &y);
         Py_DECREF(item);
-        if (!result)
-            continue; /*note, we silently skip over bad points :[ */
         ++drawn;
         pts[0] = startx;
         pts[1] = starty;
@@ -628,11 +636,17 @@ polygon(PyObject *self, PyObject *arg)
         return RAISE(PyExc_ValueError,
                      "points argument must contain more than 2 points");
 
+    for(loop = 0; loop < length; ++loop) {
+        item = PySequence_GetItem(points, loop);
+        result = pg_TwoIntsFromObj(item, &x, &y);
+        Py_DECREF(item);
+        if(!result)
+            return RAISE(PyExc_TypeError, "all points must be number pairs");
+    }
+
     item = PySequence_GetItem(points, 0);
     result = pg_TwoIntsFromObj(item, &x, &y);
     Py_DECREF(item);
-    if (!result)
-        return RAISE(PyExc_TypeError, "points must be number pairs");
     left = right = x;
     top = bottom = y;
 
@@ -644,8 +658,6 @@ polygon(PyObject *self, PyObject *arg)
         item = PySequence_GetItem(points, loop);
         result = pg_TwoIntsFromObj(item, &x, &y);
         Py_DECREF(item);
-        if (!result)
-            continue; /*note, we silently skip over bad points :[ */
         xlist[numpoints] = x;
         ylist[numpoints] = y;
         ++numpoints;

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -205,6 +205,9 @@ class DrawLineTest(unittest.TestCase):
                 self.assertTrue(all(no_gaps))
 
     def test_invalid_points(self):
+        """Test if draw.aalines and draw.lines throw a TypeError if
+        we pass invalid points to them.
+        """
         surface = pygame.Surface((20, 20))
         for draw_lines in [draw.lines, draw.aalines]:
             self.assertRaises(TypeError, lambda: draw_lines(

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -665,7 +665,10 @@ class DrawPolygonMixin:
         self.draw_polygon(GREEN, path_data, 0)
         for x in range(4, rect.width-5 +1):
             self.assertEqual(self.surface.get_at((x, 4)), GREEN)  # upper inner
-
+        
+    def test_invalid_points(self):
+        self.assertRaises(TypeError, lambda: self.draw_polygon(
+                          RED, ((0, 0), (0, 20), (20, 20), 20), 0))
 
 class DrawPolygonTest(DrawPolygonMixin, unittest.TestCase):
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -204,6 +204,13 @@ class DrawLineTest(unittest.TestCase):
                 no_gaps = lines_have_gaps(surface, draw_lines)
                 self.assertTrue(all(no_gaps))
 
+    def test_invalid_points(self):
+        surface = pygame.Surface((20, 20))
+        for draw_lines in [draw.lines, draw.aalines]:
+            self.assertRaises(TypeError, lambda: draw_lines(
+                              surface, (255, 255, 255), True,
+                              ((0, 0), (20, 20), 0)))
+
 
 class AntiAliasedLineMixin:
     '''Mixin for tests of Anti Aliasing of Lines.


### PR DESCRIPTION
Raises TypeError and not ValueError as said in issue to be consistent with the error that is raised by the python algorithm.