### PR TITLE
Change Surface type checks to allow for subclassing

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -578,9 +578,9 @@ typedef struct {
 } pgSurfaceObject;
 #define pgSurface_AsSurface(x) (((pgSurfaceObject *)x)->surf)
 #ifndef PYGAMEAPI_SURFACE_INTERNAL
-#define pgSurface_Check(x) \
-    ((x)->ob_type ==       \
-     (PyTypeObject *)PyGAME_C_API[PYGAMEAPI_SURFACE_FIRSTSLOT + 0])
+#define pgSurface_Check(x)    \
+    (PyObject_IsInstance((x), \
+        (PyObject *)PyGAME_C_API[PYGAMEAPI_SURFACE_FIRSTSLOT + 0]))
 #define pgSurface_Type \
     (*(PyTypeObject *)PyGAME_C_API[PYGAMEAPI_SURFACE_FIRSTSLOT + 0])
 #if IS_SDLv1

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1921,7 +1921,7 @@ pgPixelArray_New(PyObject *surfobj)
     Uint8 *pixels;
 
     if (!pgSurface_Check(surfobj)) {
-        return RAISE(PyExc_TypeError, "argument is no a Surface");
+        return RAISE(PyExc_TypeError, "argument is not a Surface");
     }
 
     surf = pgSurface_AsSurface(surfobj);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -401,7 +401,8 @@ static PyTypeObject pgSurface_Type = {
     surface_new,                              /* tp_new */
 };
 
-#define pgSurface_Check(x) ((x)->ob_type == &pgSurface_Type)
+#define pgSurface_Check(x) \
+    (PyObject_IsInstance((x), (PyObject *)&pgSurface_Type))
 
 #if IS_SDLv1
 
@@ -3607,7 +3608,7 @@ _init_buffer(PyObject *surf, Py_buffer *view_p, int flags)
 
     assert(surf);
     assert(view_p);
-    assert(PyObject_IsInstance(surf, (PyObject *)&pgSurface_Type));
+    assert(pgSurface_Check(surf));
     assert(PyBUF_HAS_FLAG(flags, PyBUF_PYGAME));
     consumer = ((pg_buffer *)view_p)->consumer;
     assert(consumer);

--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -2,6 +2,7 @@ import unittest
 import pygame
 import pygame.gfxdraw
 from pygame.locals import *
