### PR TITLE
Add get_init() to base module

### DIFF
--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -57,6 +57,17 @@ object instead of the module, which can be used to test for availability.
 
    .. ## pygame.quit ##
 
+.. function:: get_init
+
+   | :sl:`returns True if pygame is currently initialized`
+   | :sg:`get_init() -> bool`
+
+   Returns ``True`` if pygame is currently initialized.
+
+   New in pygame 1.9.5.
+
+   .. ## pygame.get_init ##
+
 .. exception:: error
 
    | :sl:`standard pygame exception`

--- a/src_c/doc/pygame_doc.h
+++ b/src_c/doc/pygame_doc.h
@@ -5,6 +5,8 @@
 
 #define DOC_PYGAMEQUIT "quit() -> None\nuninitialize all pygame modules"
 
+#define DOC_PYGAMEGETINIT "get_init() -> bool\nreturns True if pygame is currently initialized"
+
 #define DOC_PYGAMEERROR "raise pygame.error(message)\nstandard pygame exception"
 
 #define DOC_PYGAMEGETERROR "get_error() -> errorstr\nget the current error message"
@@ -45,6 +47,10 @@ initialize all imported pygame modules
 pygame.quit
  quit() -> None
 uninitialize all pygame modules
+
+pygame.get_init
+ get_init() -> bool
+returns True if pygame is currently initialized
 
 pygame.error
  raise pygame.error(message)

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -31,6 +31,10 @@ def quit_hook():
 
 class BaseModuleTest(unittest.TestCase):
 
+    def tearDown(self):
+        # Clean up after each test method.
+        pygame.quit()
+
     def testAutoInit(self):
         pygame.init()
         pygame.quit()
@@ -466,14 +470,17 @@ class BaseModuleTest(unittest.TestCase):
         self.assertRaises(ValueError, getattr, bp, 'length')
 
     def not_init_assertions(self):
-        self.assert_(not pygame.display.get_init(),
-                     "display shouldn't be initialized" )
+        self.assertFalse(pygame.get_init(), "pygame shouldn't be initialized")
+        self.assertFalse(pygame.display.get_init(),
+                         "display shouldn't be initialized")
+
         if 'pygame.mixer' in sys.modules:
-            self.assert_(not pygame.mixer.get_init(),
-                         "mixer shouldn't be initialized" )
+            self.assertFalse(pygame.mixer.get_init(),
+                             "mixer shouldn't be initialized")
+
         if 'pygame.font' in sys.modules:
-            self.assert_(not pygame.font.get_init(),
-                         "init shouldn't be initialized" )
+            self.assertFalse(pygame.font.get_init(),
+                             "init shouldn't be initialized")
 
         ## !!! TODO : Remove when scrap works for OS X
         import platform
@@ -490,11 +497,14 @@ class BaseModuleTest(unittest.TestCase):
         # pygame.joystick
 
     def init_assertions(self):
-        self.assert_(pygame.display.get_init())
+        self.assertTrue(pygame.get_init())
+        self.assertTrue(pygame.display.get_init())
+
         if 'pygame.mixer' in sys.modules:
-            self.assert_(pygame.mixer.get_init())
+            self.assertTrue(pygame.mixer.get_init())
+
         if 'pygame.font' in sys.modules:
-            self.assert_(pygame.font.get_init())
+            self.assertTrue(pygame.font.get_init())
 
     def test_quit__and_init(self):
         # __doc__ (as of 2008-06-25) for pygame.base.quit:
@@ -611,6 +621,22 @@ class BaseModuleTest(unittest.TestCase):
         # All modules have quit
         self.not_init_assertions()
 
+    def test_get_init(self):
+        # Test if get_init() gets the init state.
+        self.assertFalse(pygame.get_init())
+
+    def test_get_init__after_init(self):
+        # Test if get_init() gets the init state after pygame.init() called.
+        pygame.init()
+
+        self.assertTrue(pygame.get_init())
+
+    def test_get_init__after_quit(self):
+        # Test if get_init() gets the init state after pygame.quit() called.
+        pygame.init()
+        pygame.quit()
+
+        self.assertFalse(pygame.get_init())
 
     def todo_test_segfault(self):
 


### PR DESCRIPTION
This update adds a `get_init()` function to the base module.

Overview of changes:
- Add `get_init()` function to the base module.
- Update the base (`pygame.rst`) module documentation.
- Add a test method to test the new `get_init()` functionality.
- Add test methods to test the `init()` functionality.
- Add `tearDown()` to the `BaseModuleTest` test suite to ensure a consistent clean up for each of the test methods.
- Change to test helper methods to use the new `get_init()` function. Also update some deprecated `unittest` assert methods.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 53f6b992edecf848846926c31382b9c2e7bf5c46
- numpy: 1.15.4

Resolves the base item of #616.