### PR TITLE
Fix mask index out of bounds segmentation fault

### DIFF
--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -892,13 +892,11 @@ class MaskTypeTest(unittest.TestCase):
         self.assertEqual(original_mask.get_size(), expected_size)
         self.assertEqual(original_mask.get_at(unset_pos), 0)
 
-    # The skip() can be removed when issue #841 is fixed/closed.
-    @unittest.skip('can cause segmentation fault')
     def test_connected_component__out_of_bounds(self):
         """Ensure connected_component() checks bounds."""
         width, height = 19, 11
         original_size = (width, height)
-        original_mask = pygame.mask.Mask(expected_size, fill=True)
+        original_mask = pygame.mask.Mask(original_size, fill=True)
         original_count = original_mask.count()
 
         for pos in ((0, -1), (-1, 0), (0, height + 1), (width + 1, 0)):


### PR DESCRIPTION
This update fixes the segmentation fault caused by calling `pygame.mask.Mask.connected_component` with an index outside the mask's bounds.

Overview of changes:
- `IndexError` raised when an index is outside of the mask's bounds
- Fixed some memory leaks on the fail paths
- Fixed an incorrect exception message
- Removed `@unittest.skip` decorator from the related test method and fixed a variable name error


System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.4 and 1.9.5.dev0 (SDL: 1.2.15) at 1a4c7897f577ff89495e557e13f14968437c3420