### PR TITLE
Clean up deprecated assertEquals() and assertAlmostEquals()

### DIFF
--- a/test/color_test.py
+++ b/test/color_test.py
@@ -640,10 +640,10 @@ class ColorTypeTest (unittest.TestCase):
 
         t = c.normalize()
 
-        self.assertAlmostEquals(t[0], 0.800000, 5)
-        self.assertAlmostEquals(t[1], 0.149016, 5)
-        self.assertAlmostEquals(t[2], 0.760784, 5)
-        self.assertAlmostEquals(t[3], 0.215686, 5)
+        self.assertAlmostEqual(t[0], 0.800000, 5)
+        self.assertAlmostEqual(t[1], 0.149016, 5)
+        self.assertAlmostEqual(t[2], 0.760784, 5)
+        self.assertAlmostEqual(t[3], 0.215686, 5)
 
     def test_len(self):
         c = pygame.Color(204, 38, 194, 55)

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -45,17 +45,17 @@ class EventTypeTest(unittest.TestCase):
 
         e = pygame.event.Event(pygame.USEREVENT, some_attr=1, other_attr='1')
 
-        self.assertEquals(e.some_attr, 1)
-        self.assertEquals(e.other_attr, "1")
+        self.assertEqual(e.some_attr, 1)
+        self.assertEqual(e.other_attr, "1")
 
         # Event now uses tp_dictoffset and tp_members: request 62
         # on Motherhamster Bugzilla.
-        self.assertEquals(e.type, pygame.USEREVENT)
+        self.assertEqual(e.type, pygame.USEREVENT)
         self.assert_(e.dict is e.__dict__)
         e.some_attr = 12
-        self.assertEquals(e.some_attr, 12)
+        self.assertEqual(e.some_attr, 12)
         e.new_attr = 15
-        self.assertEquals(e.new_attr, 15)
+        self.assertEqual(e.new_attr, 15)
 
         # For Python 2.x a TypeError is raised for a readonly member;
         # for Python 3.x it is an AttributeError.
@@ -122,7 +122,7 @@ class EventModuleTest(unittest.TestCase):
         ret = pygame.event.get()
         should_be_blocked = [e for e in ret if e.type == event]
 
-        self.assertEquals(should_be_blocked, [])
+        self.assertEqual(should_be_blocked, [])
 
     def test_set_blocked_all(self):
         pygame.event.set_blocked(None)
@@ -136,28 +136,25 @@ class EventModuleTest(unittest.TestCase):
           # place a new event on the queue
 
         e1 = pygame.event.Event(pygame.USEREVENT, attr1='attr1')
-
         pygame.event.post(e1)
-
         posted_event = pygame.event.poll()
-        self.assertEquals (
-            e1.attr1, posted_event.attr1, race_condition_notification
-        )
+
+        self.assertEqual(e1.attr1, posted_event.attr1,
+                         race_condition_notification)
 
         # fuzzing event types
         for i in range(1, 11):
             pygame.event.post(pygame.event.Event(events[i]))
-            self.assertEquals (
-                pygame.event.poll().type, events[i], race_condition_notification
-            )
+
+            self.assertEqual(pygame.event.poll().type, events[i],
+                             race_condition_notification)
+
     def test_post_large_user_event(self):
         pygame.event.post(pygame.event.Event(pygame.USEREVENT, {'a': "a" * 1024}))
-
         e = pygame.event.poll()
-        self.assertEquals(e.type, pygame.USEREVENT)
-        self.assertEquals(e.a, "a" * 1024)
 
-
+        self.assertEqual(e.type, pygame.USEREVENT)
+        self.assertEqual(e.a, "a" * 1024)
 
     def test_get(self):
         # __doc__ (as of 2008-06-25) for pygame.event.get:
@@ -200,8 +197,9 @@ class EventModuleTest(unittest.TestCase):
           # pygame.event.event_name(type): return string
           # get the string name from and event id
 
