### PR TITLE
Add @unittest.skipIf() decorator to silently skipped tests

### DIFF
--- a/test/image__save_gl_surface_test.py
+++ b/test/image__save_gl_surface_test.py
@@ -5,6 +5,9 @@ from pygame.tests import test_utils
 import pygame
 from pygame.locals import *
 
+
+@unittest.skipIf(os.environ.get('SDL_VIDEODRIVER') == 'dummy',
+                 'OpenGL requires a non-"dummy" SDL_VIDEODRIVER')
 class GL_ImageSave(unittest.TestCase):
     def test_image_save_works_with_opengl_surfaces(self):
         """

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -636,13 +636,11 @@ class SurfaceTypeTest(unittest.TestCase):
         source.set_at((0, 0), color)
         target.blit(source, (0, 0))
 
+    @unittest.skipIf(os.environ.get('SDL_VIDEODRIVER') == 'dummy',
+                     'requires a non-"dummy" SDL_VIDEODRIVER')
     def test_image_convert_bug_131(self):
         # Bitbucket bug #131: Unable to Surface.convert(32) some 1-bit images.
         # https://bitbucket.org/pygame/pygame/issue/131/unable-to-surfaceconvert-32-some-1-bit
-
-        # Skip test_image_convert_bug_131 for headless tests.
-        if os.environ.get('SDL_VIDEODRIVER') == 'dummy':
-            return
 
         pygame.display.init()
         pygame.display.set_mode((640,480))
@@ -2296,13 +2294,11 @@ class SurfaceSelfBlitTest(unittest.TestCase):
                 surf.blit(surf, (d_x, d_y), (s_x, s_y, 50, 50))
                 self.assertEqual(surf.get_at(test_posn), rectc_right)
 
+    # https://github.com/pygame/pygame/issues/370#issuecomment-364625291
+    @unittest.skipIf('ppc64le' in platform.uname(), 'known ppc64le issue')
     def test_colorkey(self):
         # Check a workaround for an SDL 1.2.13 surface self-blit problem
         # (MotherHamster Bugzilla bug 19).
-
-        if 'ppc64le' in platform.uname():
-            # skip https://github.com/pygame/pygame/issues/370#issuecomment-364625291
-            return
         pygame.display.set_mode((100, 50))  # Needed for 8bit surface
         bitsizes = [8, 16, 24, 32]
         for bitsize in bitsizes:
@@ -2321,13 +2317,11 @@ class SurfaceSelfBlitTest(unittest.TestCase):
             comp.blit(tmp, (0, 0))
             self._assert_same(surf, comp)
 
+    # https://github.com/pygame/pygame/issues/370#issuecomment-364625291
+    @unittest.skipIf('ppc64le' in platform.uname(), 'known ppc64le issue')
     def test_blanket_alpha(self):
         # Check a workaround for an SDL 1.2.13 surface self-blit problem
         # (MotherHamster Bugzilla bug 19).
-        if 'ppc64le' in platform.uname():
-            # skip https://github.com/pygame/pygame/issues/370#issuecomment-364625291
-            return
-
         pygame.display.set_mode((100, 50))  # Needed for 8bit surface
         bitsizes = [8, 16, 24, 32]
         for bitsize in bitsizes:


### PR DESCRIPTION
This update adds the `@unittest.skipIf()` decorator to some silently skipped tests.

Note:
* The `opengl` tag is being used to skip the `test_image_save_works_with_opengl_surfaces()` test in some instances. Using the decorator here makes the skipping explicit and allows the test to be skipped when testing without tag support.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 4e42dd6ac1b050ca7cbe1e24c49942857f8304e3
