### PR TITLE
SDL2: Fix key.get_pressed() by wrapping the tuple

### DIFF
--- a/src_c/key.c
+++ b/src_c/key.c
@@ -76,7 +76,14 @@ key_get_repeat(PyObject *self, PyObject *args)
 }
 #endif /* not SDL_VERSION_ATLEAST(1, 2, 10) */
 
+
 #if IS_SDLv2
+/*
+* pgScancodeWrapper is for key_get_pressed in SDL2.
+* It converts key symbol indices to scan codes, as suggested in
+*     https://github.com/pygame/pygame/issues/659
+* so that they work with SDL_GetKeyboardState().
+*/
 typedef struct {
     PyObject_HEAD
 } pgScancodeWrapper;

--- a/test/constants_test.py
+++ b/test/constants_test.py
@@ -38,6 +38,13 @@ class KmodTests(unittest.TestCase):
         for k in self.constants:
             self.assertEqual(type(getattr(pygame.constants, k)), int)
 
+class KeyConstantTests(unittest.TestCase):
+    def test_letters(self):
+        for c in range(ord('a'), ord('z') + 1):
+            c = chr(c)
+            self.assertTrue(hasattr(pygame.constants, 'K_%s' % c),
+                                    'missing constant: K_%s' % c)
+
 ################################################################################
 
 if __name__ == '__main__':

--- a/test/key_test.py
+++ b/test/key_test.py
@@ -28,27 +28,9 @@ class KeyModuleTest(unittest.TestCase):
 
         self.fail()
 
-    def todo_test_get_pressed(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.key.get_pressed:
-
-          # pygame.key.get_pressed(): return bools
-          # get the state of all keyboard buttons
-          #
-          # Returns a sequence of boolean values representing the state of every
-          # key on the keyboard. Use the key constant values to index the array.
-          # A True value means the that button is pressed.
-          #
-          # Getting the list of pushed buttons with this function is not the
-          # proper way to handle text entry from the user. You have no way to
-          # know the order of keys pressed, and rapidly pushed keys can be
-          # completely unnoticed between two calls to pygame.key.get_pressed().
-          # There is also no way to translate these pushed keys into a fully
-          # translated character value. See the pygame.KEYDOWN events on the
-          # event queue for this functionality.
-          #
-
-        self.fail()
+    def test_get_pressed(self):
+        states = pygame.key.get_pressed()
+        self.assertEqual(states[pygame.K_RIGHT], 0)
 
     def test_name(self):
         self.assertEqual(pygame.key.name(pygame.K_RETURN), "return")


### PR DESCRIPTION
Converts key symbol indices to scan codes, as suggested in #659, so that they work with SDL_GetKeyboardState().