### PR TITLE
Remove debug print() from midi test

### DIFF
--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -331,7 +331,6 @@ class MidiModuleTest(unittest.TestCase):
         self.assertEqual(len(events), 2)
 
         for eve in events:
-            print(eve, type(eve))
             # pygame.event.Event is a function, but ...
             self.assertEqual(eve.__class__.__name__, 'Event')
             self.assertEqual(eve.vice_id, 2)


### PR DESCRIPTION
This update removes a debug `print()` in one of the midi tests.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 5de404e926f4b7563b90839fe4e91cda46dba4b3
