### PR TITLE
Update the event documentation

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -10,65 +10,67 @@
 
 Pygame handles all its event messaging through an event queue. The routines in
 this module help you manage that event queue. The input queue is heavily
-dependent on the pygame display module. If the display has not been initialized
-and a video mode not set, the event queue will not really work.
+dependent on the :mod:`pygame.display` module. If the display has not been
+initialized and a video mode not set, the event queue may not work properly.
+The event subsystem should be called from the main thread. If you want to post
+events into the queue from other threads, please use the
+:mod:`pygame.fastevent` module.
 
-The queue is a regular queue of :class:`pygame.event.EventType` event objects,
-there are a variety of ways to access the events it contains. From simply
-checking for the existence of events, to grabbing them directly off the stack.
-
-All events have a type identifier. This event type is in between the values of
-``NOEVENT`` and ``NUMEVENTS``. All user defined events can have the value of
-``USEREVENT`` or higher. It is recommended make sure your event id's follow
-this system.
-
-To get the state of various input devices, you can forego the event queue and
-access the input devices directly with their appropriate modules; mouse, key,
-and joystick. If you use this method, remember that pygame requires some form
-of communication with the system window manager and other parts of the
-platform. To keep pygame in synch with the system, you will need to call
-``pygame.event.pump()`` to keep everything current. You'll want to call this
-function usually once per game loop.
-
-The event queue offers some simple filtering. This can help performance
-slightly by blocking certain event types from the queue, use the
-``pygame.event.set_allowed()`` and ``pygame.event.set_blocked()`` to work with
-this filtering. All events default to allowed.
-
-The event subsystem should be called from the main thread.  If you want to post
-events into the queue from other threads, please use the fastevent package.
-
-Joysticks will not send any events until the device has been initialized.
-
-An ``EventType`` event object contains an event type identifier and a set of
-member data. The event object contains no method functions, just member data.
-EventType objects are retrieved from the pygame event queue. You can create
-your own new events with the ``pygame.event.Event()`` function.
-
-The SDL event queue has an upper limit on the number of events it can hold
-(128  for standard SDL 1.2).
-When the queue becomes full new events are quietly dropped.
-To prevent lost events, especially input events which signal a quit
+The event queue has an upper limit on the number of events it can hold
+(128 for standard SDL 1.2). When the queue becomes full new events are quietly
+dropped. To prevent lost events, especially input events which signal a quit
 command, your program must regularly check for events and process them.
-To speed up queue processing use :func:`pygame.event.set_blocked` to
+To speed up queue processing use :func:`pygame.event.set_blocked()` to
 limit which events get queued.
 
-All EventType instances have an event type identifier, accessible as the
-``EventType.type`` property. You may also get full access to the event object's
-attributes through the ``EventType.__dict__`` attribute. All other member
-lookups will be passed through to the object's dictionary values.
+To get the state of various input devices, you can forego the event queue and
+access the input devices directly with their appropriate modules:
+:mod:`pygame.mouse`, :mod:`pygame.key`, and :mod:`pygame.joystick`. If you use
+this method, remember that pygame requires some form of communication with the
+system window manager and other parts of the platform. To keep pygame in sync
+with the system, you will need to call :func:`pygame.event.pump()` to keep
+everything current. Usually, this should be called once per game loop.
+Note: Joysticks will not send any events until the device has been initialized.
+
+The event queue contains :class:`pygame.event.EventType` event objects.
+There are a variety of ways to access the queued events, from simply
+checking for the existence of events, to grabbing them directly off the stack.
+The event queue also offers some simple filtering which can slightly help
+performance by blocking certain event types from the queue. Use
+:func:`pygame.event.set_allowed()` and :func:`pygame.event.set_blocked()` to
+change this filtering. By default, all event types can be placed on the queue.
+
+All :class:`pygame.event.EventType` instances contain an event type identifier
+and attributes specific to that event type. The event type identifier is
+accessible as the :attr:`pygame.event.EventType.type` property. Any of the
+event specific attributes can be accessed through the
+:attr:`pygame.event.EventType.__dict__` attribute or directly as an attribute
+of the event object (as member lookups are passed through to the object's
+dictionary values). The event object has no method functions. Users can create
+their own new events with the :func:`pygame.event.Event()` function.
+
+The event type identifier is in between the values of ``NOEVENT`` and
+``NUMEVENTS``. User defined events should have a value in the inclusive range
+of ``USEREVENT`` to ``NUMEVENTS - 1``. It is recommended all user events follow
+this system.
+
+Events support equality and inequality comparisons. Two events are equal if
+they are the same type and have identical attribute values.
 
 While debugging and experimenting, you can print an event object for a quick
