### PR TITLE
Fix bugs in event module

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1332,10 +1332,12 @@ pg_event_get(PyObject *self, PyObject *args)
         if(!_pg_event_append_to_list(list, &event))
             return NULL;
     }
-
-    Py_DECREF(list);
-    return RAISE(PyExc_TypeError,
-                 "get type must be numeric or a sequence");
+    else {
+        Py_DECREF(list);
+        return RAISE(PyExc_TypeError,
+                     "get type must be numeric or a sequence");
+    }
+    return list;
 }
 #endif /* IS_SDLv2 */
 

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1380,9 +1380,11 @@ pg_event_peek(PyObject *self, PyObject *args)
 
     SDL_PumpEvents();
     result = SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, mask);
+    if (result < 0)
+        return RAISE(pgExc_SDLError, SDL_GetError());
 
     if (noargs)
-        return pgEvent_New(&event);
+        return pgEvent_New(result ? &event : NULL);
     return PyInt_FromLong(result == 1);
 }
 #else /* IS_SDLv2 */
@@ -1403,9 +1405,10 @@ pg_event_peek(PyObject *self, PyObject *args)
     SDL_PumpEvents();
 
     if (PyTuple_Size(args) == 0) {
-        if (SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) < 0)
+        result = SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT);
+        if (result < 0)
             return RAISE(pgExc_SDLError, SDL_GetError());
-        return pgEvent_New(&event);
+        return pgEvent_New(result ? &event : NULL);
     }
 
     type = PyTuple_GET_ITEM(args, 0);

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -147,6 +147,13 @@ class EventModuleTest(unittest.TestCase):
         self.assertEqual(len(queue), event_cnt)
         self.assertTrue(all(e.type == pygame.USEREVENT for e in queue))
 
+    def test_get_type(self):
+        ev = pygame.event.Event(pygame.USEREVENT)
+        pygame.event.post(ev)
+        queue = pygame.event.get(pygame.USEREVENT)
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].type, pygame.USEREVENT)
+
     def test_clear(self):
         """Ensure clear() removes all the events on the queue."""
         for e in events:

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -188,6 +188,10 @@ class EventModuleTest(unittest.TestCase):
 
         self.assertTrue(pygame.event.peek(event_types))
 
+    def test_peek_empty(self):
+        pygame.event.clear()
+        self.assertFalse(pygame.event.peek())
+
     def test_set_allowed(self):
         """Ensure a blocked event type can be unblocked/allowed."""
         event = events[0]


### PR DESCRIPTION
* `event.peek()` did not return a false value if no events were queued.
* `event.get(type)`  did not work with SDL2.