### PR TITLE
Clean up C API for rwobject.

### DIFF
--- a/docs/reST/c_api/rwobject.rst
+++ b/docs/reST/c_api/rwobject.rst
@@ -20,25 +20,27 @@ Header file: src_c/pygame.h
    Return a SDL_RWops struct filled to access *obj*.
    If *obj* is a string then let SDL open the file it names.
    Otherwise, if *obj* is a Python file-like object then use its ``read``, ``write``,
-   ``seek``, ``tell``, and ``close`` methods.
+   ``seek``, ``tell``, and ``close`` methods. If threads are available,
+   the Python GIL is acquired before calling any of the *obj* methods.
+   On error raise a Python exception and return ``NULL``.
+
+.. c:function:: SDL_RWops* pgRWopsFromFileObject(PyObject *obj)
+
+   Return a SDL_RWops struct filled to access the Python file-like object *obj*.
+   Uses its ``read``, ``write``, ``seek``, ``tell``, and ``close`` methods.
+   If threads are available, the Python GIL is acquired before calling any of the *obj* methods.
    On error raise a Python exception and return ``NULL``.
 
 .. c:function:: int pgRWopsCheckObject(SDL_RWops *rw)
 
-   Return true if *rw* is a Python file-like object wrapper returned by :c:func:`pgRWopsFromObject`.
+   Return true if *rw* is a Python file-like object wrapper returned by :c:func:`pgRWopsFromObject`
+   or :c:func:`pgRWopsFromFileObject`.
 
-.. c:function:: SDL_RWops* pgRWopsFromFileObjectThreaded(PyObject *obj)
+.. c:function:: int pgRWopsReleaseObject(SDL_RWops *context)
 
-   Return a SDL_RWops struct filled to access the Python file-like object *obj*
-   in a thread-safe manner.
-   The Python GIL is aquired before calling any of the *obj* methods
-   ``read``, ``write``, ``seek``, ``tell``, or ``close``.
-   On error raise a Python exception and return ``NULL``.
-
-.. c:function:: int pgRWopsCheckObjectThreaded(SDL_RWops *rw)
-
-   Return true if *rw* is a Python file-like object wrapper returned by
-   :c:func:`pgRWopsFromFileObjectThreaded`.
+   Free a SDL_RWops struct. If it is attached to a Python file-like object, decrement its
+   refcount. Otherwise, close the file handle.
+   Return 0 on success. On error, raise a Python exception and return a negative value.
 
 .. c:function:: PyObject* pgRWopsEncodeFilePath(PyObject *obj, PyObject *eclass)
 
@@ -56,9 +58,3 @@ Header file: src_c/pygame.h
    On error raise a Python exception and return ``NULL``,
    using *eclass* as the exception type if it is not ``NULL``.
    If *obj* is ``NULL`` assume an exception was already raised and pass it on.
