### PR TITLE
Add get_init() to freetype module

### DIFF
--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -111,12 +111,22 @@ The ``freetype`` module is new in pygame 1.9.2
    results. It is safe to call this function even if the module hasn't been
    initialized yet.
 
+.. function:: get_init
+
+   | :sl:`Returns True if the FreeType module is currently initialized.`
+   | :sg:`get_init() -> bool`
+
+   Returns ``True`` if the ``pygame.freetype`` module is currently initialized.
+
+   New in pygame 1.9.5.
+
 .. function:: was_init
 
-   | :sl:`Return whether the the FreeType library is initialized.`
+   | :sl:`DEPRECATED: Use get_init() instead.`
    | :sg:`was_init() -> bool`
 
-   Returns whether the the FreeType library is initialized.
+   DEPRECATED: Returns ``True`` if the ``pygame.freetype`` module is currently
+   initialized. Use ``get_init()`` instead.
 
 .. function:: get_cache_size
 

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -51,7 +51,7 @@ _ft_get_version(PyObject *);
 static PyObject *
 _ft_get_error(PyObject *);
 static PyObject *
-_ft_was_init(PyObject *);
+_ft_get_init(PyObject *);
 static PyObject *
 _ft_autoinit(PyObject *);
 static void
@@ -501,8 +501,10 @@ static PyMethodDef _ft_methods[] = {
     {"init", (PyCFunction)_ft_init, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEFREETYPEINIT},
     {"quit", (PyCFunction)_ft_quit, METH_NOARGS, DOC_PYGAMEFREETYPEQUIT},
-    {"was_init", (PyCFunction)_ft_was_init, METH_NOARGS,
-     DOC_PYGAMEFREETYPEWASINIT},
+    {"get_init", (PyCFunction)_ft_get_init, METH_NOARGS,
+     DOC_PYGAMEFREETYPEGETINIT},
+    {"was_init", (PyCFunction)_ft_get_init, METH_NOARGS,
+     DOC_PYGAMEFREETYPEWASINIT},  // DEPRECATED
     {"get_error", (PyCFunction)_ft_get_error, METH_NOARGS,
      DOC_PYGAMEFREETYPEGETERROR},
     {"get_version", (PyCFunction)_ft_get_version, METH_NOARGS,
@@ -2106,7 +2108,7 @@ _ft_set_default_resolution(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-_ft_was_init(PyObject *self)
+_ft_get_init(PyObject *self)
 {
     return PyBool_FromLong(FREETYPE_MOD_STATE(self)->freetype ? 1 : 0);
 }

--- a/src_c/doc/freetype_doc.h
+++ b/src_c/doc/freetype_doc.h
@@ -9,7 +9,9 @@
 
 #define DOC_PYGAMEFREETYPEQUIT "quit()\nShut down the underlying FreeType library."
 
-#define DOC_PYGAMEFREETYPEWASINIT "was_init() -> bool\nReturn whether the the FreeType library is initialized."
+#define DOC_PYGAMEFREETYPEGETINIT "get_init() -> bool\nReturns True if the FreeType module is currently initialized."
+
+#define DOC_PYGAMEFREETYPEWASINIT "was_init() -> bool\nDEPRECATED: Use get_init() instead."
 
 #define DOC_PYGAMEFREETYPEGETCACHESIZE "get_cache_size() -> long\nReturn the glyph case size"
 
@@ -122,9 +124,13 @@ pygame.freetype.quit
  quit()
 Shut down the underlying FreeType library.
 
+pygame.freetype.get_init
+ get_init() -> bool
+Returns True if the FreeType module is currently initialized.
+
 pygame.freetype.was_init
  was_init() -> bool
-Return whether the the FreeType library is initialized.
+DEPRECATED: Use get_init() instead.
 
 pygame.freetype.get_cache_size
  get_cache_size() -> long

--- a/src_py/freetype.py
+++ b/src_py/freetype.py
@@ -5,8 +5,8 @@ from pygame._freetype import (
    Font as _Font,
    STYLE_NORMAL, STYLE_OBLIQUE, STYLE_STRONG, STYLE_UNDERLINE, STYLE_WIDE,
    STYLE_DEFAULT,
-   init, quit,
-   was_init, get_cache_size, get_default_font, get_default_resolution, 
+   init, quit, get_init,
+   was_init, get_cache_size, get_default_font, get_default_resolution,
    get_error, get_version, set_default_resolution,
    _PYGAME_C_API, __PYGAMEinit__,
    )

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -3,7 +3,7 @@
 __all__ = ['Font', 'init', 'quit', 'get_default_font', 'get_init', 'SysFont']
 
 from pygame._freetype import init, Font as _Font, get_default_resolution
-from pygame._freetype import quit, get_default_font, was_init as _was_init
+from pygame._freetype import quit, get_default_font, get_init as _get_init
 from pygame._freetype import __PYGAMEinit__
 from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
 from pygame import encode_file_path
@@ -150,7 +150,7 @@ def get_init():
    """get_init() -> bool
       true if the font module is initialized"""
 
-   return _was_init()
+   return _get_init()
 
 def SysFont(name, size, bold=0, italic=0, constructor=None):
     """pygame.ftfont.SysFont(name, size, bold=False, italic=False, constructor=None) -> Font

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1445,11 +1445,13 @@ class FreeTypeFontTest(unittest.TestCase):
 
 
 class FreeTypeTest(unittest.TestCase):
+    def setUp(self):
+        ft.init()
+
+    def tearDown(self):
+        ft.quit()
 
     def test_resolution(self):
-        was_init = ft.was_init()
-        if not was_init:
-            ft.init()
         try:
             ft.set_default_resolution()
             resolution = ft.get_default_resolution()
@@ -1461,31 +1463,59 @@ class FreeTypeTest(unittest.TestCase):
             self.assertEqual(ft.get_default_resolution(), new_resolution)
         finally:
             ft.set_default_resolution()
-            if was_init:
-                ft.quit()
 
     def test_autoinit_and_autoquit(self):
         pygame.init()
-        self.assertTrue(ft.was_init())
+        self.assertTrue(ft.get_init())
         pygame.quit()
-        self.assertFalse(ft.was_init())
+        self.assertFalse(ft.get_init())
 
         # Ensure autoquit is replaced at init time
         pygame.init()
-        self.assertTrue(ft.was_init())
+        self.assertTrue(ft.get_init())
         pygame.quit()
-        self.assertFalse(ft.was_init())
+        self.assertFalse(ft.get_init())
+
+    def test_init(self):
+        # Test if module initialized after calling init().
+        ft.quit()
+        ft.init()
+
+        self.assertTrue(ft.get_init())
+
+    def test_init__multiple(self):
+        # Test if module initialized after multiple init() calls.
+        ft.init()
+        ft.init()
+
+        self.assertTrue(ft.get_init())
+
+    def test_quit(self):
+        # Test if module uninitialized after calling quit().
+        ft.quit()
+
+        self.assertFalse(ft.get_init())
+
+    def test_quit__multiple(self):
+        # Test if module initialized after multiple quit() calls.
+        ft.quit()
+        ft.quit()
+
+        self.assertFalse(ft.get_init())
+
+    def test_get_init(self):
+        # Test if get_init() gets the init state.
+        self.assertTrue(ft.get_init())
 
     def test_cache_size(self):
         DEFAULT_CACHE_SIZE = 64
-        ft.init()
         self.assertEqual(ft.get_cache_size(), DEFAULT_CACHE_SIZE)
         ft.quit()
         self.assertEqual(ft.get_cache_size(), 0)
         new_cache_size = DEFAULT_CACHE_SIZE * 2
         ft.init(cache_size=new_cache_size)
         self.assertEqual(ft.get_cache_size(), new_cache_size)
-        ft.quit()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This update adds a `get_init()` function to the freetype module.

Overview of changes:
- Add `get_init()` function to the freetype module.
- Add comments to indicate that the `was_init()` function is deprecated. Replace all occurrences of its use with `get_init()`.
- Update the freetype documentation.
- Add a test method to test the new `get_init()` functionality.
- Add `setUp()` and `tearDown()` to the `FreeTypeTest` test suite to ensure a consistent state for each of the test methods. Change the existing test methods in the `FreeTypeTest` test suite to rely on the new set up and tear down methods.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 at 3dd0a822d1ca576ac50b858f362d29f4080cd677
- numpy: 1.15.4

Resolves the _freetype and freetype items of #616.