### PR TITLE
Reduce unit test running time

### DIFF
--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -54,14 +54,26 @@ class GfxdrawDefaultTest( unittest.TestCase ):
                      surf.get_masks()))
         self.assertNotEqual(sc, color, fail_msg)
 
+    @classmethod
+    def setUpClass(cls):
+        # Necessary for Surface.set_palette.
+        pygame.init()
+        pygame.display.set_mode((1, 1))
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
     def setUp(self):
+        # This makes sure pygame is always initialized before each test (in
+        # case a test calls pygame.quit()).
+        if not pygame.get_init():
+            pygame.init()
+
         Surface = pygame.Surface
         size = self.default_size
         palette = self.default_palette
         if not self.is_started:
-            # Necessary for Surface.set_palette.
-            pygame.init()
-            pygame.display.set_mode((1, 1))
             # Create test surfaces
             self.surfaces = [Surface(size, 0, 8),
                              Surface(size, 0, 16),

--- a/test/key_test.py
+++ b/test/key_test.py
@@ -4,11 +4,19 @@ import pygame.key
 
 
 class KeyModuleTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         pygame.init()
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         pygame.quit()
+
+    def setUp(cls):
+        # This makes sure pygame is always initialized before each test (in
+        # case a test calls pygame.quit()).
+        if not pygame.get_init():
+            pygame.init()
 
     def test_import(self):
         'does it import'

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -10,11 +10,20 @@ from pygame.compat import as_unicode, unicode_, filesystem_encode
 
 
 class MixerMusicModuleTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        # Initializing the mixer is slow, so minimize the times it is called.
         pygame.mixer.init()
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         pygame.mixer.quit()
+
+    def setUp(cls):
+        # This makes sure the mixer is always initialized before each test (in
+        # case a test calls pygame.mixer.quit()).
+        if pygame.mixer.get_init() is None:
+            pygame.mixer.init()
 
     def test_load(self):
         "|tags:music|"

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -570,11 +570,20 @@ class MixerModuleTest(unittest.TestCase):
 ############################## CHANNEL CLASS TESTS #############################
 
 class ChannelTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        # Initializing the mixer is slow, so minimize the times it is called.
         mixer.init()
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         mixer.quit()
+
+    def setUp(cls):
+        # This makes sure the mixer is always initialized before each test (in
+        # case a test calls pygame.mixer.quit()).
+        if mixer.get_init() is None:
+            mixer.init()
 
     def test_channel(self):
         """Ensure Channel() creation works."""
@@ -822,11 +831,20 @@ class ChannelTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 ############################### SOUND CLASS TESTS ##############################
 
 class SoundTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        # Initializing the mixer is slow, so minimize the times it is called.
         mixer.init()
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         mixer.quit()
+
+    def setUp(cls):
+        # This makes sure the mixer is always initialized before each test (in
+        # case a test calls pygame.mixer.quit()).
+        if mixer.get_init() is None:
+            mixer.init()
 
     # See MixerModuleTest's methods test_sound_args(), test_sound_unicode(),
     # and test_array_keyword() for additional testing of Sound() creation.

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -159,7 +159,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             surf.fill((255, 255, 255))
             surf.get_bounding_rect()  # Segfault.
         finally:
-            pygame.quit()
+            pygame.display.quit()
 
     def test_copy(self):
         """Ensure a surface can be copied."""
@@ -914,7 +914,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.fail()
 
     def test_get_palette(self):
-        pygame.init()
+        pygame.display.init()
         try:
             palette = [Color(i, i, i) for i in range(256)]
             pygame.display.set_mode((100, 50))
@@ -929,11 +929,11 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             for c in palette2:
                 self.assertIsInstance(c, pygame.Color)
         finally:
-            pygame.quit()
+            pygame.display.quit()
 
     def test_get_palette_at(self):
         # See also test_get_palette
-        pygame.init()
+        pygame.display.init()
         try:
             pygame.display.set_mode((100, 50))
             surf = pygame.Surface((2, 2), 0, 8)
@@ -945,7 +945,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             self.assertRaises(IndexError, surf.get_palette_at, -1)
             self.assertRaises(IndexError, surf.get_palette_at, 256)
         finally:
-            pygame.quit()
+            pygame.display.quit()
 
     def todo_test_get_pitch(self):
 
@@ -1102,7 +1102,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         palette[11] = tuple(palette[11])[0:3] # 3 element tuple
 
         surf = pygame.Surface((2, 2), 0, 8)
-        pygame.init()
+        pygame.display.init()
         try:
             pygame.display.set_mode((100, 50))
             surf.set_palette(palette)
@@ -1128,10 +1128,10 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             self.assertRaises(ValueError, surf.set_palette,
                                   (1, 2, 3, 254))
         finally:
-            pygame.quit()
+            pygame.display.quit()
 
     def test_set_palette_at(self):
-        pygame.init()
+        pygame.display.init()
         try:
             pygame.display.set_mode((100, 50))
             surf = pygame.Surface((2, 2), 0, 8)
@@ -1154,7 +1154,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
                                   surf.set_palette_at,
                                   -1, replacement)
         finally:
-            pygame.quit()
+            pygame.display.quit()
 
     def test_subsurface(self):
 
@@ -1225,7 +1225,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         surf = pygame.Surface((2, 2), 0, 8)
         c = (1, 1, 1)  # Unlikely to be in a default palette.
         i = 67
-        pygame.init()
+        pygame.display.init()
         try:
             pygame.display.set_mode((100, 50))
             surf.set_palette_at(i, c)
@@ -1234,7 +1234,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             # Confirm it is a Color instance
             self.assertIsInstance(unmapped_c, pygame.Color)
         finally:
-            pygame.quit()
+            pygame.display.quit()
 
         # Remaining, non-pallete, cases.
         c = (128, 64, 12, 255)
@@ -1871,10 +1871,10 @@ class SurfaceBlendTest(unittest.TestCase):
 
     def setUp(self):
         # Needed for 8 bits-per-pixel color palette surface tests.
-        pygame.init()
+        pygame.display.init()
 
     def tearDown(self):
-        pygame.quit()
+        pygame.display.quit()
 
     _test_palette = [(0, 0, 0, 255),
                      (10, 30, 60, 0),
@@ -2209,10 +2209,10 @@ class SurfaceSelfBlitTest(unittest.TestCase):
 
     def setUp(self):
         # Needed for 8 bits-per-pixel color palette surface tests.
-        pygame.init()
+        pygame.display.init()
 
     def tearDown(self):
-        pygame.quit()
+        pygame.display.quit()
 
     _test_palette = [(0, 0, 0, 255),
                     (255, 0, 0, 0),
@@ -2397,10 +2397,10 @@ class SurfaceSelfBlitTest(unittest.TestCase):
 class SurfaceFillTest(unittest.TestCase):
 
     def setUp(self):
-        pygame.init()
+        pygame.display.init()
 
     def tearDown(self):
-        pygame.quit()
+        pygame.display.quit()
 
     def test_fill(self):
         screen = pygame.display.set_mode((640, 480))

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -18,17 +18,6 @@ IS_PYPY = 'PyPy' == platform.python_implementation()
 
 @unittest.skipIf(IS_PYPY, 'pypy skip known failure') # TODO
 class SurfarrayModuleTest (unittest.TestCase):
-
-    def setUp(self):
-        # Needed for 8 bits-per-pixel color palette surface tests.
-        pygame.init()
-
-        # Makes sure the same array package is used each time.
-        pygame.surfarray.use_arraytype(arraytype)
-
-    def tearDown(self):
-        pygame.quit()
-
     pixels2d = {8: True, 16: True, 24: False, 32: True}
     pixels3d = {8: False, 16: False, 24: True, 32: True}
     array2d = {8: True, 16: True, 24: True, 32: True}
@@ -43,6 +32,24 @@ class SurfarrayModuleTest (unittest.TestCase):
     test_points = [((0, 0), 1), ((4, 5), 1), ((9, 0), 2),
                    ((5, 5), 2), ((0, 11), 3), ((4, 6), 3),
                    ((9, 11), 4), ((5, 6), 4)]
+
+    @classmethod
+    def setUpClass(cls):
+        # Needed for 8 bits-per-pixel color palette surface tests.
+        pygame.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
+    def setUp(cls):
+        # This makes sure pygame is always initialized before each test (in
+        # case a test calls pygame.quit()).
+        if not pygame.get_init():
+            pygame.init()
+
+        # Makes sure the same array package is used each time.
+        pygame.surfarray.use_arraytype(arraytype)
 
     def _make_surface(self, bitsize, srcalpha=False, palette=None):
         if palette is None:


### PR DESCRIPTION
This update reduces the time required to run the unit tests.

Overview of changes:
- Moved some slow init/quit calls to class methods which are called once instead of being called per test
- Replaced some `pygame.init`/`pygame.quit` calls with quicker `pygame.display.init`/`pygame.display.quit` calls


Here are some running time samples given by the testing infrastructure. Each test was run twice to give a very rough average of the running times. The time reduction is roughly 40% (on my system).
- `py -3 -Wd -m pygame.tests` - python 3.7.2 running times
  - before changes
    - Ran 919 tests in 74.761s
    - Ran 919 tests in 75.784s
  - after changes
    - Ran 919 tests in 42.630s
    - Ran 919 tests in 42.206s

- `py -2 -Wd -m pygame.tests` - python 2.7.10 running times
  - before changes
    - Ran 892 tests in 46.316s
    - Ran 892 tests in 46.835s
  - after changes
    - Ran 892 tests in 25.985s
    - Ran 892 tests in 26.088s


System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 6830ce230ea8353bb47ddb65f764ee1720cdd747
