### PR TITLE
Add fill kwarg to the Mask constructor

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -46,7 +46,7 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
 .. class:: Mask
 
    | :sl:`pygame object for representing 2D bitmasks`
-   | :sg:`Mask((width, height)[, fill=False]) -> Mask`
+   | :sg:`Mask(size=(width, height)[, fill=False]) -> Mask`
 
    A ``Mask`` object is used to represent a 2D bitmask. Each bit in
    the mask represents a pixel. 1 is used to indicate a set bit and 0 is used
@@ -61,13 +61,15 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
    be accessed using the :func:`pygame.mask.Mask.get_at()` and
    :func:`pygame.mask.Mask.set_at()` methods.
 
-   :param list|tuple (width, height): sequence of 2 ints indicating the width
+   :param list|tuple size: sequence of 2 ints indicating the width
       and height of the mask
    :param bool fill: create mask unfilled (``False`` - default) or filled
       (``True``)
    :rtype: ``Mask`` object
 
-   .. versionadded:: 1.9.5 The keyword parameter ``fill``.
+   .. versionadded:: 1.9.5 Named parameter ``size`` (previously it was an
+      unnamed positional parameter) and the optional keyword parameter
+      ``fill``.
 
    .. method:: get_size
 

--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -46,7 +46,8 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
 .. class:: Mask
 
    | :sl:`pygame object for representing 2D bitmasks`
-   | :sg:`Mask(size=(width, height)[, fill=False]) -> Mask`
+   | :sg:`Mask(size=(width, height)) -> Mask`
+   | :sg:`Mask(size=(width, height), fill=False) -> Mask`
 
    A ``Mask`` object is used to represent a 2D bitmask. Each bit in
    the mask represents a pixel. 1 is used to indicate a set bit and 0 is used
@@ -61,8 +62,8 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
    be accessed using the :func:`pygame.mask.Mask.get_at()` and
    :func:`pygame.mask.Mask.set_at()` methods.
 
-   :param list|tuple size: sequence of 2 ints indicating the width
-      and height of the mask
+   :param size: the dimensions of the mask (width and height)
+   :type size: tuple(int, int) or list[int, int]
    :param bool fill: create mask unfilled (``False`` - default) or filled
       (``True``)
    :rtype: ``Mask`` object

--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -45,8 +45,29 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
 
 .. class:: Mask
 
-   | :sl:`pygame object for representing 2d bitmasks`
-   | :sg:`Mask((width, height)) -> Mask`
+   | :sl:`pygame object for representing 2D bitmasks`
+   | :sg:`Mask((width, height)[, fill=False]) -> Mask`
+
+   A ``Mask`` object is used to represent a 2D bitmask. Each bit in
+   the mask represents a pixel. 1 is used to indicate a set bit and 0 is used
+   to indicate an unset bit. Set bits in a mask can be used to detect
+   collisions with other masks and their set bits.
+
+   A filled mask has all of its bits set to 1, conversely an unfilled/cleared
+   mask has all of its bits set to 0. Masks can be created unfilled (default)
+   or filled by using the ``fill`` parameter. Masks can also be cleared or
+   filled using the :func:`pygame.mask.Mask.clear()` and
+   :func:`pygame.mask.Mask.fill()` methods respectively. Individual bits can
+   be accessed using the :func:`pygame.mask.Mask.get_at()` and
+   :func:`pygame.mask.Mask.set_at()` methods.
+
+   :param list|tuple (width, height): sequence of 2 ints indicating the width
+      and height of the mask
+   :param bool fill: create mask unfilled (``False`` - default) or filled
+      (``True``)
+   :rtype: ``Mask`` object
+
+   .. versionadded:: 1.9.5 The keyword parameter ``fill``.
 
    .. method:: get_size
 

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -5,7 +5,7 @@
 
 #define DOC_PYGAMEMASKFROMTHRESHOLD "from_threshold(Surface, color, threshold = (0,0,0,255), othersurface = None, palette_colors = 1) -> Mask\nCreates a mask by thresholding Surfaces"
 
-#define DOC_PYGAMEMASKMASK "Mask((width, height)[, fill=False]) -> Mask\npygame object for representing 2D bitmasks"
+#define DOC_PYGAMEMASKMASK "Mask(size=(width, height)[, fill=False]) -> Mask\npygame object for representing 2D bitmasks"
 
 #define DOC_MASKGETSIZE "get_size() -> width,height\nReturns the size of the mask."
 
