### PR TITLE
Fix erase() not always erasing correctly

### DIFF
--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -906,7 +906,7 @@ bitmask_erase(bitmask_t *a, const bitmask_t *b, int xoffset, int yoffset)
                     a_entry += a->h;
                 }
                 for (bp = b_entry, ap = a_entry; bp < b_end; bp++, ap++)
-                    *ap |= (*bp >> shift);
+                    *ap &= ~(*bp >> shift);
             }
             else /* zig-zag */
             {

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -144,6 +144,29 @@ class MaskTypeTest( unittest.TestCase ):
         self.assertRaises(IndexError, lambda : m.set_at((10,0), 1) )
         self.assertRaises(IndexError, lambda : m.set_at((0,10), 1) )
 
+    def test_erase(self):
+        """Ensure erase() clears bits."""
+        mask1 = pygame.mask.Mask((65, 3))
+        mask2 = pygame.mask.Mask((66, 4))
+        mask2.fill()
+
+        # Using rects to help determine the overlapping area.
+        rect1 = pygame.Rect((0, 0), mask1.get_size())
+        rect2 = pygame.Rect((0, 0), mask2.get_size())
+        rect1_area = rect1.w * rect1.h
+        offsets = ((0, 0), (0, 1), (1, 0), (1, 1), (0, -1), (-1, 0), (-1, -1))
+
+        for offset in offsets:
+            rect2.topleft = offset
+            overlap_rect = rect1.clip(rect2)
+            expected_count = rect1_area - (overlap_rect.w * overlap_rect.h)
+            mask1.fill()  # Ensure it's filled for testing each offset.
+
+            mask1.erase(mask2, offset)
+
+            self.assertEqual(mask1.count(), expected_count,
+                             'offset={}'.format(offset))
+
     def test_drawing(self):
         """ Test fill, clear, invert, draw, erase
         """


### PR DESCRIPTION
This update fixes the issue with `erase()` not always erasing correctly.

Overview of changes:
- Fixed the incorrect operation in `erase()`.
- Added a new test method to test `erase()` with a variety of offsets.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at ac69a760050c2cc25b8de85be16763873a3c6841

Resolves #785.