### PR TITLE
Travis ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/Library/Caches/Homebrew
+    - $HOME/.ccache
     - /Library/Caches/Homebrew
 
 matrix:
@@ -75,6 +76,7 @@ matrix:
       env: PY_VERSION=pypy3
 
 before_install:
+  - export PATH=/usr/lib/ccache:$PATH
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx_before_install.sh;  fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+before_cache:
+  - brew cleanup
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -113,7 +113,7 @@ install_or_upgrade webp ${UNIVERSAL_FLAG}
 install_or_upgrade libogg ${UNIVERSAL_FLAG}
 install_or_upgrade libvorbis ${UNIVERSAL_FLAG}
 install_or_upgrade flac ${UNIVERSAL_FLAG}
-brew install boost & prevent_stall
+brew upgrade boost & prevent_stall
 install_or_upgrade fluid-synth
 install_or_upgrade libmikmod ${UNIVERSAL_FLAG}
 install_or_upgrade smpeg

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -16,6 +16,9 @@ brew update
 echo -en 'travis_fold:end:brew.update\\r'
 export HOMEBREW_NO_AUTO_UPDATE=1
 
+brew install ccache
+export PATH="/usr/local/opt/ccache/libexec:$PATH"
+
 brew uninstall --force --ignore-dependencies pkg-config
 brew install pkg-config
 

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -32,6 +32,7 @@ fi
 
 # Only compile from source if doing a release. on tag or master.
 # This saves compile times for normal PR testing.
+ccache -s
 echo "About to install dependencies"
 echo $TRAVIS_TAG
 echo $TRAVIS_BRANCH

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -96,6 +96,14 @@ function install_or_upgrade {
     set -e
 }
 
+function prevent_stall {
+    while kill -0 "$!" 2> /dev/null
+    do
+        sleep 20
+        echo "Waiting..."
+    done
+}
+
 
 install_or_upgrade sdl ${UNIVERSAL_FLAG}
 install_or_upgrade jpeg ${UNIVERSAL_FLAG}
@@ -105,6 +113,7 @@ install_or_upgrade webp ${UNIVERSAL_FLAG}
 install_or_upgrade libogg ${UNIVERSAL_FLAG}
 install_or_upgrade libvorbis ${UNIVERSAL_FLAG}
 install_or_upgrade flac ${UNIVERSAL_FLAG}
+brew install boost & prevent_stall
 install_or_upgrade fluid-synth
 install_or_upgrade libmikmod ${UNIVERSAL_FLAG}
 install_or_upgrade smpeg


### PR DESCRIPTION
Maybe this will help a little bit. I noticed that Boost is the major bottleneck.

Related: #687

python@2 and OpenSSL also take about 6 minutes each.

Edit: "ALSO NOTE: The brew command, by design, will never use ccache."