### PR TITLE
Fix test fail due to numeric font names

### DIFF
--- a/test/font_test.py
+++ b/test/font_test.py
@@ -91,7 +91,9 @@ class FontModuleTest( unittest.TestCase ):
             # note, on ubuntu 2.6 they are all unicode strings.
 
             self.assertTrue(isinstance(name, name_types), name)
-            self.assertTrue(name.islower(), name)
+            # Font names can be comprised of only numeric characters, so
+            # just checking name.islower() will not work as expected here.
+            self.assertFalse(any(c.isupper() for c in name))
             self.assertTrue(name.isalnum(), name)
 
     def test_get_init(self):


### PR DESCRIPTION
This update fixes the failing font test.

Overview of changes:
- Check that no characters in the font name are uppercase. Checking this way allows font names that are comprised entirely of numeric characters to pass the test.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 at 3dd0a822d1ca576ac50b858f362d29f4080cd677
- numpy: 1.15.4

Resolves #740.