### PR TITLE
SDL2: Handle events better. Fix and test event.set_allowed(None)

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -240,14 +240,17 @@ typedef enum {
 } PygameVideoFlags;
 
 typedef enum {
-    SDL_NOEVENT = (Uint32)-1,
+    SDL_NOEVENT = 0,
     /* SDL 1.2 allowed for 8 user defined events. */
     SDL_NUMEVENTS = SDL_USEREVENT + 8,
     SDL_ACTIVEEVENT = SDL_NUMEVENTS,
+    PGE_EVENTBEGIN = SDL_NUMEVENTS,
     SDL_VIDEORESIZE,
     SDL_VIDEOEXPOSE,
     PGE_EVENTEND
 } PygameEventCode;
+
+#define PGE_NUMEVENTS (PGE_EVENTEND - PGE_EVENTBEGIN)
 
 typedef enum {
     SDL_APPFOCUSMOUSE,

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -905,139 +905,7 @@ pygame_poll(PyObject *self, PyObject *args)
     return pgEvent_New(NULL);
 }
 
-#if IS_SDLv2
-/* The following three functions are quick and dirty; replace */
-#pragma PG_WARN(temporary code)
-#define SDL_EVENTMASK(e) (mask_event(e))
-static const Uint32 SDL_ALLEVENTS = (Uint32)-1;
-
-static Uint32
-mask_event(Uint32 event)
-{
-    switch (event) {
-        case SDL_ACTIVEEVENT:
-            return 1;
-        case SDL_KEYDOWN:
-            return 2;
-        case SDL_KEYUP:
-            return 4;
-        case SDL_MOUSEMOTION:
-            return 8;
-        case SDL_MOUSEBUTTONDOWN:
-            return 16;
-        case SDL_MOUSEBUTTONUP:
-            return 32;
-        case SDL_JOYAXISMOTION:
-            return 64;
-        case SDL_JOYBALLMOTION:
-            return 128;
-        case SDL_JOYHATMOTION:
-            return 256;
-        case SDL_JOYBUTTONDOWN:
-            return 512;
-        case SDL_JOYBUTTONUP:
-            return 1024;
-        case SDL_VIDEORESIZE:
-            return 2048;
-        case SDL_VIDEOEXPOSE:
-            return 4096;
-        case SDL_QUIT:
-            return 8192;
-        case SDL_SYSWMEVENT:
-            return 16384;
-        case SDL_USEREVENT:
-            return 32768;
-        case (SDL_USEREVENT + 1):
-            return 65536;
-        case (SDL_USEREVENT + 2):
-            return 131072;
-        case (SDL_USEREVENT + 3):
-            return 262144;
-        case (SDL_USEREVENT + 4):
-            return 524288;
-        case (SDL_USEREVENT + 5):
-            return 1048576;
-        case (SDL_USEREVENT + 6):
-            return 2097152;
-        case (SDL_USEREVENT + 7):
-            return 4194304;
-    }
-    return 0;
-}
-
-static Uint32
-unmask_event(Uint32 bit)
-{
-    switch (bit) {
-        case 1:
-            return SDL_ACTIVEEVENT;
-        case 2:
-            return SDL_KEYDOWN;
-        case 4:
-            return SDL_KEYUP;
-        case 8:
-            return SDL_MOUSEMOTION;
-        case 16:
-            return SDL_MOUSEBUTTONDOWN;
-        case 32:
-            return SDL_MOUSEBUTTONUP;
-        case 64:
-            return SDL_JOYAXISMOTION;
-        case 128:
-            return SDL_JOYBALLMOTION;
-        case 256:
-            return SDL_JOYHATMOTION;
-        case 512:
-            return SDL_JOYBUTTONDOWN;
-        case 1024:
-            return SDL_JOYBUTTONUP;
-        case 2048:
-            return SDL_VIDEORESIZE;
-        case 4096:
-            return SDL_VIDEOEXPOSE;
-        case 8192:
-            return SDL_QUIT;
-        case 16384:
-            return SDL_SYSWMEVENT;
-        case 32768:
-            return SDL_USEREVENT;
-        case 65536:
-            return (SDL_USEREVENT + 1);
-        case 131072:
-            return (SDL_USEREVENT + 2);
-        case 262144:
-            return (SDL_USEREVENT + 3);
-        case 524288:
-            return (SDL_USEREVENT + 4);
-        case 1048576:
-            return (SDL_USEREVENT + 5);
-        case 2097152:
-            return (SDL_USEREVENT + 6);
-        case 4194304:
-            return (SDL_USEREVENT + 7);
-    }
-    return SDL_NOEVENT;
-}
-
-static int
-PG_PeepEvent(SDL_Event *event, SDL_eventaction action, Uint32 mask)
-{
-    Uint32 bit;
-    Uint32 type;
-
-    for (bit = 1; bit != 0; bit <<= 1) {
-        if (mask & bit) {
-            type = unmask_event(bit);
-            if (type != SDL_NOEVENT) {
-                if (SDL_PeepEvents(event, 1, action, type, type) == 1)
-                    return 1;
-            }
-        }
-    }
-    return 0;
-}
-#endif /* IS_SDLv2 */
-
+#if IS_SDLv1
 static PyObject *
 event_clear(PyObject *self, PyObject *args)
 {
@@ -1075,17 +943,54 @@ event_clear(PyObject *self, PyObject *args)
 
     SDL_PumpEvents();
 
-#if IS_SDLv1
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, mask) == 1)
-#else  /* IS_SDLv2 */
-    while (PG_PeepEvent(&event, SDL_GETEVENT, mask) == 1)
-#endif /* IS_SDLv2 */
     {
     }
 
     Py_RETURN_NONE;
 }
