### PR TITLE
Move the assertRaisesRegex() method to a test_utils mixin

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -2,7 +2,7 @@ import os
 
 import unittest
 from pygame.tests import test_utils
-from pygame.tests.test_utils import example_path
+from pygame.tests.test_utils import example_path, AssertRaisesRegexMixin
 try:
     from pygame.tests.test_utils.arrinter import *
 except (ImportError, NameError):
@@ -33,24 +33,7 @@ def longify(i):
     return long(i)
 
 
-class SurfaceTypeTest(unittest.TestCase):
-    def assertRaisesRegex(self, *args, **kwargs):
-        # Overriding base class method to prevent DeprecationWarnings in
-        # python >= 3.2.
-        #
-        # This method can be removed when pygame no longer supports
-        # python < 3.2.
-        try:
-            return super(SurfaceTypeTest, self).assertRaisesRegex(
-                *args, **kwargs)
-        except AttributeError:
-            try:
-                return super(SurfaceTypeTest, self).assertRaisesRegexp(
-                    *args, **kwargs)
-            except AttributeError:
-                self.skipTest(
-                    'No assertRaisesRegex/assertRaisesRegexp method')
-
+class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
     def test_set_clip( self ):
         """ see if surface.set_clip(None) works correctly.
         """

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -19,6 +19,30 @@ except NameError:
 def geterror():
     return sys.exc_info()[1]
 
+
+class AssertRaisesRegexMixin(object):
+    """Provides a way to prevent DeprecationWarnings in python >= 3.2.
+
+    For this mixin to override correctly it needs to be before the
+    unittest.TestCase in the multiple inheritance hierarchy.
+    e.g. class TestClass(AssertRaisesRegexMixin, unittest.TestCase)
+
+    This class/mixin and its usage can be removed when pygame no longer
+    supports python < 3.2.
+    """
+    def assertRaisesRegex(self, *args, **kwargs):
+        try:
+            return super(AssertRaisesRegexMixin, self).assertRaisesRegex(
+                *args, **kwargs)
+        except AttributeError:
+            try:
+                return super(AssertRaisesRegexMixin, self).assertRaisesRegexp(
+                    *args, **kwargs)
+            except AttributeError:
+                self.skipTest(
+                    'No assertRaisesRegex/assertRaisesRegexp method')
+
+
 ################################################################################
 
 this_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This update moves the `assertRaisesRegex()` method to a `test_utils` mixin. This allows for future test classes to easily reuse this code.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 4464eb4ebd06095e97b7c6a40ac66295e542aa4b