### PR TITLE
Fix surf.set_palette() crash

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1214,7 +1214,7 @@ surf_set_palette(PyObject *self, PyObject *args)
      */
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SDL_Palette *pal = surf->format->palette;
-    const SDL_Color *old_colors = pal->colors;
+    const SDL_Color *old_colors;
     SDL_Color colors[256];
 #else  /* IS_SDLv1 */
     SDL_Surface *surf = pgSurface_AsSurface(self);
@@ -1239,6 +1239,7 @@ surf_set_palette(PyObject *self, PyObject *args)
 
     if (!pal)
         return RAISE(pgExc_SDLError, "Surface is not palettitized\n");
+    old_colors = pal->colors;
 #else  /* IS_SDLv1 */
     if (!pal)
         return RAISE(pgExc_SDLError, "Surface has no palette\n");

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1130,6 +1130,13 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         finally:
             pygame.quit()
 
+    def test_set_palette__fail(self):
+        pygame.init()
+        palette = 256 * [(10, 20, 30)]
+        surf = pygame.Surface((2, 2), 0, 32)
+        self.assertRaises(pygame.error, surf.set_palette, palette)
+        pygame.quit()
+
     def test_set_palette_at(self):
         pygame.init()
         try:


### PR DESCRIPTION
A null pointer was dereferenced for surfaces without a palette.