### PR TITLE
Fixed FreeType memory leak

### DIFF
--- a/src_c/freetype/ft_wrap.c
+++ b/src_c/freetype/ft_wrap.c
@@ -507,11 +507,11 @@ _PGFT_UnloadFont(FreeTypeInstance *ft, pgFontObject *fontobj)
         quit(fontobj);
     }
 
-    if (fontobj->id.open_args.flags == FT_OPEN_STREAM) {
+    if (fontobj->id.open_args.flags == FT_OPEN_PATHNAME) {
         _PGFT_free(fontobj->id.open_args.pathname);
     fontobj->id.open_args.pathname = 0;
     }
-    else if (fontobj->id.open_args.flags == FT_OPEN_PATHNAME) {
+    else if (fontobj->id.open_args.flags == FT_OPEN_STREAM) {
         _PGFT_free(fontobj->id.open_args.stream);
     }
     fontobj->id.open_args.flags = 0;


### PR DESCRIPTION
When the font was unloaded, the wrong struct was being freed. (Does not fix #572.)