### PR TITLE
Clean up deprecated assert_() usage - part 1

### DIFF
--- a/test/base_test.py
+++ b/test/base_test.py
@@ -42,22 +42,15 @@ class BaseModuleTest(unittest.TestCase):
         self.assertEqual(quit_called, 1)
 
     def test_get_sdl_byteorder(self):
+        """Ensure the SDL byte order is valid"""
+        byte_order = pygame.get_sdl_byteorder()
+        expected_options = (pygame.LIL_ENDIAN, pygame.BIG_ENDIAN)
 
-        # __doc__ (as of 2008-06-25) for pygame.base.get_sdl_byteorder:
-
-          # pygame.get_sdl_byteorder(): return int
-          # get the byte order of SDL
-
-        self.assert_(pygame.get_sdl_byteorder() + 1)
+        self.assertIn(byte_order, expected_options)
 
     def test_get_sdl_version(self):
-
-        # __doc__ (as of 2008-06-25) for pygame.base.get_sdl_version:
-
-          # pygame.get_sdl_version(): return major, minor, patch
-          # get the version number of SDL
-
-        self.assert_( len(pygame.get_sdl_version()) == 3)
+        """Ensure the SDL version is valid"""
+        self.assertEqual(len(pygame.get_sdl_version()), 3)
 
     class ExporterBase(object):
         def __init__(self, shape, typechar, itemsize):
@@ -528,19 +521,14 @@ class BaseModuleTest(unittest.TestCase):
         self.not_init_assertions()
 
     def test_register_quit(self):
-
-        # __doc__ (as of 2008-06-25) for pygame.base.register_quit:
-
-          # register_quit(callable): return None
-          # register a function to be called when pygame quits
-
-        self.assert_(not quit_hook_ran)
+        """Ensure that a registered function is called on quit()"""
+        self.assertFalse(quit_hook_ran)
 
         pygame.init()
         pygame.register_quit(quit_hook)
         pygame.quit()
 
-        self.assert_(quit_hook_ran)
+        self.assertTrue(quit_hook_ran)
 
     def test_get_error(self):
 

--- a/test/bufferproxy_test.py
+++ b/test/bufferproxy_test.py
@@ -56,7 +56,8 @@ class BufferProxyTest(unittest.TestCase):
         p = []
         kwds['parent'] = p
         v = BufferProxy(kwds)
-        self.assert_(v.parent is p)
+
+        self.assertIs(v.parent, p)
 
     def test_before(self):
         def callback(parent):
@@ -152,10 +153,13 @@ class BufferProxyTest(unittest.TestCase):
     def test_weakref(self):
         v = BufferProxy(self.view_keywords)
         weak_v = weakref.ref(v)
-        self.assert_(weak_v() is v)
+
+        self.assertIs(weak_v(), v)
+
         v = None
         gc.collect()
-        self.assert_(weak_v() is None)
+
+        self.assertIsNone(weak_v())
 
     def test_gc(self):
         """refcount agnostic check that contained objects are freed"""
@@ -224,7 +228,9 @@ class BufferProxyTest(unittest.TestCase):
 
     def test_c_api(self):
         api = pygame.bufferproxy._PYGAME_C_API
-        self.assert_(isinstance(api, type(pygame.base._PYGAME_C_API)))
+        api_type = type(pygame.base._PYGAME_C_API)
+
+        self.assertIsInstance(api, api_type)
 
     def test_repr(self):
         v = BufferProxy(self.view_keywords)

--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -9,15 +9,21 @@ class RWopsEncodeStringTest(unittest.TestCase):
     global getrefcount
 
     def test_obj_None(self):
-        self.assert_(encode_string(None) is None)
+        encoded_string = encode_string(None)
+
+        self.assertIsNone(encoded_string)
 
     def test_returns_bytes(self):
         u = as_unicode(r"Hello")
-        self.assert_(isinstance(encode_string(u), bytes_))
+        encoded_string = encode_string(u)
+
+        self.assertIsInstance(encoded_string, bytes_)
 
     def test_obj_bytes(self):
         b = as_bytes("encyclop\xE6dia")
-        self.assert_(encode_string(b, 'ascii', 'strict') is b)
+        encoded_string = encode_string(b, 'ascii', 'strict')
+
+        self.assertIs(encoded_string, b)
 
     def test_encode_unicode(self):
         u = as_unicode(r"\u00DEe Olde Komp\u00FCter Shoppe")
@@ -35,12 +41,16 @@ class RWopsEncodeStringTest(unittest.TestCase):
 
     def test_encoding_error(self):
         u = as_unicode(r"a\x80b")
