### PR TITLE
Initialize PygameTestLoader's base class

### DIFF
--- a/test/test_utils/test_machinery.py
+++ b/test/test_utils/test_machinery.py
@@ -13,11 +13,14 @@ from . import import_submodule
 class PygameTestLoader(unittest.TestLoader):
     def __init__(self, randomize_tests=False, include_incomplete=False,
                  exclude=('interactive',)):
+        super(PygameTestLoader, self).__init__()
         self.randomize_tests = randomize_tests
+
         if exclude is None:
             self.exclude = set()
         else:
             self.exclude = set(exclude)
+
         if include_incomplete:
             self.testMethodPrefix = ('test', 'todo_')
 


### PR DESCRIPTION
Initialize the base class of PygameTestLoader.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 7e633530f516a14d2252f3d0e664e0321e934e1e
- numpy: 1.15.4

Resolves #764.