### PR TITLE
Travis/Homebrew fix

### DIFF
--- a/buildconfig/ci/travis/.travis_osx.sh
+++ b/buildconfig/ci/travis/.travis_osx.sh
@@ -20,6 +20,7 @@ if [[ "$PY_VERSION" == "pypy2" ]] || [[ "$PY_VERSION" == "pypy3" ]]; then
 	export PIP_CMD="$PY_VERSION -m pip"
 else
 
+export HOMEBREW_NO_AUTO_UPDATE=1
 source "buildconfig/ci/travis/.travis_osx_utils.sh"
 
 

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -24,6 +24,7 @@ export PATH="/usr/local/opt/ccache/libexec:$PATH"
 brew uninstall gdbm --ignore-dependencies
 brew uninstall sqlite --ignore-dependencies
 brew uninstall openssl --ignore-dependencies
+brew uninstall readline --ignore-dependencies
 
 brew uninstall --force --ignore-dependencies pkg-config
 brew install pkg-config

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -21,6 +21,10 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 brew install ccache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
+brew uninstall gdbm --ignore-dependencies
+brew uninstall sqlite --ignore-dependencies
+brew uninstall openssl --ignore-dependencies
+
 brew uninstall --force --ignore-dependencies pkg-config
 brew install pkg-config
 

--- a/buildconfig/ci/travis/.travis_osx_utils.sh
+++ b/buildconfig/ci/travis/.travis_osx_utils.sh
@@ -39,13 +39,14 @@ function install_or_upgrade_deps {
     bottled="$2"
   fi
   if [[ "$bottled" ]]; then
-    deps=$(brew deps --1 "$1")
+    deps=$(brew deps --1 "$1") || true
   else
-    deps=$(brew deps --1 --include-build "$1")
+    deps=$(brew deps --1 --include-build "$1") || true
   fi
+  deps="$(xargs -n 1 <<< $deps)"
   if [[ "$deps" ]]; then
     echo -n "$1 dependencies: "
-    echo $deps
+    echo "$deps"
     while read -r dependency; do
       echo "$1: Install dependency $dependency."
       install_or_upgrade "$dependency" ${UNIVERSAL_FLAG}


### PR DESCRIPTION
Fix the following:

```
python: Install dependency pygame/portmidi/gdbm.

pygame/portmidi/gdbm is already installed and up to date.

...

==> Installing dependencies for pygame/portmidi/python: pygame/portmidi/gdbm, pygame/portmidi/openssl, readline and pygame/portmidi/sqlite

Error: gdbm is already installed from homebrew/core!

Please `brew uninstall gdbm` first."
```

Fails for Python 2 for some other reason.