### PR TITLE
Keep surface alpha value for copied surfaces with SRCALPHA flag.

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1614,7 +1614,13 @@ surf_copy(PyObject *self)
 #endif /* IS_SDLv1 */
 
     pgSurface_Prep(self);
+#if IS_SDLv1
     newsurf = SDL_ConvertSurface(surf, surf->format, surf->flags);
+    if (surf->flags & SDL_SRCALPHA)
+        newsurf->format->alpha = surf->format->alpha;
+#else
+    newsurf = SDL_ConvertSurface(surf, surf->format, 0);
+#endif
     pgSurface_Unprep(self);
 
 #if IS_SDLv1

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -2409,6 +2409,13 @@ class SurfaceSelfBlitTest(unittest.TestCase):
         sub = surf.subsurface((1, 1, 2, 2))
         self.assertRaises(pygame.error, do_blit, surf, sub)
 
+    def test_copy_alpha(self):
+        """issue 581: alpha of surface copy with SRCALPHA is set 0."""
+        surf = pygame.Surface((16, 16), pygame.SRCALPHA)
+        self.assertEqual(surf.get_alpha(), 255)
+        surf2 = surf.copy()
+        self.assertEqual(surf2.get_alpha(), 255)
+
 
 class SurfaceFillTest(unittest.TestCase):
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -2410,8 +2410,8 @@ class SurfaceSelfBlitTest(unittest.TestCase):
         self.assertRaises(pygame.error, do_blit, surf, sub)
 
     def test_copy_alpha(self):
-        """issue 581: alpha of surface copy with SRCALPHA is set 0."""
-        surf = pygame.Surface((16, 16), pygame.SRCALPHA)
+        """issue 581: alpha of surface copy with SRCALPHA is set to 0."""
+        surf = pygame.Surface((16, 16), pygame.SRCALPHA, 32)
         self.assertEqual(surf.get_alpha(), 255)
         surf2 = surf.copy()
         self.assertEqual(surf2.get_alpha(), 255)


### PR DESCRIPTION
Closes #581.