### PR TITLE
Add get_init() to fastevent module

### DIFF
--- a/src_c/fastevent.c
+++ b/src_c/fastevent.c
@@ -75,6 +75,17 @@ fastevent_init(PyObject *self)
 #endif /* WITH_THREAD */
 }
 
+/* DOC */ static char doc_get_init[] =
+    /* DOC */
+    "pygame.fastevent.get_init() -> bool\n"
+    /* DOC */ "returns True if the fastevent module is currently initialized\n"
+    /* DOC */;
+static PyObject *
+fastevent_get_init(PyObject *self)
+{
+    return PyBool_FromLong(FE_WasInit);
+}
+
 /* DOC */ static char doc_pump[] =
     /* DOC */
     "pygame.fastevent.pump() -> None\n"
@@ -274,6 +285,7 @@ fastevent_post(PyObject *self, PyObject *arg)
 
 static PyMethodDef _fastevent_methods[] = {
     {"init", (PyCFunction)fastevent_init, METH_NOARGS, doc_init},
+    {"get_init", (PyCFunction)fastevent_get_init, METH_NOARGS, doc_get_init},
     {"get", (PyCFunction)fastevent_get, METH_NOARGS, doc_get},
     {"pump", (PyCFunction)fastevent_pump, METH_NOARGS, doc_pump},
     {"wait", (PyCFunction)fastevent_wait, METH_NOARGS, doc_wait},

--- a/test/fastevent_test.py
+++ b/test/fastevent_test.py
@@ -15,7 +15,25 @@ class FasteventModuleTest(unittest.TestCase):
         self.assert_(not event.get())
 
     def tearDown(self):
+        # fastevent.quit()  # Does not exist!
         pygame.display.quit()
+
+    def test_init(self):
+        # Test if module initialized after multiple init() calls.
+        fastevent.init()
+        fastevent.init()
+
+        self.assertTrue(fastevent.get_init())
+
+    def test_auto_quit(self):
+        # Test if module uninitialized after calling pygame.quit().
+        pygame.quit()
+
+        self.assertFalse(fastevent.get_init())
+
+    def test_get_init(self):
+        # Test if get_init() gets the init state.
+        self.assertTrue(fastevent.get_init())
 
     def test_get(self):
         # __doc__ (as of 2008-08-02) for pygame.fastevent.get:
@@ -30,14 +48,6 @@ class FasteventModuleTest(unittest.TestCase):
             [e.type for e in fastevent.get()], [pygame.USEREVENT] * 10,
             race_condition_notification
         )
-
-    def todo_test_init(self):
-        # __doc__ (as of 2008-08-02) for pygame.fastevent.init:
-
-          # pygame.fastevent.init() -> None
-          # initialize pygame.fastevent.
-
-        self.fail()
 
     def test_poll(self):
 


### PR DESCRIPTION
This update adds a `get_init()` function to the scrap module.

Overview of changes:
- Add `get_init()` function to the scrap module.
- Add a test method to test the new `get_init()` functionality. Also added test methods to test the `init()` and auto quit functionality.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 at 53f6b992edecf848846926c31382b9c2e7bf5c46
- numpy: 1.15.4

Resolves the fastevent item of #616.