### PR TITLE
Clean up deprecated assert_() usage - part 7

### DIFF
--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -3,9 +3,10 @@
 
 
 import unittest
-from pygame.tests.test_utils import unordered_equality
+
 import pygame
 from pygame import sprite
+
 
 ################################# MODULE LEVEL #################################
 
@@ -15,6 +16,7 @@ class SpriteModuleTest( unittest.TestCase ):
 ######################### SPRITECOLLIDE FUNCTIONS TEST #########################
 
 class SpriteCollideTest( unittest.TestCase ):
+
     def setUp(self):
         self.ag = sprite.AbstractGroup()
         self.ag2 = sprite.AbstractGroup()
@@ -76,15 +78,13 @@ class SpriteCollideTest( unittest.TestCase ):
 
     def test_collide_rect_ratio__collides_all_at_ratio_of_twenty(self):
         # collide_rect_ratio should collide all at a 20.0 ratio.
-        self.assert_ (
-            unordered_equality (
-                sprite.spritecollide (
-                    self.s1, self.ag2, dokill = False,
-                    collided = sprite.collide_rect_ratio(20.0)
-                ),
-                [self.s2, self.s3]
-            )
-        )
+        collided_func = sprite.collide_rect_ratio(20.0)
+        expected_sprites = sorted(self.ag2.sprites(), key=id)
+
+        collided_sprites = sorted(sprite.spritecollide(
+            self.s1, self.ag2, dokill=False, collided=collided_func), key=id)
+
+        self.assertListEqual(collided_sprites, expected_sprites)
 
     def test_collide_circle__no_radius_set(self):
         # collide_circle with no radius set.
@@ -107,48 +107,40 @@ class SpriteCollideTest( unittest.TestCase ):
 
     def test_collide_circle_ratio__no_radius_and_ratio_of_twenty(self):
         # collide_circle_ratio with no radius set, at a 20.0 ratio.
-        self.assert_ (
-            unordered_equality (
-                sprite.spritecollide (
-                    self.s1, self.ag2, dokill = False,
-                    collided = sprite.collide_circle_ratio(20.0)
-                ),
-                [self.s2, self.s3]
-            )
-        )
+        collided_func = sprite.collide_circle_ratio(20.0)
+        expected_sprites = sorted(self.ag2.sprites(), key=id)
+
+        collided_sprites = sorted(sprite.spritecollide(
+            self.s1, self.ag2, dokill=False, collided=collided_func), key=id)
+
+        self.assertListEqual(expected_sprites, collided_sprites)
 
     def test_collide_circle__with_radii_set(self):
         # collide_circle with a radius set.
-
         self.s1.radius = 50
         self.s2.radius = 10
         self.s3.radius = 400
+        collided_func = sprite.collide_circle
+        expected_sprites = sorted(self.ag2.sprites(), key=id)
 
-        self.assert_ (
-            unordered_equality (
-                sprite.spritecollide (
-                    self.s1, self.ag2, dokill = False,
-                    collided = sprite.collide_circle
-                ),
-                [self.s2, self.s3]
-            )
-        )
+        collided_sprites = sorted(
+            sprite.spritecollide(self.s1, self.ag2, dokill=False,
+                                 collided=collided_func), key=id)
+
+        self.assertListEqual(expected_sprites, collided_sprites)
 
     def test_collide_circle_ratio__with_radii_set(self):
+        # collide_circle_ratio with a radius set.
         self.s1.radius = 50
         self.s2.radius = 10
         self.s3.radius = 400
+        collided_func = sprite.collide_circle_ratio(0.5)
+        expected_sprites = sorted(self.ag2.sprites(), key=id)
 
-        # collide_circle_ratio with a radius set.
-        self.assert_ (
-            unordered_equality (
-                sprite.spritecollide (
-                    self.s1, self.ag2, dokill = False,
-                    collided = sprite.collide_circle_ratio(0.5)
-                ),
-                [self.s2, self.s3]
-            )
-        )
+        collided_sprites = sorted(sprite.spritecollide(
+            self.s1, self.ag2, dokill=False, collided=collided_func), key=id)
+
+        self.assertListEqual(expected_sprites, collided_sprites)
 
     def test_collide_mask__opaque(self):
         # make some fully opaque sprites that will collide with masks.
@@ -205,21 +197,30 @@ class SpriteCollideTest( unittest.TestCase ):
         # to calculate the collision.
 
         # s2 in, s3 out
-        self.assert_(
-            sprite.spritecollideany(self.s1, self.ag2)
-                    )
+        expected_sprite = self.s2
+        collided_sprite = sprite.spritecollideany(self.s1, self.ag2)
+
+        self.assertEqual(collided_sprite, expected_sprite)
 
         # s2 and s3 out
         self.s2.rect.move_ip(0, 10)
-        self.assertFalse(sprite.spritecollideany(self.s1, self.ag2))
+        collided_sprite = sprite.spritecollideany(self.s1, self.ag2)
+
+        self.assertIsNone(collided_sprite)
 
         # s2 out, s3 in
         self.s3.rect.move_ip(-105, -105)
-        self.assert_(sprite.spritecollideany(self.s1, self.ag2))
+        expected_sprite = self.s3
+        collided_sprite = sprite.spritecollideany(self.s1, self.ag2)
+
+        self.assertEqual(collided_sprite, expected_sprite)
 
         # s2 and s3 in
         self.s2.rect.move_ip(0, -10)