-        self.assertEquals(pygame.event.event_name(pygame.KEYDOWN), "KeyDown")
-        self.assertEquals(pygame.event.event_name(pygame.USEREVENT), "UserEvent")
+        self.assertEqual(pygame.event.event_name(pygame.KEYDOWN), "KeyDown")
+        self.assertEqual(pygame.event.event_name(pygame.USEREVENT),
+                         "UserEvent")
 
     def test_wait(self):
         # __doc__ (as of 2008-06-25) for pygame.event.wait:

--- a/test/fastevent_test.py
+++ b/test/fastevent_test.py
@@ -44,10 +44,9 @@ class FasteventModuleTest(unittest.TestCase):
         for _ in range(1, 11):
             event.post(event.Event(pygame.USEREVENT))
 
-        self.assertEquals (
-            [e.type for e in fastevent.get()], [pygame.USEREVENT] * 10,
-            race_condition_notification
-        )
+        self.assertListEqual([e.type for e in fastevent.get()],
+                             [pygame.USEREVENT] * 10,
+                             race_condition_notification)
 
     def test_poll(self):
 
@@ -59,9 +58,8 @@ class FasteventModuleTest(unittest.TestCase):
           # Returns next event on queue. If there is no event waiting on the
           # queue, this will return an event with type NOEVENT.
 
-        self.assertEquals (
-            fastevent.poll().type, pygame.NOEVENT, race_condition_notification
-        )
+        self.assertEqual(fastevent.poll().type, pygame.NOEVENT,
+                         race_condition_notification)
 
     def test_post(self):
 
@@ -86,10 +84,9 @@ class FasteventModuleTest(unittest.TestCase):
         for _ in range(1, 11):
             fastevent.post(event.Event(pygame.USEREVENT))
 
-        self.assertEquals (
-            [e.type for e in event.get()], [pygame.USEREVENT] * 10,
-            race_condition_notification
-        )
+        self.assertListEqual([e.type for e in event.get()],
+                             [pygame.USEREVENT] * 10,
+                             race_condition_notification)
 
         try:
             # Special case for post: METH_O.
@@ -136,7 +133,7 @@ class FasteventModuleTest(unittest.TestCase):
           # when the user isn't doing anything with it.
 
         event.post(pygame.event.Event(1))
-        self.assertEquals(fastevent.wait().type, 1, race_condition_notification)
+        self.assertEqual(fastevent.wait().type, 1, race_condition_notification)
 
 ################################################################################
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -59,30 +59,20 @@ class ImageModuleTest( unittest.TestCase ):
         # Read the PNG file and verify that pygame interprets it correctly
         surf = pygame.image.load(f_path)
 
-        pixel_x0_y0 = surf.get_at((0, 0))
-        pixel_x1_y0 = surf.get_at((1, 0))
-        pixel_x0_y1 = surf.get_at((0, 1))
-        pixel_x1_y1 = surf.get_at((1, 1))
-
-        self.assertEquals(pixel_x0_y0, reddish_pixel)
-        self.assertEquals(pixel_x1_y0, greenish_pixel)
-        self.assertEquals(pixel_x0_y1, bluish_pixel)
-        self.assertEquals(pixel_x1_y1, greyish_pixel)
+        self.assertEqual(surf.get_at((0, 0)), reddish_pixel)
+        self.assertEqual(surf.get_at((1, 0)), greenish_pixel)
+        self.assertEqual(surf.get_at((0, 1)), bluish_pixel)
+        self.assertEqual(surf.get_at((1, 1)), greyish_pixel)
 
         # Read the PNG file obj. and verify that pygame interprets it correctly
         f = open(f_path, 'rb')
         surf = pygame.image.load(f)
         f.close()
 
