### PR TITLE
Add get_init() to scrap module

### DIFF
--- a/docs/reST/ref/scrap.rst
+++ b/docs/reST/ref/scrap.rst
@@ -86,6 +86,17 @@ the next release.
 
    .. ## pygame.scrap.init ##
 
+.. function:: get_init
+
+   | :sl:`Returns True if the scrap module is currently initialized.`
+   | :sg:`get_init() -> bool`
+
+   Returns ``True`` if the ``pygame.scrap`` module is currently initialized.
+
+   New in pygame 1.9.5.
+
+   .. ## pygame.scrap.get_init ##
+
 .. function:: get
 
    | :sl:`Gets the data for the specified type from the clipboard.`

--- a/src_c/doc/scrap_doc.h
+++ b/src_c/doc/scrap_doc.h
@@ -3,6 +3,8 @@
 
 #define DOC_PYGAMESCRAPINIT "init () -> None\nInitializes the scrap module."
 
+#define DOC_PYGAMESCRAPGETINIT "get_init() -> bool\nReturns True if the scrap module is currently initialized."
+
 #define DOC_PYGAMESCRAPGET "get (type) -> bytes\nGets the data for the specified type from the clipboard."
 
 #define DOC_PYGAMESCRAPGETTYPES "get_types () -> list\nGets a list of the available clipboard types."
@@ -27,6 +29,10 @@ pygame module for clipboard support.
 pygame.scrap.init
  init () -> None
 Initializes the scrap module.
+
+pygame.scrap.get_init
+ get_init() -> bool
+Returns True if the scrap module is currently initialized.
 
 pygame.scrap.get
  get (type) -> bytes

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -118,6 +118,17 @@ _scrap_init(PyObject *self, PyObject *args)
 }
 #endif
 
+/*
+ * Indicates whether the scrap module is currently initialized.
+ *
+ * Note: All platforms supported here.
+ */
+static PyObject *
+_scrap_get_init(PyObject *self, PyObject *args)
+{
+    return PyBool_FromLong(pygame_scrap_initialized());
+}
+
 #if !defined(MAC_SCRAP)
 /*
  * Gets the currently available types from the active clipboard.
@@ -324,6 +335,7 @@ static PyMethodDef scrap_builtins[] = {
      defined(MAC_SCRAP))
 
     {"init", _scrap_init, 1, DOC_PYGAMESCRAPINIT},
+    {"get_init", _scrap_get_init, METH_NOARGS, DOC_PYGAMESCRAPGETINIT},
     {"contains", _scrap_contains, METH_VARARGS, DOC_PYGAMESCRAPCONTAINS},
     {"get", _scrap_get_scrap, METH_VARARGS, DOC_PYGAMESCRAPGET},
     {"get_types", _scrap_get_types, METH_NOARGS, DOC_PYGAMESCRAPGETTYPES},

--- a/test/scrap_test.py
+++ b/test/scrap_test.py
@@ -10,14 +10,28 @@ from pygame import scrap
 from pygame.compat import as_bytes
 
 class ScrapModuleTest(unittest.TestCase):
-    not_initialized = True
 
-    def setUp(self):
-        if self.not_initialized:
-            pygame.init ()
-            pygame.display.set_mode ((1, 1))
-            scrap.init ()
-            self.not_initialized = False
+    @classmethod
+    def setUpClass(cls):
+        pygame.init()
+        pygame.display.set_mode((1, 1))
+        scrap.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        # scrap.quit()  # Does not exist!
+        pygame.quit()
+
+    def test_init(self):
+        # Test if module initialized after multiple init() calls.
+        scrap.init()
+        scrap.init()
+
+        self.assertTrue(scrap.get_init())
+
+    def test_get_init(self):
+        # Test if get_init() gets the init state.
+        self.assertTrue(scrap.get_init())
 
     def todo_test_contains(self):
 
@@ -73,21 +87,6 @@ class ScrapModuleTest(unittest.TestCase):
           #           # There is some content with the word "text" in it. It's
           #           # possibly text, so print it.
           #           print pygame.scrap.get (t)
-
-        self.fail()
-
-    def todo_test_init(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.scrap.init:
-
-          # scrap.init () -> None
-          # Initializes the scrap module.
-          #
-          # Tries to initialize the scrap module and raises an exception, if it
-          # fails. Note that this module requires a set display surface, so you
-          # have to make sure, you acquired one earlier using
-          # pygame.display.set_mode().
-          #
 
         self.fail()
 


### PR DESCRIPTION
This update adds a `get_init()` function to the scrap module.

Overview of changes:
- Add `get_init()` function to the scrap module.
- Update the scrap module documentation.
- Add a test method to test the new `get_init()` functionality. Also added a test method to test the `init()` function.
- Change the `ScrapModuleTest` test suite to use `setUpClass()` and `tearDownClass()` (classmethods) to ensure a consistent set up/clean up for the whole test suite.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 at 1f337a72ca9648042bd49a3da40b9dc2e121e004
- numpy: 1.15.4

Resolves the scrap item of #616.