### PR TITLE
Add get_init() to midi module

### DIFF
--- a/docs/reST/ref/midi.rst
+++ b/docs/reST/ref/midi.rst
@@ -413,6 +413,17 @@ New in pygame 1.9.0.
 
    .. ## pygame.midi.quit ##
 
+.. function:: get_init
+
+   | :sl:`returns True if the midi module is currently initialized`
+   | :sg:`get_init() -> bool`
+
+   Returns ``True`` if the pygame.midi module is currently initialized.
+
+   New in pygame 1.9.5.
+
+   .. ## pygame.midi.get_init ##
+
 .. function:: time
 
    | :sl:`returns the current time in ms of the PortMidi timer`

--- a/src_c/doc/midi_doc.h
+++ b/src_c/doc/midi_doc.h
@@ -45,6 +45,8 @@
 
 #define DOC_PYGAMEMIDIQUIT "quit() -> None\nuninitialize the midi module"
 
+#define DOC_PYGAMEMIDIGETINIT "get_init() -> bool\nreturns True if the midi module is currently initialized"
+
 #define DOC_PYGAMEMIDITIME "time() -> time\nreturns the current time in ms of the PortMidi timer"
 
 #define DOC_PYGAMEMIDIFREQUENCYTOMIDI "frequency_to_midi(midi_note) -> midi_note\nConverts a frequency into a MIDI note. Rounds to the closest midi note."
@@ -154,6 +156,10 @@ converts midi events to pygame events
 pygame.midi.quit
  quit() -> None
 uninitialize the midi module
+
+pygame.midi.get_init
+ get_init() -> bool
+returns True if the midi module is currently initialized
 
 pygame.midi.time
  time() -> time

--- a/src_py/midi.py
+++ b/src_py/midi.py
@@ -54,6 +54,7 @@ __all__ = [
     "init",
     "midis2events",
     "quit",
+    "get_init",
     "time",
     "frequency_to_midi",
     "midi_to_frequency",
@@ -97,6 +98,18 @@ def quit():
         _init = False
         del _pypm
         #del pygame._pypm
+
+
+def get_init():
+    """returns True if the midi module is currently initialized
+    pygame.midi.get_init(): return bool
+
+    Returns True if the pygame.midi module is currently initialized.
+
+    New in pygame 1.9.5.
+    """
+    return _init
+
 
 def _check_init():
     if not _init:

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -350,6 +350,25 @@ class MidiModuleTest(unittest.TestCase):
         pygame.midi.init()
         pygame.midi.quit()
 
+    def test_get_init(self):
+        # Test if already initialized as pygame.midi.init() was called in
+        # setUp().
+        self.assertTrue(pygame.midi.get_init())
+
+        # Test if module uninitialized by calling quit().
+        pygame.midi.quit()
+        self.assertFalse(pygame.midi.get_init())
+
+        # Test if initialized after multiple init() calls.
+        pygame.midi.init()
+        pygame.midi.init()
+        self.assertTrue(pygame.midi.get_init())
+
+        # Test if initialized after multiple quit() calls.
+        pygame.midi.quit()
+        pygame.midi.quit()
+        self.assertFalse(pygame.midi.get_init())
+
     def test_time(self):
 
         mtime = pygame.midi.time()


### PR DESCRIPTION
This update adds a `get_init()` function to the midi module.

Overview of changes:
- Add `get_init()` function to the midi module.
- Add a test case to test the new functionality.
- Update the midi documentation.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 at 3dd0a822d1ca576ac50b858f362d29f4080cd677
- numpy: 1.15.4

Resolves the midi item of #616.