-        pixel_x0_y0 = surf.get_at((0, 0))
-        pixel_x1_y0 = surf.get_at((1, 0))
-        pixel_x0_y1 = surf.get_at((0, 1))
-        pixel_x1_y1 = surf.get_at((1, 1))
-
-        self.assertEquals(pixel_x0_y0, reddish_pixel)
-        self.assertEquals(pixel_x1_y0, greenish_pixel)
-        self.assertEquals(pixel_x0_y1, bluish_pixel)
-        self.assertEquals(pixel_x1_y1, greyish_pixel)
+        self.assertEqual(surf.get_at((0, 0)), reddish_pixel)
+        self.assertEqual(surf.get_at((1, 0)), greenish_pixel)
+        self.assertEqual(surf.get_at((0, 1)), bluish_pixel)
+        self.assertEqual(surf.get_at((1, 1)), greyish_pixel)
 
         os.remove(f_path)
 
@@ -174,14 +164,12 @@ class ImageModuleTest( unittest.TestCase ):
         # Read the PNG file and verify that pygame saved it correctly
         reader = png.Reader(filename=f_path)
         width, height, pixels, metadata = reader.asRGBA8()
-        pixels_as_tuples = []
-        for pixel in pixels:
-            pixels_as_tuples.append(tuple(pixel))
 
-        self.assertEquals(pixels_as_tuples[0], reddish_pixel)
-        self.assertEquals(pixels_as_tuples[1], greenish_pixel)
-        self.assertEquals(pixels_as_tuples[2], bluish_pixel)
-        self.assertEquals(pixels_as_tuples[3], greyish_pixel)
+        # pixels is a generator
+        self.assertEqual(tuple(next(pixels)), reddish_pixel)
+        self.assertEqual(tuple(next(pixels)), greenish_pixel)
+        self.assertEqual(tuple(next(pixels)), bluish_pixel)
+        self.assertEqual(tuple(next(pixels)), greyish_pixel)
 
         if not reader.file.closed:
             reader.file.close()
@@ -209,14 +197,12 @@ class ImageModuleTest( unittest.TestCase ):
         # Read the PNG file and verify that pygame saved it correctly
         reader = png.Reader(filename=f_path)
         width, height, pixels, metadata = reader.asRGB8()
-        pixels_as_tuples = []
-        for pixel in pixels:
-            pixels_as_tuples.append(tuple(pixel))
 
-        self.assertEquals(pixels_as_tuples[0], reddish_pixel)
-        self.assertEquals(pixels_as_tuples[1], greenish_pixel)
-        self.assertEquals(pixels_as_tuples[2], bluish_pixel)
-        self.assertEquals(pixels_as_tuples[3], greyish_pixel)
+        # pixels is a generator
+        self.assertEqual(tuple(next(pixels)), reddish_pixel)
+        self.assertEqual(tuple(next(pixels)), greenish_pixel)
+        self.assertEqual(tuple(next(pixels)), bluish_pixel)
+        self.assertEqual(tuple(next(pixels)), greyish_pixel)
 
         if not reader.file.closed:
             reader.file.close()
@@ -252,7 +238,7 @@ class ImageModuleTest( unittest.TestCase ):
                 s2 = pygame.image.load(temp_filename)
                 #compare contents, might only work reliably for png...
                 #   but because it's all one color it seems to work with jpg.
-                self.assertEquals(s2.get_at((0,0)), s.get_at((0,0)))
+                self.assertEqual(s2.get_at((0,0)), s.get_at((0,0)))
                 handle.close()
             finally:
                 #clean up the temp file, comment out to leave tmp file after run.

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -440,7 +440,6 @@ class MaskModuleTest(unittest.TestCase):
             self.assertEqual(mask.count(), 100)
             self.assertEqual(mask.get_bounding_rects(), [pygame.Rect((40,40,10,10))])
 
-    @unittest.expectedFailure
     def test_overlap_mask(self):
         """ |tags: ignore| """
 

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -34,10 +34,11 @@ def maskFromSurface(surface, threshold = 127):
 
 class MaskTypeTest( unittest.TestCase ):
     def assertMaskEquals(self, m1, m2):
-        self.assertEquals(m1.get_size(), m2.get_size())
+        self.assertEqual(m1.get_size(), m2.get_size())
+
         for i in range(m1.get_size()[0]):
             for j in range(m1.get_size()[1]):
