### PR TITLE
Handle Unicode objects properly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,8 @@ environment:
     PYGAME_USE_PREBUILT: "1"
     SDL_VIDEODRIVER: "dummy"
     SDL_AUDIODRIVER: "disk"
- 
+    PYTHONIOENCODING: "UTF-8"
+
   matrix:
     # - PYTHON: "pypy.exe"
     #   PYTHON_VERSION: "2.7.13"

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -323,9 +323,9 @@ typedef enum {
 
 #define PYGAMEAPI_BASE_FIRSTSLOT 0
 #if IS_SDLv1
-#define PYGAMEAPI_BASE_NUMSLOTS 19
+#define PYGAMEAPI_BASE_NUMSLOTS 20
 #else /* IS_SDLv2 */
-#define PYGAMEAPI_BASE_NUMSLOTS 23
+#define PYGAMEAPI_BASE_NUMSLOTS 24
 #endif /* IS_SDLv2 */
 #ifndef PYGAMEAPI_BASE_INTERNAL
 #define pgExc_SDLError ((PyObject *)PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT])
@@ -395,18 +395,26 @@ typedef enum {
 #define pgExc_BufferError \
     ((PyObject *)PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 18])
 
+#ifdef WIN32
+#define pg_Fopen                              \
+    (*(FILE* (*)(const char *, const char *)) \
+                 PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 19])
+#else /* !WIN32 */
+#define pg_Fopen fopen
+#endif /* !WIN32 */
+
 #if IS_SDLv2
 #define pg_GetDefaultWindow \
-    (*(SDL_Window * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 19])
+    (*(SDL_Window * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 20])
 
 #define pg_SetDefaultWindow \
-    (*(void (*)(SDL_Window *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 20])
+    (*(void (*)(SDL_Window *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 21])
 
 #define pg_GetDefaultWindowSurface \
-    (*(PyObject * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 21])
+    (*(PyObject * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 22])
 
 #define pg_SetDefaultWindowSurface \
-    (*(void (*)(PyObject *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 22])
+    (*(void (*)(PyObject *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 23])
 
 #endif /* IS_SDLv2 */
 
@@ -657,30 +665,33 @@ typedef struct {
 /*the rwobject are only needed for C side work, not accessable from python*/
 #define PYGAMEAPI_RWOBJECT_FIRSTSLOT \
     (PYGAMEAPI_EVENT_FIRSTSLOT + PYGAMEAPI_EVENT_NUMSLOTS)
-#define PYGAMEAPI_RWOBJECT_NUMSLOTS 8
+#define PYGAMEAPI_RWOBJECT_NUMSLOTS 9
 #ifndef PYGAMEAPI_RWOBJECT_INTERNAL
 #define pgRWopsFromObject           \
     (*(SDL_RWops * (*)(PyObject *)) \
          PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 0])
+#define pgRWopsFromObjectThreaded   \
+    (*(SDL_RWops * (*)(PyObject *)) \
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 1])
 #define pgRWopsCheckObject \
-    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 1])
+    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 2])
 #define pgRWopsFromFileObjectThreaded \
     (*(SDL_RWops * (*)(PyObject *))   \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 2])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 3])
 #define pgRWopsCheckObjectThreaded \
-    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 3])
+    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 4])
 #define pgRWopsEncodeFilePath                  \
     (*(PyObject * (*)(PyObject *, PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 4])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 5])
 #define pgRWopsEncodeString                                                \
     (*(PyObject * (*)(PyObject *, const char *, const char *, PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 5])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 6])
 #define pgRWopsFromFileObject       \
     (*(SDL_RWops * (*)(PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 6])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 7])
 #define pgRWopsFreeFromObject       \
     (*(void (*)(PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 7])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 8])
 #define import_pygame_rwobject() IMPORT_PYGAME_MODULE(rwobject, RWOBJECT)
 
 /* For backward compatibility */

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -395,13 +395,9 @@ typedef enum {
 #define pgExc_BufferError \
     ((PyObject *)PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 18])
 
-#ifdef WIN32
-#define pg_Fopen                              \
+#define pg_FopenUTF8                          \
     (*(FILE* (*)(const char *, const char *)) \
                  PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 19])
