### PR TITLE
SDL2: Select which screen to appear on with set_mode(display=0)

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -104,7 +104,7 @@ required).
 .. function:: set_mode
 
    | :sl:`Initialize a window or screen for display`
-   | :sg:`set_mode(resolution=(0,0), flags=0, depth=0) -> Surface`
+   | :sg:`set_mode(resolution=(0,0), flags=0, depth=0, display=0) -> Surface`
 
    This function will create a display Surface. The arguments passed in are
    requests for a display type. The actual created display will be the best
@@ -156,6 +156,10 @@ required).
         screen_width=700
         screen_height=400
         screen=pygame.display.set_mode([screen_width,screen_height])
+
+   The display index 0 means the default display is used.
+
+   The display argument is new with pygame 1.9.5.
 
    .. ## pygame.display.set_mode ##
 

--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -104,20 +104,20 @@ required).
 .. function:: set_mode
 
    | :sl:`Initialize a window or screen for display`
-   | :sg:`set_mode(resolution=(0,0), flags=0, depth=0, display=0) -> Surface`
+   | :sg:`set_mode(size=(0, 0), flags=0, depth=0, display=0) -> Surface`
 
    This function will create a display Surface. The arguments passed in are
    requests for a display type. The actual created display will be the best
    possible match supported by the system.
 
-   The resolution argument is a pair of numbers representing the width and
+   The size argument is a pair of numbers representing the width and
    height. The flags argument is a collection of additional options. The depth
    argument represents the number of bits to use for color.
 
    The Surface that gets returned can be drawn to like a regular Surface but
    changes will eventually be seen on the monitor.
 
-   If no resolution is passed or is set to (0, 0) and pygame uses ``SDL``
+   If no size is passed or is set to (0, 0) and pygame uses ``SDL``
    version 1.2.10 or above, the created Surface will have the same size as the
    current screen resolution. If only the width or height are set to 0, the
    Surface will have the same width or height as the screen resolution. Using a
@@ -129,9 +129,9 @@ required).
    will emulate an unavailable color depth which can be slow.
 
    When requesting fullscreen display modes, sometimes an exact match for the
-   requested resolution cannot be made. In these situations pygame will select
+   requested size cannot be made. In these situations pygame will select
    the closest compatible match. The returned surface will still always match
-   the requested resolution.
+   the requested size.
 
    The flags argument controls which type of display you want. There are
    several to choose from, and you can even combine multiple types using the
@@ -278,10 +278,10 @@ required).
    | :sl:`Get list of available fullscreen modes`
    | :sg:`list_modes(depth=0, flags=pygame.FULLSCREEN, display=0) -> list`
 
-   This function returns a list of possible dimensions for a specified color
+   This function returns a list of possible sizes for a specified color
    depth. The return value will be an empty list if no display modes are
    available with the given arguments. A return value of -1 means that any
