### PR TITLE
Fix warnings reported by charlesej. Close RWops file handle explicitly using pgRWopsReleaseObject().

### DIFF
--- a/docs/reST/c_api/rwobject.rst
+++ b/docs/reST/c_api/rwobject.rst
@@ -38,7 +38,8 @@ Header file: src_c/pygame.h
 
 .. c:function:: int pgRWopsReleaseObject(SDL_RWops *context)
 
-   Free a SDL_RWops struct and close the associated file handle.
+   Free a SDL_RWops struct. If it is attached to a Python file-like object, decrement its
+   refcount. Otherwise, close the file handle.
    Return 0 on success. On error, raise a Python exception and return a negative value.
 
 .. c:function:: PyObject* pgRWopsEncodeFilePath(PyObject *obj, PyObject *eclass)

--- a/docs/reST/c_api/rwobject.rst
+++ b/docs/reST/c_api/rwobject.rst
@@ -38,8 +38,7 @@ Header file: src_c/pygame.h
 
 .. c:function:: int pgRWopsReleaseObject(SDL_RWops *context)
 
-   Free a SDL_RWops struct. If it is attached to a Python file-like object, decrement its
-   refcount. Otherwise, close the file handle.
+   Free a SDL_RWops struct and close the associated file handle.
    Return 0 on success. On error, raise a Python exception and return a negative value.
 
 .. c:function:: PyObject* pgRWopsEncodeFilePath(PyObject *obj, PyObject *eclass)

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -239,6 +239,15 @@ load_font_res(const char *filename)
 #if PY3
     tmp = PyObject_GetAttrString(result, "name");
     if (tmp) {
+        PyObject *closeret;
+        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
+            Py_DECREF(result);
+            Py_DECREF(tmp);
+            result = NULL;
+            goto font_resource_end;
+        }
+        Py_DECREF(closeret);
+
         Py_DECREF(result);
         result = tmp;
     }
@@ -247,8 +256,19 @@ load_font_res(const char *filename)
     }
 #else
     if (PyFile_Check(result)) {
+        PyObject *closeret;
+
         tmp = PyFile_Name(result);
         Py_INCREF(tmp);
+
+        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
+            Py_DECREF(result);
+            Py_DECREF(tmp);
+            result = NULL;
+            goto font_resource_end;
+        }
+        Py_DECREF(closeret);
+
         Py_DECREF(result);
         result = tmp;
     }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -134,6 +134,13 @@ font_resource(const char *filename)
 #if PY3
     tmp = PyObject_GetAttrString(result, "name");
     if (tmp != NULL) {
+        PyObject *closeret;
+        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
+            Py_DECREF(result);
+            Py_DECREF(tmp);
+            return NULL;
+        }
+        Py_DECREF(closeret);
         Py_DECREF(result);
         result = tmp;
     }
@@ -142,8 +149,17 @@ font_resource(const char *filename)
     }
 #else
     if (PyFile_Check(result)) {
+        PyObject *closeret;
+
         tmp = PyFile_Name(result);
         Py_INCREF(tmp);
+
+        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
+            Py_DECREF(result);
+            Py_DECREF(tmp);
+            return NULL;
+        }
+
         Py_DECREF(result);
         result = tmp;
     }
@@ -721,6 +737,14 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
             }
             goto error;
         }
+    }
+    {
+        PyObject *tmp;
+        if (!(tmp = PyObject_CallMethod(test, "close", NULL))) {
+            Py_DECREF(test);
+            goto error;
+        }
+        Py_DECREF(tmp);
     }
     Py_DECREF(test);
     Py_BEGIN_ALLOW_THREADS;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -159,6 +159,7 @@ font_resource(const char *filename)
             Py_DECREF(tmp);
             return NULL;
         }
