### PR TITLE
Clean up deprecated failUnless()

### DIFF
--- a/test/compat_test.py
+++ b/test/compat_test.py
@@ -10,7 +10,7 @@ class CompatModuleTest(unittest.TestCase):
         ords = [ord('B'), ord('o'), 0xF6, ord('t'), ord('e'), ord('s')]
         self.assertEqual(len(r), 11)
         u = compat.as_unicode(r)
-        self.failUnless(isinstance(u, compat.unicode_))
+        self.assertIsInstance(u, compat.unicode_)
         self.assertEqual([ord(c) for c in u], ords)
 
     def test_as_bytes(self):
@@ -18,22 +18,22 @@ class CompatModuleTest(unittest.TestCase):
         s = ''.join([chr(i) for i in ords])
         self.assertEqual(len(s), len(ords))
         b = compat.as_bytes(s)
-        self.failUnless(isinstance(b, compat.bytes_))
+        self.assertIsInstance(b, compat.bytes_)
         self.assertEqual([compat.ord_(i) for i in b], ords)
 
     def test_ord_(self):
-        self.failUnless(isinstance(compat.ord_(compat.bytes_(1)[0]), int))
+        self.assertIsInstance(compat.ord_(compat.bytes_(1)[0]), int)
 
     def test_bytes_(self):
         self.assertFalse(compat.bytes_ is compat.unicode_)
-        self.failUnless(hasattr(compat.bytes_, 'capitalize'))
+        self.assertTrue(hasattr(compat.bytes_, 'capitalize'))
         self.assertFalse(hasattr(compat.bytes_, 'isdecimal'))
 
     def test_unicode_(self):
-        self.failUnless(hasattr(compat.unicode_(), 'isdecimal'))
+        self.assertTrue(hasattr(compat.unicode_(), 'isdecimal'))
 
     def test_long_(self):
-        self.failUnless(isinstance(int('99999999999999999999'), compat.long_))
+        self.assertIsInstance(int('99999999999999999999'), compat.long_)
 
     def test_geterror(self):
         msg = 'Success'
@@ -41,7 +41,7 @@ class CompatModuleTest(unittest.TestCase):
             raise TypeError(msg)
         except TypeError:
             e = compat.geterror()
-            self.failUnless(isinstance(e, TypeError))
+            self.assertIsInstance(e, TypeError)
             self.assertEqual(str(e), msg)
 
     def test_xrange_(self):
@@ -50,21 +50,21 @@ class CompatModuleTest(unittest.TestCase):
     def test_unichr_(self):
         ordval = 86
         c = compat.unichr_(ordval)
-        self.failUnless(isinstance(c, compat.unicode_))
+        self.assertIsInstance(c, compat.unicode_)
         self.assertEqual(ord(c), ordval)
 
     def test_get_BytesIO(self):
         BytesIO = compat.get_BytesIO()
         b1 = compat.as_bytes("\x00\xffabc")
         b2 = BytesIO(b1).read()
-        self.failUnless(isinstance(b2, compat.bytes_))
+        self.assertIsInstance(b2, compat.bytes_)
         self.assertEqual(b2, b1)
 
     def test_get_StringIO(self):
         StringIO = compat.get_StringIO()
         b1 = "abcde"
         b2 = StringIO(b1).read()
-        self.failUnless(isinstance(b2, str))
+        self.assertIsInstance(b2, str)
         self.assertEqual(b2, b1)
 
     def test_raw_input_(self):

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -284,13 +284,13 @@ class EventModuleTest(unittest.TestCase):
         c = pygame.event.Event(events[1], a=1)
         d = pygame.event.Event(events[0], a=2)
 
-        self.failUnless(a == a)
+        self.assertTrue(a == a)
         self.assertFalse(a != a)
-        self.failUnless(a == b)
+        self.assertTrue(a == b)
         self.assertFalse(a != b)
-        self.failUnless(a !=  c)
+        self.assertTrue(a !=  c)
         self.assertFalse(a == c)
-        self.failUnless(a != d)
+        self.assertTrue(a != d)
         self.assertFalse(a == d)
 
     def todo_test_get_blocked(self):

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -29,9 +29,9 @@ class SndarrayTest (unittest.TestCase):
                     snd = pygame.sndarray.make_sound(srcarr)
                     arr = pygame.sndarray.array(snd)
                     self._assert_compatible(arr, size)
