### PR TITLE
Clean up deprecated assert_() usage - part 3

### DIFF
--- a/test/run_tests__tests/timeout/fake_2_test.py
+++ b/test/run_tests__tests/timeout/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/timeout/sleep_test.py
+++ b/test/run_tests__tests/timeout/sleep_test.py
@@ -22,7 +22,9 @@ class KeyModuleTest(unittest.TestCase):
         stop_time = time.time() + 10.0
         while time.time() < stop_time:
             time.sleep(1)
-        self.assert_(True) 
+
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_utils/async_sub.py
+++ b/test/test_utils/async_sub.py
@@ -262,11 +262,11 @@ class AsyncTest(unittest.TestCase):
         ret_code, response = proc_in_time_or_kill(
             [sys.executable, '-c', 'while 1: pass'], time_out = 1
         )
-        
-        self.assert_( 'rocess timed out' in ret_code )
-        self.assert_( 'successfully terminated' in ret_code )
+
+        self.assertIn('rocess timed out', ret_code)
+        self.assertIn('successfully terminated', ret_code)
 
 ################################################################################
-    
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/util/relative_indentation.py
+++ b/test/util/relative_indentation.py
@@ -66,7 +66,7 @@ class Template(object):
         # if errors: raise ValueError("\n".join(errors))
                  
         template = self.template[:]
-        for ph_name, replacement in replacements.iteritems():
+        for ph_name, replacement in replacements.items():
             ph_offset = self.ph_offsets[ph_name]
     
             ph_search = re.search ("\${%s}" % ph_name, template, multi_line_re)
@@ -80,8 +80,8 @@ class Template(object):
         return template
 
 if __name__ == "__main__":
-    
-    print Template( '''
+
+    print(Template( '''
 
         def test_${test_name}(self):
             
@@ -93,19 +93,20 @@ if __name__ == "__main__":
             
             ${comments}
             
-            self.assert_(not_completed() ''' 
-    
-    ).render( test_name = 'this_please', 
+            self.assertTrue(not_completed() '''
+
+    ).render( test_name = 'this_please',
               docstring = 'Heading:\n\n    Indented Line\n    More',
-              comments  = '# some comment\n# another comment', )
+              comments  = '# some comment\n# another comment', ))
 
     check_that = Template('works with ${one} on each line, or even ${two_four}')
 
-    print check_that.render(one='one', two_four='two')
-    
+    print(check_that.render(one='one', two_four='two'))
+
     # BUG: Multiline replacements with 2 ph per line will go awry -> .ph_offsets
     #      Outside scope of stubber
-    
-    print check_that.render(one='one\n    one', two_four='two\n    not_right\n')
-    
+
+    print(check_that.render(one='one\n    one',
+                            two_four='two\n    not_right\n'))
+
 ################################################################################


### PR DESCRIPTION
This update partially cleans up the use of the deprecated `unittest.TestCase.assert_()` method.

Overview of changes:
- Replaced `assert_()` calls with an appropriate `unittest.TestCase` assert method and altered the code to work with this new method.
- General clean up in the test method where the changes are being made. This includes formatting for readability, removing stale comments, adding docstrings, and other various minor refactoring.
- `event_test.py`: Removed the assert method in `setUp()` as the `event.clear()` is already being tested in the `test_clear()` method. Added an `event.clear()` to the `tearDown()` method to empty the event queue at the end of each test. Also added in a few docstrings to methods that were not being changed.
- `relative_indentation.py`: Updated to make it python 3 compatible.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 2f5b005516d8a91c569aa9c85d47f8e871c64dfb
- numpy: 1.15.4

Resolves 5 of the 48 files for the assert_ item of #752.
Related: Part 1 PR #767, Part 2 PR #768.