### PR TITLE
SDL2: Adding float 32bit sound support when using SDL2.

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -54,6 +54,8 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    values mean unsigned audio samples will be used. An invalid value raises an
    exception.
 
+   New in pygame 2 compiled with SDL2 size can be 32, which means 32bit floats.
+
    The channels argument is used to specify whether to use mono or stereo. 1
    for mono and 2 for stereo. No other values are supported (negative values
    are treated as 1, values greater than 2 as 2).

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -54,7 +54,7 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    values mean unsigned audio samples will be used. An invalid value raises an
    exception.
 
-   New in pygame 2 compiled with SDL2 size can be 32, which means 32bit floats.
+   New in pygame 2(when compiled with SDL2) - size can be 32 (32bit floats).
 
    The channels argument is used to specify whether to use mono or stereo. 1
    for mono and 2 for stereo. No other values are supported (negative values

--- a/examples/aliens.py
+++ b/examples/aliens.py
@@ -178,6 +178,8 @@ class Score(pygame.sprite.Sprite):
 
 def main(winstyle = 0):
     # Initialize pygame
+    if pygame.get_sdl_version()[0] == 2:
+        pygame.mixer.pre_init(44100, 32, 2, 1024)
     pygame.init()
     if pygame.mixer and not pygame.mixer.get_init():
         print ('Warning, no sound')

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -231,6 +231,8 @@ _format_view_to_audio(Py_buffer *view)
             format += native_size ? sizeof(unsigned long long int) : 8;
             break;
 
+#pragma PG_WARN(Need to add support for f float format here in SDL2)
+
         default:
             PyErr_Format(PyExc_ValueError,
                          "Array has unsupported item format '%s'",

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -99,11 +99,11 @@ static int numchanneldata = 0;
 Mix_Music **current_music;
 Mix_Music **queue_music;
 
+
 static int
 _format_itemsize(Uint16 format)
 {
     int size = -1;
-
     switch (format) {
         case AUDIO_U8:
         case AUDIO_S8:
@@ -116,7 +116,7 @@ _format_itemsize(Uint16 format)
         case AUDIO_S16MSB:
             size = 2;
             break;
-#ifdef IS_SDLv2
+#if IS_SDLv2
         case AUDIO_S32LSB:
         case AUDIO_S32MSB:
         case AUDIO_F32LSB:
@@ -131,6 +131,7 @@ _format_itemsize(Uint16 format)
     }
     return size;
 }
+
 
 static PG_sample_format_t
 _format_view_to_audio(Py_buffer *view)
@@ -357,7 +358,7 @@ _init(int freq, int size, int stereo, int chunk)
         case -16:
             fmt = AUDIO_S16SYS;
             break;
-#ifdef IS_SDLv2
+#if IS_SDLv2
         case 32:
             fmt = AUDIO_F32SYS;
             break;
@@ -735,7 +736,7 @@ snd_buffer_iteminfo(char **format, Py_ssize_t *itemsize, int *channels)
     static char fmt_AUDIO_U16SYS[] = "=H";
     static char fmt_AUDIO_S16SYS[] = "=h";
 
-#ifdef IS_SDLv2
+#if IS_SDLv2
     static char fmt_AUDIO_S32LSB[] = "<i";
     static char fmt_AUDIO_S32MSB[] = ">i";
     static char fmt_AUDIO_F32LSB[] = "<f";
@@ -769,7 +770,7 @@ snd_buffer_iteminfo(char **format, Py_ssize_t *itemsize, int *channels)
             *itemsize = 2;
             return 0;
 
-#ifdef IS_SDLv2
+#if IS_SDLv2
         case AUDIO_S32LSB:
             *format = fmt_AUDIO_S32LSB;
         case AUDIO_S32MSB:

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -867,9 +867,7 @@ sound_dealloc(pgSoundObject *self)
 {
     Mix_Chunk *chunk = pgSound_AsChunk((PyObject *)self);
     if (chunk) {
-        Py_BEGIN_ALLOW_THREADS
         Mix_FreeChunk(chunk);
-        Py_END_ALLOW_THREADS
     }
     if (self->mem)
         PyMem_Free(self->mem);

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -267,18 +267,22 @@ endsound_callback(int channel)
             SDL_PushEvent(&e);
         }
         if (channeldata[channel].queue) {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             int channelnum;
             Mix_Chunk *sound = pgSound_AsChunk(channeldata[channel].queue);
             Py_XDECREF(channeldata[channel].sound);
             channeldata[channel].sound = channeldata[channel].queue;
             channeldata[channel].queue = NULL;
+            PyGILState_Release(gstate);
             channelnum = Mix_PlayChannelTimed(channel, sound, 0, -1);
             if (channelnum != -1)
                 Mix_GroupChannel(channelnum, (intptr_t)sound);
         }
         else {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             Py_XDECREF(channeldata[channel].sound);
             channeldata[channel].sound = NULL;
+            PyGILState_Release(gstate);
         }
     }
 }
