### PR TITLE
Fixed freezing while playing music from file-like objects without file descriptors

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -980,6 +980,7 @@ chan_set_volume(PyObject *self, PyObject *args)
     int result;
 #endif
     Uint8 left, right;
+    PyThreadState *_save;
 
     if (!PyArg_ParseTuple(args, "f|f", &volume, &stereovolume))
         return NULL;
@@ -994,7 +995,7 @@ chan_set_volume(PyObject *self, PyObject *args)
         left = 255;
         right = 255;
 
-        PyThreadState *_save = PyEval_SaveThread();
+        _save = PyEval_SaveThread();
         if (!Mix_SetPanning(channelnum, left, right)) {
             PyEval_RestoreThread(_save);
             return RAISE(pgExc_SDLError, Mix_GetError());
@@ -1010,7 +1011,7 @@ chan_set_volume(PyObject *self, PyObject *args)
         printf("left:%d:  right:%d:\n", left, right);
         */
 
-        PyThreadState *_save = PyEval_SaveThread();
+        _save = PyEval_SaveThread();
         if (!Mix_SetPanning(channelnum, left, right)) {
             PyEval_RestoreThread(_save);
             return RAISE(pgExc_SDLError, Mix_GetError());

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -91,13 +91,14 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
     if (!current_music)
         return RAISE(pgExc_SDLError, "music not loaded");
 
+    Py_BEGIN_ALLOW_THREADS
     Mix_HookMusicFinished(endmusic_callback);
     Mix_SetPostMix(mixmusic_callback, NULL);
     Mix_QuerySpec(&music_frequency, &music_format, &music_channels);
     music_pos = 0;
     music_pos_time = SDL_GetTicks();
 
-    Py_BEGIN_ALLOW_THREADS volume = Mix_VolumeMusic(-1);
+    volume = Mix_VolumeMusic(-1);
     val = Mix_FadeInMusicPos(current_music, loops, 0, startpos);
     Mix_VolumeMusic(volume);
     Py_END_ALLOW_THREADS
@@ -122,11 +123,13 @@ music_fadeout(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
+    Py_BEGIN_ALLOW_THREADS
     Mix_FadeOutMusic(_time);
     if (queue_music) {
         Mix_FreeMusic(queue_music);
         queue_music = NULL;
     }
+    Py_END_ALLOW_THREADS
     Py_RETURN_NONE;
 }
 
@@ -135,11 +138,13 @@ music_stop(PyObject *self)
 {
     MIXER_INIT_CHECK();
 
+    Py_BEGIN_ALLOW_THREADS
     Mix_HaltMusic();
     if (queue_music) {
         Mix_FreeMusic(queue_music);
         queue_music = NULL;
     }
+    Py_END_ALLOW_THREADS
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Same as #551 but general. Always releases the GIL before acquiring the audio mutex.

This will freeze in the current version:

```python
import pygame
import io

pygame.mixer.pre_init(buffer=512)
pygame.init()

displaySurface = pygame.display.set_mode((320, 240))

with open('music.ogg', 'rb') as f:
	h = io.BytesIO(f.read())
	pygame.mixer.music.load(h)
	pygame.mixer.music.play()

s = pygame.mixer.Sound('sound.wav')

clock = pygame.time.Clock()
running = True
while running:
	for event in pygame.event.get():
		if event.type == pygame.QUIT or\
			(event.type == pygame.KEYDOWN and\
			event.key == pygame.K_ESCAPE):
			running = False
			break
		elif event.type == pygame.KEYDOWN:
			s.play()
	pygame.display.flip()
	clock.tick(60)
```