### PR TITLE
Allow clean silencing of support prompt

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -392,9 +392,11 @@ def __color_reduce(c):
 copy_reg.pickle(Color, __color_reduce, __color_constructor)
 
 
+# Thanks for supporting pygame. Without support now, there won't be pygame later.
+if 'PYGAME_HIDE_SUPPORT_PROMPT' not in os.environ:
+    print('pygame %s' % ver)
+    print('Hello from the pygame community. https://www.pygame.org/contribute.html')
+
+
 # cleanup namespace
 del pygame, os, sys, surflock, MissingModule, copy_reg, PY_MAJOR_VERSION
-
-# Thanks for supporting pygame. Without support now, there won't be pygame later.
-print('pygame %s' % ver)
-print('Hello from the pygame community. https://www.pygame.org/contribute.html')


### PR DESCRIPTION
As nice as the prompt is, there are some situations where it's really not appropriate. At current, the best way to silence it is something like
```py
import io, sys
stdout = sys.stdout
sys.stdout = io.StringIO()
import pygame
sys.stdout = stdout
del stdout, io, sys
```
This patch would allow the user to define the `PYGAME_HIDE_SUPPORT_PROMPT` environment variable in which case importing pygame wouldn't print the extra two lines.