-
-.. c:function:: SDL_RWops* pgRWopsFromFileObject(PyObject *obj)
-
-   Return a SDL_RWops struct filled to access the Python file-like object *obj*.
-   Use its ``read``, ``write``, ``seek``, ``tell``, and ``close`` methods.
-   On error raise a Python exception and return ``NULL``.

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -695,9 +695,15 @@ typedef struct {
 #define import_pygame_rwobject() IMPORT_PYGAME_MODULE(rwobject, RWOBJECT)
 
 /* For backward compatibility */
+#ifdef WITH_THREAD
 #define pgRWopsFromFileObjectThreaded pgRWopsFromFileObject
 #define pgRWopsFromObjectThreaded pgRWopsFromObject
 #define pgRWopsCheckObjectThreaded pgRWopsCheckObject
+#else /* ~WITH_THREAD */
+#define pgRWopsFromFileObjectThreaded PG_CHECK_THREADS
+#define pgRWopsFromObjectThreaded PG_CHECK_THREADS
+#define pgRWopsCheckObjectThreaded PG_CHECK_THREADS
+#endif /* ~WITH_THREAD */
 #define RWopsFromPython RWopsFromObject
 #define RWopsCheckPython RWopsCheckObject
 #define RWopsFromPythonThreaded RWopsFromFileObjectThreaded

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -288,6 +288,14 @@ typedef enum {
 /* macros used throughout the source */
 #define RAISE(x, y) (PyErr_SetString((x), (y)), (PyObject *)NULL)
 
+#ifdef WITH_THREAD
+#define PG_CHECK_THREADS() (1)
+#else /* ~WITH_THREAD */
+#define PG_CHECK_THREADS()                        \
+    (RAISE(PyExc_NotImplementedError,             \
+          "Python built without thread support"))
+#endif /* ~WITH_THREAD */
+
 #define PyType_Init(x) (((x).ob_type) = &PyType_Type)
 #define PYGAMEAPI_LOCAL_ENTRY "_PYGAME_C_API"
 
@@ -665,36 +673,31 @@ typedef struct {
 /*the rwobject are only needed for C side work, not accessable from python*/
 #define PYGAMEAPI_RWOBJECT_FIRSTSLOT \
     (PYGAMEAPI_EVENT_FIRSTSLOT + PYGAMEAPI_EVENT_NUMSLOTS)
-#define PYGAMEAPI_RWOBJECT_NUMSLOTS 9
+#define PYGAMEAPI_RWOBJECT_NUMSLOTS 6
 #ifndef PYGAMEAPI_RWOBJECT_INTERNAL
 #define pgRWopsFromObject           \
     (*(SDL_RWops * (*)(PyObject *)) \
          PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 0])
-#define pgRWopsFromObjectThreaded   \
-    (*(SDL_RWops * (*)(PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 1])
 #define pgRWopsCheckObject \
-    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 2])
-#define pgRWopsFromFileObjectThreaded \
-    (*(SDL_RWops * (*)(PyObject *))   \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 3])
-#define pgRWopsCheckObjectThreaded \
-    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 4])
+    (*(int (*)(SDL_RWops *))PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 1])
 #define pgRWopsEncodeFilePath                  \
     (*(PyObject * (*)(PyObject *, PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 5])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 2])
 #define pgRWopsEncodeString                                                \
     (*(PyObject * (*)(PyObject *, const char *, const char *, PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 6])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 3])
 #define pgRWopsFromFileObject       \
     (*(SDL_RWops * (*)(PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 7])
-#define pgRWopsFreeFromObject       \
-    (*(void (*)(PyObject *)) \
-         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 8])
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 4])
+#define pgRWopsReleaseObject       \
+    (*(void (*)(PyObject *))       \
+         PyGAME_C_API[PYGAMEAPI_RWOBJECT_FIRSTSLOT + 5])
 #define import_pygame_rwobject() IMPORT_PYGAME_MODULE(rwobject, RWOBJECT)
 
 /* For backward compatibility */
+#define pgRWopsFromFileObjectThreaded pgRWopsFromFileObject
+#define pgRWopsFromObjectThreaded pgRWopsFromObject
+#define pgRWopsCheckObjectThreaded pgRWopsCheckObject
 #define RWopsFromPython RWopsFromObject
 #define RWopsCheckPython RWopsCheckObject
 #define RWopsFromPythonThreaded RWopsFromFileObjectThreaded

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -270,7 +270,9 @@ music_load(PyObject *self, PyObject *args)
     oencoded = pgRWopsEncodeString(obj, "UTF-8", NULL, pgExc_SDLError);
     if (oencoded == Py_None) {
         Py_DECREF(oencoded);
-        rw = pgRWopsFromFileObjectThreaded(obj);
+        if (!PG_CHECK_THREADS())
+            return NULL;
+        rw = pgRWopsFromFileObject(obj);
         if (rw == NULL) {
             return NULL;
         }
@@ -328,7 +330,9 @@ music_queue(PyObject *self, PyObject *args)
     oencoded = pgRWopsEncodeString(obj, "UTF-8", NULL, pgExc_SDLError);
     if (oencoded == Py_None) {
         Py_DECREF(oencoded);
-        rw = pgRWopsFromFileObjectThreaded(obj);
+        if (!PG_CHECK_THREADS())
+            return NULL;
+        rw = pgRWopsFromFileObject(obj);
         if (rw == NULL) {
             return NULL;
         }


### PR DESCRIPTION
Removes `pgRWopsFromFileObjectThreaded`, `pgRWopsFromObjectThreaded`, and `pgRWopsCheckObjectThreaded`. Instead, always acquire the GIL if threading is supported (and use `pgRWopsFromFileObject`, `pgRWopsFromObject`, and `pgRWopsCheckObject`). It is safe:

    Ensure that the current thread is ready to call the Python C API regardless of the current state of Python, or of the global interpreter lock. This may be called as many times as desired by a thread as long as each call is matched with a call to PyGILState_Release().

https://docs.python.org/2/c-api/init.html#c.PyGILState_Ensure