### PR TITLE
re-apply color key after convert

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1605,7 +1605,9 @@ surf_convert(PyObject *self, PyObject *args)
 #if IS_SDLv2
     Uint8 alpha;
     Uint32 colorkey;
-    int ecode;
+    Uint8 key_r, key_g, key_b, key_a = 255;
+    int has_colorkey = SDL_FALSE;
+
 #endif /* IS_SDLv2 */
 
 
@@ -1622,6 +1624,17 @@ surf_convert(PyObject *self, PyObject *args)
 #endif /* IS_SDLv1 */
 
     pgSurface_Prep(self);
+
+#if IS_SDLv2
+    if (SDL_GetColorKey(surf, &colorkey) == 0){
+        has_colorkey = SDL_TRUE;
+        if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
+            SDL_GetRGBA(colorkey, surf->format, &key_r, &key_g, &key_b, &key_a);
+        else
+            SDL_GetRGB(colorkey, surf->format, &key_r, &key_g, &key_b);
+    }
+#endif
+
     if (argobject) {
         if (pgSurface_Check(argobject)) {
             src = pgSurface_AsSurface(argobject);
@@ -1631,15 +1644,6 @@ surf_convert(PyObject *self, PyObject *args)
             newsurf = SDL_ConvertSurface(surf, src->format, flags);
 #else  /* IS_SDLv2 */
             newsurf = SDL_ConvertSurface(surf, src->format, 0);
-
-            ecode = SDL_GetColorKey(surf, &colorkey);
-            if (ecode == 0) {
-                if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
-                    PyErr_SetString(pgExc_SDLError, SDL_GetError());
-                    SDL_FreeSurface(newsurf);
-                    return NULL;
-                }
-            }
 #endif /* IS_SDLv2 */
         }
         else {
@@ -1761,18 +1765,6 @@ surf_convert(PyObject *self, PyObject *args)
 #endif /* IS_SDLv1 */
             newsurf = SDL_ConvertSurface(surf, &format, flags);
 
-#if IS_SDLv2
-            ecode = SDL_GetColorKey(surf, &colorkey);
-            if (ecode == 0) {
-                if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
-                    PyErr_SetString(pgExc_SDLError, SDL_GetError());
-                    SDL_FreeSurface(newsurf);
-                    return NULL;
-                }
-            }
-#endif
-
-
         }
     }
 #if IS_SDLv1
@@ -1790,16 +1782,17 @@ surf_convert(PyObject *self, PyObject *args)
         else
             return RAISE(pgExc_SDLError,
                          "No video mode has been set");
+    }
 
-        ecode = SDL_GetColorKey(surf, &colorkey);
-        if (ecode == 0) {
-            if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
-                PyErr_SetString(pgExc_SDLError, SDL_GetError());
-                SDL_FreeSurface(newsurf);
-                return NULL;
-            }
+    if (has_colorkey) {
+        colorkey = SDL_MapRGBA(newsurf->format, key_r, key_g, key_b, key_a);
+        if (SDL_SetColorKey(newsurf, SDL_TRUE, colorkey) != 0) {
+            PyErr_SetString(pgExc_SDLError, SDL_GetError());
+            SDL_FreeSurface(newsurf);
+            return NULL;
         }
     }
+
 #endif /* IS_SDLv2 */
     pgSurface_Unprep(self);
 


### PR DESCRIPTION
In order to set the colour key of the converted surface, get the colour
key of the old surface and map to RGB, then map back to the format of
the converted surface for applying colour key there.
This is necessary to convert 8-bit palette-mapped surfaces correctly.
The colour key of an 8-bit surface is an 8-bit palette index (usually
the first palette entry, value 0), which can not be used as colour key
when the target surface uses a different palette or RGB(A) format.
Unfortunately both are represented as 32-bit unsigned ints.

this should fix #717 