### PR TITLE
Add check for mixer init during Sound()'s creation

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1419,7 +1419,7 @@ _chunk_from_array(void *buf, PG_sample_format_t view_format, int ndim,
     Py_ssize_t loop1, loop2, step1, step2, length, length2 = 0;
 
     if (!Mix_QuerySpec(&freq, &format, &channels)) {
-        RAISE(pgExc_SDLError, "Mixer not initialized");
+        RAISE(pgExc_SDLError, "mixer not initialized");
         return -1;
     }
 
@@ -1568,6 +1568,12 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
 
     ((pgSoundObject *)self)->chunk = NULL;
     ((pgSoundObject *)self)->mem = NULL;
+
+    /* Similar to MIXER_INIT_CHECK(), but different return value. */
+    if (!SDL_WasInit(SDL_INIT_AUDIO)) {
+        RAISE(pgExc_SDLError, "mixer not initialized");
+        return -1;
+    }
 
     /* Process arguments, returning cleaner error messages than
        PyArg_ParseTupleAndKeywords would.

--- a/src_c/mixer.h
+++ b/src_c/mixer.h
@@ -28,8 +28,7 @@
 /* test mixer initializations */
 #define MIXER_INIT_CHECK() \
     if(!SDL_WasInit(SDL_INIT_AUDIO)) \
-        return RAISE(pgExc_SDLError, "mixer system not initialized")
-
+        return RAISE(pgExc_SDLError, "mixer not initialized")
 
 
 #define PYGAMEAPI_MIXER_FIRSTSLOT 0

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -5,7 +5,8 @@ import os
 import unittest
 import platform
 
-from pygame.tests.test_utils import example_path
+from pygame.tests.test_utils import example_path, AssertRaisesRegexMixin
+
 import pygame
 from pygame import mixer
 from pygame.compat import unicode_, as_bytes, bytes_
@@ -568,23 +569,38 @@ class MixerModuleTest(unittest.TestCase):
 
 ############################## CHANNEL CLASS TESTS #############################
 
-class ChannelTypeTest(unittest.TestCase):
-    def todo_test_Channel(self):
-        # __doc__ (as of 2008-08-02) for pygame.mixer.Channel:
+class ChannelTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+    def setUp(self):
+        mixer.init()
 
-          # pygame.mixer.Channel(id): return Channel
-          # Create a Channel object for controlling playback
-          #
-          # Return a Channel object for one of the current channels. The id must
-          # be a value from 0 to the value of pygame.mixer.get_num_channels().
-          #
-          # The Channel object can be used to get fine control over the playback
-          # of Sounds. A channel can only playback a single Sound at time. Using
-          # channels is entirely optional since pygame can manage them by
-          # default.
-          #
+    def tearDown(self):
+        mixer.quit()
 
-        self.fail()
+    def test_channel(self):
+        """Ensure Channel() creation works."""
+        channel = mixer.Channel(0)
+
+        # self.assertIsInstance(channel, mixer.Channel)  # Would be nice.
+        # type(pygame.mixer.Channel) gives <class 'builtin_function_or_method'>
+        # Check class name instead.
+        self.assertEqual(channel.__class__.__name__, 'Channel')
+
+    def test_channel__without_arg(self):
+        """Ensure exception for Channel() creation with no argument."""
+        with self.assertRaises(TypeError):
+            mixer.Channel()
+
+    def test_channel__invalid_id(self):
+        """Ensure exception for Channel() creation with an invalid id."""
+        with self.assertRaises(IndexError):
+            mixer.Channel(-1)
+
+    def test_channel__before_init(self):
+        """Ensure exception for Channel() creation with non-init mixer."""
+        mixer.quit()
+
+        with self.assertRaisesRegex(pygame.error, 'mixer not initialized'):
+            mixer.Channel(0)
 
     def todo_test_fadeout(self):
 
@@ -805,7 +821,65 @@ class ChannelTypeTest(unittest.TestCase):
 
 ############################### SOUND CLASS TESTS ##############################
 
-class SoundTypeTest(unittest.TestCase):
+class SoundTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+    def setUp(self):
+        mixer.init()
+
+    def tearDown(self):
+        mixer.quit()
+
+    # See MixerModuleTest's methods test_sound_args(), test_sound_unicode(),
+    # and test_array_keyword() for additional testing of Sound() creation.
+    def test_sound(self):
+        """Ensure Sound() creation with a filename works."""
+        filename = example_path(os.path.join('data', 'house_lo.wav'))
+        sound1 = mixer.Sound(filename)
+        sound2 = mixer.Sound(file=filename)
+
+        self.assertIsInstance(sound1, mixer.Sound)
+        self.assertIsInstance(sound2, mixer.Sound)
+
+    def test_sound__from_file_object(self):
+        """Ensure Sound() creation with a file object works."""
+        filename = example_path(os.path.join('data', 'house_lo.wav'))
+        file_obj = open(filename, "rb")
+
+        sound = mixer.Sound(file_obj)
+
+        self.assertIsInstance(sound, mixer.Sound)
+
+        file_obj.close()
+
+    def test_sound__from_sound_object(self):
+        """Ensure Sound() creation with a Sound() object works."""
+        filename = example_path(os.path.join('data', 'house_lo.wav'))
+        sound_obj = mixer.Sound(file=filename)
+
+        sound = mixer.Sound(sound_obj)
+
+        self.assertIsInstance(sound, mixer.Sound)
+
+    def todo_test_sound__from_buffer(self):
+        """Ensure Sound() creation with a buffer works."""
+        self.fail()
+
+    def todo_test_sound__from_array(self):
+        """Ensure Sound() creation with an array works."""
+        self.fail()
+
+    def test_sound__without_arg(self):
+        """Ensure exception raised for Sound() creation with no argument."""
+        with self.assertRaises(TypeError):
+            mixer.Sound()
+
+    def test_sound__before_init(self):
+        """Ensure exception raised for Sound() creation with non-init mixer."""
+        mixer.quit()
+        filename = example_path(os.path.join('data', 'house_lo.wav'))
+
+        with self.assertRaisesRegex(pygame.error, 'mixer not initialized'):
+            mixer.Sound(file=filename)
+
     def todo_test_fadeout(self):
 
         # __doc__ (as of 2008-08-02) for pygame.mixer.Sound.fadeout:


### PR DESCRIPTION
This update changes `Sound()`'s creation to raise an appropriate exception if the mixer is not initialized.

Overview of changes:
- Changed `Sound()`'s creation to raise an appropriate exception if mixer not initialized
- Made the error messages for the mixer not being initialized consistent
- Added creation tests for `Sound()` and `Channel()`

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 07b414848bc21476b1cabdf1ab5f7ce4157eacd5

Resolves #417.