### PR TITLE
Docs: Fix 'pre' styles.

### DIFF
--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -409,6 +409,10 @@ dl.definition {
     padding-bottom: 0.7em;
 }
 
+dt.title {
+    font-family: monospace;
+}
+
 dd {
     margin-left: 30px;
 }
@@ -443,6 +447,10 @@ span.summaryline {
 span.signature {
     font-family: {{ theme_sigfont }};
     margin-bottom: 0.5em;
+}
+
+span.pre {
+    font-family: monospace;
 }
 
 table.docutils td.toc {


### PR DESCRIPTION
It's easier to read when a monospace font is used for code:

![patch](https://i.imgur.com/KfQ5SLY.png)

vs.

![before](https://i.imgur.com/gecMg9S.png)