### PR TITLE
fix bugs in surface.blits

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2103,13 +2103,13 @@ surf_blits(PyObject *self, PyObject *args, PyObject *keywds)
             srcobject = PySequence_GetItem(item, 0);
             argpos = PySequence_GetItem(item, 1);
         }
-        if (itemlength == 3) {
+        if (itemlength >= 3) {
             /* (Surface, dest, area) */
-            argrect = PySequence_GetItem(item, 3);
+            argrect = PySequence_GetItem(item, 2);
         }
         if (itemlength == 4) {
             /* (Surface, dest, area, special_flags) */
-            special_flags = PySequence_GetItem(item, 4);
+            special_flags = PySequence_GetItem(item, 3);
         }
         Py_DECREF(item);
 


### PR DESCRIPTION
Hello! If you're in the official (at least it's linked on the official pygame website?) discord, you could see I got segfaults when trying to use surface.blits with 4 args per tuple, dug a little and found these glaring at me. Untested because I don't have the environment to compile it, but logically it should fix them.

Thanks for your time, this library is incredible