### PR TITLE
Clean up deprecated assert_() usage - part 2

### DIFF
--- a/test/fastevent_test.py
+++ b/test/fastevent_test.py
@@ -12,7 +12,6 @@ class FasteventModuleTest(unittest.TestCase):
         pygame.display.init()
         fastevent.init()
         event.clear()
-        self.assert_(not event.get())
 
     def tearDown(self):
         # fastevent.quit()  # Does not exist!
@@ -98,6 +97,16 @@ class FasteventModuleTest(unittest.TestCase):
             self.assertEqual(str(e), msg)
         else:
             self.fail()
+
+    def test_post__clear(self):
+        """Ensure posted events can be cleared."""
+        for _ in range(10):
+            fastevent.post(event.Event(pygame.USEREVENT))
+
+        event.clear()
+
+        self.assertListEqual(fastevent.get(), [])
+        self.assertListEqual(event.get(), [])
 
     def todo_test_pump(self):
 

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -241,27 +241,33 @@ class FontTypeTest( unittest.TestCase ):
         f = pygame_font.Font(None, 20)
         um = f.metrics(as_unicode("."))
         bm = f.metrics(as_bytes("."))
+
         self.assertEqual(len(um), 1)
         self.assertEqual(len(bm), 1)
-        self.assert_(um[0] is not None)
-        self.assert_(um == bm)
+        self.assertIsNotNone(um[0])
+        self.assertEqual(um, bm)
+
         u = u"\u212A"
         b = u.encode("UTF-16")[2:] # Keep byte order consistent. [2:] skips BOM
         bm = f.metrics(b)
-        self.assert_(len(bm) == 2)
+
+        self.assertEqual(len(bm), 2)
+
         try:  # FIXME why do we do this try/except ?
             um = f.metrics(u)
         except pygame.error:
             pass
         else:
-            self.assert_(len(um) == 1)
-            self.assert_(bm[0] != um[0])
-            self.assert_(bm[1] != um[0])
+            self.assertEqual(len(um), 1)
+            self.assertNotEqual(bm[0], um[0])
+            self.assertNotEqual(bm[1], um[0])
 
         if UCS_4:
             u = u"\U00013000"
             bm = f.metrics(u)
-            self.assert_(len(bm) == 1 and bm[0] is None)
+
+            self.assertEqual(len(bm), 1)
+            self.assertIsNone(bm[0])
 
         return # unfinished
         # The documentation is useless here. How large a list?
@@ -364,11 +370,14 @@ class FontTypeTest( unittest.TestCase ):
         text = as_unicode("Xg")
         size = f.size(text)
         w, h = size
-        self.assert_(isinstance(w, int) and isinstance(h, int))
         s = f.render(text, False, (255, 255, 255))
-        self.assert_(size == s.get_size())
         btext = text.encode("ascii")
-        self.assert_(f.size(btext) == size)
+
+        self.assertIsInstance(w, int)
+        self.assertIsInstance(h, int)
+        self.assertEqual(s.get_size(), size)
+        self.assertEqual(f.size(btext), size)
+
         text = as_unicode(r"\u212A")
         btext = text.encode("UTF-16")[2:] # Keep the byte order consistent.
         bsize = f.size(btext)
@@ -377,7 +386,7 @@ class FontTypeTest( unittest.TestCase ):
         except pygame.error:
             pass
         else:
-            self.assert_(size != bsize)
+            self.assertNotEqual(size, bsize)
 
     def test_font_file_not_found(self):
         # A per BUG reported by Bo Jangeborg on pygame-user mailing list,
@@ -398,8 +407,8 @@ class FontTypeTest( unittest.TestCase ):
         font_name = pygame_font.get_default_font()
         font_path = os.path.join(os.path.split(pygame.__file__)[0],
                                  pygame_font.get_default_font())
-        f = open(font_path, "rb")
-        font = pygame_font.Font(f, 20)
+        with open(font_path, "rb") as f:
+            font = pygame_font.Font(f, 20)
 
     def test_load_default_font_filename(self):
         # In font_init, a special case is when the filename argument is