@@ -65,7 +65,7 @@ pygame.mask.from_threshold
 Creates a mask by thresholding Surfaces
 
 pygame.mask.Mask
- Mask((width, height)[, fill=False]) -> Mask
+ Mask(size=(width, height)[, fill=False]) -> Mask
 pygame object for representing 2D bitmasks
 
 pygame.mask.Mask.get_size

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -5,7 +5,7 @@
 
 #define DOC_PYGAMEMASKFROMTHRESHOLD "from_threshold(Surface, color, threshold = (0,0,0,255), othersurface = None, palette_colors = 1) -> Mask\nCreates a mask by thresholding Surfaces"
 
-#define DOC_PYGAMEMASKMASK "Mask(size=(width, height)[, fill=False]) -> Mask\npygame object for representing 2D bitmasks"
+#define DOC_PYGAMEMASKMASK "Mask(size=(width, height)) -> Mask\nMask(size=(width, height), fill=False) -> Mask\npygame object for representing 2D bitmasks"
 
 #define DOC_MASKGETSIZE "get_size() -> width,height\nReturns the size of the mask."
 
@@ -65,7 +65,8 @@ pygame.mask.from_threshold
 Creates a mask by thresholding Surfaces
 
 pygame.mask.Mask
- Mask(size=(width, height)[, fill=False]) -> Mask
+ Mask(size=(width, height)) -> Mask
+ Mask(size=(width, height), fill=False) -> Mask
 pygame object for representing 2D bitmasks
 
 pygame.mask.Mask.get_size

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -5,7 +5,7 @@
 
 #define DOC_PYGAMEMASKFROMTHRESHOLD "from_threshold(Surface, color, threshold = (0,0,0,255), othersurface = None, palette_colors = 1) -> Mask\nCreates a mask by thresholding Surfaces"
 
-#define DOC_PYGAMEMASKMASK "Mask((width, height)) -> Mask\npygame object for representing 2d bitmasks"
+#define DOC_PYGAMEMASKMASK "Mask((width, height)[, fill=False]) -> Mask\npygame object for representing 2D bitmasks"
 
 #define DOC_MASKGETSIZE "get_size() -> width,height\nReturns the size of the mask."
 
@@ -65,8 +65,8 @@ pygame.mask.from_threshold
 Creates a mask by thresholding Surfaces
 
 pygame.mask.Mask
- Mask((width, height)) -> Mask
-pygame object for representing 2d bitmasks
+ Mask((width, height)[, fill=False]) -> Mask
+pygame object for representing 2D bitmasks
 
 pygame.mask.Mask.get_size
  get_size() -> width,height

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1561,7 +1561,7 @@ Mask(PyObject *self, PyObject *args, PyObject *kwargs)
     int w, h;
     int fill = 0; /* Default is false. */
     pgMaskObject *maskobj;
-    char *keywords[] = {"", "fill", NULL};
+    char *keywords[] = {"size", "fill", NULL};
 #if PY3
     const char *format = "(ii)|p";
 #else

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -40,6 +40,39 @@ class MaskTypeTest( unittest.TestCase ):
             for j in range(m1.get_size()[1]):
                 self.assertEqual(m1.get_at((i,j)), m2.get_at((i,j)))
 
+    def test_mask(self):
+        """Ensure masks are created correctly."""
+        expected_count = 0
+        expected_size = (11, 23)
+        mask = pygame.mask.Mask(expected_size)
+
+        self.assertEqual(mask.count(), expected_count)
+        self.assertEqual(mask.get_size(), expected_size)
+
+    def test_mask__fill_kwarg(self):
+        """Ensure masks are created correctly using the fill keyword."""
+        width, height = 37, 47
+        expected_size = (width, height)
+        fill_counts = {True : width * height, False : 0 }
+
+        for fill, expected_count in fill_counts.items():
+            mask = pygame.mask.Mask(expected_size, fill=fill)
+
+            self.assertEqual(mask.count(), expected_count)
+            self.assertEqual(mask.get_size(), expected_size)
+
+    def test_mask__fill_arg(self):
+        """Ensure masks are created correctly using a fill arg."""
+        width, height = 59, 71
+        expected_size = (width, height)
+        fill_counts = {True : width * height, False : 0 }
+
+        for fill, expected_count in fill_counts.items():
+            mask = pygame.mask.Mask(expected_size, fill)
+
+            self.assertEqual(mask.count(), expected_count)
+            self.assertEqual(mask.get_size(), expected_size)
+
     def todo_test_get_at(self):
 
         # __doc__ (as of 2008-08-02) for pygame.mask.Mask.get_at:

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -41,13 +41,17 @@ class MaskTypeTest( unittest.TestCase ):
                 self.assertEqual(m1.get_at((i,j)), m2.get_at((i,j)))
 
     def test_mask(self):