+        Py_DECREF(closeret);
 
         Py_DECREF(result);
         result = tmp;

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -437,21 +437,10 @@ pgRWopsFromFileObject(PyObject *obj)
 static int
 pgRWopsReleaseObject(SDL_RWops *context)
 {
-    if (pgRWopsCheckObject(context)) {
-        pgRWHelper *helper = (pgRWHelper *)context->hidden.unknown.data1;
-        Py_XDECREF(helper->seek);
-        Py_XDECREF(helper->tell);
-        Py_XDECREF(helper->write);
-        Py_XDECREF(helper->read);
-        Py_XDECREF(helper->close);
-        PyMem_Del(helper);
-        SDL_FreeRW(context);
-    } else {
-        int ret;
-        if ((ret = SDL_RWclose(context)) < 0) {
-            RAISE(PyExc_IOError, SDL_GetError());
-            return ret;
-        }
+    int ret;
+    if ((ret = SDL_RWclose(context)) < 0) {
+        RAISE(PyExc_IOError, SDL_GetError());
+        return ret;
     }
     return 0;
 }

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -37,6 +37,7 @@ typedef struct {
     PyObject *seek;
     PyObject *tell;
     PyObject *close;
+    PyObject *file;
     int fileno;
 } pgRWHelper;
 
@@ -386,6 +387,7 @@ _pg_rw_close(SDL_RWops *context)
     Py_XDECREF(helper->write);
     Py_XDECREF(helper->read);
     Py_XDECREF(helper->close);
+    Py_XDECREF(helper->file);
 
     PyMem_Del(helper);
 #ifdef WITH_THREAD
@@ -414,10 +416,15 @@ pgRWopsFromFileObject(PyObject *obj)
         PyMem_Del(helper);
         return (SDL_RWops *)PyErr_NoMemory();
     }
+
     helper->fileno = PyObject_AsFileDescriptor(obj);
     if (helper->fileno == -1)
         PyErr_Clear();
     fetch_object_methods(helper, obj);
+
+    helper->file = obj;
+    Py_INCREF(obj);
+
     rw->hidden.unknown.data1 = (void *)helper;
 #if IS_SDLv2
     rw->size = _pg_rw_size;
@@ -437,10 +444,44 @@ pgRWopsFromFileObject(PyObject *obj)
 static int
 pgRWopsReleaseObject(SDL_RWops *context)
 {
-    int ret;
-    if ((ret = SDL_RWclose(context)) < 0) {
-        RAISE(PyExc_IOError, SDL_GetError());
-        return ret;
+    if (pgRWopsCheckObject(context)) {
+#ifdef WITH_THREAD
+        PyGILState_STATE state = PyGILState_Ensure();
+#endif /* WITH_THREAD */
+
+        pgRWHelper *helper = (pgRWHelper *)context->hidden.unknown.data1;
+        PyObject *fileobj = helper->file;
+        int filerefcnt = Py_REFCNT(fileobj) - 1 - 5 /* 5 helper functions */;
+
+        if (filerefcnt) {
+            Py_XDECREF(helper->seek);
+            Py_XDECREF(helper->tell);
+            Py_XDECREF(helper->write);
+            Py_XDECREF(helper->read);
+            Py_XDECREF(helper->close);
+            Py_DECREF(fileobj);
+            PyMem_Del(helper);
+            SDL_FreeRW(context);
+        }
+        else {
+            int ret;
+            if ((ret = SDL_RWclose(context)) < 0) {
+                RAISE(PyExc_IOError, SDL_GetError());
+                Py_DECREF(fileobj);
+                return ret;
+            }
+        }
+
+#ifdef WITH_THREAD
+        PyGILState_Release(state);
+#endif /* WITH_THREAD */
+    }
+    else {
+        int ret;
+        if ((ret = SDL_RWclose(context)) < 0) {
+            RAISE(PyExc_IOError, SDL_GetError());
+            return ret;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
See #792. Prevent "unclosed file" warning by explicitly closing a file handle when loading fonts.

Close #792.