### PR TITLE
Compile for PyPy 3 and PyPy fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,12 +139,12 @@ Dependencies
      numpy package for its multidimensional numeric arrays.
      Dependency versions:
 
-     * Python >= 2.7
+     * Python >= 2.7 or PyPy >= 6.0.0 (and pypy3)
      * SDL >= 1.2.15
      * SDL_mixer >= 1.2.13
-     * SDL_image (version?)
-     * SDL_tff (version ?)
-     * SDL_gfx (optional, version?)
+     * SDL_image >= 1.2.12
+     * SDL_tff >= 2.0.11
+     * SDL_gfx (optional, vendored in)
      * NumPy >= 1.6.2 (optional)
 
 

--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -438,9 +438,6 @@ def setup_prebuilt_sdl1(prebuilt_dir):
         try:
             do_copy = True
             for line in setup_in:
-                if is_pypy and is_python3:
-                    if line.startswith('_freetype'):
-                        continue
                 if line.startswith('#--StartConfig'):
                     do_copy = False
                     setup_.write(setup_win_in.read())

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -2087,13 +2087,21 @@ _ft_clear(PyObject *mod)
  * FREETYPE MODULE DECLARATION
  ****************************************************/
 #if PY3
+#ifndef PYPY_VERSION
 struct PyModuleDef _freetypemodule = {
     PyModuleDef_HEAD_INIT,  MODULE_NAME, DOC_PYGAMEFREETYPE,
     sizeof(_FreeTypeState), _ft_methods, 0,
     _ft_traverse,           _ft_clear,   0};
-#else
+#else /* PYPY_VERSION */
 _FreeTypeState _modstate;