-display of its type and members. Events that come from the system will have a
-guaranteed set of member items based on the type. Here is a list of the
-event attributes defined with each event type.
+display of its type and members. The function :func:`pygame.event.event_name()`
+can be used to get a string representing the name of the event type.
+
+Events that come from the system will have a guaranteed set of member
+attributes based on the type. The following is a list event types with their
+specific attributes.
 
 ::
 
-    QUIT	            none
+    QUIT	      none
     ACTIVEEVENT	      gain, state
-    KEYDOWN	          unicode, key, mod
-    KEYUP	            key, mod
+    KEYDOWN	      unicode, key, mod
+    KEYUP	      key, mod
     MOUSEMOTION	      pos, rel, buttons
     MOUSEBUTTONUP     pos, button
     MOUSEBUTTONDOWN   pos, button
@@ -81,18 +83,27 @@ event attributes defined with each event type.
     VIDEOEXPOSE       none
     USEREVENT         code
 
-Events support equality comparison. Two events are equal if they are the same
-type and have identical attribute values. Inequality checks also work.
+|
 
 .. versionadded:: 1.9.2
 
-    On MacOSX, USEREVENT can have `code = pygame.USEREVENT_DROPFILE`. That
-    means the user is trying to open a file with your application. The filename
-    can be found at `event.filename`
+On MacOSX when a file is opened using a pygame application, a ``USEREVENT``
+with its ``code`` attribute set to ``pygame.USEREVENT_DROPFILE`` is generated.
+There is an additional attribute called ``filename`` where the name of the file
+being accessed is stored.
+
+::
+
+    USEREVENT         code=pygame.USEREVENT_DROPFILE, filename
+
+|
 
 .. versionadded:: 1.9.5
 
-    When compiled with SDL2, pygame has these events.
+When compiled with SDL2, pygame has these additional events and their
+attributes.
+
+::
 
     AUDIODEVICEADDED   which, iscapture
     AUDIODEVICEREMOVED which, iscapture
@@ -102,6 +113,8 @@ type and have identical attribute values. Inequality checks also work.
     MULTIGESTURE       touch_id, x, y, pinched, rotated, num_fingers
     TEXTEDITING        text, start, length
     TEXTINPUT          text
+
+|
 
 .. function:: pump
 
@@ -170,9 +183,9 @@ type and have identical attribute values. Inequality checks also work.
    | :sg:`peek(type) -> bool`
    | :sg:`peek(typelist) -> bool`
 
-   Returns true if there are any events of the given type waiting on the queue.
-   If a sequence of event types is passed, this will return True if any of
-   those events are on the queue.
+   Returns ``True`` if there are any events of the given type waiting on the
+   queue. If a sequence of event types is passed, this will return ``True`` if
+   any of those events are on the queue.
 
    .. ## pygame.event.peek ##
 
@@ -184,20 +197,21 @@ type and have identical attribute values. Inequality checks also work.
    | :sg:`clear(typelist) -> None`
 
    Remove all events or events of a specific type from the queue. This has the
-   same effect as ``pygame.event.get()`` except nothing is returned. This can
-   be slightly more efficient when clearing a full event queue.
+   same effect as :func:`pygame.event.get()` except ``None`` is returned. This
+   can be slightly more efficient when clearing a full event queue.
 
    .. ## pygame.event.clear ##
 
 .. function:: event_name
 
-   | :sl:`get the string name from and event id`
+   | :sl:`get the string name from an event id`
    | :sg:`event_name(type) -> string`
 
-   Pygame uses integer ids to represent the event types. If you want to report
-   these types to the user they should be converted to strings. This will
-   return a the simple name for an event type. The string is in the WordCap
-   style.
+   Returns a string representing the name (in CapWords style) of the given
+   event type.
+
+   "UserEvent" is returned for all values in the user event id range.
+   "Unknown" is returned when the event type does not exist.
 
    .. ## pygame.event.event_name ##
 