+#else /* IS_SDLv2 */
+static PyObject *
+event_clear(PyObject *self, PyObject *args)
+{
+    SDL_Event event;
+    int loop, num;
+    PyObject *type;
+    int val;
 
+    if (PyTuple_Size(args) != 0 && PyTuple_Size(args) != 1)
+        return RAISE(PyExc_ValueError, "get requires 0 or 1 argument");
+
+    VIDEO_INIT_CHECK();
+
+    if (PyTuple_Size(args) == 0) {
+        SDL_PumpEvents();
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+    } else {
+        type = PyTuple_GET_ITEM(args, 0);
+        if (PySequence_Check(type)) {
+            num = PySequence_Size(type);
+            SDL_PumpEvents();
+            for (loop = 0; loop < num; ++loop) {
+                if (!pg_IntFromObjIndex(type, loop, &val))
+                    return RAISE(
+                        PyExc_TypeError,
+                        "type sequence must contain valid event types");
+                SDL_FlushEvent(val);
+            }
+        }
+        else if (pg_IntFromObj(type, &val))
+            SDL_FlushEvent(val);
+        else
+            return RAISE(PyExc_TypeError,
+                         "get type must be numeric or a sequence");
+    }
+
+    Py_RETURN_NONE;
+}
+#endif /* IS_SDLv2 */
+
+#if IS_SDLv1
 static PyObject *
 event_get(PyObject *self, PyObject *args)
 {
@@ -1127,11 +1032,7 @@ event_get(PyObject *self, PyObject *args)
 
     SDL_PumpEvents();
 
-#if IS_SDLv1
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, mask) == 1)
-#else  /* IS_SDLv2 */
-    while (PG_PeepEvent(&event, SDL_GETEVENT, mask) == 1)
-#endif /* IS_SDLv2 */
     {
         e = pgEvent_New(&event);
         if (!e) {
@@ -1144,7 +1045,76 @@ event_get(PyObject *self, PyObject *args)
     }
     return list;
 }
+#else /* IS_SDLv2 */
+static PG_INLINE void
+event_append_to_list(PyObject *list, SDL_Event *event)
+{
+    PyObject *e = pgEvent_New(&event);
+    if (!e) {
+        Py_DECREF(list);
+        return NULL;
+    }
+    PyList_Append(list, e);
+    Py_DECREF(e);
+}
 
