### PR TITLE
Fix zero sized mask outline segmentation fault

### DIFF
--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -1309,8 +1309,6 @@ class MaskTypeTest(unittest.TestCase):
             mask = pygame.mask.Mask(size)
             self.assertEqual(mask.angle(), 0.0)
 
-    # The skip() can be removed when issue #875 is fixed/closed.
-    @unittest.skip('can cause segmentation fault')
     def test_zero_mask_outline(self):
         """Ensures outline correctly handles zero sized masks."""
         expected_points = []
@@ -1323,8 +1321,6 @@ class MaskTypeTest(unittest.TestCase):
             self.assertListEqual(points, expected_points,
                                  'size={}'.format(size))
 
-    # The skip() can be removed when issue #875 is fixed/closed.
-    @unittest.skip('can cause segmentation fault')
     def test_zero_mask_outline__with_arg(self):
         """Ensures outline correctly handles zero sized masks
         when using the skip pixels argument."""


### PR DESCRIPTION
This update fixes the segmentation fault caused by calling `pygame.mask.Mask.outline` on a zero sized mask.

Overview of changes:
- Changed outline to work correctly with zero sized masks
- Fixed some memory leaks on the fail paths
- Cleaned up array initialization
- Removed `@unittest.skip` decorators from the now passing tests

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 67a94cc1d0787fca9bbc5771a595cd7eec4a366d

Resolves #875.