### PR TITLE
joystick.get_name(): Use locale encoding. Fix #674

### DIFF
--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -168,7 +168,7 @@ joy_get_name(PyObject *self)
     int joy_id = pgJoystick_AsID(self);
     JOYSTICK_INIT_CHECK();
 #if IS_SDLv1
-    return Text_FromUTF8(SDL_JoystickName(joy_id));
+    return Text_FromLocale(SDL_JoystickName(joy_id));
 #else  /* IS_SDLv2 */
     return Text_FromUTF8(SDL_JoystickNameForIndex(joy_id));
 #endif /* IS_SDLv2 */

--- a/src_c/pgcompat.h
+++ b/src_c/pgcompat.h
@@ -36,6 +36,7 @@
 /* Text interface. Use unicode strings. */
 #define Text_Type PyUnicode_Type
 #define Text_Check PyUnicode_Check
+#define Text_FromLocale(s) PyUnicode_DecodeLocale((s), "strict")
 #define Text_FromUTF8 PyUnicode_FromString
 #define Text_FromUTF8AndSize PyUnicode_FromStringAndSize
 #define Text_FromFormat PyUnicode_FromFormat
@@ -88,6 +89,7 @@
 /* Text interface. Use ascii strings. */
 #define Text_Type PyString_Type
 #define Text_Check PyString_Check
+#define Text_FromLocale PyString_FromString
 #define Text_FromUTF8 PyString_FromString
 #define Text_FromUTF8AndSize PyString_FromStringAndSize
 #define Text_FromFormat PyString_FromFormat


### PR DESCRIPTION
SDL1 doesn't use UTF-8 here. Closes #674.

I'm not able to test this, so I'm not sure if it solves the problem.