### PR TITLE
SDL2: convert_alpha() used wrong pixel format. + Fix mask example

### DIFF
--- a/examples/mask.py
+++ b/examples/mask.py
@@ -19,7 +19,7 @@ def maskFromSurface(surface, threshold = 127):
     if key:
         for y in range(surface.get_height()):
             for x in range(surface.get_width()):
-                if surface.get_at((x+0.1,y+0.1)) != key:
+                if surface.get_at((x,y)) != key:
                     mask.set_at((x,y),1)
     else:
         for y in range(surface.get_height()):

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1777,10 +1777,7 @@ surf_convert(PyObject *self, PyObject *args)
     }
 #if IS_SDLv1
     else {
-        if (SDL_WasInit(SDL_INIT_VIDEO))
-            newsurf = SDL_DisplayFormat(surf);
-        else
-            newsurf = SDL_ConvertSurface(surf, surf->format, surf->flags);
+        newsurf = SDL_DisplayFormat(surf);
     }
 #else  /* IS_SDLv2 */
     else {
@@ -1791,7 +1788,8 @@ surf_convert(PyObject *self, PyObject *args)
             newsurf = SDL_ConvertSurface(surf, screen_surf->format, 0);
         }
         else
-            newsurf = SDL_ConvertSurface(surf, surf->format, 0);
+            return RAISE(pgExc_SDLError,
+                         "No video mode has been set");
 
         ecode = SDL_GetColorKey(surf, &colorkey);
         if (ecode == 0) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1822,6 +1822,10 @@ surf_convert_alpha(PyObject *self, PyObject *args)
     PyObject *final;
     pgSurfaceObject *srcsurf = NULL;
     SDL_Surface *newsurf, *src;
+#if IS_SDLv2
+    PyObject *pg_winsurf;
+    SDL_Surface *winsurf;
+#endif
 
     if (!SDL_WasInit(SDL_INIT_VIDEO))
         return RAISE(pgExc_SDLError,
@@ -1829,6 +1833,16 @@ surf_convert_alpha(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "|O!", &pgSurface_Type, &srcsurf))
         return NULL;
+
+#if IS_SDLv2
+    pg_winsurf = pg_GetDefaultWindowSurface();
+    if (!pg_winsurf) {
+        return RAISE(pgExc_SDLError,
+                     "pygame.display.set_mode() must be used"
+                     "before converting");
+    }
+    winsurf = pgSurface_AsSurface(pg_winsurf);
+#endif /* IS_SDLv2 */
 
     pgSurface_Prep(self);
     if (srcsurf) {
@@ -1841,14 +1855,14 @@ surf_convert_alpha(PyObject *self, PyObject *args)
 #if IS_SDLv1
         newsurf = SDL_DisplayFormatAlpha(surf);
 #else
-        newsurf = SDL_ConvertSurfaceFormat(surf, surf->format->format, 0);
+        newsurf = SDL_ConvertSurfaceFormat(surf, winsurf->format->format, 0);
 #endif
     }
     else
 #if IS_SDLv1
         newsurf = SDL_DisplayFormatAlpha(surf);
 #else
-        newsurf = SDL_ConvertSurfaceFormat(surf, surf->format->format, 0);
+        newsurf = SDL_ConvertSurfaceFormat(surf, winsurf->format->format, 0);
 #endif
     pgSurface_Unprep(self);
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -674,6 +674,45 @@ class SurfaceTypeTest(unittest.TestCase):
         self.assertRaises(pygame.error, im2.convert, 8)
         self.assertEqual(pygame.get_error(), "Empty destination palette")
 
+    def test_convert_init(self):
+        """ Ensure initialization exceptions are raised
+            for surf.convert()."""
+        surf = pygame.Surface((1, 1))
+        self.assertRaisesRegexp(pygame.error,
+                                'display initialized', surf.convert)
+        pygame.display.init()
+        try:
+            try:
+                surf.convert(32)
+                surf.convert(pygame.Surface((1, 1)))
+            except pygame.error:
+                self.fail("convert() should not raise an exception here.")
+            self.assertRaisesRegexp(pygame.error, 'No video mode', surf.convert)
+            pygame.display.set_mode((640,480))
+            try:
+                surf.convert()
+            except pygame.error:
+                self.fail("convert() should not raise an exception here.")
+        finally:
+            pygame.display.quit()
+
+    def test_convert_alpha_init(self):
+        """ Ensure initialization exceptions are raised
+            for surf.convert_alpha()."""
+        surf = pygame.Surface((1, 1))
+        self.assertRaisesRegexp(pygame.error,
+                                'display initialized', surf.convert_alpha)
+        pygame.display.init()
+        try:
+            self.assertRaisesRegexp(pygame.error, 'No video mode', surf.convert_alpha)
+            pygame.display.set_mode((640,480))
+            try:
+                surf.convert_alpha()
+            except pygame.error:
+                self.fail("convert_alpha() should not raise an exception here.")
+        finally:
+            pygame.display.quit()
+
     def todo_test_convert(self):
 
         # __doc__ (as of 2008-08-02) for pygame.surface.Surface.convert:

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -682,11 +682,12 @@ class SurfaceTypeTest(unittest.TestCase):
                                 'display initialized', surf.convert)
         pygame.display.init()
         try:
-            try:
-                surf.convert(32)
-                surf.convert(pygame.Surface((1, 1)))
-            except pygame.error:
-                self.fail("convert() should not raise an exception here.")
+            if os.environ.get('SDL_VIDEODRIVER') != 'dummy':
+                try:
+                    surf.convert(32)
+                    surf.convert(pygame.Surface((1, 1)))
+                except pygame.error:
+                    self.fail("convert() should not raise an exception here.")
             self.assertRaisesRegexp(pygame.error, 'No video mode', surf.convert)
             pygame.display.set_mode((640,480))
             try:


### PR DESCRIPTION
Fix #713.

The first commit makes the `mask` example work for BMPs.

The second commit fixes the `mask` example for GIFs and PNGs. Loading GIFs sets the color key in SDL2, but not in SDL1. For some reason, the example uses floats in that case. That's why the TypeError is only raised with SDL2.

It seems like it might be a problem that color keys behave differently with SDL2?