### PR TITLE
Clean up deprecated assert_() usage - part 6

### DIFF
--- a/test/cdrom_test.py
+++ b/test/cdrom_test.py
@@ -96,35 +96,24 @@ class CDTypeTest(unittest.TestCase):
     def tearDown(self):
         pygame.cdrom.quit()
 
-    def test_1_eject(self):
-
-        # __doc__ (as of 2008-07-02) for pygame.cdrom.CD.eject:
-
-          # CD.eject(): return None
-          # eject or open the cdrom drive
-
+    def test_eject(self):
+        """Ensure CD drive opens/ejects."""
         # should raise if cd object not initialized
         if self.cd:
             self.cd.init()
             self.cd.eject()
 
-            self.assert_(question('Did the cd eject?'))
+            self.assertTrue(question('Did the CD eject?'))
 
-            prompt("Please close the cd drive")
+            prompt("Please close the CD drive.")
 
-    def test_2_get_name(self):
-
-        # __doc__ (as of 2008-07-02) for pygame.cdrom.CD.get_name:
-
-          # CD.get_name(): return name
-          # the system name of the cdrom drive
-
+    def test_get_name(self):
+        """Ensure correct name for CD drive."""
         if self.cd:
             cd_name = self.cd.get_name()
 
-            self.assert_ (
-                question('Is %s the correct name for the cd drive?' % cd_name)
-            )
+            self.assertTrue(
+                question('Is %s the correct name for the CD drive?' % cd_name))
 
     def todo_test_get_all(self):
 

--- a/test/run_tests__tests/everything/fake_2_test.py
+++ b/test/run_tests__tests/everything/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/everything/incomplete_todo_test.py
+++ b/test/run_tests__tests/everything/incomplete_todo_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def todo_test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def todo_test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/everything/magic_tag_test.py
+++ b/test/run_tests__tests/everything/magic_tag_test.py
@@ -19,19 +19,20 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/everything/sleep_test.py
+++ b/test/run_tests__tests/everything/sleep_test.py
@@ -22,7 +22,8 @@ class KeyModuleTest(unittest.TestCase):
         stop_time = time.time() + 10.0
         while time.time() < stop_time:
             time.sleep(1)
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/exclude/fake_2_test.py
+++ b/test/run_tests__tests/exclude/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/exclude/invisible_tag_test.py
+++ b/test/run_tests__tests/exclude/invisible_tag_test.py
@@ -19,22 +19,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/exclude/magic_tag_test.py
+++ b/test/run_tests__tests/exclude/magic_tag_test.py
@@ -19,19 +19,20 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/infinite_loop/fake_1_test.py
+++ b/test/run_tests__tests/infinite_loop/fake_1_test.py
@@ -17,23 +17,24 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
         while True:
-            pass 
+            pass
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/infinite_loop/fake_2_test.py
+++ b/test/run_tests__tests/infinite_loop/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/print_stdout/fake_2_test.py
+++ b/test/run_tests__tests/print_stdout/fake_2_test.py
@@ -17,22 +17,23 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/print_stdout/fake_3_test.py
+++ b/test/run_tests__tests/print_stdout/fake_3_test.py
@@ -17,24 +17,25 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
         sys.stdout.write("jibberish ruins everything\n")
-        self.assert_(False) 
+        self.assertTrue(False)
 
     def test_name(self):
         sys.stdout.write("forgot to remove debug crap\n")
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/run_tests__tests/print_stdout/fake_4_test.py
+++ b/test/run_tests__tests/print_stdout/fake_4_test.py
@@ -17,24 +17,25 @@ import unittest
 
 class KeyModuleTest(unittest.TestCase):
     def test_get_focused(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_mods(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_get_pressed(self):
-        self.assert_(False, "Some Jibberish") 
+        self.assertTrue(False, "Some Jibberish")
 
     def test_name(self):
-        self.assert_(True) 
+        self.assertTrue(True)
 
     def test_set_mods(self):
         if 1:
             if 1:
-                assert False 
+                assert False
 
     def test_set_repeat(self):
-        self.assert_(True) 
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This update partially cleans up the use of the deprecated `unittest.TestCase.assert_()` method.

Overview of changes:
- Replaced `assert_()` calls with an appropriate `unittest.TestCase` assert method.
- General clean up in the test method where the changes are being made. This includes formatting for readability, removing stale comments, adding docstrings, and other various minor refactoring.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 8711f71a7f58c6ff375f0ace20edf6ad73c23fe6

Resolves 13 of the 48 files for the assert_ item of #752.
Related: Parts 1-5 PRs #767, #768, #771, #776, #777.