+static PyObject *
+event_get(PyObject *self, PyObject *args)
+{
+    SDL_Event event;
+    int loop, num;
+    PyObject *type, *list;
+    int val;
+
+    if (PyTuple_Size(args) != 0 && PyTuple_Size(args) != 1)
+        return RAISE(PyExc_ValueError, "get requires 0 or 1 argument");
+
+    VIDEO_INIT_CHECK();
+
+    list = PyList_New(0);
+    if (!list)
+        return NULL;
+    SDL_PumpEvents();
+
+    if (PyTuple_Size(args) == 0) {
+        while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) == 1) {
+            event_append_to_list(list, &event);
+        }
+        return list;
+    }
+
+    type = PyTuple_GET_ITEM(args, 0);
+    if (PySequence_Check(type)) {
+        num = PySequence_Size(type);
+        for (loop = 0; loop < num; ++loop) {
+            if (!pg_IntFromObjIndex(type, loop, &val)) {
+                Py_DECREF(list);
+                return RAISE(
+                    PyExc_TypeError,
+                    "type sequence must contain valid event types");
+            }
+            if (SDL_PeepEvents(&event, 1, SDL_GETEVENT, val, val) < 0) {
+                Py_DECREF(list);
+                return RAISE(pgExc_SDLError, SDL_GetError());
+            }
+            event_append_to_list(list, &event);
+        }
+    }
+    else if (pg_IntFromObj(type, &val)) {
+        if (SDL_PeepEvents(&event, 1, SDL_GETEVENT, val, val) < 0) {
+            Py_DECREF(list);
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        }
+        event_append_to_list(list, &event);
+    }
+
+    Py_DECREF(list);
+    return RAISE(PyExc_TypeError,
+                 "get type must be numeric or a sequence");
+}
+#endif /* IS_SDLv2 */
+
+#if IS_SDLv1
 static PyObject *
 event_peek(PyObject *self, PyObject *args)
 {
@@ -1184,16 +1154,61 @@ event_peek(PyObject *self, PyObject *args)
     }
 
     SDL_PumpEvents();
-#if IS_SDLv1
     result = SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, mask);
-#else  /* IS_SDLv2 */
-    result = PG_PeepEvent(&event, SDL_PEEKEVENT, mask);
-#endif /* IS_SDLv2 */
 
     if (noargs)
         return pgEvent_New(&event);
     return PyInt_FromLong(result == 1);
 }
+#else /* IS_SDLv2 */
+static PyObject *
+event_peek(PyObject *self, PyObject *args)
+{
+    SDL_Event event;
+    int result;
+    int loop, num;
+    PyObject *type;
+    int val;
+
+    if (PyTuple_Size(args) != 0 && PyTuple_Size(args) != 1)
+        return RAISE(PyExc_ValueError, "peek requires 0 or 1 argument");
+
+    VIDEO_INIT_CHECK();
+
+    SDL_PumpEvents();
+
+    if (PyTuple_Size(args) == 0) {
+        if (SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) < 0)
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        return pgEvent_New(&event);
+    }
+
+    type = PyTuple_GET_ITEM(args, 0);
+    if (PySequence_Check(type)) {
+        num = PySequence_Size(type);
+        for (loop = 0; loop < num; ++loop) {
+            if (!pg_IntFromObjIndex(type, loop, &val))
+                return RAISE(
+                    PyExc_TypeError,
+                    "type sequence must contain valid event types");
+            result = SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, val, val);
+			if (result < 0) {
+                return RAISE(pgExc_SDLError, SDL_GetError());
+            } else if (result == 1) {
+                return PyInt_FromLong(1);
+            }
+        }
+    }
+    else if (pg_IntFromObj(type, &val)) {
+        result = SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, val, val);
+        if (result < 0)
+            return RAISE(pgExc_SDLError, SDL_GetError());
+        return PyInt_FromLong(result == 1);
+    }
+    return RAISE(PyExc_TypeError,
+                 "peek type must be numeric or a sequence");
+}
+#endif /* IS_SDLv2 */
 
 static PyObject *
 event_post(PyObject *self, PyObject *args)