@@ -212,8 +226,8 @@ type and have identical attribute values. Inequality checks also work.
    default all events can be placed on the queue. It is safe to disable an
    event type multiple times.
 
-   If None is passed as the argument, this has the opposite effect and ``ALL``
-   of the event types are allowed to be placed on the queue.
+   If ``None`` is passed as the argument, ALL of the event types are blocked
+   from being placed on the queue.
 
    .. ## pygame.event.set_blocked ##
 
@@ -224,11 +238,11 @@ type and have identical attribute values. Inequality checks also work.
    | :sg:`set_allowed(typelist) -> None`
    | :sg:`set_allowed(None) -> None`
 
-   The given event types are allowed to appear on the event queue. By default
-   all events can be placed on the queue. It is safe to enable an event type
-   multiple times.
+   The given event types are allowed to appear on the event queue. By default,
+   all event types can be placed on the queue. It is safe to enable an event
+   type multiple times.
 
-   If None is passed as the argument, ``NONE`` of the event types are allowed
+   If ``None`` is passed as the argument, ALL of the event types are allowed
    to be placed on the queue.
 
    .. ## pygame.event.set_allowed ##
@@ -238,7 +252,7 @@ type and have identical attribute values. Inequality checks also work.
    | :sl:`test if a type of event is blocked from the queue`
    | :sg:`get_blocked(type) -> bool`
 
-   Returns true if the given event type is blocked from the queue.
+   Returns ``True`` if the given event type is blocked from the queue.
 
    .. ## pygame.event.get_blocked ##
 
@@ -249,7 +263,7 @@ type and have identical attribute values. Inequality checks also work.
 
    When your program runs in a windowed environment, it will share the mouse
    and keyboard devices with other applications that have focus. If your
-   program sets the event grab to True, it will lock all input into your
+   program sets the event grab to ``True``, it will lock all input into your
    program.
 
    It is best to not always grab the input, since it prevents the user from
@@ -262,8 +276,7 @@ type and have identical attribute values. Inequality checks also work.
    | :sl:`test if the program is sharing input devices`
    | :sg:`get_grab() -> bool`
 
-   Returns true when the input events are grabbed for this application. Use
-   ``pygame.event.set_grab()`` to control this state.
+   Returns ``True`` when the input events are grabbed for this application.
 
    .. ## pygame.event.get_grab ##
 
@@ -272,15 +285,14 @@ type and have identical attribute values. Inequality checks also work.
    | :sl:`place a new event on the queue`
    | :sg:`post(Event) -> None`
 
-   This places a new event at the end of the event queue. These Events will
-   later be retrieved from the other queue functions.
+   Places the given event at the end of the event queue.
 
    This is usually used for placing ``pygame.USEREVENT`` events on the queue.
    Although any type of event can be placed, if using the system event types
    your program should be sure to create the standard attributes with
    appropriate values.
 
-   If the SDL event queue is full a :exc:`pygame.error` is raised.
+   If the event queue is full a :exc:`pygame.error` is raised.
 
    .. ## pygame.event.post ##
 
@@ -288,41 +300,51 @@ type and have identical attribute values. Inequality checks also work.
 
    | :sl:`create a new event object`
    | :sg:`Event(type, dict) -> EventType instance`
-   | :sg:`Event(type, **attributes) -> EventType instance`
+   | :sg:`Event(type, \**attributes) -> EventType instance`
 
-   Creates a new event with the given type. The event is created with the given
-   attributes and values. The attributes can come from a dictionary argument
-   with string keys, or from keyword arguments.
+   Creates a new event with the given type and attributes. The attributes can
+   come from a dictionary argument with string keys or from keyword arguments.
+
+   .. ## pygame.event.Event ##
 
 .. class:: EventType
 
-   | :sl:`pygame object for representing SDL events`
+   | :sl:`pygame object for representing events`
 
-   A Python object that represents an SDL event. User event instances are
-   created with an `Event` function call. The `EventType` type is not directly
-   callable. `EventType` instances support attribute assignment and deletion.
+   A pygame object that represents an event. User event instances are created
+   with an :func:`pygame.event.Event()` function call. The ``EventType`` type
+   is not directly callable. ``EventType`` instances support attribute
+   assignment and deletion.
 
    .. attribute:: type
 
