### PR TITLE
Fix FreeType SDL_RWops leak

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -706,7 +706,7 @@ _ftfont_dealloc(pgFontObject *self)
     _PGFT_UnloadFont(self->freetype, self);
 #ifdef HAVE_PYGAME_SDL_RWOPS
     if (src) {
-        SDL_RWclose(src);
+        pgRWopsFreeFromObject(src);
     }
 #endif
     _PGFT_Quit(self->freetype);

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -700,7 +700,15 @@ _ftfont_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
 static void
 _ftfont_dealloc(pgFontObject *self)
 {
+#ifdef HAVE_PYGAME_SDL_RWOPS
+    SDL_RWops *src = _PGFT_GetRWops(self);
+#endif
     _PGFT_UnloadFont(self->freetype, self);
+#ifdef HAVE_PYGAME_SDL_RWOPS
+    if (src) {
+        SDL_RWclose(src);
+    }
+#endif
     _PGFT_Quit(self->freetype);
 
     Py_XDECREF(self->path);

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -650,7 +650,7 @@ typedef struct {
 /*the rwobject are only needed for C side work, not accessable from python*/
 #define PYGAMEAPI_RWOBJECT_FIRSTSLOT \
     (PYGAMEAPI_EVENT_FIRSTSLOT + PYGAMEAPI_EVENT_NUMSLOTS)
-#define PYGAMEAPI_RWOBJECT_NUMSLOTS 7
+#define PYGAMEAPI_RWOBJECT_NUMSLOTS 8
 #ifndef PYGAMEAPI_RWOBJECT_INTERNAL
 #define pgRWopsFromObject           \
     (*(SDL_RWops * (*)(PyObject *)) \
@@ -671,6 +671,9 @@ typedef struct {
 #define pgRWopsFromFileObject       \
     (*(SDL_RWops * (*)(PyObject *)) \
          PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 6])
+#define pgRWopsFreeFromObject       \
+    (*(void (*)(PyObject *)) \
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 7])
 #define import_pygame_rwobject() IMPORT_PYGAME_MODULE(rwobject, RWOBJECT)
 
 /* For backward compatibility */

--- a/src_c/freetype/ft_wrap.c
+++ b/src_c/freetype/ft_wrap.c
@@ -494,6 +494,14 @@ _PGFT_TryLoadFont_RWops(FreeTypeInstance *ft, pgFontObject *fontobj,
 
     return init(ft, fontobj);
 }
+
+SDL_RWops*
+_PGFT_GetRWops(pgFontObject *fontobj)
+{
+    if (fontobj->id.open_args.flags == FT_OPEN_STREAM)
+        return fontobj->id.open_args.stream->descriptor.pointer;
+    return NULL;
+}
 #endif
 
 void

--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -284,6 +284,7 @@ int _PGFT_TryLoadFont_Filename(FreeTypeInstance *,
 #ifdef HAVE_PYGAME_SDL_RWOPS
 int _PGFT_TryLoadFont_RWops(FreeTypeInstance *,
                             pgFontObject *, SDL_RWops *, long);
+SDL_RWops* _PGFT_GetRWops(pgFontObject *fontobj);
 #endif
 void _PGFT_UnloadFont(FreeTypeInstance *, pgFontObject *);
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -570,6 +570,23 @@ pgRWopsCheckObjectThreaded(SDL_RWops *rw)
 #endif
 }
 
+static int
+pgRWopsFreeFromObject(SDL_RWops *context)
+{
+    pgRWHelper *helper = (pgRWHelper *)context->hidden.unknown.data1;
+    PyObject *result;
+    int retval = 0;
+
+    Py_XDECREF(helper->seek);
+    Py_XDECREF(helper->tell);
+    Py_XDECREF(helper->write);
+    Py_XDECREF(helper->read);
+    Py_XDECREF(helper->close);
+    PyMem_Del(helper);
+    SDL_FreeRW(context);
+    return retval;
+}
+
 #ifdef WITH_THREAD
 #if IS_SDLv2
 static Sint64
@@ -909,6 +926,7 @@ MODINIT_DEFINE(rwobject)
     c_api[4] = pgRWopsEncodeFilePath;
     c_api[5] = pgRWopsEncodeString;
     c_api[6] = pgRWopsFromFileObject;
+    c_api[7] = pgRWopsFreeFromObject;
     apiobj = encapsulate_api(c_api, "rwobject");
     if (apiobj == NULL) {
         DECREF_MOD(module);

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -158,6 +158,14 @@ class FreeTypeFontTest(unittest.TestCase):
         f.__init__(self._bmp_8_75dpi_path, size=12)
         self.assertEqual(f.size, 12.0)
 
+    def test_freetype_Font_dealloc(self):
+        import sys
+        handle = open(self._sans_path, 'rb')
+        def load_font():
+            tempFont = ft.Font(handle)
+        load_font()
+        self.assertEqual(sys.getrefcount(handle), 2)
+
     def test_freetype_Font_scalable(self):
 
         f = self._TEST_FONTS['sans']


### PR DESCRIPTION
Fixes #572. Not sure whether the first or second commit is cleaner. Added 2nd as the user may not expect pygame to close a stream that they passed to it? At least in CPython, files normally close when the ref count hits 0, so either works.