-#endif
+struct PyModuleDef _freetypemodule = {
+    PyModuleDef_HEAD_INIT,  MODULE_NAME, DOC_PYGAMEFREETYPE,
+    -1 /* PyModule_GetState() not implemented */, _ft_methods, 0,
+    _ft_traverse, _ft_clear, 0};
+#endif /* PYPY_VERSION */
+#else /* PY2 */
+_FreeTypeState _modstate;
+#endif /* PY2 */
 
 MODINIT_DEFINE(_freetype)
 {

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -52,9 +52,16 @@ typedef struct _display_state_s {
 } _DisplayState;
 
 #if PY3
+#ifndef PYPY_VERSION
 static struct PyModuleDef _module;
 #define DISPLAY_MOD_STATE(mod) ((_DisplayState *)PyModule_GetState(mod))
 #define DISPLAY_STATE DISPLAY_MOD_STATE(PyState_FindModule(&_module))
+#else /* PYPY_VERSION */
+static struct PyModuleDef _module;
+static _DisplayState _modstate = {0};
+#define DISPLAY_MOD_STATE(mod) (&_modstate)
+#define DISPLAY_STATE DISPLAY_MOD_STATE(0)
+#endif /* PYPY_VERSION */
 #else /* PY2 */
 static _DisplayState _modstate = {0};
 #define DISPLAY_MOD_STATE(mod) (&_modstate)
@@ -1622,6 +1629,7 @@ static PyMethodDef _pg_display_methods[] = {
 
 #if IS_SDLv2
 #if PY3
+#ifndef PYPY_VERSION
 static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                      "display",
                                      DOC_PYGAMEDISPLAY,
@@ -1632,7 +1640,18 @@ static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                      NULL,
                                      NULL,
                                      NULL};
-#endif
+#else /* PYPY_VERSION */
+static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
+                                     "display",
+                                     DOC_PYGAMEDISPLAY,
+                                     -1, /* PyModule_GetState() not implemented */
+                                     _pg_display_methods,
+                                     NULL,
+                                     NULL,
+                                     NULL,
+                                     NULL};
+#endif /* PYPY_VERSION */
+#endif /* PY3 */
 
 MODINIT_DEFINE(display)
 {

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -55,7 +55,7 @@
 /* For filtering out UCS-4 and larger characters when Python is
  * built with Py_UNICODE_WIDE.
  */
-#if PY2 && !defined(Py_UNICODE_IS_SURROGATE)
+#if PY2 && !defined(Py_UNICODE_IS_SURROGATE) || defined(PYPY_VERSION)
 #define Py_UNICODE_IS_SURROGATE(ch) (0xD800 <= (ch) && (ch) <= 0xDFFF)
 #endif
 

--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -233,7 +233,7 @@ typedef struct {
     FT_UInt resolution;
 } _FreeTypeState;
 
-#ifdef IS_PYTHON_3
+#if defined(IS_PYTHON_3) && !defined(PYPY_VERSION)
     extern struct PyModuleDef _freetypemodule;
 #   define FREETYPE_MOD_STATE(mod) ((_FreeTypeState*)PyModule_GetState(mod))
 #   define FREETYPE_STATE \

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -158,6 +158,7 @@ class FreeTypeFontTest(unittest.TestCase):
         f.__init__(self._bmp_8_75dpi_path, size=12)
         self.assertEqual(f.size, 12.0)
 
+    @unittest.skipIf(IS_PYPY, "PyPy doesn't use refcounting")
     def test_freetype_Font_dealloc(self):
         import sys
         handle = open(self._sans_path, 'rb')

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -169,7 +169,8 @@ class ImageModuleTest( unittest.TestCase ):
         pygame.image.save(surf, f_path)
 
         # Read the PNG file and verify that pygame saved it correctly
-        width, height, pixels, metadata = png.Reader(filename=f_path).asRGBA8()
+        reader = png.Reader(filename=f_path)
+        width, height, pixels, metadata = reader.asRGBA8()
         pixels_as_tuples = []
         for pixel in pixels:
             pixels_as_tuples.append(tuple(pixel))
@@ -179,6 +180,9 @@ class ImageModuleTest( unittest.TestCase ):
         self.assertEquals(pixels_as_tuples[2], bluish_pixel)
         self.assertEquals(pixels_as_tuples[3], greyish_pixel)
 
+        if not reader.file.closed:
+            reader.file.close()
+        del reader
         os.remove(f_path)
 
     def testSavePNG24(self):
@@ -200,7 +204,8 @@ class ImageModuleTest( unittest.TestCase ):
         pygame.image.save(surf, f_path)
 
         # Read the PNG file and verify that pygame saved it correctly
-        width, height, pixels, metadata = png.Reader(filename=f_path).asRGB8()
+        reader = png.Reader(filename=f_path)
+        width, height, pixels, metadata = reader.asRGB8()
         pixels_as_tuples = []
         for pixel in pixels:
             pixels_as_tuples.append(tuple(pixel))
@@ -210,6 +215,9 @@ class ImageModuleTest( unittest.TestCase ):
         self.assertEquals(pixels_as_tuples[2], bluish_pixel)
         self.assertEquals(pixels_as_tuples[3], greyish_pixel)
 
+        if not reader.file.closed:
+            reader.file.close()
+        del reader
         os.remove(f_path)
 
     def test_save(self):
@@ -233,13 +241,16 @@ class ImageModuleTest( unittest.TestCase ):
                 pygame.image.save(s, temp_filename)
                 # test the magic numbers at the start of the file to ensure they are saved
                 #   as the correct file type.
-                self.assertEqual((1, fmt), (test_magic(open(temp_filename, "rb"), magic_hex[fmt.lower()]), fmt))
+                handle = open(temp_filename, "rb")
+                self.assertEqual((1, fmt), (test_magic(handle, magic_hex[fmt.lower()]), fmt))
+                handle.close()
                 # load the file to make sure it was saved correctly.
                 #    Note load can load a jpg saved with a .png file name.
                 s2 = pygame.image.load(temp_filename)
                 #compare contents, might only work reliably for png...
                 #   but because it's all one color it seems to work with jpg.
                 self.assertEquals(s2.get_at((0,0)), s.get_at((0,0)))
+                handle.close()
             finally:
                 #clean up the temp file, comment out to leave tmp file after run.
                 os.remove(temp_filename)

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -331,6 +331,7 @@ class PixelArrayTypeTest (unittest.TestCase, TestMixin):
             self.assertEqual (ar[3][5], sf.map_rgb ((10, 10, 10)))
             self.assertEqual (ar[3][6], sf.map_rgb ((10, 10, 10)))
 
+    @unittest.skipIf(IS_PYPY, 'skipping for PyPy (segfaults on mac pypy3 6.0.0)')
     def test_contains (self):
         for bpp in (8, 16, 24, 32):
             sf = pygame.Surface ((10, 20), 0, bpp)


### PR DESCRIPTION
I also enabled FreeType (but had to avoid using the module state). Rect seems to be broken.