-        self.assert_(sprite.spritecollideany(self.s1, self.ag2))
+        expected_sprite_choices = self.ag2.sprites()
+        collided_sprite = sprite.spritecollideany(self.s1, self.ag2)
+
+        self.assertIn(collided_sprite, expected_sprite_choices)
 
     def test_spritecollideany__with_collided_callback(self):
 
@@ -251,42 +252,46 @@ class SpriteCollideTest( unittest.TestCase ):
 
             return return_container[0]
 
-        # This should return True because return_container[0] is True
-        self.assert_(
-            sprite.spritecollideany(self.s1, self.ag2, collided_callback)
-                    )
+        # This should return a sprite from self.ag2 because the callback
+        # function (collided_callback()) currently returns True.
+        expected_sprite_choices = self.ag2.sprites()
+        collided_sprite = sprite.spritecollideany(self.s1, self.ag2,
+                                                  collided_callback)
+
+        self.assertIn(collided_sprite, expected_sprite_choices)
 
         # The callback function should have been called only once, so self.s1
         # should have only been passed as an argument once
-        self.assert_(len(arg_dict_a) == 1 and arg_dict_a[self.s1] == 1)
+        self.assertEqual(len(arg_dict_a), 1)
+        self.assertEqual(arg_dict_a[self.s1], 1)
 
         # The callback function should have been called only once, so self.s2
         # exclusive-or self.s3 should have only been passed as an argument
         # once
-        self.assert_(
-            len(arg_dict_b) == 1 and list(arg_dict_b.values())[0] == 1 and
-            (self.s2 in arg_dict_b or self.s3 in arg_dict_b)
-                    )
+        self.assertEqual(len(arg_dict_b), 1)
+        self.assertEqual(list(arg_dict_b.values())[0], 1)
+        self.assertTrue(self.s2 in arg_dict_b or self.s3 in arg_dict_b)
 
         arg_dict_a.clear()
         arg_dict_b.clear()
         return_container[0] = False
 
-        # This should return False because return_container[0] is False
-        self.assertFalse(
-            sprite.spritecollideany(self.s1, self.ag2, collided_callback)
-                        )
+        # This should return None because the callback function
+        # (collided_callback()) currently returns False.
+        collided_sprite = sprite.spritecollideany(self.s1, self.ag2,
+                                                  collided_callback)
+
+        self.assertIsNone(collided_sprite)
 
         # The callback function should have been called as many times as
         # there are sprites in self.ag2
-        self.assert_(len(arg_dict_a) == 1 and arg_dict_a[self.s1] == 2)
+        self.assertEqual(len(arg_dict_a), 1)
+        self.assertEqual(arg_dict_a[self.s1], len(self.ag2))
+        self.assertEqual(len(arg_dict_b), len(self.ag2))
 
-        # The callback function should have been twice because self.s2 and
-        # self.s3 should have been passed once each
-        self.assert_(
-            len(arg_dict_b) == 2 and
-            arg_dict_b[self.s2] == 1 and arg_dict_b[self.s3] == 1
-                    )
+        # Each sprite in self.ag2 should be called once.
+        for s in self.ag2:
+            self.assertEqual(arg_dict_b[s], 1)
 
     def test_groupcollide__without_collided_callback(self):
 
@@ -294,27 +299,36 @@ class SpriteCollideTest( unittest.TestCase ):
         # collision detection between group and group
 
         # test no kill
+        expected_dict = {self.s1: [self.s2]}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False)
-        self.assert_(crashed == {self.s1: [self.s2]})
+
+        self.assertDictEqual(expected_dict, crashed)
 
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False)
-        self.assert_(crashed == {self.s1: [self.s2]})
 
-        # test killb
+        self.assertDictEqual(expected_dict, crashed)
+
+        # Test dokill2=True (kill colliding sprites in second group).
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, True)
-        self.assert_(crashed == {self.s1: [self.s2]})
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False)
-        self.assert_(crashed == {})
 
-        # test killa
+        self.assertDictEqual(expected_dict, crashed)
+
+        # Test dokill1=True (kill colliding sprites in first group).
         self.s3.rect.move_ip(-100, -100)
-
+        expected_dict = {self.s1: [self.s3]}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, True, False)
-        self.assert_(crashed == {self.s1: [self.s3]})
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False)
-        self.assert_(crashed == {})
+
+        self.assertDictEqual(expected_dict, crashed)
 
     def test_groupcollide__with_collided_callback(self):
 
@@ -322,74 +336,97 @@ class SpriteCollideTest( unittest.TestCase ):
         collided_callback_false = lambda spr_a, spr_b: False
 
         # test no kill
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False,
                                              collided_callback_false)
-        self.assert_(crashed == {})
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {self.s1: sorted(self.ag2.sprites(), key=id)}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False,
                                              collided_callback_true)
-        self.assert_(crashed == {self.s1: [self.s2, self.s3]} or
-                     crashed == {self.s1: [self.s3, self.s2]})
+        for value in crashed.values():
+            value.sort(key=id)
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        # expected_dict is the same again for this collide
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, False,
                                              collided_callback_true)
