### PR TITLE
Close font files

### DIFF
--- a/src_py/freetype.py
+++ b/src_py/freetype.py
@@ -2,7 +2,7 @@
 
 import sys
 from pygame._freetype import (
-   Font as _Font,
+   Font,
    STYLE_NORMAL, STYLE_OBLIQUE, STYLE_STRONG, STYLE_UNDERLINE, STYLE_WIDE,
    STYLE_DEFAULT,
    init, quit, get_init,
@@ -43,29 +43,3 @@ def SysFont(name, size, bold=0, italic=0, constructor=None):
             return font
 
     return _SysFont(name, size, bold, italic, constructor)
-
-
-class Font(_Font):
-    def __init__(self, file, *args, **kwargs):
-        self._file = None
-
-        if sys.platform == 'win32':
-            if isinstance(file, bytes):
-                # Windows paths are unicode...
-                enc = sys.getfilesystemencoding()
-                file = file.decode(enc, 'strict')
-            if isinstance(file, compat.unicode_):
-                # ...but we can't pass a unicode path to Freetype,
-                # so we'll open the file in Python and pass the handle instead.
-                self._file = open(file, 'rb')
-
-        file_arg = file if self._file is None else self._file
-        super(Font, self).__init__(file_arg, *args, **kwargs)
-
-    def __del__(self):
-        if sys.platform == 'win32':
-            # In cases where only __new__ is called (with no __init__ call),
-            # the self._file attribute might not exist.
-            file_attr = getattr(self, '_file', None)
-            if file_attr is not None:
-                file_attr.close()

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -166,6 +166,7 @@ class FreeTypeFontTest(unittest.TestCase):
             tempFont = ft.Font(handle)
         load_font()
         self.assertEqual(sys.getrefcount(handle), 2)
+        handle.close()
 
     def test_freetype_Font_scalable(self):
 


### PR DESCRIPTION
This update closes some open font files.

Overview of changes:
- Closed the open file in `test_freetype_Font_dealloc()`.
- Closed the open file in the `Font` class when the object is deleted/destroyed.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at fe8e32d8c77d426fb18d30aaae97f8f81e12406c

Resolves part of #792.