-#else /* !WIN32 */
-#define pg_Fopen fopen
-#endif /* !WIN32 */
 
 #if IS_SDLv2
 #define pg_GetDefaultWindow \

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -188,6 +188,44 @@ pg_SetDefaultWindowSurface(PyObject *);
 #endif /* IS_SDLv2 */
 
 
+#ifdef WIN32
+static FILE*
+pg_Fopen(const char *filename, const char *mode) {
+    FILE *fp = NULL;
+    static wchar_t modebuf[24];
+    size_t nameInputSize = strlen(filename) + 1;
+    size_t namebuf_chars = MultiByteToWideChar(CP_UTF8, 0, filename, nameInputSize, 0, 0);
+    wchar_t* namebuf;
+    if (namebuf_chars == 0)
+        return NULL;
+    namebuf = malloc(namebuf_chars * sizeof(wchar_t));
+
+    if (!namebuf)
+        goto leave;
+    if (MultiByteToWideChar(CP_UTF8, 0, filename, nameInputSize,
+                            namebuf, namebuf_chars) == 0) {
+        PyErr_Format(PyExc_OSError, "error code %u", GetLastError());
+        goto leave;
+    }
+    if (MultiByteToWideChar(CP_UTF8, 0, mode, -1,
+                            modebuf, sizeof(modebuf) / sizeof(wchar_t)) == 0) {
+        PyErr_Format(PyExc_OSError, "error code %u", GetLastError());
+        goto leave;
+    }
+
+    fp = _wfopen(namebuf, modebuf);
+
+leave:
+    free(namebuf);
+    return fp;
+}
+#else /* !WIN32 */
+static FILE*
+pg_Fopen(const char *filename, const char *mode) {
+    return fopen(filename, mode);
+}
+#endif /* !WIN32 */
+
 static int
 pg_CheckSDLVersions(void) /*compare compiled to linked*/
 {
@@ -2154,14 +2192,15 @@ MODINIT_DEFINE(base)
     c_api[16] = pgBuffer_Release;
     c_api[17] = pgDict_AsBuffer;
     c_api[18] = pgExc_BufferError;
+    c_api[19] = pg_Fopen;
 #if IS_SDLv1
-#define FILLED_SLOTS 19
+#define FILLED_SLOTS 20
 #else /* IS_SDLv2 */
-    c_api[19] = pg_GetDefaultWindow;
-    c_api[20] = pg_SetDefaultWindow;
-    c_api[21] = pg_GetDefaultWindowSurface;
-    c_api[22] = pg_SetDefaultWindowSurface;
-#define FILLED_SLOTS 23
+    c_api[20] = pg_GetDefaultWindow;
+    c_api[21] = pg_SetDefaultWindow;
+    c_api[22] = pg_GetDefaultWindowSurface;
+    c_api[23] = pg_SetDefaultWindowSurface;
+#define FILLED_SLOTS 24
 #endif /* IS_SDLv2 */
 
 #if PYGAMEAPI_BASE_NUMSLOTS != FILLED_SLOTS

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -85,6 +85,24 @@ utf_8_needs_UCS_4(const char *str)
     return 0;
 }
 
+static PyObject *
+pg_open_obj(PyObject *obj, const char *mode)
+{
+    PyObject *result;
+    PyObject *open;
+    PyObject *bltins = PyImport_ImportModule(BUILTINS_MODULE);
+    if (!bltins)
+        return NULL;
+    open = PyObject_GetAttrString(bltins, "open");
+    Py_DECREF(bltins);
+    if (!open)
+        return NULL;
+
+    result = PyObject_CallFunction(open, "Os", obj, mode);
+    Py_DECREF(open);
+    return result;
+}
+
 /* Return an encoded file path, a file-like object or a NULL pointer.
  * May raise a Python error. Use PyErr_Occurred to check.
  */
@@ -624,7 +642,9 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     int fontsize;
     TTF_Font *font = NULL;
     PyObject *obj;