-        self.assert_(crashed == {self.s1: [self.s2, self.s3]} or
-                     crashed == {self.s1: [self.s3, self.s2]})
+        for value in crashed.values():
+            value.sort(key=id)
 
-        # test killb
+        self.assertDictEqual(expected_dict, crashed)
+
+        # Test dokill2=True (kill colliding sprites in second group).
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, True,
                                              collided_callback_false)
-        self.assert_(crashed == {})
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {self.s1: sorted(self.ag2.sprites(), key=id)}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, True,
                                              collided_callback_true)
-        self.assert_(crashed == {self.s1: [self.s2, self.s3]} or
-                     crashed == {self.s1: [self.s3, self.s2]})
+        for value in crashed.values():
+            value.sort(key=id)
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, False, True,
                                              collided_callback_true)
-        self.assert_(crashed == {})
 
-        # test killa
+        self.assertDictEqual(expected_dict, crashed)
+
+        # Test dokill1=True (kill colliding sprites in first group).
         self.ag.add(self.s2)
         self.ag2.add(self.s3)
-
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, True, False,
                                              collided_callback_false)
-        self.assert_(crashed == {})
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {self.s1: [self.s3], self.s2: [self.s3]}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, True, False,
                                              collided_callback_true)
-        self.assert_(crashed == {self.s1: [self.s3], self.s2: [self.s3]})
 
+        self.assertDictEqual(expected_dict, crashed)
+
+        expected_dict = {}
         crashed = pygame.sprite.groupcollide(self.ag, self.ag2, True, False,
                                              collided_callback_true)
-        self.assert_(crashed == {})
+
+        self.assertDictEqual(expected_dict, crashed)
 
     def test_collide_rect(self):
-
         # Test colliding - some edges touching
-        self.assert_(pygame.sprite.collide_rect(self.s1, self.s2))
-        self.assert_(pygame.sprite.collide_rect(self.s2, self.s1))
+        self.assertTrue(pygame.sprite.collide_rect(self.s1, self.s2))
+        self.assertTrue(pygame.sprite.collide_rect(self.s2, self.s1))
 
         # Test colliding - all edges touching
         self.s2.rect.center = self.s3.rect.center
-        self.assert_(pygame.sprite.collide_rect(self.s2, self.s3))
-        self.assert_(pygame.sprite.collide_rect(self.s3, self.s2))
+
+        self.assertTrue(pygame.sprite.collide_rect(self.s2, self.s3))
+        self.assertTrue(pygame.sprite.collide_rect(self.s3, self.s2))
 
         # Test colliding - no edges touching
         self.s2.rect.inflate_ip(10, 10)
-        self.assert_(pygame.sprite.collide_rect(self.s2, self.s3))
-        self.assert_(pygame.sprite.collide_rect(self.s3, self.s2))
+
+        self.assertTrue(pygame.sprite.collide_rect(self.s2, self.s3))
+        self.assertTrue(pygame.sprite.collide_rect(self.s3, self.s2))
 
         # Test colliding - some edges intersecting
         self.s2.rect.center = (self.s1.rect.right, self.s1.rect.bottom)
-        self.assert_(pygame.sprite.collide_rect(self.s1, self.s2))
-        self.assert_(pygame.sprite.collide_rect(self.s2, self.s1))
+
+        self.assertTrue(pygame.sprite.collide_rect(self.s1, self.s2))
+        self.assertTrue(pygame.sprite.collide_rect(self.s2, self.s1))
 
         # Test not colliding
         self.assertFalse(pygame.sprite.collide_rect(self.s1, self.s3))
         self.assertFalse(pygame.sprite.collide_rect(self.s3, self.s1))
+
 
 ################################################################################
 
@@ -451,24 +488,23 @@ class AbstractGroupTypeTest( unittest.TestCase ):
         self.assertEqual(True, self.ag2.has(self.s3))
 
     def test_add(self):
-
         ag3 = sprite.AbstractGroup()
-        self.assertFalse(self.s1 in ag3)
-        self.assertFalse(self.s2 in ag3)
-        self.assertFalse(self.s3 in ag3)
-        self.assertFalse(self.s4 in ag3)
+        sprites = (self.s1, self.s2, self.s3, self.s4)
+
+        for s in sprites:
+            self.assertNotIn(s, ag3)
 
         ag3.add(self.s1, [self.s2], self.ag2)
-        self.assert_(self.s1 in ag3)
-        self.assert_(self.s2 in ag3)
-        self.assert_(self.s3 in ag3)
-        self.assert_(self.s4 in ag3)
+
+        for s in sprites:
+            self.assertIn(s, ag3)
 
     def test_add_internal(self):
+        self.assertNotIn(self.s1, self.ag2)
 
-        self.assertFalse(self.s1 in self.ag2)
         self.ag2.add_internal(self.s1)
-        self.assert_(self.s1 in self.ag2)
+
+        self.assertIn(self.s1, self.ag2)
 
     def test_clear(self):
 
@@ -494,8 +530,7 @@ class AbstractGroupTypeTest( unittest.TestCase ):
         self.assertFalse(self.s2 in self.ag)
 
     def test_has_internal(self):
-
-        self.assert_(self.ag.has_internal(self.s1))
+        self.assertTrue(self.ag.has_internal(self.s1))
         self.assertFalse(self.ag.has_internal(self.s3))
 
     def test_remove(self):