@@ -850,7 +854,9 @@ sound_dealloc(pgSoundObject *self)
 {
     Mix_Chunk *chunk = pgSound_AsChunk((PyObject *)self);
     if (chunk) {
+        Py_BEGIN_ALLOW_THREADS
         Mix_FreeChunk(chunk);
+        Py_END_ALLOW_THREADS
     }
     if (self->mem)
         PyMem_Free(self->mem);

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -222,6 +222,14 @@ _format_view_to_audio(Py_buffer *view)
             format += native_size ? sizeof(unsigned long int) : 4;
             break;
 
+        case 'f':
+            format += native_size ? sizeof(float) : 4;
+            break;
+
+        case 'd':
+            format += native_size ? sizeof(double) : 8;
+            break;
+
         case 'q':
             format |= PG_SAMPLE_SIGNED;
             format += native_size ? sizeof(long long int) : 8;

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1592,6 +1592,7 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
 
     if (file != NULL) {
         rw = pgRWopsFromObject(file);
+
         if (rw == NULL) {
             /* pgRWopsFromObject only raises critical Python exceptions,
                so automatically pass them on.

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -239,8 +239,6 @@ _format_view_to_audio(Py_buffer *view)
             format += native_size ? sizeof(unsigned long long int) : 8;
             break;
 
-#pragma PG_WARN(Need to add support for f float format here in SDL2)
-
         default:
             PyErr_Format(PyExc_ValueError,
                          "Array has unsupported item format '%s'",
@@ -702,41 +700,15 @@ static PyGetSetDef sound_getset[] = {
 /*buffer protocol*/
 
 /*
-
-Have to convert between SDL and python format constants.
+snd_buffer_iteminfo converts between SDL and python format constants.
 
 https://wiki.libsdl.org/SDL_AudioSpec
-
-returns:
-    format: buffer string showing the format.
-    itemsize: bytes for each item.
-
-
 https://docs.python.org/3/library/struct.html#format-characters
 
-x   pad byte    no value
-c   char    bytes of length 1   1
-b   signed char     integer     1   (1),(3)
-B   unsigned char   integer     1   (3)
-?   _Bool   bool    1   (1)
-h   short   integer     2   (3)
-H   unsigned short  integer     2   (3)
-i   int     integer     4   (3)
-I   unsigned int    integer     4   (3)
-l   long    integer     4   (3)
-L   unsigned long   integer     4   (3)
-q   long long   integer     8   (2), (3)
-Q   unsigned long long  integer     8   (2), (3)
-n   ssize_t     integer         (4)
-N   size_t  integer         (4)
-e   (7)     float   2   (5)
-f   float   float   4   (5)
-d   double  float   8   (5)
-s   char[]  bytes
-p   char[]  bytes
-P   void *  integer         (6)
-
-
+returns:
+    -1 on error, else 0.
+    format: buffer string showing the format.
+    itemsize: bytes for each item.
 */
 static int
 snd_buffer_iteminfo(char **format, Py_ssize_t *itemsize, int *channels)

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -309,6 +309,18 @@ pgRWopsFromObject(PyObject *obj)
         Py_DECREF(oencoded);
         if (rw) {
             return rw;
+        } else {
+#if PY3
+            if (PyUnicode_Check(obj)) {
+                SDL_ClearError();
+                RAISE(PyExc_FileNotFoundError, "No such file or directory.");
+#else
+            if (PyUnicode_Check(obj) || PyString_Check(obj)) {
+                SDL_ClearError();
+                RAISE(PyExc_IOError, "No such file or directory.");
+#endif
+                return NULL;
+            }
         }
         SDL_ClearError();
     }

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -171,14 +171,18 @@ class MixerModuleTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), emsg)
 
         ufake_path = unicode_('12345678')
-        self.assertRaises(pygame.error, mixer.Sound, ufake_path)
+        self.assertRaises(IOError, mixer.Sound, ufake_path)
+        self.assertRaises(IOError, mixer.Sound, '12345678')
 
         with self.assertRaises(TypeError) as cm:
             mixer.Sound(buffer=unicode_('something'))
         emsg = 'Unicode object not allowed as buffer object'
         self.assertEqual(str(cm.exception), emsg)
         self.assertEqual(get_bytes(mixer.Sound(buffer=sample)), sample)
-        self.assertEqual(get_bytes(mixer.Sound(sample)), sample)
+        if type(sample) != str:
+            somebytes = get_bytes(mixer.Sound(sample))
+            # on python 2 we do not allow using string except as file name.
+            self.assertEqual(somebytes, sample)
         self.assertEqual(get_bytes(mixer.Sound(file=bwave_path)), snd_bytes)
         self.assertEqual(get_bytes(mixer.Sound(bwave_path)), snd_bytes)
 
@@ -287,7 +291,7 @@ class MixerModuleTest(unittest.TestCase):
 
     def test_array_interface(self):
         mixer.init(22050, -16, 1)
-        snd = mixer.Sound(as_bytes('\x00\x7f') * 20)
+        snd = mixer.Sound(buffer=as_bytes('\x00\x7f') * 20)
         d = snd.__array_interface__
         self.assertTrue(isinstance(d, dict))
         if pygame.get_sdl_byteorder() == pygame.LIL_ENDIAN:

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -15,6 +15,9 @@ IS_PYPY = 'PyPy' == platform.python_implementation()
 
 FREQUENCIES = [11025, 22050, 44100, 48000]
 SIZES       = [-16, -8, 8, 16]
+if pygame.get_sdl_version()[0] >= 2:
+    SIZES.append(32)
+
 CHANNELS    = [1, 2]
 BUFFERS     = [3024]
 
@@ -28,6 +31,8 @@ CONFIGS = [{'frequency' : f, 'size' : s, 'channels': c}
 # And probably, we don't need to be so exhaustive, hence:
 
 CONFIG = {'frequency' : 22050, 'size' : -16, 'channels' : 2} # base config
+if pygame.get_sdl_version()[0] >= 2:
+    CONFIG = {'frequency' : 44100, 'size' : 32, 'channels' : 2} # base config
 
 ############################## MODULE LEVEL TESTS ##############################
 

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import int8, int16, uint8, uint16, array, alltrue
+from numpy import int8, int16, uint8, uint16, float32, array, alltrue
 
 import pygame
 from pygame.compat import as_bytes
@@ -153,6 +153,22 @@ class SndarrayTest (unittest.TestCase):
         self.assertEqual(pygame.sndarray.get_arraytype(), 'numpy')
 
         self.assertRaises(ValueError, do_use_arraytype, 'not an option')
+
+
+    def test_float32(self):
+        """ sized arrays work with Sounds and 32bit float arrays.
+        """
+        if pygame.get_sdl_version()[0] < 2:
+            return
+        try:
+            pygame.mixer.init(22050, 32, 2)
+        except pygame.error:
+            # Not all sizes are supported on all systems.
+            return
+        arr = array([[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]], float32)
+        newsound = pygame.mixer.Sound(array=arr)
+        pygame.mixer.quit()
+
 
 
 if __name__ == '__main__':

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -95,6 +95,10 @@ class SndarrayTest (unittest.TestCase):
         check_sound(-16, 2, [[0, -0x7fff], [-0x7fff, 0],
                              [0x7fff, 0], [0, 0x7fff]])
 
+        if pygame.get_sdl_version()[0] >= 2:
+            check_sound(32, 2, [[0.0, -1.0], [-1.0, 0],
+                                 [1.0, 0], [0, 1.0]])
+
     def test_samples(self):
 
         null_byte = as_bytes('\x00')
@@ -135,6 +139,10 @@ class SndarrayTest (unittest.TestCase):
         check_sample(-16, 1, [0, 0x7fff, -0x7fff, -1])
         check_sample(-16, 2, [[0, -0x7fff], [-0x7fff, 0],
                              [0x7fff, 0], [0, 0x7fff]])
+
+        if pygame.get_sdl_version()[0] >= 2:
+            check_sample(32, 2, [[0.0, -1.0], [-1.0, 0],
+                                 [1.0, 0], [0, 1.0]])
 
     def test_use_arraytype(self):
 


### PR DESCRIPTION
- [x] add some more example wav files in as tests (there are a few 32bit tests for mixer, no 32bit wav files)
- [x] add `pygame.mixer.pre_init(44100, 32, 2, 1024)` in examples/aliens.py when sdl2 is used. So this can be use to test if setting pre init to 32 bit works.
- [x] remove `pre_init` in `__init__.py` and let SDL2 do it's thing.
- [x] making a Sound from a ">f" format numpy array fails
- [x] fix for Sound('some-wrong-filename.wav') #454 on python2.
