### PR TITLE
Issue15 Add test for sprite.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ cache:
     - $HOME/Library/Caches/pip/wheels
     - /Library/Caches/pip/wheels
 
-# So commits do not get built twice. 
-# Only test master and tagged releases on push
-#   always test things that aren't pushes (like PRs)
-if: type != push OR branch = master OR branch =~ /^\d+\.\d+(\.\d+)?(-\S*)?$/
-
 
 matrix:
   include:
@@ -35,58 +30,11 @@ matrix:
       python: 3.7
       dist: xenial
 
-    # pypy build is broken. The pypy on travis is really old.
-    # - os: linux
-    #   sudo: required
-    #   python: pypy
-
-    # Should only need one OSX build because older builds can work on newer machines ok.
-    #https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
-    - os: osx
-      osx_image: xcode7.3
-      language: generic
-      env:
-        - PY_VERSION=3
-        - PY_VERSION_=3.7
-        - MAKEFLAGS=-j8
-    - os: osx
-      osx_image: xcode7.3
-      language: generic
-      env:
-        - PY_VERSION=2
-        - MAKEFLAGS=-j8
-    - os: osx
-      osx_image: xcode7.3
-      language: generic
-      env:
-        - PY_VERSION=3
-        - PY_VERSION_=3.6
-        - MAKEFLAGS=-j8
-    # - os: osx
-    #   osx_image: xcode7.3
-    #   language: generic
-    #   env:
-    #     - PY_VERSION=pypy3
-    #     - MAKEFLAGS=-j8
-    # - os: osx
-    #   osx_image: xcode7.3
-    #   language: generic
-    #   env:
-    #     - PY_VERSION=pypy2
-    #     - MAKEFLAGS=-j8
-    #     # - MACOSX_DEPLOYMENT_TARGET=10.6
-
-
   allow_failures:
     - python: pypy
-    - os: osx
-      env: PY_VERSION=pypy2
-    - os: osx
-      env: PY_VERSION=pypy3
 
 before_install:
   - export PATH=/usr/lib/ccache:$PATH
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx_before_install.sh;  fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get update
@@ -96,15 +44,11 @@ before_install:
         xfonts-cyrillic fluid-soundfont-gm musescore-soundfont-gm
     fi
 install:
-  - "python buildconfig/ci/travis/.travis_osx_upload_whl.py --write-config"
   - $(set | grep PYPI_ | python -c "import sys;print('\n'.join(['unset %s' % l.split('=')[0] for l in sys.stdin.readlines() if l.startswith('PYPI')]))")
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then PYTHON_EXE=python PIP_CMD=pip; fi
   - "$PIP_CMD install --upgrade pip"
   - "$PIP_CMD install --upgrade numpy"
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $PIP_CMD install delocate twine; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $PYTHON_EXE setup.py install -noheaders -auto; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx_install.sh; fi
 env:
   global:
     - SDL_VIDEODRIVER=dummy
@@ -116,7 +60,6 @@ script:
   - $PYTHON_EXE -m pygame.tests.__main__ --exclude opengl --time_out 300
 
 after_success:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx_after_success.sh; fi
 
 after_script:
   - rm -f .travis_tmp

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -628,6 +628,26 @@ class LayeredGroupBase:
         self.assertEqual(len(self.LG._spritelist), 1)
         self.assertEqual(layer, expected_layer)
 
+    def test_add_bad_class_sprite(self):
+        expected_layer = 100
+        spr = BadSpriteInstance()
+        
+        try:
+            # Should not be able to add bad sprite
+            self.LG.add(spr, layer=expected_layer)
+        except (TypeError, AttributeError):
+            checker0 = True
+        
+        try:
+            # Should not add the attribute _spritelayers to bad sprite
+            self.assertEqual(self._spritelayers, 1)
+        except AttributeError:
+            checker1 = True
+
+        self.assertTrue(checker0)
+        self.assertTrue(checker1)
+
+
     def test_add__overriding_sprite_layer_attr(self):
         expected_layer = 200
         spr = self.sprite()
@@ -1100,6 +1120,9 @@ class DirtySpriteTypeTest(SpriteBase, unittest.TestCase):
                sprite.OrderedUpdates,
                sprite.LayeredDirty, ]
 
+class BadSpriteInstance():
+    pass
+
 ############################## BUG TESTS #######################################
 
 class SingleGroupBugsTest(unittest.TestCase):
@@ -1135,6 +1158,5 @@ class SingleGroupBugsTest(unittest.TestCase):
 
 
 ################################################################################
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -636,17 +636,11 @@ class LayeredGroupBase:
             # Should not be able to add bad sprite
             self.LG.add(spr, layer=expected_layer)
         except (TypeError, AttributeError):
-            checker0 = True
+            checker = True
         
-        try:
-            # Should not add the attribute _spritelayers to bad sprite
-            self.assertEqual(self._spritelayers, 1)
-        except AttributeError:
-            checker1 = True
-
-        self.assertTrue(checker0)
-        self.assertTrue(checker1)
-
+        self.assertTrue(checker)
+        # Sprite should not have been added to the layer
+        self.assertFalse(hasattr(self, '_spritelayers'))
 
     def test_add__overriding_sprite_layer_attr(self):
         expected_layer = 200


### PR DESCRIPTION
Adding coverage for lines 714-726 by entering the exception clause in the add() function. This is done by sending a sprite to add() that is an instance of a bad class that does nothing (i.e. not the correct Sprite class). This results in that it now only lacks coverage for 720-723, I couldn't think of a way to test those lines.