@@ -529,10 +564,10 @@ class AbstractGroupTypeTest( unittest.TestCase ):
         self.assertFalse(self.ag.has_internal(self.s1))
 
     def test_sprites(self):
+        expected_sprites = sorted((self.s1, self.s2), key=id)
+        sprite_list = sorted(self.ag.sprites(), key=id)
 
-        sprite_list = self.ag.sprites()
-        self.assert_(sprite_list == [self.s1, self.s2] or
-                     sprite_list == [self.s2, self.s1])
+        self.assertListEqual(sprite_list, expected_sprites)
 
     def test_update(self):
 
@@ -555,272 +590,311 @@ class AbstractGroupTypeTest( unittest.TestCase ):
 
 class LayeredGroupBase:
     def test_get_layer_of_sprite(self):
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = 666
         spr = self.sprite()
-        self.LG.add(spr, layer=666)
-        self.assert_(len(self.LG._spritelist)==1)
-        self.assert_(self.LG.get_layer_of_sprite(spr)==666)
-        self.assert_(self.LG.get_layer_of_sprite(spr)==self.LG._spritelayers[spr])
+        self.LG.add(spr, layer=expected_layer)
+        layer = self.LG.get_layer_of_sprite(spr)
 
+        self.assertEqual(len(self.LG._spritelist), 1)
+        self.assertEqual(layer, self.LG.get_layer_of_sprite(spr))
+        self.assertEqual(layer, expected_layer)
+        self.assertEqual(layer, self.LG._spritelayers[spr])
 
     def test_add(self):
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = self.LG._default_layer
         spr = self.sprite()
         self.LG.add(spr)
