### PR TITLE
Build commits once on travis, and appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -107,6 +107,9 @@ install:
 # install step instead.
 build: off
 
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ cache:
     - $HOME/Library/Caches/pip/wheels
     - /Library/Caches/pip/wheels
 
+# So commits do not get built twice. 
+# Only test master and tagged releases on push
+#   always test things that aren't pushes (like PRs)
+if: type != push OR branch = master OR branch =~ /^\d+\.\d+(\.\d+)?(-\S*)?$/
+
+
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
So that commits are only built for a PR, master branch, or version number tags.

Before both travis and appveyor were building for both the branch and PR.