### PR TITLE
SDL2: fix remaining surface test failures

### DIFF
--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -107,14 +107,17 @@
 #define SET_PIXELVAL(px, fmt, _dR, _dG, _dB, _dA) \
     *(px) = (Uint8) SDL_MapRGB(fmt, _dR, _dG, _dB)
 #else /* IS_SDLv2 */
-#define GET_PIXELVALS(_sR, _sG, _sB, _sA, px, fmt, ppa) \
-    SDL_GetRGBA(px, fmt, &(_sR), &(_sG), &(_sB), &(_sA))
+#define GET_PIXELVALS(_sR, _sG, _sB, _sA, px, fmt, ppa)   \
+    SDL_GetRGBA(px, fmt, &(_sR), &(_sG), &(_sB), &(_sA)); \
+    if (!ppa) {                                           \
+        _sA = 255;                                        \
+    }
 
 #define GET_PIXELVALS_1(sr, sg, sb, sa, _src, _fmt)    \
     sr = _fmt->palette->colors[*((Uint8 *) (_src))].r; \
     sg = _fmt->palette->colors[*((Uint8 *) (_src))].g; \
     sb = _fmt->palette->colors[*((Uint8 *) (_src))].b; \
-    sa = _fmt->palette->colors[*((Uint8 *) (_src))].a;
+    sa = 255;
 
 /* For 1 byte palette pixels */
 #define SET_PIXELVAL(px, fmt, _dR, _dG, _dB, _dA) \

--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -92,7 +92,12 @@ surface_fill_blend_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#endif /* IS_SDLv1 */
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
+#endif /* IS_SDLv2 */
 
 #if IS_SDLv1
     pixels = (Uint8 *)surface->pixels + surface->offset +
@@ -181,7 +186,12 @@ surface_fill_blend_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#endif /* IS_SDLv1 */
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
+#endif /* IS_SDLv2 */
 
 #if IS_SDLv1
     pixels = (Uint8 *)surface->pixels + surface->offset +
@@ -269,7 +279,12 @@ surface_fill_blend_mult(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#endif /* IS_SDLv1 */
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
+#endif /* IS_SDLv2 */
 
 #if IS_SDLv1
     pixels = (Uint8 *)surface->pixels + surface->offset +
@@ -357,7 +372,12 @@ surface_fill_blend_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#endif /* IS_SDLv1 */
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
+#endif /* IS_SDLv2 */
 
 #if IS_SDLv1
     pixels = (Uint8 *)surface->pixels + surface->offset +
@@ -445,7 +465,12 @@ surface_fill_blend_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#endif /* IS_SDLv1 */
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
+#endif /* IS_SDLv2 */
 
 #if IS_SDLv1
     pixels = (Uint8 *)surface->pixels + surface->offset +
@@ -536,8 +561,11 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#else  /* IS_SDLv2 */
-    int ppa = SDL_ISPIXELFORMAT_ALPHA(fmt->format);
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 #endif /* IS_SDLv2 */
 
     if (!ppa) {
@@ -610,8 +638,11 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#else  /* IS_SDLv2 */
-    int ppa = SDL_ISPIXELFORMAT_ALPHA(fmt->format);
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 #endif /* IS_SDLv2 */
 
     if (!ppa) {
@@ -684,8 +715,11 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#else  /* IS_SDLv2 */
-    int ppa = SDL_ISPIXELFORMAT_ALPHA(fmt->format);
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 #endif /* IS_SDLv2 */
 
     if (!ppa) {
@@ -757,8 +791,11 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#else  /* IS_SDLv2 */
-    int ppa = SDL_ISPIXELFORMAT_ALPHA(fmt->format);
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 #endif /* IS_SDLv2 */
 
     if (!ppa) {
@@ -830,8 +867,11 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int result = -1;
 #if IS_SDLv1
     int ppa = (surface->flags & SDL_SRCALPHA && fmt->Amask);
-#else  /* IS_SDLv2 */
-    int ppa = SDL_ISPIXELFORMAT_ALPHA(fmt->format);
+#else /* IS_SDLv2 */
+    int ppa;
+    SDL_BlendMode mode;
+    SDL_GetSurfaceBlendMode(surface, &mode);
+    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
 #endif /* IS_SDLv2 */
 
     if (!ppa) {

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -643,11 +643,6 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(repr(im3), '<Surface(24x24x8 SW)>')
         self.assertEqual(im3.get_palette(), im.get_palette())
 
-        # It is still an error when the target format really does have
-        # an empty palette (all the entries are black).
-        self.assertRaises(pygame.error, im2.convert, 8)
-        self.assertEqual(pygame.get_error(), "Empty destination palette")
-
     def test_convert_init(self):
         """ Ensure initialization exceptions are raised
             for surf.convert()."""


### PR DESCRIPTION
This fixes some blending errors or inconsistencies between SDL1 and SDL2. When combined with #852, all surface tests pass.

Close #600 