### PR TITLE
Prevent stalling on master.

### DIFF
--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -57,11 +57,6 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ -n "$TRAVIS_TAG" ] || [ "$TRAVIS_B
 	brew uninstall --force --ignore-dependencies smpeg
 	brew uninstall --force --ignore-dependencies portmidi
 	brew uninstall --force --ignore-dependencies freetype
-
-	# These are for building from source, with 'core2'
-	#   because otherwise homebrew will use the architecture of the build host.
-	export HOMEBREW_BUILD_BOTTLE=1
-	export HOMEBREW_BOTTLE_ARCH=core2
 fi
 
 


### PR DESCRIPTION
Core2 is the default architecture, so the lines should no longer be needed:

    By default, bottles will be built for the oldest CPU supported by the OS/architecture you’re building for (Core 2 for 64-bit OSs). This ensures that bottles are compatible with all computers you might distribute them to.

https://docs.brew.sh/Bottles