### PR TITLE
freetype rotation rendering bugfix

### DIFF
--- a/src_c/freetype/ft_cache.c
+++ b/src_c/freetype/ft_cache.c
@@ -63,7 +63,7 @@ set_node_key(NodeKey *key, GlyphIndex_t id, const FontRenderMode *mode)
     KeyFields *fields = &key->fields;
     const FT_UInt16 style_mask = ~(FT_STYLE_UNDERLINE);
     const FT_UInt16 rflag_mask = ~(FT_RFLAG_VERTICAL | FT_RFLAG_KERNING);
-    unsigned short rot = (unsigned short)FX6_TRUNC(mode->rotation_angle);
+    unsigned short rot = (unsigned short)(((unsigned int)(mode->rotation_angle))>>16);
 
     memset(key, 0, sizeof(*key));
     fields->id = id;

--- a/src_c/freetype/ft_layout.c
+++ b/src_c/freetype/ft_layout.c
@@ -610,8 +610,7 @@ _PGFT_LoadGlyph(FontGlyph *glyph, GlyphIndex_t id,
     v_advance_rotated.x = 0;
     v_advance_rotated.y = ft_metrics->vertAdvance + strong_delta.y;
     if (rotation_angle != 0) {
-        FT_Angle counter_rotation = INT_TO_FX6(360) - rotation_angle;
-
+        FT_Angle counter_rotation = INT_TO_FX16(360) - rotation_angle;
         FT_Vector_Rotate(&h_advance_rotated, rotation_angle);
         FT_Vector_Rotate(&v_advance_rotated, counter_rotation);
     }


### PR DESCRIPTION
The bug #629  is caused by the mistaken cache key calculation. 