### PR TITLE
SDL2: Fix key mods test.

### DIFF
--- a/test/key_test.py
+++ b/test/key_test.py
@@ -38,8 +38,6 @@ class KeyModuleTest(unittest.TestCase):
         self.assertEqual(pygame.key.name(pygame.K_SPACE), "space")
 
     def test_set_and_get_mods(self):
-        self.assertEqual(pygame.key.get_mods(), pygame.KMOD_NONE)
-
         pygame.key.set_mods(pygame.KMOD_CTRL)
         self.assertEqual(pygame.key.get_mods(), pygame.KMOD_CTRL)
 


### PR DESCRIPTION
key_test now fails with this exception:

```
loading test.key_test
...F.
======================================================================
FAIL: test_set_and_get_mods (test.key_test.KeyModuleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\David\Documents\dev\pygame\test\key_test.py", line 41, in test_set_and_get_mods
    self.assertEqual(pygame.key.get_mods(), pygame.KMOD_NONE)
AssertionError: 4096 != 0
```

The test's assumptions are wrong. The initial state might not be KMOD_NONE, since numlock or capslock might be active, so I just removed the assertion.

I don't know why, but it doesn't fail with SDL1, even though it should.

Should close #532 