-                self.assertEquals(m1.get_at((i,j)), m2.get_at((i,j)))
+                self.assertEqual(m1.get_at((i,j)), m2.get_at((i,j)))
 
     def todo_test_get_at(self):
 
@@ -171,7 +172,8 @@ class MaskTypeTest( unittest.TestCase ):
                 m2 = pygame.Mask(s2)
                 o = m1.convolve(m2)
                 for i in (0,1):
-                    self.assertEquals(o.get_size()[i], m1.get_size()[i] + m2.get_size()[i] - 1)
+                    self.assertEqual(o.get_size()[i],
+                                     m1.get_size()[i] + m2.get_size()[i] - 1)
 
     def test_convolve__point_identities(self):
         """Convolving with a single point is the identity, while convolving a point with something flips it."""
@@ -207,10 +209,10 @@ class MaskTypeTest( unittest.TestCase ):
         full = pygame.Mask((2,2))
         full.fill()
 
-        self.assertEquals(full.convolve(full, None, ( 0,  3)).count(), 0)
-        self.assertEquals(full.convolve(full, None, ( 0,  2)).count(), 3)
-        self.assertEquals(full.convolve(full, None, (-2, -2)).count(), 1)
-        self.assertEquals(full.convolve(full, None, (-3, -3)).count(), 0)
+        self.assertEqual(full.convolve(full, None, ( 0,  3)).count(), 0)
+        self.assertEqual(full.convolve(full, None, ( 0,  2)).count(), 3)
+        self.assertEqual(full.convolve(full, None, (-2, -2)).count(), 1)
+        self.assertEqual(full.convolve(full, None, (-3, -3)).count(), 0)
 
     def test_convolve(self):
         """Tests the definition of convolution"""
@@ -220,18 +222,18 @@ class MaskTypeTest( unittest.TestCase ):
 
         for i in range(conv.get_size()[0]):
             for j in range(conv.get_size()[1]):
-                self.assertEquals(conv.get_at((i,j)) == 0, m1.overlap(m2, (i - 99, j - 99)) is None)
-
+                self.assertEqual(conv.get_at((i,j)) == 0,
+                                 m1.overlap(m2, (i - 99, j - 99)) is None)
 
     def test_connected_components(self):
         """
         """
 
         m = pygame.Mask((10,10))
-        self.assertEquals(repr(m.connected_components()), "[]")
+        self.assertEqual(repr(m.connected_components()), "[]")
 
         comp = m.connected_component()
-        self.assertEquals(m.count(), comp.count())
+        self.assertEqual(m.count(), comp.count())
 
         m.set_at((0,0), 1)
         m.set_at((1,1), 1)
@@ -240,10 +242,10 @@ class MaskTypeTest( unittest.TestCase ):
         comps1 = m.connected_components(1)
         comps2 = m.connected_components(2)
         comps3 = m.connected_components(3)
-        self.assertEquals(comp.count(), comps[0].count())
-        self.assertEquals(comps1[0].count(), 2)
-        self.assertEquals(comps2[0].count(), 2)
-        self.assertEquals(repr(comps3), "[]")
+        self.assertEqual(comp.count(), comps[0].count())
+        self.assertEqual(comps1[0].count(), 2)
+        self.assertEqual(comps2[0].count(), 2)
+        self.assertEqual(repr(comps3), "[]")
 
         m.set_at((9, 9), 1)
         comp = m.connected_component()
@@ -253,13 +255,13 @@ class MaskTypeTest( unittest.TestCase ):
         comps1 = m.connected_components(1)
         comps2 = m.connected_components(2)
         comps3 = m.connected_components(3)