@@ -1231,7 +1246,11 @@ event_post(PyObject *self, PyObject *args)
 static int
 CheckEventInRange(int evt)
 {
+#if IS_SDLv1
     return evt >= 0 && evt < SDL_NUMEVENTS;
+#else /* IS_SDLv2 */
+    return evt >= 0 && evt < PGE_EVENTEND; /* needed for extras */
+#endif /* IS_SDLv2 */
 }
 
 static PyObject *

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1259,7 +1259,7 @@ set_allowed(PyObject *self, PyObject *args)
         }
     }
     else if (type == Py_None)
-        SDL_EventState(0xFF, SDL_IGNORE);
+        SDL_EventState(0xFF, SDL_ENABLE);
     else if (pg_IntFromObj(type, &val)) {
         if (!CheckEventInRange(val))
             return RAISE(PyExc_ValueError, "Invalid event");

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1049,7 +1049,7 @@ event_get(PyObject *self, PyObject *args)
 static PG_INLINE void
 event_append_to_list(PyObject *list, SDL_Event *event)
 {
-    PyObject *e = pgEvent_New(&event);
+    PyObject *e = pgEvent_New(event);
     if (!e) {
         Py_DECREF(list);
         return NULL;

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1258,9 +1258,15 @@ set_allowed(PyObject *self, PyObject *args)
             SDL_EventState(val, SDL_ENABLE);
         }
     }
-    else if (type == Py_None)
+    else if (type == Py_None) {
+#if IS_SDLv2
+        for (int i=SDL_FIRSTEVENT; i<SDL_LASTEVENT; i++) {
+            SDL_EventState(i, SDL_ENABLE);
+        }
+#else
         SDL_EventState(0xFF, SDL_ENABLE);
-    else if (pg_IntFromObj(type, &val)) {
+#endif /* IS_SDLv2 */
+    } else if (pg_IntFromObj(type, &val)) {
         if (!CheckEventInRange(val))
             return RAISE(PyExc_ValueError, "Invalid event");
         SDL_EventState(val, SDL_ENABLE);
@@ -1295,9 +1301,15 @@ set_blocked(PyObject *self, PyObject *args)
             SDL_EventState(val, SDL_IGNORE);
         }
     }
-    else if (type == Py_None)
+    else if (type == Py_None) {
+#if IS_SDLv2
+        for (int i=SDL_FIRSTEVENT; i<SDL_LASTEVENT; i++) {
+            SDL_EventState(i, SDL_IGNORE);
+        }
+#else
         SDL_EventState(0xFF, SDL_IGNORE);
-    else if (pg_IntFromObj(type, &val)) {
+#endif /* IS_SDLv2 */
+    } else if (pg_IntFromObj(type, &val)) {
         if (!CheckEventInRange(val))
             return RAISE(PyExc_ValueError, "Invalid event");
         SDL_EventState(val, SDL_IGNORE);

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1255,15 +1255,15 @@ set_allowed(PyObject *self, PyObject *args)
                              "type sequence must contain valid event types");
             if (!CheckEventInRange(val))
                 return RAISE(PyExc_ValueError, "Invalid event in sequence");
-            SDL_EventState((Uint8)val, SDL_ENABLE);
+            SDL_EventState(val, SDL_ENABLE);
         }
     }
     else if (type == Py_None)
-        SDL_EventState((Uint8)0xFF, SDL_IGNORE);
+        SDL_EventState(0xFF, SDL_IGNORE);
     else if (pg_IntFromObj(type, &val)) {
         if (!CheckEventInRange(val))
             return RAISE(PyExc_ValueError, "Invalid event");
-        SDL_EventState((Uint8)val, SDL_ENABLE);
+        SDL_EventState(val, SDL_ENABLE);
     }
     else
         return RAISE(PyExc_TypeError, "type must be numeric or a sequence");
@@ -1292,15 +1292,15 @@ set_blocked(PyObject *self, PyObject *args)
                              "type sequence must contain valid event types");
             if (!CheckEventInRange(val))
                 return RAISE(PyExc_ValueError, "Invalid event in sequence");
-            SDL_EventState((Uint8)val, SDL_IGNORE);
+            SDL_EventState(val, SDL_IGNORE);
         }
     }
     else if (type == Py_None)
