### PR TITLE
Clean up deprecated assert_() usage - part 5

### DIFF
--- a/test/run_tests__tests/all_ok/fake_2_test.py
+++ b/test/run_tests__tests/all_ok/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/all_ok/fake_3_test.py
+++ b/test/run_tests__tests/all_ok/fake_3_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/all_ok/fake_4_test.py
+++ b/test/run_tests__tests/all_ok/fake_4_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/all_ok/fake_5_test.py
+++ b/test/run_tests__tests/all_ok/fake_5_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/all_ok/fake_6_test.py
+++ b/test/run_tests__tests/all_ok/fake_6_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/failures1/fake_2_test.py
+++ b/test/run_tests__tests/failures1/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/failures1/fake_3_test.py
+++ b/test/run_tests__tests/failures1/fake_3_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/failures1/fake_4_test.py
+++ b/test/run_tests__tests/failures1/fake_4_test.py
@@ -17,24 +17,25 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(False, "Some Jibberish") 
+        self.assertTrue(False, "Some Jibberish")
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
         if 1:
             if 1:
-                assert False 
+                assert False
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/incomplete/fake_2_test.py
+++ b/test/run_tests__tests/incomplete/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True)
+        self.assertTrue(True)
 
     def todo_test_get_pressed(self):
         self.fail()
 
     def test_name(self):
-        self.assert_(True)
+        self.assertTrue(True)
 
     def todo_test_set_mods(self):
         self.fail()
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/incomplete/fake_3_test.py
+++ b/test/run_tests__tests/incomplete/fake_3_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/incomplete_todo/fake_2_test.py
+++ b/test/run_tests__tests/incomplete_todo/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def todo_test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def todo_test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/incomplete_todo/fake_3_test.py
+++ b/test/run_tests__tests/incomplete_todo/fake_3_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/print_stderr/fake_2_test.py
+++ b/test/run_tests__tests/print_stderr/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/print_stderr/fake_3_test.py
+++ b/test/run_tests__tests/print_stderr/fake_3_test.py
@@ -17,23 +17,24 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
         sys.stderr.write("jibberish messes things up\n")
-        self.assert_(False)
+        self.assertTrue(False)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/print_stderr/fake_4_test.py
+++ b/test/run_tests__tests/print_stderr/fake_4_test.py
@@ -17,24 +17,25 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(False, "Some Jibberish") 
+        self.assertTrue(False, "Some Jibberish")
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
         if 1:
             if 1:
-                assert False 
+                assert False
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This update partially cleans up the use of the deprecated `unittest.TestCase.assert_()` method.

Overview of changes:
- Replaced `assert_() `calls with an appropriate `unittest.TestCase` assert method.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 6b465bb9ea1d4899ae8db6f13f2860d0084a8f05
- numpy: 1.15.4

Resolves 15 of the 48 files for the assert_ item of #752.
Related: Parts 1-4 PRs #767, #768, #771, #776.