### PR TITLE
Fix indirection compile warning

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1080,7 +1080,7 @@ get_bounding_rects(bitmask_t *input, int *num_bounding_boxes,
     h = input->h;
 
     if (!w || !h) {
-        ret_rects = rects;
+        *ret_rects = rects;
         return 0;
     }
     /* a temporary image to assign labels to each bit of the mask */


### PR DESCRIPTION
This update fixes the following compile warning in `mask.c`.

```
src_c/mask.c(1083): warning C4047: '=': 'GAME_Rect **' differs in levels of indirection from 'GAME_Rect *'
```

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 3a84be5e0e4b8ac9fecc130913f1d68e7484db55