-        SDL_EventState((Uint8)0xFF, SDL_IGNORE);
+        SDL_EventState(0xFF, SDL_IGNORE);
     else if (pg_IntFromObj(type, &val)) {
         if (!CheckEventInRange(val))
             return RAISE(PyExc_ValueError, "Invalid event");
-        SDL_EventState((Uint8)val, SDL_IGNORE);
+        SDL_EventState(val, SDL_IGNORE);
     }
     else
         return RAISE(PyExc_TypeError, "type must be numeric or a sequence");
@@ -1330,13 +1330,13 @@ get_blocked(PyObject *self, PyObject *args)
                              "type sequence must contain valid event types");
             if (!CheckEventInRange(val))
                 return RAISE(PyExc_ValueError, "Invalid event in sequence");
-            isblocked |= SDL_EventState((Uint8)val, SDL_QUERY) == SDL_IGNORE;
+            isblocked |= SDL_EventState(val, SDL_QUERY) == SDL_IGNORE;
         }
     }
     else if (pg_IntFromObj(type, &val)) {
         if (!CheckEventInRange(val))
             return RAISE(PyExc_ValueError, "Invalid event");
-        isblocked = SDL_EventState((Uint8)val, SDL_QUERY) == SDL_IGNORE;
+        isblocked = SDL_EventState(val, SDL_QUERY) == SDL_IGNORE;
     }
     else
         return RAISE(PyExc_TypeError, "type must be numeric or a sequence");

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -171,7 +171,9 @@ class EventModuleTest(unittest.TestCase):
         for _ in range(1, 11):
             pygame.event.post(pygame.event.Event(pygame.USEREVENT))
 