+from pygame.tests.test_utils import SurfaceSubclass
 
 def intensity(c, i):
     """Return color c changed by intensity i
@@ -83,6 +84,17 @@ class GfxdrawDefaultTest( unittest.TestCase ):
                 self.surfaces.append(Surface(size, flags, bitsize, masks))
         for surf in self.surfaces:
             surf.fill(self.background_color)
+
+    def test_gfxdraw__subclassed_surface(self):
+        """Ensure pygame.gfxdraw works on subclassed surfaces."""
+        surface = SurfaceSubclass((11, 13), SRCALPHA, 32)
+        surface.fill(pygame.Color('blue'))
+        expected_color = pygame.Color('red')
+        x, y = 1, 2
+
+        pygame.gfxdraw.pixel(surface, x, y, expected_color)
+
+        self.assertEqual(surface.get_at((x, y)), expected_color)
 
     def test_pixel(self):
         """pixel(surface, x, y, color): return None"""

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -9,6 +9,8 @@ import weakref
 import gc
 import unittest
 
+from pygame.tests.test_utils import SurfaceSubclass
+
 try:
     from pygame.tests.test_utils import arrinter
 except NameError:
@@ -142,6 +144,13 @@ class PixelArrayTypeTest (unittest.TestCase, TestMixin):
         del ar
         gc.collect ()
         self.assertTrue (r() is None)
+
+    def test_pixelarray__subclassed_surface(self):
+        """Ensure the PixelArray constructor accepts subclassed surfaces."""
+        surface = SurfaceSubclass((3, 5), 0, 32)
+        pixelarray = pygame.PixelArray(surface)
+
+        self.assertIsInstance(pixelarray, pygame.PixelArray)
 
     # Sequence interfaces
     def test_get_column (self):
@@ -356,6 +365,17 @@ class PixelArrayTypeTest (unittest.TestCase, TestMixin):
             sf.fill((0, 0, 0))
             ar = pygame.PixelArray(sf)
             self.assertTrue(ar.surface is sf)
+
+    def test_get_surface__subclassed_surface(self):
+        """Ensure the surface attribute can handle subclassed surfaces."""
+        expected_surface = SurfaceSubclass((5, 3), 0, 32)
+        pixelarray = pygame.PixelArray(expected_surface)
+
+        surface = pixelarray.surface
+
+        self.assertIs(surface, expected_surface)
+        self.assertIsInstance(surface, pygame.Surface)
+        self.assertIsInstance(surface, SurfaceSubclass)
 
     def test_set_slice (self):
         for bpp in (8, 16, 24, 32):
@@ -710,6 +730,24 @@ class PixelArrayTypeTest (unittest.TestCase, TestMixin):
         w2, h2 = sf2.get_size ()
         self.assertEqual (w2, w)
         self.assertEqual (h2, h_slice)
+
+    def test_make_surface__subclassed_surface(self):
+        """Ensure make_surface can handle subclassed surfaces."""
+        expected_size = (3, 5)
+        expected_flags = 0
+        expected_depth = 32
+        original_surface = SurfaceSubclass(expected_size, expected_flags,
+                                           expected_depth)
+        pixelarray = pygame.PixelArray(original_surface)
+
+        surface = pixelarray.make_surface()
+
+        self.assertIsNot(surface, original_surface)
+        self.assertIsInstance(surface, pygame.Surface)
+        self.assertNotIsInstance(surface, SurfaceSubclass)
+        self.assertEqual(surface.get_size(), expected_size)
+        self.assertEqual(surface.get_flags(), expected_flags)
+        self.assertEqual(surface.get_bitsize(), expected_depth)
 
     def test_iter (self):
         for bpp in (8, 16, 24, 32):

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -2,7 +2,8 @@ import os
 
 import unittest
 from pygame.tests import test_utils
-from pygame.tests.test_utils import example_path, AssertRaisesRegexMixin
+from pygame.tests.test_utils import (
+        example_path, AssertRaisesRegexMixin, SurfaceSubclass)
 try:
     from pygame.tests.test_utils.arrinter import *
 except (ImportError, NameError):
@@ -34,6 +35,24 @@ def longify(i):
 
 
 class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+    def test_surface__pixel_format_as_surface_subclass(self):
+        """Ensure a subclassed surface can be used for pixel format
+        when creating a new surface."""
+        expected_depth = 16
+        expected_flags = SRCALPHA
+        expected_size = (13, 37)
+        depth_surface = SurfaceSubclass((11, 21), expected_flags,
+                                        expected_depth)
+
+        surface = pygame.Surface(expected_size, 0, depth_surface)
+
+        self.assertIsNot(surface, depth_surface)
+        self.assertIsInstance(surface, pygame.Surface)
+        self.assertNotIsInstance(surface, SurfaceSubclass)
+        self.assertEqual(surface.get_size(), expected_size)
+        self.assertEqual(surface.get_flags(), expected_flags)
+        self.assertEqual(surface.get_bitsize(), expected_depth)
+
     def test_set_clip( self ):
         """ see if surface.set_clip(None) works correctly.
         """
@@ -626,31 +645,38 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         # https://bitbucket.org/pygame/pygame/issue/131/unable-to-surfaceconvert-32-some-1-bit
 
         pygame.display.init()
-        pygame.display.set_mode((640,480))
+        try:
+            pygame.display.set_mode((640,480))
 
-        im  = pygame.image.load(example_path(os.path.join("data", "city.png")))
-        im2 = pygame.image.load(example_path(os.path.join("data", "brick.png")))
+            im  = pygame.image.load(example_path(
+                os.path.join("data", "city.png")))
+            im2 = pygame.image.load(example_path(
+                os.path.join("data", "brick.png")))
 
-        self.assertEqual(im.get_palette(),
-                         ((0, 0, 0, 255), (255, 255, 255, 255)))
-        self.assertEqual(im2.get_palette(), ((0, 0, 0, 255), (0, 0, 0, 255)))
+            self.assertEqual(im.get_palette(),
+                             ((0, 0, 0, 255), (255, 255, 255, 255)))
+            self.assertEqual(im2.get_palette(),
+                            ((0, 0, 0, 255), (0, 0, 0, 255)))
 
-        self.assertEqual(repr(im.convert(32)),  '<Surface(24x24x32 SW)>')
-        self.assertEqual(repr(im2.convert(32)), '<Surface(469x137x32 SW)>')
+            self.assertEqual(repr(im.convert(32)),  '<Surface(24x24x32 SW)>')
+            self.assertEqual(repr(im2.convert(32)), '<Surface(469x137x32 SW)>')
 
-        # Ensure a palette format to palette format works.
-        im3 = im.convert(8)
-        self.assertEqual(repr(im3), '<Surface(24x24x8 SW)>')
-        self.assertEqual(im3.get_palette(), im.get_palette())
+            # Ensure a palette format to palette format works.
+            im3 = im.convert(8)
+            self.assertEqual(repr(im3), '<Surface(24x24x8 SW)>')
+            self.assertEqual(im3.get_palette(), im.get_palette())
 
-        # It is still an error when the target format really does have
-        # an empty palette (all the entries are black).
-        self.assertRaises(pygame.error, im2.convert, 8)
-        self.assertEqual(pygame.get_error(), "Empty destination palette")
+            # It is still an error when the target format really does have
+            # an empty palette (all the entries are black).
+            self.assertRaises(pygame.error, im2.convert, 8)
+            self.assertEqual(pygame.get_error(), "Empty destination palette")
+        finally:
+            pygame.display.quit()
 
     def test_convert_init(self):
         """ Ensure initialization exceptions are raised
             for surf.convert()."""
+        pygame.display.quit()
         surf = pygame.Surface((1, 1))
 
         self.assertRaisesRegex(pygame.error, 'display initialized',
@@ -679,6 +705,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
     def test_convert_alpha_init(self):
         """ Ensure initialization exceptions are raised
             for surf.convert_alpha()."""
+        pygame.display.quit()
         surf = pygame.Surface((1, 1))
 
         self.assertRaisesRegex(pygame.error, 'display initialized',
@@ -724,6 +751,24 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 
         self.fail()
 
+    def test_convert__pixel_format_as_surface_subclass(self):
+        """Ensure convert accepts a Surface subclass argument."""
+        expected_size = (23, 17)
+        convert_surface = SurfaceSubclass(expected_size, 0, 32)
+        depth_surface = SurfaceSubclass((31, 61), 0, 32)
+
+        pygame.display.init()
+        try:
+            surface = convert_surface.convert(depth_surface)
+
+            self.assertIsNot(surface, depth_surface)
+            self.assertIsNot(surface, convert_surface)
+            self.assertIsInstance(surface, pygame.Surface)
+            self.assertIsInstance(surface, SurfaceSubclass)
+            self.assertEqual(surface.get_size(), expected_size)
+        finally:
+            pygame.display.quit()
+
     def todo_test_convert_alpha(self):
 
         # __doc__ (as of 2008-08-02) for pygame.surface.Surface.convert_alpha:
@@ -743,6 +788,28 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
           #
 
         self.fail()
+
+    def test_convert_alpha__pixel_format_as_surface_subclass(self):
+        """Ensure convert_alpha accepts a Surface subclass argument."""
+        expected_size = (23, 17)
+        convert_surface = SurfaceSubclass(expected_size, SRCALPHA, 32)
+        depth_surface = SurfaceSubclass((31, 57), SRCALPHA, 32)
+
+        pygame.display.init()
+        try:
+            pygame.display.set_mode((60, 60))
+
+            # This is accepted as an argument, but its values are ignored.
+            # See issue #599.
+            surface = convert_surface.convert_alpha(depth_surface)
+
+            self.assertIsNot(surface, depth_surface)
+            self.assertIsNot(surface, convert_surface)
+            self.assertIsInstance(surface, pygame.Surface)
+            self.assertIsInstance(surface, SurfaceSubclass)
+            self.assertEqual(surface.get_size(), expected_size)
+        finally:
+            pygame.display.quit()
 
     def todo_test_get_abs_offset(self):
 
@@ -1319,11 +1386,6 @@ class SurfaceSubtypeTest(unittest.TestCase):
     def tearDown(self):
         pygame.display.quit()
 
-    class MySurface(pygame.Surface):
-        def __init__(self, *args, **kwds):
-            super(SurfaceSubtypeTest.MySurface, self).__init__(*args, **kwds)
-            self.an_attribute = True
-
     def test_copy(self):
         """Ensure method copy() preserves the surface's class
 
