### PR TITLE
Add @unittest.expectedFailure decorator

### DIFF
--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -440,9 +440,9 @@ class MaskModuleTest(unittest.TestCase):
             self.assertEqual(mask.count(), 100)
             self.assertEqual(mask.get_bounding_rects(), [pygame.Rect((40,40,10,10))])
 
+    @unittest.expectedFailure
     def test_overlap_mask(self):
-        """ |tags: ignore| """
-
+        # This test currently fails. See issue #410 for more details.
         mask = pygame.mask.Mask((50, 50))
         mask.fill()
         mask2 = pygame.mask.Mask((300, 10))


### PR DESCRIPTION
Added the `@unittest.expectedFailure` decorator to `test_overlap_mask()` test.

Overview of changes:
- Add  `@unittest.expectedFailure` decorator to `test_overlap_mask()` test.
- Remove the `|tags: ignore|` docstring as the decorator handles the failing test method.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 7e633530f516a14d2252f3d0e664e0321e934e1e
- numpy: 1.15.4

Resolves #758.