-        self.assert_ ( len(pygame.event.get()) >= 10 )
+        queue = pygame.event.get()
+        self.assert_ ( len(queue) >= 10 )
+        self.assert_ ( all(e.type == pygame.USEREVENT for e in queue) )
 
     def test_clear(self):
 

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -7,8 +7,8 @@ from pygame.compat import as_unicode
 ################################################################################
 
 events = (
-    pygame.NOEVENT,
-    pygame.ACTIVEEVENT,
+#   pygame.NOEVENT,
+#   pygame.ACTIVEEVENT,
     pygame.KEYDOWN,
     pygame.KEYUP,
     pygame.MOUSEMOTION,
@@ -24,7 +24,7 @@ events = (
     pygame.QUIT,
     pygame.SYSWMEVENT,
     pygame.USEREVENT,
-    pygame.NUMEVENTS,
+#   pygame.NUMEVENTS,
 )
 
 class EventTypeTest(unittest.TestCase):
@@ -77,7 +77,7 @@ class EventTypeTest(unittest.TestCase):
         # For Python 3.x str(event) to raises an UnicodeEncodeError when
         # an event attribute is a string with a non-ascii character.
         try:
-            str(pygame.event.Event(events[1], a=as_unicode(r"\xed")))
+            str(pygame.event.Event(events[0], a=as_unicode(r"\xed")))
         except UnicodeEncodeError:
             self.fail("Event object raised exception for non-ascii character")
         # Passed.
@@ -111,7 +111,7 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.set_blocked(None): return None
           # control which events are allowed on the queue
 
-        event = events[2]
+        event = events[0]
 
         pygame.event.set_blocked(event)
 
@@ -123,6 +123,11 @@ class EventModuleTest(unittest.TestCase):
         should_be_blocked = [e for e in ret if e.type == event]
 
         self.assertEquals(should_be_blocked, [])
+
+    def test_set_blocked_all(self):
+        pygame.event.set_blocked(None)
+        for e in events:
+            self.assert_(pygame.event.get_blocked(e))
 
     def test_post__and_poll(self):
         # __doc__ (as of 2008-06-25) for pygame.event.post:
@@ -177,7 +182,7 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.clear(typelist): return None
           # remove all events from the queue
 
-        for e in events[1:]:
+        for e in events:
             pygame.event.post(pygame.event.Event(e))
 
         self.assert_(pygame.event.poll())  # there are some events on queue
@@ -202,7 +207,7 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.wait(): return Event
           # wait for a single event from the queue
 
-        pygame.event.post ( pygame.event.Event(events[2]) )
+        pygame.event.post ( pygame.event.Event(events[0]) )
         self.assert_(pygame.event.wait())
 
     def test_peek(self):
@@ -238,7 +243,6 @@ class EventModuleTest(unittest.TestCase):
         self.assert_(not pygame.event.get_blocked(event))
 
     def test_set_allowed_all(self):
-        Event = pygame.event.Event
         pygame.event.set_blocked(None)
         for e in events:
             self.assert_(pygame.event.get_blocked(e))
@@ -273,10 +277,10 @@ class EventModuleTest(unittest.TestCase):
         self.assert_(not pygame.event.get_grab())
 
     def test_event_equality(self):
-        a = pygame.event.Event(events[1], a=1)
-        b = pygame.event.Event(events[1], a=1)
-        c = pygame.event.Event(events[2], a=1)
-        d = pygame.event.Event(events[1], a=2)
+        a = pygame.event.Event(events[0], a=1)
+        b = pygame.event.Event(events[0], a=1)
+        c = pygame.event.Event(events[1], a=1)
+        d = pygame.event.Event(events[0], a=2)
 
         self.failUnless(a == a)
         self.assertFalse(a != a)

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -231,11 +231,20 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.set_allowed(None): return None
           # control which events are allowed on the queue
 
-        event = events[2]
+        event = events[0]
         pygame.event.set_blocked(event)
         self.assert_(pygame.event.get_blocked(event))
         pygame.event.set_allowed(event)
         self.assert_(not pygame.event.get_blocked(event))
+
+    def test_set_allowed_all(self):
+        Event = pygame.event.Event
+        pygame.event.set_blocked(None)
+        for e in events:
+            self.assert_(pygame.event.get_blocked(e))
+        pygame.event.set_allowed(None)
+        for e in events:
+            self.assert_(not pygame.event.get_blocked(e))
 
     def test_pump(self):
         # __doc__ (as of 2008-06-25) for pygame.event.pump:

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -233,6 +233,7 @@ class EventModuleTest(unittest.TestCase):
         if os.environ.get('SDL_VIDEODRIVER') == 'dummy':
             return
 
+        surf = pygame.display.set_mode((10,10))
         pygame.event.set_grab(True)
         self.assert_(pygame.event.get_grab())
         pygame.event.set_grab(False)

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -6,6 +6,27 @@ from pygame.compat import as_unicode
 
 ################################################################################
 
+events = (
+    pygame.NOEVENT,
+    pygame.ACTIVEEVENT,
+    pygame.KEYDOWN,
+    pygame.KEYUP,
+    pygame.MOUSEMOTION,
+    pygame.MOUSEBUTTONDOWN,
+    pygame.MOUSEBUTTONUP,
+    pygame.JOYAXISMOTION,
+    pygame.JOYBALLMOTION,
+    pygame.JOYHATMOTION,
+    pygame.JOYBUTTONDOWN,
+    pygame.JOYBUTTONUP,
+    pygame.VIDEORESIZE,
+    pygame.VIDEOEXPOSE,
+    pygame.QUIT,
+    pygame.SYSWMEVENT,
+    pygame.USEREVENT,
+    pygame.NUMEVENTS,
+)
+
 class EventTypeTest(unittest.TestCase):
     def test_Event(self):
         # __doc__ (as of 2008-08-02) for pygame.event.Event:
@@ -56,7 +77,7 @@ class EventTypeTest(unittest.TestCase):
         # For Python 3.x str(event) to raises an UnicodeEncodeError when
         # an event attribute is a string with a non-ascii character.
         try:
-            str(pygame.event.Event(1, a=as_unicode(r"\xed")))
+            str(pygame.event.Event(events[1], a=as_unicode(r"\xed")))
         except UnicodeEncodeError:
             self.fail("Event object raised exception for non-ascii character")
         # Passed.
@@ -90,14 +111,16 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.set_blocked(None): return None
           # control which events are allowed on the queue
 
-        pygame.event.set_blocked(2)
+        event = events[2]
 
-        self.assert_(pygame.event.get_blocked(2))
+        pygame.event.set_blocked(event)
 
-        pygame.event.post(pygame.event.Event(2))
+        self.assert_(pygame.event.get_blocked(event))
 
-        events = pygame.event.get()
-        should_be_blocked = [e for e in events if e.type == 2]
+        pygame.event.post(pygame.event.Event(event))
+
+        ret = pygame.event.get()
+        should_be_blocked = [e for e in ret if e.type == event]
 
         self.assertEquals(should_be_blocked, [])
 
@@ -118,9 +141,9 @@ class EventModuleTest(unittest.TestCase):
 
         # fuzzing event types
         for i in range(1, 11):
-            pygame.event.post(pygame.event.Event(i))
+            pygame.event.post(pygame.event.Event(events[i]))
             self.assertEquals (
-                pygame.event.poll().type, i, race_condition_notification
+                pygame.event.poll().type, events[i], race_condition_notification
             )
     def test_post_large_user_event(self):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, {'a': "a" * 1024}))