-                    self.failUnless(alltrue(arr == srcarr),
-                                    "size: %i\n%s\n%s" %
-                                    (size, arr, test_data))
+                    self.assertTrue(alltrue(arr == srcarr),
+                                    "size: %i\n%s\n%s" % (
+                                        size, arr, test_data))
             finally:
                 pygame.mixer.quit()
 
@@ -49,18 +49,17 @@ class SndarrayTest (unittest.TestCase):
                              [0x7fff, 0], [0, 0x7fff]])
 
     def test_get_arraytype(self):
-        self.failUnless((pygame.sndarray.get_arraytype() in
-                         ['numpy']),
-                        ("unknown array type %s" %
-                         pygame.sndarray.get_arraytype()))
+        array_type = pygame.sndarray.get_arraytype()
+
+        self.assertEqual(array_type, 'numpy',
+                         "unknown array type %s" % array_type)
 
     def test_get_arraytypes(self):
         arraytypes = pygame.sndarray.get_arraytypes()
-        self.failUnless('numpy' in arraytypes)
+        self.assertIn('numpy', arraytypes)
 
         for atype in arraytypes:
-            self.failUnless(atype in ['numpy'],
-                            "unknown array type %s" % atype)
+            self.assertEqual(atype, 'numpy', "unknown array type %s" % atype)
 
     def test_make_sound(self):
 
@@ -76,9 +75,9 @@ class SndarrayTest (unittest.TestCase):
                     srcarr = array(test_data, self.array_dtypes[size])
                     snd = pygame.sndarray.make_sound(srcarr)
                     arr = pygame.sndarray.samples(snd)
-                    self.failUnless(alltrue(arr == srcarr),
-                                    "size: %i\n%s\n%s" %
-                                    (size, arr, test_data))
+                    self.assertTrue(alltrue(arr == srcarr),
+                                    "size: %i\n%s\n%s" % (
+                                        size, arr, test_data))
             finally:
                 pygame.mixer.quit()
 
@@ -121,9 +120,9 @@ class SndarrayTest (unittest.TestCase):
                     ##print ('Y %s' % (test_data,))
                     samples[...] = test_data
                     arr = pygame.sndarray.array(snd)
-                    self.failUnless(alltrue(samples == arr),
-                                    "size: %i\n%s\n%s" %
-                                    (size, arr, test_data))
+                    self.assertTrue(alltrue(samples == arr),
+                                    "size: %i\n%s\n%s" % (
+                                        size, arr, test_data))
             finally:
                 pygame.mixer.quit()
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -73,7 +73,7 @@ class SurfaceTypeTest(unittest.TestCase):
         # set it with a tuple.
         s.set_at((0,0), (10,10,10, 255))
         r = s.get_at((0,0))
-        self.failUnless(isinstance(r, pygame.Color))
+        self.assertIsInstance(r, pygame.Color)
         self.assertEqual(r, (10,10,10, 255))
 
         # try setting a color with a single integer.
@@ -799,7 +799,7 @@ class SurfaceTypeTest(unittest.TestCase):
         surf.set_at((1, 0), c10)
         surf.set_at((1, 1), c11)
         c = surf.get_at((0, 0))
-        self.failUnless(isinstance(c, pygame.Color))
+        self.assertIsInstance(c, pygame.Color)
         self.assertEqual(c, c00)
         self.assertEqual(surf.get_at((0, 1)), c01)
         self.assertEqual(surf.get_at((1, 0)), c10)
@@ -849,11 +849,11 @@ class SurfaceTypeTest(unittest.TestCase):
 
     def todo_test_get_colorkey(self):
         surf = pygame.surface((2, 2), 0, 24)
-        self.failUnless(surf.get_colorykey() is None)
+        self.assertIsNone(surf.get_colorykey())
         colorkey = pygame.Color(20, 40, 60)
         surf.set_colorkey(colorkey)
         ck = surf.get_colorkey()
-        self.failUnless(isinstance(ck, pygame.Color))
+        self.assertIsInstance(ck, pygame.Color)
         self.assertEqual(ck, colorkey)
 
     def todo_test_get_height(self):
@@ -944,7 +944,7 @@ class SurfaceTypeTest(unittest.TestCase):
             for c2, c in zip(palette2, palette):
                 self.assertEqual(c2, c)
             for c in palette2:
-                self.failUnless(isinstance(c, pygame.Color))
+                self.assertIsInstance(c, pygame.Color)
         finally:
             pygame.quit()
 
