### PR TITLE
Add version information macros.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Credits
 
      Ulf Ekström for his pixel perfect collision detection code.
 
-     Pete Shinners - orginal author.
+     Pete Shinners - original author.
 
      David Clark - for filling the right-hand-man position
 
@@ -113,7 +113,7 @@ Credits
      Michael Benfield, David Lau
 
      There's many more folks out there who've submitted helpful ideas, kept
-     this project going, and basically made my life easer, Thanks!
+     this project going, and basically made my life easier. Thanks!
 
      Many thank you's for people making documentation comments, and adding to the
      pygame.org wiki.
@@ -163,7 +163,7 @@ License
 
      This basically means you can use pygame in any project you want,
      but if you make any changes or additions to pygame itself, those
-     must be released with a compatible license. (preferably submitted
+     must be released with a compatible license (preferably submitted
      back to the pygame project). Closed source and commercial games are
      fine.
 

--- a/docs/reST/c_api/version.rst
+++ b/docs/reST/c_api/version.rst
@@ -1,0 +1,31 @@
+.. include:: ../common.txt
+
+.. highlight:: c
+
+******************************************
+  API exported by pygame.version
+******************************************
+
+src_py/version.py
+=================
+
+Header file: src_c/pygame.h
+
+Version information can be retrieved at compile-time using these macros.
+
+.. versionadded:: 1.9.5
+
+.. c:macro:: PG_MAJOR_VERSION
+
+.. c:macro:: PG_MINOR_VERSION
+
+.. c:macro:: PG_PATCH_VERSION
+
+.. c:function:: PG_VERSIONNUM(MAJOR, MINOR, PATCH)
+
+   Returns an integer representing the given version.
+
+.. c:function:: PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)
+
+   Returns true if the current version is at least equal
+   to the specified version.

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -84,6 +84,15 @@ _alloca(size_t size);
 
 #include <Python.h>
 
+/* the version macros are defined since version 1.9.5 */
+#define PG_MAJOR_VERSION 1
+#define PG_MINOR_VERSION 9
+#define PG_PATCH_VERSION 5
+#define PG_VERSIONNUM(MAJOR, MINOR, PATCH) (1000*(MAJOR) + 100*(MINOR) + (PATCH))
+#define PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)                             \
+    (PG_VERSIONNUM(PG_MAJOR_VERSION, PG_MINOR_VERSION, PG_PATCH_VERSION) >= \
+     PG_VERSIONNUM(MAJOR, MINOR, PATCH))
+
 /* Cobjects vanish in Python 3.2; so we will code as though we use capsules */
 #if defined(Py_CAPSULE_H)
 #define PG_HAVE_CAPSULE 1
@@ -216,6 +225,10 @@ typedef struct pg_bufferinfo_s {
 #else
 #define IS_SDLv1 1
 #define IS_SDLv2 0
+#endif
+
+#if IS_SDLv1 && PG_MAJOR_VERSION >= 2
+#error pygame 2 requires SDL 2
 #endif
 
 #if IS_SDLv2

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+
+pg_header = os.path.join('src_c', '_pygame.h')
+
+
+class VersionTest(unittest.TestCase):
+    @unittest.skipIf(not os.path.isfile(pg_header),
+                     "Skipping because we cannot find _pygame.h")
+    def test_pg_version_consistency(self):
+        from pygame import version
+        pgh_major = -1
+        pgh_minor = -1
+        pgh_patch = -1
+        import re
+        major_exp_search = re.compile('define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
+        minor_exp_search = re.compile('define\s+PG_MINOR_VERSION\s+([0-9]+)').search
+        patch_exp_search = re.compile('define\s+PG_PATCH_VERSION\s+([0-9]+)').search
+        with open(pg_header) as f:
+            for line in f:
+                if pgh_major == -1:
+                    m = major_exp_search(line)
+                    if m: pgh_major = int(m.group(1))
+                if pgh_minor == -1:
+                    m = minor_exp_search(line)
+                    if m: pgh_minor = int(m.group(1))
+                if pgh_patch == -1:
+                    m = patch_exp_search(line)
+                    if m: pgh_patch = int(m.group(1))
+        self.assertEqual(pgh_major, version.vernum[0])
+        self.assertEqual(pgh_minor, version.vernum[1])
+        self.assertEqual(pgh_patch, version.vernum[2])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds the following macros:

* PG_MAJOR_VERSION
* PG_MINOR_VERSION
* PG_PATCH_VERSION
* PG_VERSIONNUM(MAJOR, MINOR, PATCH) (1000*(MAJOR) + 100*(MINOR) + (PATCH))
* PG_VERSION_ATLEAST(MAJOR, MINOR, PATCH)

Analogous macros exist in SDL.

setup.py makes sure the version info is consistent between the version module, setup script, and header.