### PR TITLE
Document making docs

### DIFF
--- a/docs/reST/_templates/header.h
+++ b/docs/reST/_templates/header.h
@@ -24,10 +24,9 @@
 {#- -#}
 
 
-/* Auto generated file: with makeref.py .  Docs go in src/ *.doc . */
+/* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 {% for item in hdr_items -%}
 #define {{ cmacro(item) }} "{{ join_sigs(item) }}{{ item['summary'] }}"
-
 {% endfor %}
 
 /* Docs in a comment... slightly easier to read. */

--- a/docs/reST/conf.py
+++ b/docs/reST/conf.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.abspath('.'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.coverage', 'ext.headers', 'ext.boilerplate',
-              'ext.customversion']
+              'ext.customversion', 'ext.edit_on_github']
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Pygame'
-copyright = u'2011, Pygame Developers'
+copyright = u'2011-2019, Pygame Developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -221,3 +221,7 @@ headers_mkdirs = True
 headers_filename_sfx = '_doc'
 
 smartquotes = False
+
+edit_on_github_project = 'pygame/pygame'
+edit_on_github_branch = 'master'
+

--- a/docs/reST/ext/edit_on_github.py
+++ b/docs/reST/ext/edit_on_github.py
@@ -1,0 +1,42 @@
+"""
+from: https://gist.github.com/mgedmin/6052926
+Sphinx extension to add ReadTheDocs-style "Edit on GitHub" links to the
+sidebar.
+Loosely based on https://github.com/astropy/astropy/pull/347
+"""
+
+import os
+import warnings
+
+
+__licence__ = 'BSD (3 clause)'
+
+
+def get_github_url(app, view, path):
+    return 'https://github.com/{project}/{view}/{branch}/docs/reST/{path}'.format(
+        project=app.config.edit_on_github_project,
+        view=view,
+        branch=app.config.edit_on_github_branch,
+        path=path)
+
+
+def html_page_context(app, pagename, templatename, context, doctree):
+    if templatename != 'page.html':
+        return
+
+    if not app.config.edit_on_github_project:
+        warnings.warn("edit_on_github_project not specified")
+        return
+
+    path = os.path.relpath(doctree.get('source'), app.builder.srcdir)
+    show_url = get_github_url(app, 'blob', path)
+    edit_url = get_github_url(app, 'edit', path)
+
+    context['show_on_github_url'] = show_url
+    context['edit_on_github_url'] = edit_url
+
+
+def setup(app):
+    app.add_config_value('edit_on_github_project', '', True)
+    app.add_config_value('edit_on_github_branch', 'master', True)
+    app.connect('html-page-context', html_page_context)

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -86,7 +86,6 @@ We render three sets of items based on how useful to most apps.
 	  </p>
 
 
-
 {%-   endif  %}
 	</td>
       </tr>
@@ -96,6 +95,10 @@ We render three sets of items based on how useful to most apps.
 
 {%- block body %}
 {%-   block section %}{% endblock %}
+
+<br /><br />
+<hr />
+<a href="{{ edit_on_github_url }}" rel="nofollow">{{ _('Edit on GitHub') }}</a>
 {%- endblock %}
 
 

--- a/src_c/doc/README.rst
+++ b/src_c/doc/README.rst
@@ -1,0 +1,5 @@
+These files are generated from the rst files in docs/reST/ref/
+
+Both the .rst file and the generated .h file should be committed.
+
+To generate docs run: python setup.py docs


### PR DESCRIPTION
- A src_c/doc/README.rst with a few bits of dev info.
- Put the correct spot for where the docs are at top of src_c/doc/*.h files.
- Add Edit on Github link to bottom of html docs.

Running `python3 setup.py docs` and then looking at bottom of docs/ref/mask.html should show the Edit on github link.