### PR TITLE
Undefined default parameter value

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -218,7 +218,7 @@ aalines(PyObject *self, PyObject *arg)
     float pts[4];
     Uint8 rgba[4];
     Uint32 color;
-    int closed, blend;
+    int closed, blend=1;
     int result, loop, length;
     float *xlist, *ylist;
 


### PR DESCRIPTION
Calling aalines() without setting blend had undefined behavior. Could potentially equal 0