-        """Ensure masks are created correctly."""
+        """Ensure masks are created correctly without fill parameter."""
         expected_count = 0
         expected_size = (11, 23)
-        mask = pygame.mask.Mask(expected_size)
+        mask1 = pygame.mask.Mask(expected_size)
+        mask2 = pygame.mask.Mask(size=expected_size)
 
-        self.assertEqual(mask.count(), expected_count)
-        self.assertEqual(mask.get_size(), expected_size)
+        self.assertEqual(mask1.count(), expected_count)
+        self.assertEqual(mask1.get_size(), expected_size)
+
+        self.assertEqual(mask2.count(), expected_count)
+        self.assertEqual(mask2.get_size(), expected_size)
 
     def test_mask__fill_kwarg(self):
         """Ensure masks are created correctly using the fill keyword."""
@@ -58,8 +62,10 @@ class MaskTypeTest( unittest.TestCase ):
         for fill, expected_count in fill_counts.items():
             mask = pygame.mask.Mask(expected_size, fill=fill)
 
-            self.assertEqual(mask.count(), expected_count)
-            self.assertEqual(mask.get_size(), expected_size)
+            self.assertEqual(mask.count(), expected_count,
+                             'fill={}'.format(fill))
+            self.assertEqual(mask.get_size(), expected_size,
+                             'fill={}'.format(fill))
 
     def test_mask__fill_arg(self):
         """Ensure masks are created correctly using a fill arg."""
@@ -70,8 +76,30 @@ class MaskTypeTest( unittest.TestCase ):
         for fill, expected_count in fill_counts.items():
             mask = pygame.mask.Mask(expected_size, fill)
 
-            self.assertEqual(mask.count(), expected_count)
-            self.assertEqual(mask.get_size(), expected_size)
+            self.assertEqual(mask.count(), expected_count,
+                             'fill={}'.format(fill))
+            self.assertEqual(mask.get_size(), expected_size,
+                             'fill={}'.format(fill))
+
+    def test_mask__size_kwarg(self):
+        """Ensure masks are created correctly using the size keyword."""
+        width, height = 73, 83
+        expected_size = (width, height)
+        fill_counts = {True : width * height, False : 0 }
+
+        for fill, expected_count in fill_counts.items():
+            mask1 = pygame.mask.Mask(fill=fill, size=expected_size)
+            mask2 = pygame.mask.Mask(size=expected_size, fill=fill)
+
+            self.assertEqual(mask1.count(), expected_count,
+                             'fill={}'.format(fill))
+            self.assertEqual(mask1.get_size(), expected_size,
+                             'fill={}'.format(fill))
+
+            self.assertEqual(mask2.count(), expected_count,
+                             'fill={}'.format(fill))
+            self.assertEqual(mask2.get_size(), expected_size,
+                             'fill={}'.format(fill))
 
     def todo_test_get_at(self):
 


### PR DESCRIPTION
This update adds a `fill` keyword parameter to the `Mask` constructor.

Overview of changes:
* Added the `fill` keyword parameter to the `Mask` constructor. The default value is `False` to maintain backward compatibility.
* Changed the `Mask` constructor to raise a `PyExc_MemoryError` if `bitmask_create()` fails to return a valid mask object.
* Updated the `pygame.mask` documentation.
* Added test methods to test `Mask` constructor parameters.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 5de404e926f4b7563b90839fe4e91cda46dba4b3

Resolves the "Add an argument to the `Mask()` constructor..." item of #800.