### PR TITLE
Make the joystick doc code example python 2 compatible

### DIFF
--- a/docs/reST/ref/code_examples/joystick_calls.py
+++ b/docs/reST/ref/code_examples/joystick_calls.py
@@ -1,136 +1,142 @@
 import pygame
 
-# Define some colors
-BLACK    = (   0,   0,   0)
-WHITE    = ( 255, 255, 255)
 
-# This is a simple class that will help us print to the screen
+# Define some colors.
+BLACK = pygame.Color('black')
+WHITE = pygame.Color('white')
+
+
+# This is a simple class that will help us print to the screen.
 # It has nothing to do with the joysticks, just outputting the
 # information.
-class TextPrint:
+class TextPrint(object):
     def __init__(self):
         self.reset()
         self.font = pygame.font.Font(None, 20)
 
-    def print(self, screen, textString):
+    def tprint(self, screen, textString):
         textBitmap = self.font.render(textString, True, BLACK)
-        screen.blit(textBitmap, [self.x, self.y])
+        screen.blit(textBitmap, (self.x, self.y))
         self.y += self.line_height
-        
+
     def reset(self):
         self.x = 10
         self.y = 10
         self.line_height = 15
-        
+
     def indent(self):
         self.x += 10
-        
+
     def unindent(self):
         self.x -= 10
-    
+
 
 pygame.init()
- 
-# Set the width and height of the screen [width,height]
-size = [500, 700]
-screen = pygame.display.set_mode(size)
+
+# Set the width and height of the screen (width, height).
+screen = pygame.display.set_mode((500, 700))
 
 pygame.display.set_caption("My Game")
 
-#Loop until the user clicks the close button.
+# Loop until the user clicks the close button.
 done = False
 
-# Used to manage how fast the screen updates
+# Used to manage how fast the screen updates.
 clock = pygame.time.Clock()
 
-# Initialize the joysticks
+# Initialize the joysticks.
 pygame.joystick.init()
-    
-# Get ready to print
+
+# Get ready to print.
 textPrint = TextPrint()
 
 # -------- Main Program Loop -----------
-while done==False:
+while not done:
+    #
     # EVENT PROCESSING STEP
-    for event in pygame.event.get(): # User did something
-        if event.type == pygame.QUIT: # If user clicked close
-            done=True # Flag that we are done so we exit this loop
-        
-        # Possible joystick actions: JOYAXISMOTION JOYBALLMOTION JOYBUTTONDOWN JOYBUTTONUP JOYHATMOTION
-        if event.type == pygame.JOYBUTTONDOWN:
+    #
+    # Possible joystick actions: JOYAXISMOTION, JOYBALLMOTION, JOYBUTTONDOWN,
+    # JOYBUTTONUP, JOYHATMOTION
+    for event in pygame.event.get(): # User did something.
+        if event.type == pygame.QUIT: # If user clicked close.
+            done = True # Flag that we are done so we exit this loop.
+        elif event.type == pygame.JOYBUTTONDOWN:
             print("Joystick button pressed.")
-        if event.type == pygame.JOYBUTTONUP:
+        elif event.type == pygame.JOYBUTTONUP:
             print("Joystick button released.")
-            
- 
+
+    #
     # DRAWING STEP
+    #
     # First, clear the screen to white. Don't put other drawing commands
     # above this, or they will be erased with this command.
     screen.fill(WHITE)
     textPrint.reset()
 
-    # Get count of joysticks
+    # Get count of joysticks.
     joystick_count = pygame.joystick.get_count()
 
-    textPrint.print(screen, "Number of joysticks: {}".format(joystick_count) )
+    textPrint.tprint(screen, "Number of joysticks: {}".format(joystick_count))
     textPrint.indent()
-    
+
     # For each joystick:
     for i in range(joystick_count):
         joystick = pygame.joystick.Joystick(i)
         joystick.init()
-    
-        textPrint.print(screen, "Joystick {}".format(i) )
+
+        textPrint.tprint(screen, "Joystick {}".format(i))
         textPrint.indent()
-    
-        # Get the name from the OS for the controller/joystick
+
+        # Get the name from the OS for the controller/joystick.
         name = joystick.get_name()
-        textPrint.print(screen, "Joystick name: {}".format(name) )
-        
+        textPrint.tprint(screen, "Joystick name: {}".format(name))
+
         # Usually axis run in pairs, up/down for one, and left/right for
         # the other.
         axes = joystick.get_numaxes()
-        textPrint.print(screen, "Number of axes: {}".format(axes) )
+        textPrint.tprint(screen, "Number of axes: {}".format(axes))
         textPrint.indent()
-        
-        for i in range( axes ):
-            axis = joystick.get_axis( i )
-            textPrint.print(screen, "Axis {} value: {:>6.3f}".format(i, axis) )
+
+        for i in range(axes):
+            axis = joystick.get_axis(i)
+            textPrint.tprint(screen, "Axis {} value: {:>6.3f}".format(i, axis))
         textPrint.unindent()
-            
+
         buttons = joystick.get_numbuttons()
-        textPrint.print(screen, "Number of buttons: {}".format(buttons) )
+        textPrint.tprint(screen, "Number of buttons: {}".format(buttons))
         textPrint.indent()
 
-        for i in range( buttons ):
-            button = joystick.get_button( i )
-            textPrint.print(screen, "Button {:>2} value: {}".format(i,button) )
+        for i in range(buttons):
+            button = joystick.get_button(i)
+            textPrint.tprint(screen,
+                             "Button {:>2} value: {}".format(i, button))
         textPrint.unindent()
-            
-        # Hat switch. All or nothing for direction, not like joysticks.
-        # Value comes back in an array.
+
         hats = joystick.get_numhats()
-        textPrint.print(screen, "Number of hats: {}".format(hats) )
+        textPrint.tprint(screen, "Number of hats: {}".format(hats))
         textPrint.indent()
 
-        for i in range( hats ):
-            hat = joystick.get_hat( i )
-            textPrint.print(screen, "Hat {} value: {}".format(i, str(hat)) )
-        textPrint.unindent()
-        
+        # Hat position. All or nothing for direction, not a float like
+        # get_axis(). Position is a tuple of int values (x, y).
+        for i in range(hats):
+            hat = joystick.get_hat(i)
+            textPrint.display(screen, "Hat {} value: {}".format(i, str(hat)))
         textPrint.unindent()
 
-    
+        textPrint.unindent()
+
+    #
     # ALL CODE TO DRAW SHOULD GO ABOVE THIS COMMENT
-    
+    #
+
     # Go ahead and update the screen with what we've drawn.
     pygame.display.flip()
 
-    # Limit to 20 frames per second
+    # Limit to 20 frames per second.
     clock.tick(20)
-    
+
 # Close the window and quit.
 # If you forget this line, the program will 'hang'
 # on exit if running from IDLE.
-pygame.quit ()
+pygame.quit()
 


### PR DESCRIPTION
This update makes the joystick documentation code example python 2 compatible.

Overview of changes:
- Renamed `TextPrint`'s `print()` method to `tprint()` (based on the fix supplied by "Frank" in issue #162)
- Some refactoring/rewording/formatting

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 4e42dd6ac1b050ca7cbe1e24c49942857f8304e3

Resolves #162.