### PR TITLE
Raise a ValueError when creating negative size masks

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -511,7 +511,7 @@ mask_from_surface(PyObject *self, PyObject *args)
 
     if (surf->w < 0 || surf->h < 0) {
         return RAISE(PyExc_ValueError,
-                     "Cannot create mask with negative size");
+                     "cannot create mask with negative size");
     }
 
     /* lock the surface, release the GIL. */
@@ -1578,6 +1578,11 @@ Mask(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, keywords, &w, &h,
                                      &fill))
         return NULL;
+
+    if (w < 0 || h < 0) {
+        return RAISE(PyExc_ValueError,
+                     "cannot create mask with negative size");
+    }
 
     mask = bitmask_create(w, h);
     if (!mask)

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -51,6 +51,12 @@ class MaskTypeTest( unittest.TestCase ):
         self.assertEqual(mask2.count(), expected_count)
         self.assertEqual(mask2.get_size(), expected_size)
 
+    def test_mask__negative_size(self):
+        """Ensure the mask contructor handles negative sizes correctly."""
+        for size in ((1, -1), (-1, 1), (-1, -1)):
+            with self.assertRaises(ValueError):
+                mask = pygame.Mask(size)
+
     def test_mask__fill_kwarg(self):
         """Ensure masks are created correctly using the fill keyword."""
         width, height = 37, 47
@@ -655,12 +661,16 @@ class MaskTypeTest( unittest.TestCase ):
         #TODO: this should really make one bounding rect.
         #self.assertEqual(repr(r), "[<rect(0, 0, 5, 2)>]")
 
-    def test_negative_size_mask(self):
+    def test_scale__negative_size(self):
+        """Ensure scale handles negative sizes correctly."""
         mask = pygame.Mask((100, 100))
+
         with self.assertRaises(ValueError):
             mask.scale((-1, -1))
+
         with self.assertRaises(ValueError):
             mask.scale((-1, 10))
+
         with self.assertRaises(ValueError):
             mask.scale((10, -1))
 


### PR DESCRIPTION
This update changes `Mask`'s constructor to raise a `ValueError` when the size argument is negative.

Overview of changes:
- Changed `Mask`'s constructor to raise a `ValueError` when size is negative
- Made the 'negative size' `ValueError` messages consistent
- Added a test for creating negative sized masks and renamed a test method

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 6830ce230ea8353bb47ddb65f764ee1720cdd747

Resolves #846.