### PR TITLE
get_error(): Use locale encoding as fallback for the error string, SDL 1 & Python 3

### DIFF
--- a/test/base_test.py
+++ b/test/base_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf8 -*-
+
 import sys
 import unittest
 
@@ -560,7 +562,15 @@ class BaseModuleTest(unittest.TestCase):
         pygame.set_error("")
         self.assertEqual(pygame.get_error(), "")
 
-
+    def test_unicode_error(self):
+        if sys.version_info.major > 2:
+            pygame.set_error(u'你好')
+            self.assertEqual(u'你好', pygame.get_error())
+        else:
+            # no unicode objects for now
+            pygame.set_error(u'你好')
+            encstr = u'你好'.encode('utf8')
+            self.assertEqual(encstr, pygame.get_error())
 
     def test_init(self):
 


### PR DESCRIPTION
This is because SDL 1 uses CP_ACP in some cases. Attempting to decode the error string using UTF-8 and then `PyUnicode_DecodeLocale()` if that doesn't work prevents an exception from being raised.

Close https://github.com/pygame/pygame/issues/632