-        self.assertEquals(comp.count(), 2)
-        self.assertEquals(comp1.count(), 2)
-        self.assertEquals(comp2.count(), 0)
-        self.assertEquals(len(comps), 2)
-        self.assertEquals(len(comps1), 2)
-        self.assertEquals(len(comps2), 1)
-        self.assertEquals(len(comps3), 0)
+        self.assertEqual(comp.count(), 2)
+        self.assertEqual(comp1.count(), 2)
+        self.assertEqual(comp2.count(), 0)
+        self.assertEqual(len(comps), 2)
+        self.assertEqual(len(comps1), 2)
+        self.assertEqual(len(comps2), 1)
+        self.assertEqual(len(comps3), 0)
 
 
     def test_get_bounding_rects(self):
@@ -277,11 +279,9 @@ class MaskTypeTest( unittest.TestCase ):
 
         r = m.get_bounding_rects()
 
-        self.assertEquals(repr(r), "[<rect(0, 0, 2, 2)>, <rect(0, 3, 1, 1)>, <rect(3, 3, 1, 1)>]")
-
-
-
-
+        self.assertEqual(
+                repr(r),
+                "[<rect(0, 0, 2, 2)>, <rect(0, 3, 1, 1)>, <rect(3, 3, 1, 1)>]")
 
         #1100
         #1111
@@ -297,8 +297,7 @@ class MaskTypeTest( unittest.TestCase ):
         m.set_at((3,1), 1)
 
         r = m.get_bounding_rects()
-        self.assertEquals(repr(r), "[<rect(0, 0, 4, 2)>]")
-
+        self.assertEqual(repr(r), "[<rect(0, 0, 4, 2)>]")
 
         #00100
         #01110
@@ -323,9 +322,7 @@ class MaskTypeTest( unittest.TestCase ):
         m.set_at((4,2), 0)
 
         r = m.get_bounding_rects()
-        self.assertEquals(repr(r), "[<rect(1, 0, 3, 3)>]")
-
-
+        self.assertEqual(repr(r), "[<rect(1, 0, 3, 3)>]")
 
         #00010
         #00100
@@ -350,10 +347,7 @@ class MaskTypeTest( unittest.TestCase ):
         m.set_at((4,2), 0)
 
         r = m.get_bounding_rects()
-        self.assertEquals(repr(r), "[<rect(1, 0, 3, 3)>]")
-
-
-
+        self.assertEqual(repr(r), "[<rect(1, 0, 3, 3)>]")
 
         #00011
         #11111
@@ -372,7 +366,7 @@ class MaskTypeTest( unittest.TestCase ):
 
         r = m.get_bounding_rects()
         #TODO: this should really make one bounding rect.
-        #self.assertEquals(repr(r), "[<rect(0, 0, 5, 2)>]")
+        #self.assertEqual(repr(r), "[<rect(0, 0, 5, 2)>]")
 
     def test_negative_size_mask(self):
         mask = pygame.Mask((100, 100))
@@ -446,6 +440,7 @@ class MaskModuleTest(unittest.TestCase):
             self.assertEqual(mask.count(), 100)
             self.assertEqual(mask.get_bounding_rects(), [pygame.Rect((40,40,10,10))])
 
+    @unittest.expectedFailure
     def test_overlap_mask(self):
         """ |tags: ignore| """
 

--- a/test/scrap_test.py
+++ b/test/scrap_test.py
@@ -112,12 +112,11 @@ class ScrapModuleTest(unittest.TestCase):
 
     def test_scrap_put_text (self):
         scrap.put (pygame.SCRAP_TEXT, as_bytes("Hello world"))
-        self.assertEquals (scrap.get (pygame.SCRAP_TEXT),
-                           as_bytes("Hello world"))
-
+        self.assertEqual(scrap.get(pygame.SCRAP_TEXT), as_bytes("Hello world"))
         scrap.put (pygame.SCRAP_TEXT, as_bytes("Another String"))
-        self.assertEquals (scrap.get (pygame.SCRAP_TEXT),
-                           as_bytes("Another String"))
+
+        self.assertEqual(scrap.get(pygame.SCRAP_TEXT),
+                         as_bytes("Another String"))
 
     def test_scrap_put_image (self):
         if 'pygame.image' not in sys.modules:
@@ -125,14 +124,16 @@ class ScrapModuleTest(unittest.TestCase):
         sf = pygame.image.load (
             trunk_relative_path("examples/data/asprite.bmp")
         )
-        string = pygame.image.tostring (sf, "RGBA")
-        scrap.put (pygame.SCRAP_BMP, string)
-        self.assertEquals (scrap.get(pygame.SCRAP_BMP), string)
+        expected_string = pygame.image.tostring(sf, "RGBA")
+        scrap.put(pygame.SCRAP_BMP, expected_string)
+
+        self.assertEqual(scrap.get(pygame.SCRAP_BMP), expected_string)
 
     def test_put (self):
         scrap.put ("arbitrary buffer", as_bytes("buf"))
         r = scrap.get ("arbitrary buffer")
-        self.assertEquals (r, as_bytes("buf"))
+
+        self.assertEqual(r, as_bytes("buf"))
 
 class X11InteractiveTest(unittest.TestCase):
     __tags__ = ['ignore', 'subprocess_ignore']

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -315,9 +315,9 @@ class SurfaceTypeTest(unittest.TestCase):
         for w in xrange_(0, 255, 32):
             for h in xrange_(0, 127, 15):
                 s = pygame.Surface((w, h))
-                self.assertEquals(s.get_width(), w)
-                self.assertEquals(s.get_height(), h)
-                self.assertEquals(s.get_size(), (w, h))
+                self.assertEqual(s.get_width(), w)
+                self.assertEqual(s.get_height(), h)
+                self.assertEqual(s.get_size(), (w, h))
 
     def test_get_view(self):
         # Check that BufferProxys are returned when array depth is supported,
@@ -534,8 +534,11 @@ class SurfaceTypeTest(unittest.TestCase):
 
         for colorkey in colorkeys:
             s.set_colorkey(colorkey)
-            for t in range(4): s.set_colorkey(s.get_colorkey())
-            self.assertEquals(s.get_colorkey(), colorkey)
+
+            for t in range(4):
+                s.set_colorkey(s.get_colorkey())
+
+            self.assertEqual(s.get_colorkey(), colorkey)
 
     def test_set_masks(self):
         s = pygame.Surface((32,32))
@@ -605,7 +608,7 @@ class SurfaceTypeTest(unittest.TestCase):
         dst.blit(src, (0,0))
 
         for pt in test_utils.rect_area_pts(src.get_rect()):
-            self.assertEquals ( dst.get_at(pt)[1], src.get_at(pt)[1] )
+            self.assertEqual(dst.get_at(pt)[1], src.get_at(pt)[1])
 
     def todo_test_blit__blit_to_self(self): #TODO
         src = pygame.Surface( (256,256), SRCALPHA, 32)
@@ -633,7 +636,7 @@ class SurfaceTypeTest(unittest.TestCase):
         # TODO:
         # what is the correct behaviour ?? should it blend? what algorithm?
 
-        self.assertEquals(s.get_at((0,0)), (32,32,32,31))
+        self.assertEqual(s.get_at((0,0)), (32,32,32,31))
 
     def test_blit__SRCALPHA32_to_8(self):
         # Bug: fatal
@@ -658,8 +661,9 @@ class SurfaceTypeTest(unittest.TestCase):
         im  = pygame.image.load(example_path(os.path.join("data", "city.png")))
         im2 = pygame.image.load(example_path(os.path.join("data", "brick.png")))
 
-        self.assertEquals( im.get_palette(),  ((0, 0, 0, 255), (255, 255, 255, 255)) )
-        self.assertEquals( im2.get_palette(), ((0, 0, 0, 255), (0, 0, 0, 255)) )
+        self.assertEqual(im.get_palette(),
+                         ((0, 0, 0, 255), (255, 255, 255, 255)))
+        self.assertEqual(im2.get_palette(), ((0, 0, 0, 255), (0, 0, 0, 255)))
 
         self.assertEqual(repr(im.convert(32)),  '<Surface(24x24x32 SW)>')
         self.assertEqual(repr(im2.convert(32)), '<Surface(469x137x32 SW)>')