@@ -1331,11 +1393,18 @@ class SurfaceSubtypeTest(unittest.TestCase):
         instances of the subclass. Non Surface fields are uncopied, however.
         This includes instance attributes.
         """
-        ms1 = self.MySurface((32, 32), pygame.SRCALPHA, 32)
+        expected_size = (32, 32)
+        ms1 = SurfaceSubclass(expected_size, SRCALPHA, 32)
         ms2 = ms1.copy()
-        self.assertTrue(isinstance(ms2, self.MySurface))
-        self.assertTrue(ms1.an_attribute)
-        self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
+
+        self.assertIsNot(ms1, ms2)
+        self.assertIsInstance(ms1, pygame.Surface)
+        self.assertIsInstance(ms2, pygame.Surface)
+        self.assertIsInstance(ms1, SurfaceSubclass)
+        self.assertIsInstance(ms2, SurfaceSubclass)
+        self.assertTrue(ms1.test_attribute)
+        self.assertRaises(AttributeError, getattr, ms2, "test_attribute")
+        self.assertEqual(ms2.get_size(), expected_size)
 
     def test_convert(self):
         """Ensure method convert() preserves the surface's class
@@ -1344,12 +1413,18 @@ class SurfaceSubtypeTest(unittest.TestCase):
         instances of the subclass. Non Surface fields are omitted, however.
         This includes instance attributes.
         """
-        ms1 = self.MySurface((32, 32), 0, 24)
+        expected_size = (32, 32)
+        ms1 = SurfaceSubclass(expected_size, 0, 24)
         ms2 = ms1.convert(24)
-        self.assertTrue(ms2 is not ms1)
-        self.assertTrue(isinstance(ms2, self.MySurface))
-        self.assertTrue(ms1.an_attribute)
-        self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
+
+        self.assertIsNot(ms1, ms2)
+        self.assertIsInstance(ms1, pygame.Surface)
+        self.assertIsInstance(ms2, pygame.Surface)
+        self.assertIsInstance(ms1, SurfaceSubclass)
+        self.assertIsInstance(ms2, SurfaceSubclass)
+        self.assertTrue(ms1.test_attribute)
+        self.assertRaises(AttributeError, getattr, ms2, "test_attribute")
+        self.assertEqual(ms2.get_size(), expected_size)
 
     def test_convert_alpha(self):
         """Ensure method convert_alpha() preserves the surface's class
