### PR TITLE
Ensure opened test files are closed properly

### DIFF
--- a/test/cursors_test.py
+++ b/test/cursors_test.py
@@ -42,8 +42,8 @@ class CursorsModuleTest(unittest.TestCase):
         cursor = pygame.cursors.load_xbm(cursorfile, maskfile)
 
         # Test that load_xbm will take file objects as arguments
-        cursorfile, maskfile = [open(pth) for pth in (cursorfile, maskfile)]
-        cursor = pygame.cursors.load_xbm(cursorfile, maskfile)
+        with open(cursorfile) as cursor_f, open(maskfile) as mask_f:
+            cursor = pygame.cursors.load_xbm(cursor_f, mask_f)
 
         # Is it in a format that mouse.set_cursor won't blow up on?
         pygame.display.init()

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -162,11 +162,17 @@ class FreeTypeFontTest(unittest.TestCase):
     def test_freetype_Font_dealloc(self):
         import sys
         handle = open(self._sans_path, 'rb')
+
         def load_font():
             tempFont = ft.Font(handle)
-        load_font()
-        self.assertEqual(sys.getrefcount(handle), 2)
-        handle.close()
+
+        try:
+            load_font()
+
+            self.assertEqual(sys.getrefcount(handle), 2)
+        finally:
+            # Ensures file is closed even if test fails.
+            handle.close()
 
     def test_freetype_Font_scalable(self):
 

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -43,15 +43,14 @@ class MixerMusicModuleTest(unittest.TestCase):
         """test loading music from file-like objects."""
         formats = ['ogg', 'wav']
         data_fname = example_path('data')
-        ret = []
         for f in formats:
             path = os.path.join(data_fname, 'house_lo.%s' % f)
             if os.sep == '\\':
                 path = path.replace('\\', '\\\\')
             bmusfn = filesystem_encode(path)
-            musf = open(bmusfn, 'rb')
-            ret.append(pygame.mixer.music.load(musf))
-        return ret
+
+            with open(bmusfn, 'rb') as musf:
+                pygame.mixer.music.load(musf)
 
     def test_load_unicode(self):
         """test non-ASCII unicode path"""

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -842,13 +842,12 @@ class SoundTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
     def test_sound__from_file_object(self):
         """Ensure Sound() creation with a file object works."""
         filename = example_path(os.path.join('data', 'house_lo.wav'))
-        file_obj = open(filename, "rb")
 
-        sound = mixer.Sound(file_obj)
+        # Using 'with' ensures the file is closed even if test fails.
+        with open(filename, "rb") as file_obj:
+            sound = mixer.Sound(file_obj)
 
-        self.assertIsInstance(sound, mixer.Sound)
-
-        file_obj.close()
+            self.assertIsInstance(sound, mixer.Sound)
 
     def test_sound__from_sound_object(self):
         """Ensure Sound() creation with a Sound() object works."""


### PR DESCRIPTION
This update ensures that open test files are closed properly, even if the test fails.

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 6830ce230ea8353bb47ddb65f764ee1720cdd747