@@ -154,8 +177,8 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.clear(typelist): return None
           # remove all events from the queue
 
-        for _ in range(1, 11):
-            pygame.event.post(pygame.event.Event(_))
+        for e in events[1:]:
+            pygame.event.post(pygame.event.Event(e))
 
         self.assert_(pygame.event.poll())  # there are some events on queue
 
@@ -179,7 +202,7 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.wait(): return Event
           # wait for a single event from the queue
 
-        pygame.event.post ( pygame.event.Event(2) )
+        pygame.event.post ( pygame.event.Event(events[2]) )
         self.assert_(pygame.event.wait())
 
     def test_peek(self):
@@ -208,10 +231,11 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.set_allowed(None): return None
           # control which events are allowed on the queue
 
-        pygame.event.set_blocked(2)
-        self.assert_(pygame.event.get_blocked(2))
-        pygame.event.set_allowed(2)
-        self.assert_(not pygame.event.get_blocked(2))
+        event = events[2]
+        pygame.event.set_blocked(event)
+        self.assert_(pygame.event.get_blocked(event))
+        pygame.event.set_allowed(event)
+        self.assert_(not pygame.event.get_blocked(event))
 
     def test_pump(self):
         # __doc__ (as of 2008-06-25) for pygame.event.pump:
@@ -240,10 +264,10 @@ class EventModuleTest(unittest.TestCase):
         self.assert_(not pygame.event.get_grab())
 
     def test_event_equality(self):
-        a = pygame.event.Event(1, a=1)
-        b = pygame.event.Event(1, a=1)
-        c = pygame.event.Event(2, a=1)
-        d = pygame.event.Event(1, a=2)
+        a = pygame.event.Event(events[1], a=1)
+        b = pygame.event.Event(events[1], a=1)
+        c = pygame.event.Event(events[2], a=1)
+        d = pygame.event.Event(events[1], a=2)
 
         self.failUnless(a == a)
         self.assertFalse(a != a)

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -170,8 +170,8 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.event_name(type): return string
           # get the string name from and event id
 
-        self.assertEquals(pygame.event.event_name(2), "KeyDown")
-        self.assertEquals(pygame.event.event_name(24), "UserEvent")
+        self.assertEquals(pygame.event.event_name(pygame.KEYDOWN), "KeyDown")
+        self.assertEquals(pygame.event.event_name(pygame.USEREVENT), "UserEvent")
 
     def test_wait(self):
         # __doc__ (as of 2008-06-25) for pygame.event.wait:
@@ -190,7 +190,7 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.peek(typelist): return bool
           # test if event types are waiting on the queue
 
-        event_types = [2, 3, 4]
+        event_types = [pygame.KEYDOWN, pygame.KEYUP, pygame.MOUSEMOTION]
 
         for event_type in event_types:
             pygame.event.post (


### PR DESCRIPTION
Fixes #584. The mask that SDL 1 uses only supports 32 events, so I replaced `PG_PeepEvent()` with separate event functions for SDL2. Among other things, SDL_VIDEORESIZE and SDL_VIDEOEXPOSE should work now.

Switched to using constants instead of literals in the event unit tests since SDL 2's constants are different.

`event.set_allowed(None)` was broken (for SDL 1 as well). Added unit tests for it and (`event.set_blocked(None)`) as well.