-      | :sl:`SDL event type identifier.`
+      | :sl:`event type identifier.`
       | :sg:`type -> int`
 
-      Read only. Predefined event identifiers are `QUIT` and `MOUSEMOTION`, for
-      example. For user created event objects, this is the `type` argument
-      passed to :func:`pygame.event.Event`.
+      Read-only. The event type identifier. For user created event
+      objects, this is the ``type`` argument passed to
+      :func:`pygame.event.Event()`.
+
+      For example, some predefined event identifiers are ``QUIT`` and
+      ``MOUSEMOTION``.
+
+      .. ## pygame.event.EventType.type ##
 
    .. attribute:: __dict__
 
-      | :sl:`Event object attribute dictionary`
+      | :sl:`event attribute dictionary`
       | :sg:`__dict__ -> dict`
 
-      Read only. The event type specific attributes of an event. As an example,
-      this would contain the `unicode`, `key`, and `mod` attributes of a
-      `KEYDOWN` event. The `dict` attribute is a synonym, for backward
-      compatibility.
+      Read-only. The event type specific attributes of an event. The
+      ``dict`` attribute is a synonym for backward compatibility.
 
-   Mutable attributes are new to pygame 1.9.2.
+      For example, the attributes of a ``KEYDOWN`` event would be ``unicode``,
+      ``key``, and ``mod``
 
-   .. ## pygame.event.Event ##
+      .. ## pygame.event.EventType.__dict__ ##
+
+   Mutable attributes are new in pygame 1.9.2.
+
+   .. ## pygame.event.EventType ##
 
 .. ## pygame.event ##

--- a/src_c/doc/event_doc.h
+++ b/src_c/doc/event_doc.h
@@ -13,7 +13,7 @@
 
 #define DOC_PYGAMEEVENTCLEAR "clear() -> None\nclear(type) -> None\nclear(typelist) -> None\nremove all events from the queue"
 
-#define DOC_PYGAMEEVENTEVENTNAME "event_name(type) -> string\nget the string name from and event id"
+#define DOC_PYGAMEEVENTEVENTNAME "event_name(type) -> string\nget the string name from an event id"
 
 #define DOC_PYGAMEEVENTSETBLOCKED "set_blocked(type) -> None\nset_blocked(typelist) -> None\nset_blocked(None) -> None\ncontrol which events are allowed on the queue"
 
@@ -29,11 +29,11 @@
 
 #define DOC_PYGAMEEVENTEVENT "Event(type, dict) -> EventType instance\nEvent(type, **attributes) -> EventType instance\ncreate a new event object"
 
-#define DOC_PYGAMEEVENTEVENTTYPE "pygame object for representing SDL events"
+#define DOC_PYGAMEEVENTEVENTTYPE "pygame object for representing events"
 
-#define DOC_EVENTTYPETYPE "type -> int\nSDL event type identifier."
+#define DOC_EVENTTYPETYPE "type -> int\nevent type identifier."
 
-#define DOC_EVENTTYPEDICT "__dict__ -> dict\nEvent object attribute dictionary"
+#define DOC_EVENTTYPEDICT "__dict__ -> dict\nevent attribute dictionary"
 
 
 
@@ -75,7 +75,7 @@ remove all events from the queue
 
 pygame.event.event_name
  event_name(type) -> string
-get the string name from and event id
+get the string name from an event id
 
 pygame.event.set_blocked
  set_blocked(type) -> None
@@ -111,14 +111,14 @@ pygame.event.Event
 create a new event object
 
 pygame.event.EventType
-pygame object for representing SDL events
+pygame object for representing events
 
 pygame.event.EventType.type
  type -> int
-SDL event type identifier.
+event type identifier.
 
 pygame.event.EventType.__dict__
  __dict__ -> dict
-Event object attribute dictionary
+event attribute dictionary
 
 */


### PR DESCRIPTION
Updated the `pygame.event` documentation.

Overview of changes:
- Various rewording and formatting.
- Rearranged/joined some of the paragraphs for better flow.
- Added/fixed code links and markdown.
- Added some clarifying text where required.
- Fixed spelling and usage errors.

Resolves #773.