@@ -957,7 +957,7 @@ class SurfaceTypeTest(unittest.TestCase):
             color = pygame.Color(1, 2, 3, 255)
             surf.set_palette_at(0, color)
             color2 = surf.get_palette_at(0)
-            self.failUnless(isinstance(color2, pygame.Color))
+            self.assertIsInstance(color2, pygame.Color)
             self.assertEqual(color2, color)
             self.assertRaises(IndexError, surf.get_palette_at, -1)
             self.assertRaises(IndexError, surf.get_palette_at, 256)
@@ -1249,7 +1249,7 @@ class SurfaceTypeTest(unittest.TestCase):
             unmapped_c = surf.unmap_rgb(i)
             self.assertEqual(unmapped_c, c)
             # Confirm it is a Color instance
-            self.failUnless(isinstance(unmapped_c, pygame.Color))
+            self.assertIsInstance(unmapped_c, pygame.Color)
         finally:
             pygame.quit()
 
@@ -1266,7 +1266,7 @@ class SurfaceTypeTest(unittest.TestCase):
                                  "%s != %s, flags: %i, bitsize: %i" %
                                  (unmapped_c, comparison_c, flags, bitsize))
             # Confirm it is a Color instance
-            self.failUnless(isinstance(unmapped_c, pygame.Color))
+            self.assertIsInstance(unmapped_c, pygame.Color)
 
     def test_scroll(self):
         scrolls = [(8, 2, 3),

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -152,12 +152,11 @@ class SurfarrayModuleTest (unittest.TestCase):
                         ac[1] == sc[1] and
                         ac[2] == sc[2])
             for posn, i in self.test_points:
-                self.failUnless(same_color(arr[posn], surf.get_at(posn)),
-                                "%s != %s: flags: %i, bpp: %i, posn: %s" %
-                                (tuple(arr[posn]),
-                                 surf.get_at(posn),
-                                 surf.get_flags(), surf.get_bitsize(),
-                                 posn))
+                self.assertTrue(same_color(arr[posn], surf.get_at(posn)),
+                                "%s != %s: flags: %i, bpp: %i, posn: %s" % (
+                                    tuple(arr[posn]), surf.get_at(posn),
+                                    surf.get_flags(), surf.get_bitsize(),
+                                    posn))
 
     def test_array_alpha(self):
 
@@ -187,16 +186,16 @@ class SurfarrayModuleTest (unittest.TestCase):
                                            x, y,
                                            surf.get_bitsize())))
             else:
-                self.failUnless(alltrue(arr == 255))
+                self.assertTrue(alltrue(arr == 255))
 
         # No per-pixel alpha when blanket alpha is None.
         for surf in targets:
             blacket_alpha = surf.get_alpha()
             surf.set_alpha(None)
             arr = pygame.surfarray.array_alpha(surf)
-            self.failUnless(alltrue(arr == 255),
-                            "bitsize: %i, flags: %i" %
-                            (surf.get_bitsize(), surf.get_flags()))
+            self.assertTrue(alltrue(arr == 255),
+                            "bitsize: %i, flags: %i" % (
+                                surf.get_bitsize(), surf.get_flags()))
             surf.set_alpha(blacket_alpha)
 
         # Bug for per-pixel alpha surface when blanket alpha 0.
@@ -209,9 +208,9 @@ class SurfarrayModuleTest (unittest.TestCase):
                             "bitsize: %i, flags: %i" %
                             (surf.get_bitsize(), surf.get_flags()))
             else:
-                self.failUnless(alltrue(arr == 255),
-                                "bitsize: %i, flags: %i" %
-                                (surf.get_bitsize(), surf.get_flags()))
+                self.assertTrue(alltrue(arr == 255),
+                                "bitsize: %i, flags: %i" % (
+                                    surf.get_bitsize(), surf.get_flags()))
             surf.set_alpha(blanket_alpha)
 
     def test_array_colorkey(self):
@@ -234,7 +233,8 @@ class SurfarrayModuleTest (unittest.TestCase):
                 p = [surf.unmap_rgb(surf.map_rgb(c)) for c in p]
             surf.set_colorkey(None)
             arr = pygame.surfarray.array_colorkey(surf)
-            self.failUnless(alltrue(arr == 255))
+            self.assertTrue(alltrue(arr == 255))
+
             for i in range(1, len(palette)):
                 surf.set_colorkey(p[i])
                 alphas = [255] * len(p)