-   requested resolution should work (this is likely the case for windowed
+   requested size should work (this is likely the case for windowed
    modes). Mode sizes are sorted from biggest to smallest.
 
    If depth is 0, ``SDL`` will choose the current/best color depth for the

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -569,7 +569,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     char *title = state->title;
 
     const char *keywords[] = {
-        "resolution",
+        "size",
         "flags",
         "depth",
         "display",
@@ -942,7 +942,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     char *title, *icontitle;
 
     const char *keywords[] = {
-        "resolution",
+        "size",
         "flags",
         "depth",
         "display",

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -553,7 +553,7 @@ pg_gl_get_attribute(PyObject *self, PyObject *arg)
 
 #if IS_SDLv2
 static PyObject *
-pg_set_mode(PyObject *self, PyObject *arg)
+pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 {
     static const char *const DefaultTitle = "pygame window";
 
@@ -565,9 +565,19 @@ pg_set_mode(PyObject *self, PyObject *arg)
     int flags = 0;
     int w = 0;
     int h = 0;
+    int display = 0;
     char *title = state->title;
 
-    if (!PyArg_ParseTuple(arg, "|(ii)ii", &w, &h, &flags, &depth))
+    const char *keywords[] = {
+        "resolution",
+        "flags",
+        "depth",
+        "display",
+        NULL
+    };
+
+    if (!PyArg_ParseTupleAndKeywords(arg, kwds, "|(ii)iii", keywords,
+                                     &w, &h, &flags, &depth, &display))
         return NULL;
 
     if (w < 0 || h < 0)
@@ -641,8 +651,10 @@ pg_set_mode(PyObject *self, PyObject *arg)
             sdl_flags |= SDL_WINDOWEVENT_HIDDEN;
         if (!(sdl_flags & SDL_WINDOWEVENT_HIDDEN))
             sdl_flags |= SDL_WINDOW_SHOWN;
-        win = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED,
-                               SDL_WINDOWPOS_UNDEFINED, w, h, sdl_flags);
+        win = SDL_CreateWindow(title,
+                               SDL_WINDOWPOS_UNDEFINED_DISPLAY(display),
+                               SDL_WINDOWPOS_UNDEFINED_DISPLAY(display),
+                               w, h, sdl_flags);
         if (!win)
             return RAISE(pgExc_SDLError, SDL_GetError());
 
@@ -918,17 +930,27 @@ pg_num_displays()
 
 #else /* IS_SDLv1 */
 static PyObject *
-pg_set_mode(PyObject *self, PyObject *arg)
+pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 {
     SDL_Surface *surf;
     int depth = 0;
     int flags = SDL_SWSURFACE;
     int w = 0;
     int h = 0;
+    int display = 0;
     int hasbuf;
     char *title, *icontitle;
 
-    if (!PyArg_ParseTuple(arg, "|(ii)ii", &w, &h, &flags, &depth))
+    const char *keywords[] = {
+        "resolution",
+        "flags",
+        "depth",
+        "display",
+        NULL
+    };
+
+    if (!PyArg_ParseTupleAndKeywords(arg, kwds, "|(ii)iii", keywords,
+                                     &w, &h, &flags, &depth, &display))
         return NULL;
 
     if (w < 0 || h < 0)
@@ -1775,7 +1797,7 @@ static PyMethodDef _pg_display_methods[] = {
     {"get_surface", (PyCFunction)pg_get_surface, METH_NOARGS,
      DOC_PYGAMEDISPLAYGETSURFACE},
 
-    {"set_mode", pg_set_mode, METH_VARARGS, DOC_PYGAMEDISPLAYSETMODE},
+    {"set_mode", pg_set_mode, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYSETMODE},
     {"mode_ok", pg_mode_ok, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYMODEOK},
     {"list_modes", pg_list_modes, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYLISTMODES},
     {"get_num_displays", pg_num_displays, METH_NOARGS, DOC_PYGAMEDISPLAYGETNUMDISPLAYS},

--- a/src_c/doc/display_doc.h
+++ b/src_c/doc/display_doc.h
@@ -7,7 +7,7 @@
 
 #define DOC_PYGAMEDISPLAYGETINIT "get_init() -> bool\nReturns True if the display module has been initialized"
 
-#define DOC_PYGAMEDISPLAYSETMODE "set_mode(resolution=(0,0), flags=0, depth=0) -> Surface\nInitialize a window or screen for display"
+#define DOC_PYGAMEDISPLAYSETMODE "set_mode(resolution=(0,0), flags=0, depth=0, display=0) -> Surface\nInitialize a window or screen for display"
 
 #define DOC_PYGAMEDISPLAYGETSURFACE "get_surface() -> Surface\nGet a reference to the currently set display surface"
 
@@ -71,7 +71,7 @@ pygame.display.get_init
 Returns True if the display module has been initialized
 
 pygame.display.set_mode
- set_mode(resolution=(0,0), flags=0, depth=0) -> Surface
+ set_mode(resolution=(0,0), flags=0, depth=0, display=0) -> Surface
 Initialize a window or screen for display
 
 pygame.display.get_surface

--- a/src_c/doc/display_doc.h
+++ b/src_c/doc/display_doc.h
@@ -7,7 +7,7 @@
 
 #define DOC_PYGAMEDISPLAYGETINIT "get_init() -> bool\nReturns True if the display module has been initialized"
 
-#define DOC_PYGAMEDISPLAYSETMODE "set_mode(resolution=(0,0), flags=0, depth=0, display=0) -> Surface\nInitialize a window or screen for display"
+#define DOC_PYGAMEDISPLAYSETMODE "set_mode(size=(0, 0), flags=0, depth=0, display=0) -> Surface\nInitialize a window or screen for display"
 
 #define DOC_PYGAMEDISPLAYGETSURFACE "get_surface() -> Surface\nGet a reference to the currently set display surface"
 
@@ -71,7 +71,7 @@ pygame.display.get_init
 Returns True if the display module has been initialized
 
 pygame.display.set_mode
- set_mode(resolution=(0,0), flags=0, depth=0, display=0) -> Surface
+ set_mode(size=(0, 0), flags=0, depth=0, display=0) -> Surface
 Initialize a window or screen for display
 
 pygame.display.get_surface

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -444,7 +444,7 @@ class DisplayModuleTest(unittest.TestCase):
 
     def test_set_mode_kwargs(self):
 
-        pygame.display.set_mode(size=(0, 0), flags=0, depth=0, display=0)
+        pygame.display.set_mode(size=(1, 1), flags=0, depth=0, display=0)
 
 
     def todo_test_set_palette(self):

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -442,57 +442,10 @@ class DisplayModuleTest(unittest.TestCase):
 
         self.fail()
 
-    def todo_test_set_mode(self):
+    def test_set_mode_kwargs(self):
 
-        # __doc__ (as of 2008-08-02) for pygame.display.set_mode:
+        pygame.display.set_mode(size=(0, 0), flags=0, depth=0, display=0)
 
-          # pygame.display.set_mode(resolution=(0,0), flags=0, depth=0): return Surface
-          # initialize a window or screen for display
-          #
-          # This function will create a display Surface. The arguments passed in
-          # are requests for a display type. The actual created display will be
-          # the best possible match supported by the system.
-          #
-          # The resolution argument is a pair of numbers representing the width
-          # and height. The flags argument is a collection of additional
-          # options.  The depth argument represents the number of bits to use
-          # for color.
-          #
-          # The Surface that gets returned can be drawn to like a regular
-          # Surface but changes will eventually be seen on the monitor.
-          #
-          # If no resolution is passed or is set to (0, 0) and pygame uses SDL
-          # version 1.2.10 or above, the created Surface will have the same size
-          # as the current screen resolution. If only the width or height are
-          # set to 0, the Surface will have the same width or height as the
-          # screen resolution. Using a SDL version prior to 1.2.10 will raise an
-          # exception.
-          #
-          # It is usually best to not pass the depth argument. It will default
-          # to the best and fastest color depth for the system. If your game
-          # requires a specific color format you can control the depth with this
-          # argument. Pygame will emulate an unavailable color depth which can
-          # be slow.
-          #
-          # When requesting fullscreen display modes, sometimes an exact match
-          # for the requested resolution cannot be made. In these situations
-          # pygame will select the closest compatable match. The returned
-          # surface will still always match the requested resolution.
-          #
-          # The flags argument controls which type of display you want. There
-          # are several to choose from, and you can even combine multiple types
-          # using the bitwise or operator, (the pipe "|" character). If you pass
-          # 0 or no flags argument it will default to a software driven window.
-          # Here are the display flags you will want to choose from:
-          #
-          #    pygame.FULLSCREEN    create a fullscreen display
-          #    pygame.DOUBLEBUF     recommended for HWSURFACE or OPENGL
-          #    pygame.HWSURFACE     hardware accelerated, only in FULLSCREEN
-          #    pygame.OPENGL        create an opengl renderable display
-          #    pygame.RESIZABLE     display window should be sizeable
-          #    pygame.NOFRAME       display window will have no border or controls
-
-        self.fail()
 
     def todo_test_set_palette(self):
 


### PR DESCRIPTION
This lets you to select a display to use with `set_mode()`. Keyword arguments were also added.