--- a/test/image__save_gl_surface_test.py
+++ b/test/image__save_gl_surface_test.py
@@ -7,38 +7,35 @@ from pygame.locals import *
 
 class GL_ImageSave(unittest.TestCase):
     def test_image_save_works_with_opengl_surfaces(self):
-        "|tags:display,slow,opengl|"
+        """
+        |tags:display,slow,opengl|
+        """
 
         pygame.display.init()
-
-
         screen = pygame.display.set_mode((640,480), OPENGL|DOUBLEBUF)
-
         pygame.display.flip()
 
         tmp_dir = test_utils.get_tmp_dir()
         # Try the imageext module.
         tmp_file = os.path.join(tmp_dir, "opengl_save_surface_test.png")
-
         pygame.image.save(screen, tmp_file)
 
-        self.assert_(os.path.exists(tmp_file))
+        self.assertTrue(os.path.exists(tmp_file))
 
         os.remove(tmp_file)
 
         # Only test the image module.
         tmp_file = os.path.join(tmp_dir, "opengl_save_surface_test.bmp")
-
         pygame.image.save(screen, tmp_file)
 
-        self.assert_(os.path.exists(tmp_file))
+        self.assertTrue(os.path.exists(tmp_file))
 
         os.remove(tmp_file)
 
         # stops tonnes of tmp dirs building up in trunk dir
         os.rmdir(tmp_dir)
-
-
         pygame.display.quit()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -66,10 +66,13 @@ class ImageextModuleTest( unittest.TestCase ):
             os.remove(temp_file)
         except IOError:
             raise unittest.SkipTest('the path cannot be opened')
-        self.assert_(not os.path.exists(temp_file))
+
+        self.assertFalse(os.path.exists(temp_file))
+
         try:
             imageext.save_extended(im, temp_file)
-            self.assert_(os.path.getsize(temp_file) > 10)
+
+            self.assertGreater(os.path.getsize(temp_file), 10)
         finally:
             try:
                 os.remove(temp_file)

--- a/test/pixelcopy_test.py
+++ b/test/pixelcopy_test.py
@@ -495,14 +495,16 @@ class PixelCopyTestWithArray(unittest.TestCase):
         color = array([11, 17, 59], uint8)
         target = zeros((5, 7), int32)
         map_array(target, color, surf)
-        self.assert_(alltrue(target == surf.map_rgb(color)))
+
+        self.assertTrue(alltrue(target == surf.map_rgb(color)))
 
         # array column stripes
         stripe = array([[2, 5, 7], [11, 19, 23], [37, 53, 101]], uint8)
         target = zeros((4, stripe.shape[0]), int32)
         map_array(target, stripe, surf)
         target_stripe = array([surf.map_rgb(c) for c in stripe], int32)
-        self.assert_(alltrue(target == target_stripe))
+
+        self.assertTrue(alltrue(target == target_stripe))
 
         # array row stripes
         stripe = array([[[2, 5, 7]],
@@ -512,7 +514,8 @@ class PixelCopyTestWithArray(unittest.TestCase):
         target = zeros((stripe.shape[0], 3), int32)
         map_array(target, stripe, surf)
         target_stripe = array([[surf.map_rgb(c)] for c in stripe[:,0]], int32)
-        self.assert_(alltrue(target == target_stripe))
+
+        self.assertTrue(alltrue(target == target_stripe))
 
         # mismatched shape
         w = 4


### PR DESCRIPTION
This update partially cleans up the use of the deprecated `unittest.TestCase.assert_()` method.

Overview of changes:
- Replaced `assert_()` calls with an appropriate `unittest.TestCase` assert method and altered the code to work with this new method.
- General clean up in the test method where the changes are being made. This includes formatting for readability, removing stale comments, adding docstrings, and other various minor refactoring.
- `fastevent_test.py`: Moved the assert method in `setUp()` to its own test method.
- `font_test.py`: Ensured the open file in `test_font_file_not_found()` is closed.
- `image_test.py`: Created an assert method (`_assertSurfaceEqual()`) to help identify the reason for any possible surface mismatches.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 33293dddb25a9d4f222568724db09bc60bc5ec18
- numpy: 1.15.4

Resolves 6 of the 48 files for the assert_ item of #752.
Related: Part 1 PR #767.