@@ -1207,9 +1211,9 @@ class SurfaceTypeTest(unittest.TestCase):
         self.assertRaises(ValueError, surf.subsurface, (0,0,1,1,666))
 
 
-        self.assertEquals(s.get_shifts(), surf.get_shifts())
-        self.assertEquals(s.get_masks(), surf.get_masks())
-        self.assertEquals(s.get_losses(), surf.get_losses())
+        self.assertEqual(s.get_shifts(), surf.get_shifts())
+        self.assertEqual(s.get_masks(), surf.get_masks())
+        self.assertEqual(s.get_losses(), surf.get_losses())
 
         # Issue 2 at Bitbucket.org/pygame/pygame
         surf = pygame.Surface.__new__(pygame.Surface)
@@ -2116,7 +2120,8 @@ class SurfaceBlendTest(unittest.TestCase):
         area = (1, 1, 30, 30)
         s1 = pygame.Surface((4, 4), 0, 32)
         r = s1.fill(special_flags=pygame.BLEND_ADD, color=color, rect=area)
-        self.assertEquals(pygame.Rect((1, 1, 3, 3)), r)
+
+        self.assertEqual(pygame.Rect((1, 1, 3, 3)), r)
         self.assert_(s1.get_at((0, 0)) == (0, 0, 0, 255))
         self.assert_(s1.get_at((1, 1)) == color)
 

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -645,16 +645,14 @@ class SurfarrayModuleTest (unittest.TestCase):
             pygame.surfarray.use_arraytype (atype)
 
             ar = pygame.surfarray.pixels2d (sf)
-            self.assertEquals (sf.get_locked (), True)
+            self.assertTrue(sf.get_locked())
 
             sf.unlock ()
-            self.assertEquals (sf.get_locked (), True)
+            self.assertTrue(sf.get_locked())
 
             del ar
-            self.assertEquals (sf.get_locked (), False)
-            self.assertEquals (sf.get_locks (), ())
-
-        #print ("test_surf_lock - end")
+            self.assertFalse(sf.get_locked())
+            self.assertEqual(sf.get_locks(), ())
 
 
 if __name__ == '__main__':

--- a/test/util/build_page/libs/build_client/regexes.py
+++ b/test/util/build_page/libs/build_client/regexes.py
@@ -21,7 +21,7 @@ FAIL: EventModuleTest.test_set_blocked
 ----------------------------------------------------------------------
 Traceback (most recent call last):
   File "C:\PyGame\trunk\test\event_test.py", line 65, in test_set_blocked
-    self.assertEquals(should_be_blocked, [])
+    self.assertEqual(should_be_blocked, [])
 AssertionError: [<Event(2-KeyDown {})>] != []
 
 ----------------------------------------------------------------------
@@ -163,6 +163,7 @@ __all__ = [a for a in dir() if a.endswith("_RE")]
 ################################################################################
 
 if __name__ == '__main__':
-    for attr in __all__: print "%s," % attr
+    for attr in __all__:
+        print("%s," % attr)
 
 ################################################################################


### PR DESCRIPTION
This update cleans up the use of the deprecated `unittest.TestCase.assertEquals()` and  `unittest.TestCase.assertAlmostEquals()` methods.

Overview of changes:
- Replace `assertEquals()`/`assertAlmostEquals()` with an appropriate `unittest.TestCase` assert method and alter the code to work with this new method.
- Some formatting for readability.
- Add the decorator `@unittest.expectedFailure` to the failing test method `test_overlap_mask()`. The test method was tagged with `|tags: ignore|`, but `unittest` should be informed of the expected the failure.
- Update `print` in `regexes.py` to make it python 3 compatible.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 269d6892fea8bf0aaacf5e13b55d7805e4937469
- numpy: 1.15.4

Resolves the assertEquals and assertAlmostEquals items of #752.