### PR TITLE
Add aatrigon/aapolygon horizontal edge tests

### DIFF
--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -521,9 +521,9 @@ class GfxdrawDefaultTest( unittest.TestCase ):
         bg_color = pygame.Color('white')
         line_color = pygame.Color('black')
         width, height = 11, 10
-        expected_surface = pygame.Surface((width, height))
+        expected_surface = pygame.Surface((width, height), 0, 32)
         expected_surface.fill(bg_color)
-        surface = pygame.Surface((width, height))
+        surface = pygame.Surface((width, height), 0, 32)
         surface.fill(bg_color)
 
         x1, y1 = width - 1, 0
@@ -652,9 +652,9 @@ class GfxdrawDefaultTest( unittest.TestCase ):
         bg_color = pygame.Color('white')
         line_color = pygame.Color('black')
         width, height = 11, 10
-        expected_surface = pygame.Surface((width, height))
+        expected_surface = pygame.Surface((width, height), 0, 32)
         expected_surface.fill(bg_color)
-        surface = pygame.Surface((width, height))
+        surface = pygame.Surface((width, height), 0, 32)
         surface.fill(bg_color)
 
         points = ((0, 0), (0, height - 1), (width - 1, height - 1),

--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -507,6 +507,49 @@ class GfxdrawDefaultTest( unittest.TestCase ):
             for posn in bg_test_points:
                 self.check_at(surf, posn, bg_adjusted)
 
+    @unittest.expectedFailure
+    def test_aatrigon__with_horizontal_edge(self):
+        """Ensure aatrigon draws horizontal edges correctly.
+
+        This test creates 2 surfaces and draws an aatrigon on each. The pixels
+        on each surface are compared to ensure they are the same. The only
+        difference between the 2 aatrigons is the order the points are drawn.
+        The order of the points should have no impact on the final drawing.
+
+        Related to issue #622.
+        """
+        bg_color = pygame.Color('white')
+        line_color = pygame.Color('black')
+        width, height = 11, 10
+        expected_surface = pygame.Surface((width, height))
+        expected_surface.fill(bg_color)
+        surface = pygame.Surface((width, height))
+        surface.fill(bg_color)
+
+        x1, y1 = width - 1, 0
+        x2, y2 = (width - 1) // 2, height - 1
+        x3, y3 = 0, 0
+
+        # The points in this order draw as expected.
+        pygame.gfxdraw.aatrigon(expected_surface, x1, y1, x2, y2, x3, y3,
+                                line_color)
+
+        # The points in reverse order fail to draw the horizontal edge along
+        # the top.
+        pygame.gfxdraw.aatrigon(surface, x3, y3, x2, y2, x1, y1, line_color)
+
+        # The surfaces are locked for a possible speed up of pixel access.
+        expected_surface.lock()
+        surface.lock()
+        for x in range(width):
+            for y in range(height):
+                self.assertEqual(expected_surface.get_at((x, y)),
+                                 surface.get_at((x, y)),
+                                 'pos=({}, {})'.format(x, y))
+
+        surface.unlock()
+        expected_surface.unlock()
+
     def test_filled_trigon(self):
         """filled_trigon(surface, x1, y1, x2, y2, x3, y3, color): return None"""
         fg = self.foreground_color
@@ -593,6 +636,50 @@ class GfxdrawDefaultTest( unittest.TestCase ):
                 self.check_not_at(surf, posn, fg_adjusted)
             for posn in bg_test_points:
                 self.check_at(surf, posn, bg_adjusted)
+
+    @unittest.expectedFailure
+    def test_aapolygon__with_horizontal_edge(self):
+        """Ensure aapolygon draws horizontal edges correctly.
+
+        This test creates 2 surfaces and draws a polygon on each. The pixels
+        on each surface are compared to ensure they are the same. The only
+        difference between the 2 polygons is that one is drawn using
+        aapolygon() and the other using multiple line() calls. They should
+        produce the same final drawing.
+
+        Related to issue #622.
+        """
+        bg_color = pygame.Color('white')
+        line_color = pygame.Color('black')
+        width, height = 11, 10
+        expected_surface = pygame.Surface((width, height))
+        expected_surface.fill(bg_color)
+        surface = pygame.Surface((width, height))
+        surface.fill(bg_color)
+
+        points = ((0, 0), (0, height - 1), (width - 1, height - 1),
+                  (width - 1, 0))
+
+        # The points are used to draw the expected aapolygon using the line()
+        # function.
+        for (x1, y1), (x2, y2) in zip(points, points[1:] + points[:1]):
+            pygame.gfxdraw.line(expected_surface, x1, y1, x2, y2, line_color)
+
+        # The points in this order fail to draw the horizontal edge along
+        # the top.
+        pygame.gfxdraw.aapolygon(surface, points, line_color)
+
+        # The surfaces are locked for a possible speed up of pixel access.
+        expected_surface.lock()
+        surface.lock()
+        for x in range(width):
+            for y in range(height):
+                self.assertEqual(expected_surface.get_at((x, y)),
+                                 surface.get_at((x, y)),
+                                 'pos=({}, {})'.format(x, y))
+
+        surface.unlock()
+        expected_surface.unlock()
 
     def test_filled_polygon(self):
         """filled_polygon(surface, points, color): return None"""


### PR DESCRIPTION
This update adds `aatrigon()` and `aapolygon()` test methods to test for the horizontal line problem raised in issue #622.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 8a63c06f2e082b8c7e3c0fce035a0a7e4ca55d85