-    PyObject *oencoded;
+    PyObject *test;
+    PyObject *oencoded = NULL;
+    const char *filename;
 
     self->font = NULL;
     if (!PyArg_ParseTuple(args, "Oi", &obj, &fontsize)) {
@@ -657,64 +677,57 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
         if (fontsize <= 1) {
             fontsize = 1;
         }
-    }
-    else {
-        oencoded = pgRWopsEncodeFilePath(obj, NULL);
-        if (oencoded == NULL) {
-            goto error;
-        }
-        if (oencoded == Py_None) {
-            Py_DECREF(oencoded);
-        }
-        else {
-            Py_DECREF(obj);
-            obj = oencoded;
-        }
-    }
-    if (Bytes_Check(obj)) {
-        FILE *test;
-        const char *filename = Bytes_AS_STRING(obj);
-        if (filename == NULL)
-            goto error;
 
-        /*check if it is a valid file, else SDL_ttf segfaults*/
-        test = fopen(filename, "rb");
-        if (test == NULL) {
-            PyObject *tmp = NULL;
+        oencoded = obj;
+        Py_INCREF(oencoded);
+        filename = Bytes_AS_STRING(oencoded);
+    } else {
+        /* SDL accepts UTF8 */
+        oencoded = pgRWopsEncodeString(obj, "UTF8", NULL, NULL);
+        if (!oencoded || oencoded == Py_None) {
+            Py_XDECREF(oencoded);
+            oencoded = NULL;
+            PyErr_Clear();
+            goto fileobject;
+        }
+        filename = Bytes_AS_STRING(oencoded);
+    }
 
-            if (strcmp(filename, font_defaultname) == 0) {
-                /* filename is the default font; get it's resource
-                 */
-                tmp = font_resource(font_defaultname);
-                if (tmp == NULL) {
-                    if (PyErr_Occurred() == NULL) {
-                        PyErr_Format(PyExc_IOError,
-                                     "unable to read font file '%.1024s'",
-                                     filename);
-                    }
-                    goto error;
+    /*check if it is a valid file, else SDL_ttf segfaults*/
+    test = pg_open_obj(obj, "rb");
+    if (test == NULL) {
+        if (strcmp(filename, font_defaultname) == 0) {
+            PyObject *tmp;
+            PyErr_Clear();
+            tmp = font_resource(font_defaultname);
+            if (tmp == NULL) {
+                if (!PyErr_Occurred()) {
+                    PyErr_Format(PyExc_IOError,
+                                 "unable to read font file '%.1024s'",
+                                 filename);
                 }
-                Py_DECREF(obj);
-                obj = tmp;
-                if (Bytes_Check(obj)) {
-                    filename = Bytes_AS_STRING(obj);
-                    test = fopen(filename, "rb");
-                }
+                goto error;
             }
-            if (test == NULL) {
+            Py_DECREF(obj);
+            obj = tmp;
+            filename = Bytes_AS_STRING(obj);
+            test = pg_open_obj(obj, "rb");
+        }
+        if (test == NULL) {
+            if (!PyErr_Occurred()) {
                 PyErr_Format(PyExc_IOError,
                              "unable to read font file '%.1024s'",
                              filename);
-                goto error;
             }
-        }
-        if (test != NULL) {
-            fclose(test);
-            Py_BEGIN_ALLOW_THREADS;
-            font = TTF_OpenFont(filename, fontsize);
-            Py_END_ALLOW_THREADS;
+            goto error;
         }
     }
+    Py_DECREF(test);
+    Py_BEGIN_ALLOW_THREADS;
+    font = TTF_OpenFont(filename, fontsize);
+    Py_END_ALLOW_THREADS;
+
+fileobject:
     if (font == NULL) {
 #if FONT_HAVE_RWOPS
         SDL_RWops *rw = pgRWopsFromFileObject(obj);
@@ -743,11 +756,13 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
         goto error;
     }
 
+    Py_XDECREF(oencoded);
     Py_DECREF(obj);
     self->font = font;
     return 0;
 
 error:
+    Py_XDECREF(oencoded);
     Py_DECREF(obj);
     return -1;
 }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -149,7 +149,7 @@ font_resource(const char *filename)
     }
 #endif
 
-    tmp = pgRWopsEncodeFilePath(result, NULL);
+    tmp = pgRWopsEncodeString(result, "UTF-8", NULL, NULL);
     if (tmp == NULL) {
         Py_DECREF(result);
         return NULL;

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -204,10 +204,11 @@ write_png(const char *file_name, png_bytep *rows, int w, int h, int colortype,
     png_structp png_ptr = NULL;
     png_infop info_ptr = NULL;
     FILE *fp;
-    char *doing = "open for writing";
+    char *doing;
 
-    if (!(fp = pg_Fopen(file_name, "wb")))
-        goto fail;
+    if (!(fp = pg_FopenUTF8(file_name, "wb"))) {
+        return -1;
+    }
 
     doing = "create png write struct";
     if (!(png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL,
@@ -497,8 +498,7 @@ write_jpeg(const char *file_name, unsigned char **image_buffer,
     cinfo.err = jpeg_std_error(&jerr);
     jpeg_create_compress(&cinfo);
 
-    if (!(outfile = pg_Fopen(file_name, "wb"))) {
-        SDL_SetError("SaveJPEG: could not open %s", file_name);
+    if (!(outfile = pg_FopenUTF8(file_name, "wb"))) {
         return -1;
     }
     j_stdio_dest(&cinfo, outfile);

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -96,7 +96,8 @@ image_load_ext(PyObject *self, PyObject *arg)
         return NULL;
     }
 
-    oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);
+    /*oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);*/
+    oencoded = pgRWopsEncodeString(obj, "UTF-8", NULL, pgExc_SDLError);
     if (oencoded == NULL) {
         return NULL;
     }
@@ -123,7 +124,8 @@ image_load_ext(PyObject *self, PyObject *arg)
         if (name == NULL) {
             oname = PyObject_GetAttrString(obj, "name");
             if (oname != NULL) {
-                oencoded = pgRWopsEncodeFilePath(oname, NULL);
+                /*oencoded = pgRWopsEncodeFilePath(oname, NULL);*/
+                oencoded = pgRWopsEncodeString(oname, "UTF-8", NULL, NULL);
                 Py_DECREF(oname);
                 if (oencoded == NULL) {
                     return NULL;
@@ -201,10 +203,10 @@ write_png(const char *file_name, png_bytep *rows, int w, int h, int colortype,
 {
     png_structp png_ptr = NULL;
     png_infop info_ptr = NULL;
-    FILE *fp = NULL;
+    FILE *fp;
     char *doing = "open for writing";
 
-    if (!(fp = fopen(file_name, "wb")))
+    if (!(fp = pg_Fopen(file_name, "wb")))
         goto fail;
 
     doing = "create png write struct";
@@ -495,7 +497,7 @@ write_jpeg(const char *file_name, unsigned char **image_buffer,
     cinfo.err = jpeg_std_error(&jerr);
     jpeg_create_compress(&cinfo);
 
-    if ((outfile = fopen(file_name, "wb")) == NULL) {
+    if (!(outfile = pg_Fopen(file_name, "wb"))) {
         SDL_SetError("SaveJPEG: could not open %s", file_name);
         return -1;
     }
@@ -752,7 +754,7 @@ image_save_ext(PyObject *self, PyObject *arg)
     pgSurface_Prep(surfobj);
 #endif /* IS_SDLv2 */
 
-    oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);
+    oencoded = pgRWopsEncodeString(obj, "UTF-8", NULL, pgExc_SDLError);
     if (oencoded == Py_None) {
         PyErr_Format(PyExc_TypeError,
                      "Expected a string for the file argument: got %.1024s",

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -267,7 +267,7 @@ music_load(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
-    oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);
+    oencoded = pgRWopsEncodeString(obj, "UTF-8", NULL, pgExc_SDLError);
     if (oencoded == Py_None) {
         Py_DECREF(oencoded);
         rw = pgRWopsFromFileObjectThreaded(obj);
@@ -325,7 +325,7 @@ music_queue(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
-    oencoded = pgRWopsEncodeFilePath(obj, pgExc_SDLError);
+    oencoded = pgRWopsEncodeString(obj, "UTF-8", NULL, pgExc_SDLError);
     if (oencoded == Py_None) {
         Py_DECREF(oencoded);
         rw = pgRWopsFromFileObjectThreaded(obj);

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -31,10 +31,12 @@ class Font(_Font):
             size = 1
         if isinstance(file, unicode_):
             try:
-                file = self.__encode_file_path(file, ValueError)
+                bfile = self.__encode_file_path(file, ValueError)
             except ValueError:
-                pass
-        if isinstance(file, bytes_) and file == self.__default_font:
+                bfile = ''
+        else:
+            bfile = file
+        if isinstance(bfile, bytes_) and bfile == self.__default_font:
             file = None
         if file is None:
             resolution = int(self.__get_default_resolution() * 0.6875)

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf8 -*-
+
 import sys
 import os
 import unittest
@@ -5,8 +7,11 @@ import platform
 
 import pygame
 from pygame import font as pygame_font  # So font can be replaced with ftfont
-from pygame.compat import as_unicode, as_bytes, xrange_, filesystem_errors
+from pygame.compat import as_unicode, unicode_, as_bytes, xrange_, filesystem_errors
 from pygame.compat import PY_MAJOR_VERSION
+
+FONTDIR = os.path.join(os.path.dirname (os.path.abspath (__file__)),
+                       'fixtures', 'fonts')
 
 UCS_4 = sys.maxunicode > 0xFFFF
 
@@ -379,7 +384,7 @@ class FontTypeTest( unittest.TestCase ):
         pygame_font.init()
         self.assertRaises(IOError,
                           pygame_font.Font,
-                          'some-fictional-font.ttf', 20)
+                          unicode_('some-fictional-font.ttf'), 20)
 
     def test_load_from_file(self):
         font_name = pygame_font.get_default_font()
@@ -399,13 +404,28 @@ class FontTypeTest( unittest.TestCase ):
         # identical to the default font file name.
         f = pygame_font.Font(pygame_font.get_default_font(), 20)
 
-    def test_load_from_file_unicode(self):
-        base_dir = os.path.dirname(pygame.__file__)
-        font_path = os.path.join(base_dir, pygame_font.get_default_font())
-        if os.path.sep == '\\':
-            font_path = font_path.replace('\\', '\\\\')
-        ufont_path = as_unicode(font_path)
-        f = pygame_font.Font(ufont_path, 20)
+    def _load_unicode(self, path):
+        import shutil
+        fdir = unicode_(FONTDIR)
+        temp = os.path.join(fdir, path)
+        pgfont = os.path.join(fdir, u'test_sans.ttf')
+        shutil.copy(pgfont, temp)
+        try:
+            with open(temp, 'rb') as f:
+                pass
+        except IOError:
+            raise unittest.SkipTest('the path cannot be opened')
+        try:
+            pygame_font.Font(temp, 20)
+        finally:
+            os.remove(temp)
+
+    def test_load_from_file_unicode_0(self):
+        """ASCII string as a unicode object"""
+        self._load_unicode(u'temp_file.ttf')
+
+    def test_load_from_file_unicode_1(self):
+        self._load_unicode(u'你好.ttf')
 
     def test_load_from_file_bytes(self):
         font_path = os.path.join(os.path.split(pygame.__file__)[0],

--- a/test/ftfont_test.py
+++ b/test/ftfont_test.py
@@ -13,7 +13,8 @@ for name in dir(font_test):
     obj = getattr(font_test, name)
     if (isinstance(obj, type) and  # conditional and
         issubclass(obj, unittest.TestCase)):
-        globals()[name] = obj
+        new_name = 'Ft%s' % name
+        globals()[new_name] = type(new_name, (obj, ), {})
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import array
 import os
 import tempfile
@@ -5,7 +7,7 @@ import unittest
 
 from pygame.tests.test_utils import example_path, png
 import pygame, pygame.image, pygame.pkgdata
-from pygame.compat import xrange_, ord_
+from pygame.compat import xrange_, ord_, unicode_
 
 
 def test_magic(f, magic_hex):
@@ -265,8 +267,37 @@ class ImageModuleTest( unittest.TestCase ):
         self.assertEqual(colorkey1, colorkey2)
         self.assertEqual(p1, s2.get_at((0,0)))
 
+    def test_load_unicode_path(self):
+        import shutil
+        orig = unicode_(example_path("data/asprite.bmp"))
+        temp = os.path.join(unicode_(example_path('data')), u'你好.bmp')
+        shutil.copy(orig, temp)
+        try:
+            im = pygame.image.load(temp)
+        finally:
+            os.remove(temp)
 
+    def _unicode_save(self, temp_file):
+        im = pygame.Surface((10, 10), 0, 32)
+        try:
+            with open(temp_file, 'w') as f:
+                pass
+            os.remove(temp_file)
+        except IOError:
+            raise unittest.SkipTest('the path cannot be opened')
+        self.assert_(not os.path.exists(temp_file))
+        try:
+            pygame.image.save(im, temp_file)
+            self.assert_(os.path.getsize(temp_file) > 10)
+        finally:
+            try:
+                os.remove(temp_file)
+            except EnvironmentError:
+                pass
 
+    def test_save_unicode_path(self):
+        """save unicode object with non-ASCII chars"""
+        self._unicode_save(u"你好.bmp")
 
     def assertPremultipliedAreEqual(self, string1, string2, source_string):
         self.assertEqual(len(string1), len(string2))

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 import os
 import os.path
 import sys
@@ -18,13 +19,15 @@ class ImageextModuleTest( unittest.TestCase ):
     def test_load_non_string_file(self):
         self.assertRaises(pygame.error, imageext.load_extended, [])
 
+    @unittest.skip("SDL silently removes invalid characters")
     def test_save_bad_filename(self):
         im = pygame.Surface((10, 10), 0, 32)
-        u = as_unicode(r"a\x00b\x00c.png")
+        u = u"a\x00b\x00c.png"
         self.assertRaises(pygame.error, imageext.save_extended, im, u)
 
+    @unittest.skip("SDL silently removes invalid characters")
     def test_load_bad_filename(self):
-        u = as_unicode(r"a\x00b\x00c.png")
+        u = u"a\x00b\x00c.png"
         self.assertRaises(pygame.error, imageext.load_extended, u)
 
     def test_save_unknown_extension(self):
@@ -36,17 +39,22 @@ class ImageextModuleTest( unittest.TestCase ):
         s = "foo.bar"
         self.assertRaises(pygame.error, imageext.load_extended, s)
 
+    def test_load_unknown_file(self):
+        s = "nonexistent.png"
+        self.assertRaises(pygame.error, imageext.load_extended, s)
+
     def test_load_unicode_path(self):
         u = unicode_(example_path("data/alien1.png"))
         im = imageext.load_extended(u)
 
-    def test_save_unicode_path(self):
-        temp_file = unicode_("tmpimg.png")
+    def _unicode_save(self, temp_file):
         im = pygame.Surface((10, 10), 0, 32)
         try:
+            with open(temp_file, 'w') as f:
+                pass
             os.remove(temp_file)
-        except EnvironmentError:
-            pass
+        except IOError:
+            raise unittest.SkipTest('the path cannot be opened')
         self.assert_(not os.path.exists(temp_file))
         try:
             imageext.save_extended(im, temp_file)
@@ -56,6 +64,13 @@ class ImageextModuleTest( unittest.TestCase ):
                 os.remove(temp_file)
             except EnvironmentError:
                 pass
+
+    def test_save_unicode_path_0(self):
+        """unicode object with ASCII chars"""
+        self._unicode_save(u"temp_file.png")
+
+    def test_save_unicode_path_1(self):
+        self._unicode_save(u"你好.png")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -43,9 +43,20 @@ class ImageextModuleTest( unittest.TestCase ):
         s = "nonexistent.png"
         self.assertRaises(pygame.error, imageext.load_extended, s)
 
-    def test_load_unicode_path(self):
+    def test_load_unicode_path_0(self):
         u = unicode_(example_path("data/alien1.png"))
         im = imageext.load_extended(u)
+
+    def test_load_unicode_path_1(self):
+        """non-ASCII unicode"""
+        import shutil
+        orig = unicode_(example_path("data/alien1.png"))
+        temp = os.path.join(unicode_(example_path('data')), u'你好.png')
+        shutil.copy(orig, temp)
+        try:
+            im = imageext.load_extended(temp)
+        finally:
+            os.remove(temp)
 
     def _unicode_save(self, temp_file):
         im = pygame.Surface((10, 10), 0, 32)

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -1,13 +1,21 @@
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 import unittest
 
 from pygame.tests.test_utils import example_path
 import pygame
-from pygame.compat import as_unicode, filesystem_encode
+from pygame.compat import as_unicode, unicode_, filesystem_encode
 
 
 class MixerMusicModuleTest(unittest.TestCase):
+    def setUp(self):
+        pygame.mixer.init()
+
+    def tearDown(self):
+        pygame.mixer.quit()
+
     def test_load(self):
         "|tags:music|"
         # __doc__ (as of 2008-07-13) for pygame.mixer_music.load:
@@ -16,7 +24,6 @@ class MixerMusicModuleTest(unittest.TestCase):
           # Load a music file for playback
 
         data_fname = example_path('data')
-        pygame.mixer.init()
 
         # The mp3 test file can crash smpeg on some systems.
         ## formats = ['mp3', 'ogg', 'wav']
@@ -37,7 +44,25 @@ class MixerMusicModuleTest(unittest.TestCase):
             #pygame.mixer.music.load(open(musfn))
             #musf = open(musfn)
             #pygame.mixer.music.load(musf)
-        pygame.mixer.quit()
+
+    def test_load_unicode(self):
+        """test non-ASCII unicode path"""
+        import shutil
+        ep = unicode_(example_path('data'))
+        temp_file = os.path.join(ep, u'你好.wav')
+        org_file = os.path.join(ep, u'house_lo.wav')
+        try:
+            with open(temp_file, 'w') as f:
+                pass
+            os.remove(temp_file)
+        except IOError:
+            raise unittest.SkipTest('the path cannot be opened')
+        shutil.copy(org_file, temp_file)
+        try:
+            pygame.mixer.music.load(temp_file)
+            pygame.mixer.music.load(org_file) # unload
+        finally:
+            os.remove(temp_file)
 
     def todo_test_queue(self):
 

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf8 -*-
+
 import sys
 import os
 import unittest
@@ -79,7 +81,7 @@ class MixerModuleTest(unittest.TestCase):
         mixer.init(0, 0, 0)
         self.assertEqual(mixer.get_init(), (44100, 8, 1))
 
-    @unittest.expectedFailure
+    @unittest.skip('SDL_mixer bug')
     def test_get_init__returns_exact_values_used_for_init(self):
         # fix in 1.9 - I think it's a SDL_mixer bug.
 
@@ -196,6 +198,24 @@ class MixerModuleTest(unittest.TestCase):
         snd2 = mixer.Sound(array=snd)
         self.assertEqual(snd.get_raw(), snd2.get_raw())
 
+    def test_sound_unicode(self):
+        """test non-ASCII unicode path"""
+        mixer.init()
+        import shutil
+        ep = unicode_(example_path('data'))
+        temp_file = os.path.join(ep, u'你好.wav')
+        org_file = os.path.join(ep, u'house_lo.wav')
+        shutil.copy(org_file, temp_file)
+        try:
+            with open(temp_file, 'rb') as f:
+                pass
+        except IOError:
+            raise unittest.SkipTest('the path cannot be opened')
+        try:
+            sound = mixer.Sound(temp_file)
+            del sound
+        finally:
+            os.remove(temp_file)
 
     @unittest.skipIf(os.environ.get('SDL_AUDIODRIVER') == 'disk',
                     'this test fails without real sound card')


### PR DESCRIPTION
Unicode objects now work for Sound(), music.load(), .image.load_extended()/load(), image.save_extended()/save(), ftfont, and font.

Changes: SDL generally expects UTF-8 strings, so I switched to using that in a lot of places. `fopen()` in Windows cannot handle UTF-8, so I added workarounds for that.

I had to disable `test_save_bad_filename()` and `test_load_bad_filename()` for now. SDL simply strips out "bad" characters instead of returning an error.

Close #37 
Close #645 

Related PR: #649