### PR TITLE
Fix aaline()/aalines() not drawing on a surface's border

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -107,7 +107,6 @@ class DrawLineTest(unittest.TestCase):
     """Class for testing line(), aaline(), lines() and aalines().
     """
 
-    @unittest.expectedFailure
     def test_line_color(self):
         """Checks if the line drawn with line_is_color() is the correct color.
         """
@@ -126,7 +125,6 @@ class DrawLineTest(unittest.TestCase):
                 for color in colors:
                     self.assertTrue(line_is_color(surface, color, draw_line))
 
-    @unittest.expectedFailure
     def test_line_gaps(self):
         """Tests if the line drawn with line_has_gaps() contains any gaps.
 
@@ -150,7 +148,6 @@ class DrawLineTest(unittest.TestCase):
             for surface in surfaces:
                 self.assertTrue(line_has_gaps(surface, draw_line))
 
-    @unittest.expectedFailure
     def test_lines_color(self):
         """Tests if the lines drawn with lines_are_color() are the correct color.
         """
@@ -175,11 +172,8 @@ class DrawLineTest(unittest.TestCase):
                     in_border = lines_are_color(surface, color, draw_lines)
                     self.assertTrue(all(in_border))
 
-    @unittest.expectedFailure
     def test_lines_gaps(self):
-        """|tags: ignore|
-
-        Tests if the lines drawn with lines_have_gaps() contain any gaps.
+        """Tests if the lines drawn with lines_have_gaps() contain any gaps.
 
         See: #512
         """


### PR DESCRIPTION
This update fixes aaline()/aalines() not drawing on a surface's border.

Overview of changes:
* Changed the aaline draw code to clip using the correct surface size, to prevent it from drawing outside the surface's bounds, and to use the correct brightness.
* Removed the `@unittest.expectedFailure` decorators (and the ignore tag) as these tests are now passing.

Notes:
* Issue #801 has been opened to track some aaline related issues with `draw_py.py`.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at ae1226c11ce61d3ea368047e7173e93b6cb8807b

Resolves #512 and resolves #732.