-        self.assert_(len(self.LG._spritelist)==1)
-        self.assert_(self.LG.get_layer_of_sprite(spr)==self.LG._default_layer)
+        layer = self.LG.get_layer_of_sprite(spr)
+
+        self.assertEqual(len(self.LG._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__sprite_with_layer_attribute(self):
-        #test_add_sprite_with_layer_attribute
-
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = 100
         spr = self.sprite()
-        spr._layer = 100
+        spr._layer = expected_layer
         self.LG.add(spr)
-        self.assert_(len(self.LG._spritelist)==1)
-        self.assert_(self.LG.get_layer_of_sprite(spr)==100)
+        layer = self.LG.get_layer_of_sprite(spr)
+
+        self.assertEqual(len(self.LG._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__passing_layer_keyword(self):
-        # test_add_sprite_passing_layer
-
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = 100
         spr = self.sprite()
-        self.LG.add(spr, layer=100)
-        self.assert_(len(self.LG._spritelist)==1)
-        self.assert_(self.LG.get_layer_of_sprite(spr)==100)
+        self.LG.add(spr, layer=expected_layer)
+        layer = self.LG.get_layer_of_sprite(spr)
+
+        self.assertEqual(len(self.LG._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__overriding_sprite_layer_attr(self):
-        # test_add_sprite_overriding_layer_attr
-
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = 200
         spr = self.sprite()
         spr._layer = 100
-        self.LG.add(spr, layer=200)
-        self.assert_(len(self.LG._spritelist)==1)
-        self.assert_(self.LG.get_layer_of_sprite(spr)==200)
+        self.LG.add(spr, layer=expected_layer)
+        layer = self.LG.get_layer_of_sprite(spr)
+
+        self.assertEqual(len(self.LG._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__adding_sprite_on_init(self):
-        # test_add_sprite_init
-
         spr = self.sprite()
         lrg2 = sprite.LayeredUpdates(spr)
-        self.assert_(len(lrg2._spritelist)==1)
-        self.assert_(lrg2._spritelayers[spr]==lrg2._default_layer)
+        expected_layer = lrg2._default_layer
+        layer = lrg2._spritelayers[spr]
+
+        self.assertEqual(len(lrg2._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__sprite_init_layer_attr(self):
-        # test_add_sprite_init_layer_attr
-
+        expected_layer = 20
         spr = self.sprite()
-        spr._layer = 20
+        spr._layer = expected_layer
         lrg2 = sprite.LayeredUpdates(spr)
-        self.assert_(len(lrg2._spritelist)==1)
-        self.assert_(lrg2._spritelayers[spr]==20)
+        layer = lrg2._spritelayers[spr]
+
+        self.assertEqual(len(lrg2._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__sprite_init_passing_layer(self):
-        # test_add_sprite_init_passing_layer
-
+        expected_layer = 33
         spr = self.sprite()
-        lrg2 = sprite.LayeredUpdates(spr, layer=33)
-        self.assert_(len(lrg2._spritelist)==1)
-        self.assert_(lrg2._spritelayers[spr]==33)
+        lrg2 = sprite.LayeredUpdates(spr, layer=expected_layer)
+        layer = lrg2._spritelayers[spr]
+
+        self.assertEqual(len(lrg2._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__sprite_init_overiding_layer(self):
-        # test_add_sprite_init_overiding_layer
-
+        expected_layer = 33
         spr = self.sprite()
         spr._layer = 55
-        lrg2 = sprite.LayeredUpdates(spr, layer=33)
-        self.assert_(len(lrg2._spritelist)==1)
-        self.assert_(lrg2._spritelayers[spr]==33)
+        lrg2 = sprite.LayeredUpdates(spr, layer=expected_layer)
+        layer = lrg2._spritelayers[spr]
+
+        self.assertEqual(len(lrg2._spritelist), 1)
+        self.assertEqual(layer, expected_layer)
 
     def test_add__spritelist(self):
-        # test_add_spritelist
+        expected_layer = self.LG._default_layer
+        sprite_count = 10
+        sprites = [self.sprite() for _ in range(sprite_count)]
 
-        self.assert_(len(self.LG._spritelist)==0)
-        sprites = []
-        for i in range(10):
-            sprites.append(self.sprite())
         self.LG.add(sprites)
-        self.assert_(len(self.LG._spritelist)==10)
-        for i in range(10):
-            self.assert_(self.LG.get_layer_of_sprite(sprites[i])==self.LG._default_layer)
+
+        self.assertEqual(len(self.LG._spritelist), sprite_count)
+
+        for i in range(sprite_count):
+            layer = self.LG.get_layer_of_sprite(sprites[i])
+
+            self.assertEqual(layer, expected_layer)
 
     def test_add__spritelist_with_layer_attr(self):
-        # test_add_spritelist_with_layer_attr
-
-        self.assert_(len(self.LG._spritelist)==0)
         sprites = []
-        for i in range(10):
+        sprite_and_layer_count = 10
+        for i in range(sprite_and_layer_count):
             sprites.append(self.sprite())
             sprites[-1]._layer = i
+
         self.LG.add(sprites)
-        self.assert_(len(self.LG._spritelist)==10)
-        for i in range(10):
-            self.assert_(self.LG.get_layer_of_sprite(sprites[i])==i)
+
+        self.assertEqual(len(self.LG._spritelist), sprite_and_layer_count)
+
+        for i in range(sprite_and_layer_count):
+            layer = self.LG.get_layer_of_sprite(sprites[i])
+
+            self.assertEqual(layer, i)
 
     def test_add__spritelist_passing_layer(self):
-        # test_add_spritelist_passing_layer
+        expected_layer = 33
+        sprite_count = 10
+        sprites = [self.sprite() for _ in range(sprite_count)]
 
-        self.assert_(len(self.LG._spritelist)==0)
-        sprites = []
-        for i in range(10):
-            sprites.append(self.sprite())
-        self.LG.add(sprites, layer=33)
-        self.assert_(len(self.LG._spritelist)==10)
-        for i in range(10):
-            self.assert_(self.LG.get_layer_of_sprite(sprites[i])==33)
+        self.LG.add(sprites, layer=expected_layer)
+
+        self.assertEqual(len(self.LG._spritelist), sprite_count)
+
+        for i in range(sprite_count):
+            layer = self.LG.get_layer_of_sprite(sprites[i])
+
+            self.assertEqual(layer, expected_layer)
 
     def test_add__spritelist_overriding_layer(self):
-        # test_add_spritelist_overriding_layer
-
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = 33
         sprites = []
-        for i in range(10):
+        sprite_and_layer_count = 10
+        for i in range(sprite_and_layer_count):
             sprites.append(self.sprite())
             sprites[-1].layer = i
-        self.LG.add(sprites, layer=33)
-        self.assert_(len(self.LG._spritelist)==10)
-        for i in range(10):
-            self.assert_(self.LG.get_layer_of_sprite(sprites[i])==33)
+
+        self.LG.add(sprites, layer=expected_layer)
+
+        self.assertEqual(len(self.LG._spritelist), sprite_and_layer_count)
+
+        for i in range(sprite_and_layer_count):
+            layer = self.LG.get_layer_of_sprite(sprites[i])
+
+            self.assertEqual(layer, expected_layer)
 
     def test_add__spritelist_init(self):
-        # test_add_spritelist_init
+        sprite_count = 10
+        sprites = [self.sprite() for _ in range(sprite_count)]
 
-        self.assert_(len(self.LG._spritelist)==0)
-        sprites = []
-        for i in range(10):
-            sprites.append(self.sprite())
         lrg2 = sprite.LayeredUpdates(sprites)
-        self.assert_(len(lrg2._spritelist)==10)
-        for i in range(10):
-            self.assert_(lrg2.get_layer_of_sprite(sprites[i])==self.LG._default_layer)
+        expected_layer = lrg2._default_layer
+
+        self.assertEqual(len(lrg2._spritelist), sprite_count)
+
+        for i in range(sprite_count):
+            layer = lrg2.get_layer_of_sprite(sprites[i])
+
+            self.assertEqual(layer, expected_layer)
 
     def test_remove__sprite(self):
-        # test_remove_sprite
-
-        self.assert_(len(self.LG._spritelist)==0)
         sprites = []
-        for i in range(10):
+        sprite_count = 10
+        for i in range(sprite_count):
             sprites.append(self.sprite())
             sprites[-1].rect = 0
+
         self.LG.add(sprites)
-        self.assert_(len(self.LG._spritelist)==10)
-        for i in range(10):
+
+        self.assertEqual(len(self.LG._spritelist), sprite_count)
+
+        for i in range(sprite_count):
             self.LG.remove(sprites[i])
-        self.assert_(len(self.LG._spritelist)==0)
+
+        self.assertEqual(len(self.LG._spritelist), 0)
 
     def test_sprites(self):
-        # test_sprites
-
-        self.assert_(len(self.LG._spritelist)==0)
         sprites = []
-        for i in range(10):
+        sprite_and_layer_count = 10
+        for i in range(sprite_and_layer_count, 0, -1):
             sprites.append(self.sprite())
-            sprites[-1]._layer = 10-i
+            sprites[-1]._layer = i
+
         self.LG.add(sprites)
-        self.assert_(len(self.LG._spritelist)==10)
-        for idx,spr in enumerate(self.LG.sprites()):
-            self.assert_(spr == sprites[9-idx])
+
+        self.assertEqual(len(self.LG._spritelist), sprite_and_layer_count)
+
+        # Sprites should be ordered based on their layer (bottom to top),
+        # which is the reverse order of the sprites list.
+        expected_sprites = list(reversed(sprites))
+        actual_sprites = self.LG.sprites()
+
+        self.assertListEqual(actual_sprites, expected_sprites)
 
     def test_layers(self):
-        # test_layers
-
-        self.assert_(len(self.LG._spritelist)==0)
         sprites = []
-        for i in range(10):
+        expected_layers = []
+        layer_count = 10
+        for i in range(layer_count):
+            expected_layers.append(i)
             for j in range(5):
                 sprites.append(self.sprite())
                 sprites[-1]._layer = i
         self.LG.add(sprites)
-        lays = self.LG.layers()
-        for i in range(10):
-            self.assert_(lays[i] == i)
 
-    def test_add__layers_are_correct(self):  #TODO
-        # test_layers2
+        layers = self.LG.layers()
 
-        self.assert_(len(self.LG)==0)
-        layers = [1,4,6,8,3,6,2,6,4,5,6,1,0,9,7,6,54,8,2,43,6,1]
+        self.assertListEqual(layers, expected_layers)
+
+    def test_add__layers_are_correct(self):
+        layers = [1, 4, 6, 8, 3, 6, 2, 6, 4, 5, 6, 1, 0, 9, 7, 6, 54, 8, 2,
+                  43, 6, 1]
         for lay in layers:
             self.LG.add(self.sprite(), layer=lay)
         layers.sort()
+
         for idx, spr in enumerate(self.LG.sprites()):
-            self.assert_(self.LG.get_layer_of_sprite(spr)==layers[idx])
+            layer = self.LG.get_layer_of_sprite(spr)
+
+            self.assertEqual(layer, layers[idx])
 
     def test_change_layer(self):
-        # test_change_layer
-
-        self.assert_(len(self.LG._spritelist)==0)
+        expected_layer = 99
         spr = self.sprite()
-        self.LG.add(spr, layer=99)
-        self.assert_(self.LG._spritelayers[spr] == 99)
-        self.LG.change_layer(spr, 44)
-        self.assert_(self.LG._spritelayers[spr] == 44)
+        self.LG.add(spr, layer=expected_layer)
 
+        self.assertEqual(self.LG._spritelayers[spr], expected_layer)
+
+        expected_layer = 44
+        self.LG.change_layer(spr, expected_layer)
+
+        self.assertEqual(self.LG._spritelayers[spr], expected_layer)
+
+        expected_layer = 77
         spr2 = self.sprite()
         spr2.layer = 55
         self.LG.add(spr2)
-        self.LG.change_layer(spr2, 77)
-        self.assert_(spr2.layer == 77)
+        self.LG.change_layer(spr2, expected_layer)
+
+        self.assertEqual(spr2.layer, expected_layer)
 
     def test_get_top_layer(self):
-        # test_get_top_layer
-
-        layers = [1,5,2,8,4,5,3,88,23,0]
+        layers = [1, 5, 2, 8, 4, 5, 3, 88, 23, 0]
         for i in layers:
             self.LG.add(self.sprite(), layer=i)
-        self.assert_(self.LG.get_top_layer()==max(layers))
-        self.assert_(self.LG.get_top_layer()==max(self.LG._spritelayers.values()))
-        self.assert_(self.LG.get_top_layer()==self.LG._spritelayers[self.LG._spritelist[-1]])
+        top_layer = self.LG.get_top_layer()
+
+        self.assertEqual(top_layer, self.LG.get_top_layer())
+        self.assertEqual(top_layer, max(layers))
+        self.assertEqual(top_layer, max(self.LG._spritelayers.values()))
+        self.assertEqual(top_layer,
+                         self.LG._spritelayers[self.LG._spritelist[-1]])
 
     def test_get_bottom_layer(self):
-        # test_get_bottom_layer
-
-        layers = [1,5,2,8,4,5,3,88,23,0]
+        layers = [1, 5, 2, 8, 4, 5, 3, 88, 23, 0]
         for i in layers:
             self.LG.add(self.sprite(), layer=i)
-        self.assert_(self.LG.get_bottom_layer()==min(layers))
-        self.assert_(self.LG.get_bottom_layer()==min(self.LG._spritelayers.values()))
-        self.assert_(self.LG.get_bottom_layer()==self.LG._spritelayers[self.LG._spritelist[0]])
+        bottom_layer = self.LG.get_bottom_layer()
+
+        self.assertEqual(bottom_layer, self.LG.get_bottom_layer())
+        self.assertEqual(bottom_layer, min(layers))
+        self.assertEqual(bottom_layer, min(self.LG._spritelayers.values()))
+        self.assertEqual(bottom_layer,
+                         self.LG._spritelayers[self.LG._spritelist[0]])
 
     def test_move_to_front(self):
-        # test_move_to_front
-
-        layers = [1,5,2,8,4,5,3,88,23,0]
+        layers = [1, 5, 2, 8, 4, 5, 3, 88, 23, 0]
         for i in layers:
             self.LG.add(self.sprite(), layer=i)
         spr = self.sprite()
         self.LG.add(spr, layer=3)
-        self.assert_(spr != self.LG._spritelist[-1])
+
+        self.assertNotEqual(spr, self.LG._spritelist[-1])
+
         self.LG.move_to_front(spr)
-        self.assert_(spr == self.LG._spritelist[-1])
+
+        self.assertEqual(spr, self.LG._spritelist[-1])
 
     def test_move_to_back(self):
-        # test_move_to_back
-
-        layers = [1,5,2,8,4,5,3,88,23,0]
+        layers = [1, 5, 2, 8, 4, 5, 3, 88, 23, 0]
         for i in layers:
             self.LG.add(self.sprite(), layer=i)
         spr = self.sprite()
         self.LG.add(spr, layer=55)
-        self.assert_(spr != self.LG._spritelist[0])
+
+        self.assertNotEqual(spr, self.LG._spritelist[0])
+
         self.LG.move_to_back(spr)
-        self.assert_(spr == self.LG._spritelist[0])
+
+        self.assertEqual(spr, self.LG._spritelist[0])
 
     def test_get_top_sprite(self):
-        # test_get_top_sprite
-
-        layers = [1,5,2,8,4,5,3,88,23,0]
+        layers = [1, 5, 2, 8, 4, 5, 3, 88, 23, 0]
         for i in layers:
             self.LG.add(self.sprite(), layer=i)
-        self.assert_(self.LG.get_layer_of_sprite(self.LG.get_top_sprite())== self.LG.get_top_layer())
+        expected_layer = self.LG.get_top_layer()
+        layer = self.LG.get_layer_of_sprite(self.LG.get_top_sprite())
+
+        self.assertEqual(layer, expected_layer)
 
     def test_get_sprites_from_layer(self):
-        # test_get_sprites_from_layer
-
-        self.assert_(len(self.LG)==0)
         sprites = {}
-        layers = [1,4,5,6,3,7,8,2,1,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9,0,1,6,5,4,3,2]
+        layers = [1, 4, 5, 6, 3, 7, 8, 2, 1, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4,
+                  5, 6, 7, 8, 9, 0, 1, 6, 5, 4, 3, 2]
         for lay in layers:
             spr = self.sprite()
             spr._layer = lay
@@ -831,19 +905,19 @@ class LayeredGroupBase:
 
         for lay in self.LG.layers():
             for spr in self.LG.get_sprites_from_layer(lay):
-                self.assert_(spr in sprites[lay])
+                self.assertIn(spr, sprites[lay])
+
                 sprites[lay].remove(spr)
                 if len(sprites[lay]) == 0:
                     del sprites[lay]
-        self.assert_(len(sprites.values())==0)
+
+        self.assertEqual(len(sprites.values()), 0)
 
     def test_switch_layer(self):
-        # test_switch_layer
-
-        self.assert_(len(self.LG)==0)
         sprites1 = []
         sprites2 = []
-        layers = [3,2,3,2,3,3,2,2,3,2,3,2,3,2,3,2,3,3,2,2,3,2,3]
+        layers = [3, 2, 3, 2, 3, 3, 2, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 3, 2, 2,
+                  3, 2, 3]
         for lay in layers:
             spr = self.sprite()
             spr._layer = lay
@@ -853,27 +927,32 @@ class LayeredGroupBase:
             else:
                 sprites2.append(spr)
 
-        for spr in sprites1:
-            self.assert_(spr in self.LG.get_sprites_from_layer(2))
-        for spr in sprites2:
-            self.assert_(spr in self.LG.get_sprites_from_layer(3))
-        self.assert_(len(self.LG)==len(sprites1)+len(sprites2))
+        sprites1.sort(key=id)
+        sprites2.sort(key=id)
+        layer2_sprites = sorted(self.LG.get_sprites_from_layer(2), key=id)
+        layer3_sprites = sorted(self.LG.get_sprites_from_layer(3), key=id)
 
-        self.LG.switch_layer(2,3)
+        self.assertListEqual(sprites1, layer2_sprites)
+        self.assertListEqual(sprites2, layer3_sprites)
+        self.assertEqual(len(self.LG), len(sprites1) + len(sprites2))
 
-        for spr in sprites1:
-            self.assert_(spr in self.LG.get_sprites_from_layer(3))
-        for spr in sprites2:
-            self.assert_(spr in self.LG.get_sprites_from_layer(2))
-        self.assert_(len(self.LG)==len(sprites1)+len(sprites2))
+        self.LG.switch_layer(2, 3)
+        layer2_sprites = sorted(self.LG.get_sprites_from_layer(2), key=id)
+        layer3_sprites = sorted(self.LG.get_sprites_from_layer(3), key=id)
+
+        self.assertListEqual(sprites1, layer3_sprites)
+        self.assertListEqual(sprites2, layer2_sprites)
+        self.assertEqual(len(self.LG), len(sprites1) + len(sprites2))
 
     def test_copy(self):
-
         self.LG.add(self.sprite())
         spr = self.LG.sprites()[0]
         lg_copy = self.LG.copy()
-        self.assert_(isinstance(lg_copy, type(self.LG)))
-        self.assert_(spr in lg_copy and lg_copy in spr.groups())
+
+        self.assertIsInstance(lg_copy, type(self.LG))
+        self.assertIn(spr, lg_copy)
+        self.assertIn(lg_copy, spr.groups())
+
 
 ########################## LAYERED RENDER GROUP TESTS ##########################
 
@@ -928,7 +1007,7 @@ class SpriteBase:
             self.sprite.add_internal(g)
 
         for g in self.groups:
-            self.assert_(g in self.sprite.groups())
+            self.assertIn(g, self.sprite.groups())
 
     def test_remove_internal(self):
 
@@ -956,52 +1035,51 @@ class SpriteBase:
         self.assertEqual(test_sprite.sink, [1, 2, 3])
 
     def test___init____added_to_groups_passed(self):
-        self.sprite = self.Sprite(self.groups)
+        expected_groups = sorted(self.groups, key=id)
+        sprite = self.Sprite(self.groups)
+        groups = sorted(sprite.groups(), key=id)
 
-        self.assert_(unordered_equality(
-            self.sprite.groups(),
-            self.groups
-        ))
+        self.assertListEqual(groups, expected_groups)
 
     def test_add(self):
+        expected_groups = sorted(self.groups, key=id)
         self.sprite.add(self.groups)
+        groups = sorted(self.sprite.groups(), key=id)
 
-        self.assert_(unordered_equality(
-            self.sprite.groups(),
-            self.groups
-        ))
+        self.assertListEqual(groups, expected_groups)
 
     def test_alive(self):
-        self.assert_(
-            not self.sprite.alive(),
-            "Sprite should not be alive if in no groups"
-        )
+        self.assertFalse(self.sprite.alive(),
+                         "Sprite should not be alive if in no groups")
 
         self.sprite.add(self.groups)
-        self.assert_(self.sprite.alive())
+
+        self.assertTrue(self.sprite.alive())
 
     def test_groups(self):
         for i, g in enumerate(self.groups):
+            expected_groups = sorted(self.groups[:i+1], key=id)
             self.sprite.add(g)
+            groups = sorted(self.sprite.groups(), key=id)
 
-            groups = self.sprite.groups()
-            self.assert_( unordered_equality (
-                    groups,
-                    self.groups[:i+1],
-            ))
+            self.assertListEqual(groups, expected_groups)
 
     def test_kill(self):
         self.sprite.add(self.groups)
 
-        self.assert_(self.sprite.alive())
+        self.assertTrue(self.sprite.alive())
+
         self.sprite.kill()
 
-        self.assert_(not self.sprite.groups() and not self.sprite.alive() )
+        self.assertListEqual(self.sprite.groups(), [])
+        self.assertFalse(self.sprite.alive())
 
     def test_remove(self):
         self.sprite.add(self.groups)
         self.sprite.remove(self.groups)
-        self.assert_(not self.sprite.groups())
+
+        self.assertListEqual(self.sprite.groups(), [])
+
 
 ############################## SPRITE CLASS TESTS ##############################
 
@@ -1045,12 +1123,16 @@ class SingleGroupBugsTest(unittest.TestCase):
         g.sprite = s
         del s
         gc.collect()
-        self.assert_(r() is not None)
+
+        self.assertIsNotNone(r())
+
         g.update()
         g.draw(screen)
         g.sprite = MySprite()
         gc.collect()
-        self.assert_(r() is None)
+
+        self.assertIsNone(r())
+
 
 ################################################################################
 

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -91,26 +91,6 @@ def gradient(width, height):
         for t in xrange_(height):
             yield (l,t), tuple(map(rgba_between, (l, t, l, l+t)))
 
-def unordered_equality(seq1, seq2):
-    """
-    
-    Tests to see if the contents of one sequence is contained in the other
-    and that they are of the same length.
-    
-    """
-            
-    if len(seq1) != len(seq2):
-        return False
-
-    # if isinstance(seq1, dict) and isinstance(seq2, dict):
-    #    seq1 = seq1.items()
-    #    seq2 = seq2.items()
-
-    for val in seq1:
-        if val not in seq2:
-            return False
-        
-    return True
 
 def rect_area_pts(rect):
     for l in xrange_(rect.left, rect.right):


### PR DESCRIPTION
This update partially cleans up the use of the deprecated `unittest.TestCase.assert_()` method.

Overview of changes:
- Replaced `assert_()` calls with an appropriate `unittest.TestCase` assert method.
- General clean up in the test method where the changes are being made. This includes formatting for readability, removing stale comments, and other various minor refactoring.
- Removed the `unordered_equality()` function from `test_utils.py`. It is no longer being used and it was not testing for duplicate items (e.g. [1, 1, 2] and [1, 2, 2] were considered equal).

Notes:
- There are a lot of changes in this update. I can break it into smaller PRs if requested.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 1f13216c26c98e64e196e7b6f7e74ba83660b3f5

Resolves 1 (final file) of the 48 files for the assert_ item of #752.
Related: Parts 1-6 PRs #767, #768, #771, #776, #777, #778.