### PR TITLE
Fix zero sized mask connected_component(s) segmentation fault

### DIFF
--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -1342,8 +1342,6 @@ class MaskTypeTest(unittest.TestCase):
         """Ensures convolve correctly handles zero sized masks."""
         self.fail()
 
-    # The skip() can be removed when issue #870 is fixed/closed.
-    @unittest.skip('can cause segmentation fault')
     def test_zero_mask_connected_component(self):
         """Ensures connected_component correctly handles zero sized masks."""
         expected_count = 0
@@ -1357,8 +1355,6 @@ class MaskTypeTest(unittest.TestCase):
             self.assertEqual(cc_mask.count(), expected_count,
                              'size={}'.format(size))
 
-    # The skip() can be removed when issue #870 is fixed/closed.
-    @unittest.skip('IndexError not raised')
     def test_zero_mask_connected_component__indexed(self):
         """Ensures connected_component correctly handles zero sized masks
         when using an index argument."""
@@ -1368,8 +1364,6 @@ class MaskTypeTest(unittest.TestCase):
             with self.assertRaises(IndexError):
                 cc_mask = mask.connected_component((0, 0))
 
-    # The skip() can be removed when issue #870 is fixed/closed.
-    @unittest.skip('can cause segmentation fault')
     def test_zero_mask_connected_components(self):
         """Ensures connected_components correctly handles zero sized masks."""
         expected_cc_masks = []


### PR DESCRIPTION
This update fixes the segmentation fault caused by calling `pygame.mask.Mask.connected_component` and `pygame.mask.Mask.connected_components` on a zero sized mask.

Overview of changes:
- Changed connected_component(s) to work correctly with zero sized masks
- Updated several comments
- Removed @unittest.skip decorators from the now passing tests

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 67a94cc1d0787fca9bbc5771a595cd7eec4a366d

Resolves #870.