@@ -1359,13 +1434,19 @@ class SurfaceSubtypeTest(unittest.TestCase):
         however. This includes instance attributes.
         """
         pygame.display.set_mode((40, 40))
-        s = pygame.Surface((32, 32), pygame.SRCALPHA, 16)
-        ms1 = self.MySurface((32, 32), pygame.SRCALPHA, 32)
+        expected_size = (32, 32)
+        s = pygame.Surface(expected_size, SRCALPHA, 16)
+        ms1 = SurfaceSubclass(expected_size, SRCALPHA, 32)
         ms2 = ms1.convert_alpha(s)
-        self.assertTrue(ms2 is not ms1)
-        self.assertTrue(isinstance(ms2, self.MySurface))
-        self.assertTrue(ms1.an_attribute)
-        self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
+
+        self.assertIsNot(ms1, ms2)
+        self.assertIsInstance(ms1, pygame.Surface)
+        self.assertIsInstance(ms2, pygame.Surface)
+        self.assertIsInstance(ms1, SurfaceSubclass)
+        self.assertIsInstance(ms2, SurfaceSubclass)
+        self.assertTrue(ms1.test_attribute)
+        self.assertRaises(AttributeError, getattr, ms2, "test_attribute")
+        self.assertEqual(ms2.get_size(), expected_size)
 
     def test_subsurface(self):
         """Ensure method subsurface() preserves the surface's class
