### PR TITLE
Draw: data validate

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -72,6 +72,17 @@ draw_ellipse(SDL_Surface *dst, int x, int y, int width, int height, int solid,
 static void
 draw_fillpoly(SDL_Surface *dst, int *vx, int *vy, int n, Uint32 color);
 
+// validation of a draw color
+#define CHECK_LOAD_COLOR(colorobj)                                         \
+    if (PyInt_Check(colorobj))                                             \
+        color = (Uint32)PyInt_AsLong(colorobj);                            \
+    else if (pg_RGBAFromColorObj(colorobj, rgba))                          \
+        color =                                                            \
+            SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]); \
+    else                                                                   \
+        return RAISE(PyExc_TypeError, "invalid color argument");
+
+
 static PyObject *
 aaline(PyObject *self, PyObject *arg)
 {
@@ -96,10 +107,7 @@ aaline(PyObject *self, PyObject *arg)
             PyExc_ValueError,
             "unsupported bit depth for aaline draw (supports 32 & 24 bit)");
 
-    if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     if (!pg_TwoFloatsFromObj(start, &startx, &starty))
         return RAISE(PyExc_TypeError, "Invalid start position argument");
@@ -163,12 +171,7 @@ line(PyObject *self, PyObject *arg)
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
         return RAISE(PyExc_ValueError, "unsupport bit depth for line draw");
 
-    if (PyInt_Check(colorobj))
-        color = (Uint32)PyInt_AsLong(colorobj);
-    else if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     if (!pg_TwoIntsFromObj(start, &startx, &starty))
         return RAISE(PyExc_TypeError, "Invalid start position argument");
@@ -234,10 +237,7 @@ aalines(PyObject *self, PyObject *arg)
             PyExc_ValueError,
             "unsupported bit depth for aaline draw (supports 32 & 24 bit)");
 
-    if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     closed = PyObject_IsTrue(closedobj);
 
@@ -325,12 +325,7 @@ lines(PyObject *self, PyObject *arg)
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
         return RAISE(PyExc_ValueError, "unsupport bit depth for line draw");
 
-    if (PyInt_Check(colorobj))
-        color = (Uint32)PyInt_AsLong(colorobj);
-    else if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     closed = PyObject_IsTrue(closedobj);
 
@@ -422,12 +417,7 @@ arc(PyObject *self, PyObject *arg)
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
         return RAISE(PyExc_ValueError, "unsupport bit depth for drawing");
 
-    if (PyInt_Check(colorobj))
-        color = (Uint32)PyInt_AsLong(colorobj);
-    else if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     if (width < 0)
         return RAISE(PyExc_ValueError, "negative width");
@@ -479,12 +469,7 @@ ellipse(PyObject *self, PyObject *arg)
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
         return RAISE(PyExc_ValueError, "unsupport bit depth for drawing");
 
-    if (PyInt_Check(colorobj))
-        color = (Uint32)PyInt_AsLong(colorobj);
-    else if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     if (width < 0)
         return RAISE(PyExc_ValueError, "negative width");
@@ -536,12 +521,7 @@ circle(PyObject *self, PyObject *arg)
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
         return RAISE(PyExc_ValueError, "unsupport bit depth for drawing");
 
-    if (PyInt_Check(colorobj))
-        color = (Uint32)PyInt_AsLong(colorobj);
-    else if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     if (radius < 0)
         return RAISE(PyExc_ValueError, "negative radius");
@@ -613,12 +593,7 @@ polygon(PyObject *self, PyObject *arg)
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
         return RAISE(PyExc_ValueError, "unsupport bit depth for line draw");
 
-    if (PyInt_Check(colorobj))
-        color = (Uint32)PyInt_AsLong(colorobj);
-    else if (pg_RGBAFromColorObj(colorobj, rgba))
-        color = SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]);
-    else
-        return RAISE(PyExc_TypeError, "invalid color argument");
+    CHECK_LOAD_COLOR(colorobj)
 
     if (!PySequence_Check(points))
         return RAISE(PyExc_TypeError,

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -242,7 +242,6 @@ class DrawLineTest(unittest.TestCase):
                 # make sure, nothing was drawn :
                 self.assertTrue(all(surf.get_at(pt) == RED for pt in check_pts))
 
-    @unittest.expectedFailure # aaline and aalines do not accept a number
     def test_color_validation(self):
         surf = pygame.Surface((10, 10))
         colors = 123456, (1, 10, 100), RED # but not '#ab12df' or 'red' ...

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -204,7 +204,6 @@ class DrawLineTest(unittest.TestCase):
                 no_gaps = lines_have_gaps(surface, draw_lines)
                 self.assertTrue(all(no_gaps))
 
-    @unittest.expectedFailure
     def test_path_data_validation(self):
         '''Test validation of multi-point drawing methods.
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -242,6 +242,40 @@ class DrawLineTest(unittest.TestCase):
                 # make sure, nothing was drawn :
                 self.assertTrue(all(surf.get_at(pt) == RED for pt in check_pts))
 
+    @unittest.expectedFailure # aaline and aalines do not accept a number
+    def test_color_validation(self):
+        surf = pygame.Surface((10, 10))
+        colors = 123456, (1, 10, 100), RED # but not '#ab12df' or 'red' ...
+        points = ((0, 0), (1, 1), (1, 0))
+        # 1. valid colors
+        for col in colors:
+            draw.line(surf, col, (0, 0), (1, 1))
+            draw.aaline(surf, col, (0, 0), (1, 1))
+            draw.aalines(surf, col, True, points)
+            draw.lines(surf, col, True, points)
+            draw.arc(surf, col, pygame.Rect(0, 0, 3, 3), 15, 150)
+            draw.ellipse(surf, col, pygame.Rect(0, 0, 3, 6), 1)
+            draw.circle(surf, col, (7, 3), 2)
+            draw.polygon(surf, col, points, 0)
+        # 2. invalid colors
+        for col in ('invalid', 1.256, object(), None, '#ab12df', 'red'):
+            with self.assertRaises(TypeError):
+                draw.line(surf, col, (0, 0), (1, 1))
+            with self.assertRaises(TypeError):
+                draw.aaline(surf, col, (0, 0), (1, 1))
+            with self.assertRaises(TypeError):
+                draw.aalines(surf, col, True, points)
+            with self.assertRaises(TypeError):
+                draw.lines(surf, col, True, points)
+            with self.assertRaises(TypeError):
+                draw.arc(surf, col, pygame.Rect(0, 0, 3, 3), 15, 150)
+            with self.assertRaises(TypeError):
+                draw.ellipse(surf, col, pygame.Rect(0, 0, 3, 6), 1)
+            with self.assertRaises(TypeError):
+                draw.circle(surf, col, (7, 3), 2)
+            with self.assertRaises(TypeError):
+                draw.polygon(surf, col, points, 0)
+
 
 class AntiAliasedLineMixin:
     '''Mixin for tests of Anti Aliasing of Lines.


### PR DESCRIPTION
* a macro for validating colours 
* `aaline` and `aalines` now also accept *integer* as color (like the other drawing functions)
* `aalines`, `lines` and `polygon` : full validation of the path points instead of skipping points
* tests for color and path validation for all drawing functions

[edit] : this closes #521 