### PR TITLE
Add customized repr()/str() output for Mask objects

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1512,26 +1512,33 @@ mask_dealloc(PyObject *self)
     PyObject_DEL(self);
 }
 
+static PyObject *
+mask_repr(PyObject *self)
+{
+    bitmask_t *mask = pgMask_AsBitmap(self);
+    return Text_FromFormat("<Mask(%dx%d)>", mask->w, mask->h);
+}
+
 static PyTypeObject pgMask_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.mask.Mask",
-    sizeof(pgMaskObject),
-    0,
-    mask_dealloc,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    NULL,
-    0,
-    (hashfunc)NULL,
-    (ternaryfunc)NULL,
-    (reprfunc)NULL,
-    0L,
-    0L,
-    0L,
-    0L,
+    TYPE_HEAD(NULL, 0) "pygame.mask.Mask", /* tp_name */
+    sizeof(pgMaskObject), /* tp_basicsize */
+    0,                    /* tp_itemsize */
+    mask_dealloc,         /* tp_dealloc */
+    0,                    /* tp_print */
+    0,                    /* tp_getattr */
+    0,                    /* tp_setattr */
+    0,                    /* tp_as_async (formerly tp_compare/tp_reserved) */
+    (reprfunc)mask_repr,  /* tp_repr */
+    0,                    /* tp_as_number */
+    NULL,                 /* tp_as_sequence */
+    0,                    /* tp_as_mapping */
+    (hashfunc)NULL,       /* tp_hash */
+    (ternaryfunc)NULL,    /* tp_call */
+    (reprfunc)NULL,       /* tp_str */
+    0L,                   /* tp_getattro */
+    0L,                   /* tp_setattro */
+    0L,                   /* tp_as_buffer */
+    0L,                   /* tp_flags */
     DOC_PYGAMEMASKMASK, /* Documentation string */
     0,                  /* tp_traverse */
     0,                  /* tp_clear */


### PR DESCRIPTION
This update adds customized output for `repr()`/`str()` calls on Mask objects.

Overview of changes:
* Added a function to the `tp_repr` field to handle `repr()` calls. The `tp_str` field is left as `NULL`, so that `str()` calls will convert to `repr()` calls.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at ae1226c11ce61d3ea368047e7173e93b6cb8807b

Resolves the "Add customized `repr()`/`str()` output for `Mask` objects" item of #800.