-        self.assert_(encode_string(u, 'ascii', 'strict') is None)
+        encoded_string = encode_string(u, 'ascii', 'strict')
+
+        self.assertIsNone(encoded_string)
 
     def test_check_defaults(self):
         u = as_unicode(r"a\u01F7b")
         b = u.encode("unicode_escape", "backslashreplace")
-        self.assert_(encode_string(u) == b)
+        encoded_string = encode_string(u)
+
+        self.assertEqual(encoded_string, b)
 
     def test_etype(self):
         u = as_unicode(r"a\x80b")
@@ -49,9 +59,11 @@ class RWopsEncodeStringTest(unittest.TestCase):
 
     def test_string_with_null_bytes(self):
         b = as_bytes("a\x00b\x00c")
-        self.assert_(encode_string(b, etype=SyntaxError) is b)
-        u = b.decode()
-        self.assert_(encode_string(u, 'ascii', 'strict') == b)
+        encoded_string = encode_string(b, etype=SyntaxError)
+        encoded_decode_string = encode_string(b.decode(), 'ascii', 'strict')
+
+        self.assertIs(encoded_string, b)
+        self.assertEqual(encoded_decode_string, b)
 
     try:
         from sys import getrefcount as _g
@@ -84,14 +96,18 @@ class RWopsEncodeFilePathTest(unittest.TestCase):
     # RWopsEncodeString
     def test_encoding(self):
         u = as_unicode(r"Hello")
-        self.assert_(isinstance(encode_file_path(u), bytes_))
+        encoded_file_path = encode_file_path(u)
+
+        self.assertIsInstance(encoded_file_path, bytes_)
 
     def test_error_fowarding(self):
         self.assertRaises(SyntaxError, encode_file_path)
 
     def test_path_with_null_bytes(self):
         b = as_bytes("a\x00b\x00c")
-        self.assert_(encode_file_path(b) is None)
+        encoded_file_path = encode_file_path(b)
+
+        self.assertIsNone(encoded_file_path)
 
     def test_etype(self):
         b = as_bytes("a\x00b\x00c")

--- a/test/threads_test.py
+++ b/test/threads_test.py
@@ -22,35 +22,36 @@ class WorkerQueueTypeTest(unittest.TestCase):
         wq.wait()
         wq.stop()
 
-        self.assert_(fr.result  == 2)
+        self.assertEqual(fr.result, 2)
         self.assertEqual(fr2.result, 3)
 
-    def test_do(self):
+    def todo_test_do(self):
 
         # __doc__ (as of 2008-06-28) for pygame.threads.WorkerQueue.do:
 
           # puts a function on a queue for running later.
           #
-        return
+
+        self.fail()
 
     def test_stop(self):
-
-        # __doc__ (as of 2008-06-28) for pygame.threads.WorkerQueue.stop:
-
-          # Stops the WorkerQueue, waits for all of the threads to finish up.
-          #
-
+        """Ensure stop() stops the worker queue"""
         wq = WorkerQueue()
 
-        self.assert_(len(wq.pool) > 0)
-        for t in wq.pool: self.assert_(t.isAlive())
+        self.assertGreater(len(wq.pool), 0)
 
-        for i in xrange_(200): wq.do(lambda x: x+1, i)
+        for t in wq.pool:
+            self.assertTrue(t.isAlive())
+
+        for i in xrange_(200):
+            wq.do(lambda x: x+1, i)
 
         wq.stop()
-        for t in wq.pool: self.assert_(not t.isAlive())
 
-        self.assert_(wq.queue.get() is STOP)
+        for t in wq.pool:
+            self.assertFalse(t.isAlive())
+
+        self.assertIs(wq.queue.get(), STOP)
 
     def todo_test_threadloop(self):
 
@@ -75,6 +76,7 @@ class WorkerQueueTypeTest(unittest.TestCase):
 
         wq.stop()
 
+
 class ThreadsModuleTest(unittest.TestCase):
     def todo_test_benchmark_workers(self):
         "tags:long_running"
@@ -92,32 +94,19 @@ class ThreadsModuleTest(unittest.TestCase):
         self.fail()
 
     def test_init(self):
-
-        # __doc__ (as of 2008-06-28) for pygame.threads.init:
-
-          # Does a little test to see if threading is worth it.
-          #   Sets up a global worker queue if it's worth it.
-          #
-          # Calling init() is not required, but is generally better to do.
-
+        """Ensure init() sets up the worker queue"""
         threads.init(8)
 
-        self.assert_(isinstance(threads._wq, WorkerQueue))
+        self.assertIsInstance(threads._wq, WorkerQueue)
 
         threads.quit()
 
     def test_quit(self):
-
-        # __doc__ (as of 2008-06-28) for pygame.threads.quit:
-
-          # cleans up everything.
-          #
-
+        """Ensure quit() cleans up the worker queue"""
         threads.init(8)
