### PR TITLE
Fixes #565 pygame.freetype.Font.get_metrics does not respect style & …

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -1412,11 +1412,11 @@ _ftfont_getmetrics(pgFontObject *self, PyObject *args, PyObject *kwds)
     ASSERT_SELF_IS_ALIVE(self);
 
     /*
-     * Build the render mode with the given size and no
-     * rotation/styles/vertical text
+     * Build the render mode with the given size and support
+     * for rotation/styles/size changes in text
      */
     if (_PGFT_BuildRenderMode(self->freetype, self, &render, face_size,
-                              FT_STYLE_NORMAL, 0))
+                              FT_STYLE_DEFAULT, self->rotation))
         goto error;
 
     /* get metrics */

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -126,7 +126,7 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertRaises(OverflowError, ft.Font, file=None, size=-1)
 
         f = ft.Font(None, size=24)
-        self.assert_(f.height > 0)
+        self.assertTrue(f.height > 0)
         self.assertRaises(IOError, f.__init__,
                           os.path.join(FONTDIR, 'nonexistant.ttf'))
 
@@ -1422,6 +1422,26 @@ class FreeTypeFontTest(unittest.TestCase):
         f = self._TEST_FONTS['sans']
         self.assertRaises(pygame.error, f.render_to,
                           null_surface, (0, 0), "Crash!", size=12)
+
+    def test_issue_565(self):
+        """get_metrics supporting rotation/styles/size"""
+
+        tests = [
+            {'method': 'size', 'value': 36, 'msg': 'metrics same for size'},
+            {'method': 'rotation', 'value': 90, 'msg': 'metrics same for rotation'},
+            {'method': 'oblique', 'value': True, 'msg': 'metrics same for oblique'}
+        ]
+        text = "|"
+
+        def run_test(method, value, msg):
+            font = ft.Font(self._sans_path, size=24)
+            before = font.get_metrics(text)
+            font.__setattr__(method, value)
+            after = font.get_metrics(text)
+            self.assertNotEqual(before, after, msg)
+
+        for test in tests:
+            run_test(*test.values())
 
 
 class FreeTypeTest(unittest.TestCase):


### PR DESCRIPTION
…rotation

- added new tests to test/freetype_test.py
- cleaned up deprecated warning in test/freetype_test.py
- modified code to support style, rotation in src_c/freetype.c