### PR TITLE
Remove the 'ignore' tag from test_ellipse()

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -34,11 +34,10 @@ class DrawEllipseTest(unittest.TestCase):
     Class for testing ellipse().
     """
     def test_ellipse(self):
-        """|tags: ignore|
+        """Tests ellipses of differing sizes on surfaces of differing sizes.
 
-        Draws ellipses of differing sizes on surfaces of differing sizes and
-        checks to see if the number of sides touching the border of the surface
-        is correct.
+        Checks if the number of sides touching the border of the surface is
+        correct.
         """
 
         left_top = [(0, 0), (1, 0), (0, 1), (1, 1)]


### PR DESCRIPTION
This update removes the `ignore` tag from `test_ellipse()`. This test now passes as issue #233 was resolved by PR #511.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 4e42dd6ac1b050ca7cbe1e24c49942857f8304e3