@@ -408,19 +408,18 @@ class SurfarrayModuleTest (unittest.TestCase):
                                          int(rint(farr[x, y])))
 
     def test_get_arraytype(self):
-        self.failUnless((pygame.surfarray.get_arraytype() in
-                         ['numpy']),
-                        ("unknown array type %s" %
-                         pygame.surfarray.get_arraytype()))
+        array_type = pygame.surfarray.get_arraytype()
+
+        self.assertEqual(array_type, 'numpy',
+                         "unknown array type %s" % array_type)
 
     def test_get_arraytypes(self):
 
         arraytypes = pygame.surfarray.get_arraytypes()
-        self.failUnless('numpy' in arraytypes)
+        self.assertIn('numpy', arraytypes)
 
         for atype in arraytypes:
-            self.failUnless(atype in ['numpy'],
-                            "unknown array type %s" % atype)
+            self.assertEqual(atype, 'numpy', "unknown array type %s" % atype)
 
     def test_make_surface(self):
 
@@ -432,7 +431,7 @@ class SurfarrayModuleTest (unittest.TestCase):
         for bitsize, dtype in [(8, uint8), (16, uint16), (24, uint32)]:
 ## Even this simple assertion fails for 2d arrays. Where's the problem?
 ##            surf = pygame.surfarray.make_surface(self._make_array2d(dtype))
-##            self.failUnless(surf.get_bitsize() >= bitsize,
+##            self.assertGreaterEqual(surf.get_bitsize(), bitsize,
 ##                            "not %i >= %i)" % (surf.get_bitsize(), bitsize))
 ##
             surf = pygame.surfarray.make_surface(self._make_src_array3d(dtype))
@@ -489,10 +488,10 @@ class SurfarrayModuleTest (unittest.TestCase):
         for surf in sources:
             self.assertFalse(surf.get_locked())
             arr = pygame.surfarray.pixels2d(surf)
-            self.failUnless(surf.get_locked())
+            self.assertTrue(surf.get_locked())
             self._fill_array2d(arr, surf)
             surf.unlock()
-            self.failUnless(surf.get_locked())
+            self.assertTrue(surf.get_locked())
             del arr
             self.assertFalse(surf.get_locked())
             self.assertEqual(surf.get_locks(), ())
@@ -511,10 +510,10 @@ class SurfarrayModuleTest (unittest.TestCase):
         for surf in sources:
             self.assertFalse(surf.get_locked())
             arr = pygame.surfarray.pixels3d(surf)
-            self.failUnless(surf.get_locked())
+            self.assertTrue(surf.get_locked())
             self._fill_array3d(arr)
             surf.unlock()
-            self.failUnless(surf.get_locked())
+            self.assertTrue(surf.get_locked())
             del arr
             self.assertFalse(surf.get_locked())
             self.assertEqual(surf.get_locks(), ())
@@ -551,9 +550,9 @@ class SurfarrayModuleTest (unittest.TestCase):
 
         self.assertFalse(surf.get_locked())
         arr = pygame.surfarray.pixels_alpha(surf)
-        self.failUnless(surf.get_locked())
+        self.assertTrue(surf.get_locked())
         surf.unlock()
-        self.failUnless(surf.get_locked())
+        self.assertTrue(surf.get_locked())
 
         for (x, y), i in self.test_points:
             self.assertEqual(arr[x, y], palette[i][3])
@@ -610,9 +609,9 @@ class SurfarrayModuleTest (unittest.TestCase):
         for surf in [surf24, surf32, surf32a]:
             self.assertFalse(surf.get_locked())
             arr = pixels_rgb(surf)
-            self.failUnless(surf.get_locked())
+            self.assertTrue(surf.get_locked())
             surf.unlock()
-            self.failUnless(surf.get_locked())
+            self.assertTrue(surf.get_locked())
 
             for (x, y), i in self.test_points:
                 self.assertEqual(arr[x, y], plane[i])


### PR DESCRIPTION
This update cleans up the use of the deprecated `unittest.TestCase.failUnless()` method.

Overview of changes:
- Replace `failUnless()` with an appropriate `unittest.TestCase` assert method and alter the code to work with this new method.
- Some formatting for readability.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 269d6892fea8bf0aaacf5e13b55d7805e4937469
- numpy: 1.15.4

Resolves the failUnless item of #752.