-
         threads.quit()
 
-        self.assert_(threads._wq is None)
+        self.assertIsNone(threads._wq)
 
     def test_tmap(self):
         # __doc__ (as of 2008-06-28) for pygame.threads.tmap:
@@ -138,17 +127,13 @@ class ThreadsModuleTest(unittest.TestCase):
 
         self.assertEqual(tmapped, mapped)
 
-    def test_tmap__None_func_and_multiple_sequences(self):
-        return     #TODO
-
-        """ Using a None as func and multiple seqences """
+    def todo_test_tmap__None_func_and_multiple_sequences(self):
+        """Using a None as func and multiple sequences"""
+        self.fail()
 
         res =  tmap(None, [1,2,3,4])
-
         res2 = tmap(None, [1,2,3,4], [22, 33, 44, 55])
-
         res3 = tmap(None, [1,2,3,4], [22, 33, 44, 55, 66])
-
         res4 = tmap(None, [1,2,3,4,5], [22, 33, 44, 55])
 
         self.assertEqual([1, 2, 3, 4], res)
@@ -164,32 +149,26 @@ class ThreadsModuleTest(unittest.TestCase):
         self.assertEqual(list(r), list(r2))
 
     def test_FuncResult(self):
-        # as of 2008-06-28
-        # FuncResult(f, callback = None, errback = None)
-
-        # Used for wrapping up a function call so that the results are stored
-        #      inside the instances result attribute.
-
-
-        #     f - is the function we that we call
-        #         callback(result) - this is called when the function(f) returns
-        #         errback(exception) - this is called when the function(f) raises
-        #                                an exception.
-
+        """Ensure FuncResult sets its result and exception attributes"""
         # Results are stored in result attribute
         fr = FuncResult(lambda x:x+1)
         fr(2)
+
         self.assertEqual(fr.result, 3)
 
         # Exceptions are store in exception attribute
-        self.assert_(fr.exception is None,  "when no exception raised")
+        self.assertIsNone(fr.exception, "no exception should be raised")
 
         exception = ValueError('rast')
+
         def x(sdf):
             raise exception
+
         fr = FuncResult(x)
         fr(None)
-        self.assert_(fr.exception is exception)
+
+        self.assertIs(fr.exception, exception)
+
 
 ################################################################################
 

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -6,8 +6,10 @@ Clock = pygame.time.Clock
 
 class ClockTypeTest(unittest.TestCase):
     def test_construction(self):
+        """Ensure a Clock object can be created"""
         c = Clock()
-        self.assert_(c, "Clock can be constructed")
+
+        self.assertTrue(c, "Clock cannot be constructed")
 
     def todo_test_get_fps(self):
 
@@ -30,7 +32,7 @@ class ClockTypeTest(unittest.TestCase):
         #     c.tick()
         #     time.sleep(delay_per_frame)
         #
-        # self.assert_(99.0 < c.get_fps() < 101.0)
+        # self.assertTrue(99.0 < c.get_fps() < 101.0)
 
     def todo_test_get_rawtime(self):
 
@@ -67,7 +69,7 @@ class ClockTypeTest(unittest.TestCase):
         #
         # time.sleep(0.02)
         #
-        # self.assert_(20 <= c.get_time() <= 30)
+        # self.assertTrue(20 <= c.get_time() <= 30)
 
 
     def todo_test_tick(self):
@@ -106,7 +108,7 @@ class ClockTypeTest(unittest.TestCase):
         # for outlier in [min(collection), max(collection)]:
         #     if outlier != 5: collection.remove(outlier)
         #
-        # self.assert_(sum(collection) / len(collection) == 5)
+        # self.assertEqual(sum(collection) / len(collection), 5)
 
     def todo_test_tick_busy_loop(self):
 

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -804,9 +804,9 @@ class TransformModuleTest( unittest.TestCase ):
 
         # s.set_at((2, 0), color)
 
-        # self.assert_(s.get_at((0, 0)) != color)
+        # self.assertNotEqual(s.get_at((0, 0)), color)
         # s = pygame.transform.rotate(s, 90)
-        # self.assert_(s.get_at((0, 0)) == color)
+        # self.assertEqual(s.get_at((0, 0)), color)
 
         self.fail()
 


### PR DESCRIPTION
This update partially cleans up the use of the deprecated `unittest.TestCase.assert_()` method.

Overview of changes:
- Replace `assert_()` with an appropriate `unittest.TestCase` assert method and alter the code to work with this new method.
- General clean up in the test method where the changes are being made. This includes formatting for readability, removing stale comments, adding docstrings, and other various minor refactoring.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 33293dddb25a9d4f222568724db09bc60bc5ec18
- numpy: 1.15.4

Resolves 6 of the 48 files for the `assert_` item of #752.