@@ -1374,11 +1455,18 @@ class SurfaceSubtypeTest(unittest.TestCase):
         return instances of the subclass. Non Surface fields are uncopied,
         however. This includes instance attributes.
         """
-        ms1 = self.MySurface((32, 32), pygame.SRCALPHA, 32)
-        ms2 = ms1.subsurface((4, 5, 10, 12))
-        self.assertTrue(isinstance(ms2, self.MySurface))
-        self.assertTrue(ms1.an_attribute)
-        self.assertRaises(AttributeError, getattr, ms2, "an_attribute")
+        expected_size = (10, 12)
+        ms1 = SurfaceSubclass((32, 32), SRCALPHA, 32)
+        ms2 = ms1.subsurface((4, 5), expected_size)
+
+        self.assertIsNot(ms1, ms2)
+        self.assertIsInstance(ms1, pygame.Surface)
+        self.assertIsInstance(ms2, pygame.Surface)
+        self.assertIsInstance(ms1, SurfaceSubclass)
+        self.assertIsInstance(ms2, SurfaceSubclass)
+        self.assertTrue(ms1.test_attribute)
+        self.assertRaises(AttributeError, getattr, ms2, "test_attribute")
+        self.assertEqual(ms2.get_size(), expected_size)
 
 
 class SurfaceGetBufferTest(unittest.TestCase):

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -171,6 +171,14 @@ def import_submodule(module):
         m = getattr(m, n)
     return m
 
+
+class SurfaceSubclass(pygame.Surface):
+    """A subclassed Surface to test inheritance."""
+    def __init__(self, *args, **kwargs):
+        super(SurfaceSubclass, self).__init__(*args, **kwargs)
+        self.test_attribute = True
+
+
 def test():
     """
     

--- a/test/transform_test.py
+++ b/test/transform_test.py
@@ -681,6 +681,38 @@ class TransformModuleTest( unittest.TestCase ):
                                          None, THRESHOLD_BEHAVIOR_COUNT, s2)
         self.assertEqual(num_threshold_pixels, 0)
 
+    def test_threshold__subclassed_surface(self):
+        """Ensure threshold accepts subclassed surfaces."""
+        expected_size = (13, 11)
+        expected_flags = 0
+        expected_depth = 32
+        expected_color = (90, 80, 70, 255)
+        expected_count = 0
+        surface = test_utils.SurfaceSubclass(expected_size, expected_flags,
+                                             expected_depth)
+        dest_surface = test_utils.SurfaceSubclass(expected_size,
+                                                  expected_flags,
+                                                  expected_depth)
+        search_surface = test_utils.SurfaceSubclass(expected_size,
+                                                    expected_flags,
+                                                    expected_depth)
+        surface.fill((10, 10, 10))
+        dest_surface.fill((255, 255, 255))
+        search_surface.fill((20, 20, 20))
+
+        count = pygame.transform.threshold(
+            dest_surf=dest_surface, surf=surface, threshold=(1, 1, 1),
+            set_color=expected_color, search_color=None,
+            search_surf=search_surface)
+
+        self.assertIsInstance(dest_surface, pygame.Surface)
+        self.assertIsInstance(dest_surface, test_utils.SurfaceSubclass)
+        self.assertEqual(count, expected_count)
+        self.assertEqual(dest_surface.get_at((0,0)), expected_color)
+        self.assertEqual(dest_surface.get_bitsize(), expected_depth)
+        self.assertEqual(dest_surface.get_size(), expected_size)
+        self.assertEqual(dest_surface.get_flags(), expected_flags)
+
     def test_laplacian(self):
         """
         """
@@ -771,13 +803,54 @@ class TransformModuleTest( unittest.TestCase ):
 
         self.assertEqual(sr.get_at((0,0)), (10,53,50,255))
 
+    def test_average_surfaces__subclassed_surfaces(self):
+        """Ensure average_surfaces accepts subclassed surfaces."""
+        expected_size = (23, 17)
+        expected_flags = 0
+        expected_depth = 32
+        expected_color = (50, 50, 50, 255)
+        surfaces = []
 
+        for color in ((40, 60, 40), (60, 40, 60)):
+            s = test_utils.SurfaceSubclass(expected_size, expected_flags,
+                                           expected_depth)
+            s.fill(color)
+            surfaces.append(s)
 
+        surface = pygame.transform.average_surfaces(surfaces)
 
+        self.assertIsInstance(surface, pygame.Surface)
+        self.assertNotIsInstance(surface, test_utils.SurfaceSubclass)
+        self.assertEqual(surface.get_at((0,0)), expected_color)
+        self.assertEqual(surface.get_bitsize(), expected_depth)
+        self.assertEqual(surface.get_size(), expected_size)
+        self.assertEqual(surface.get_flags(), expected_flags)
 
+    def test_average_surfaces__subclassed_destination_surface(self):
+        """Ensure average_surfaces accepts a destination subclassed surface."""
+        expected_size = (13, 27)
+        expected_flags = 0
+        expected_depth = 32
+        expected_color = (15, 15, 15, 255)
+        surfaces = []
 
+        for color in ((10, 10, 20), (20, 20, 10), (30, 30, 30)):
+            s = test_utils.SurfaceSubclass(expected_size, expected_flags,
+                                           expected_depth)
+            s.fill(color)
+            surfaces.append(s)
+        expected_dest_surface = surfaces.pop()
 
+        dest_surface = pygame.transform.average_surfaces(surfaces,
+                                                         expected_dest_surface)
 
+        self.assertIsInstance(dest_surface, pygame.Surface)
+        self.assertIsInstance(dest_surface, test_utils.SurfaceSubclass)
+        self.assertIs(dest_surface, expected_dest_surface)
+        self.assertEqual(dest_surface.get_at((0,0)), expected_color)
+        self.assertEqual(dest_surface.get_bitsize(), expected_depth)
+        self.assertEqual(dest_surface.get_size(), expected_size)
+        self.assertEqual(dest_surface.get_flags(), expected_flags)
 
     def test_average_color(self):
         """


### PR DESCRIPTION
This update changes the type checking which is preventing `Surface` subclasses from being used in these areas: `gfxdraw`, `PixelArray`, `transform` and `Surface`. Note that some other areas are already working with `Surface` subclasses.

Overview of changes:
- Changed the `Surface` type checks to allow for subclassing
- Added tests to some areas that are using the `Surface` type check
- Added more checking to some existing `Surface` subclass tests
- Changed some `Surface` tests to ensure better set up and clean up
- Added a common `Surface` subclass to test_utils
- Fixed a spelling mistake in a related exception message

System details:
* os: windows 10 (64bit)
* python: 3.7.2 (64bit) and 2.7.10 (64bit)
* pygame: 1.9.5.dev0 (SDL: 1.2.15) at 6830ce230ea8353bb47ddb65f764ee1720cdd747

Resolves #147.