### PR TITLE
SDL2: Fix failing sndarray tests

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -820,10 +820,19 @@ snd_buffer_iteminfo(char **format, Py_ssize_t *itemsize, int *channels)
 #if IS_SDLv2
         case AUDIO_S32LSB:
             *format = fmt_AUDIO_S32LSB;
+            *itemsize = 4;
+            return 0;
+
         case AUDIO_S32MSB:
             *format = fmt_AUDIO_S32MSB;
+            *itemsize = 4;
+            return 0;
+
         case AUDIO_F32LSB:
             *format = fmt_AUDIO_F32LSB;
+            *itemsize = 4;
+            return 0;
+
         case AUDIO_F32MSB:
             *format = fmt_AUDIO_F32MSB;
             *itemsize = 4;

--- a/test/sndarray_test.py
+++ b/test/sndarray_test.py
@@ -7,8 +7,11 @@ from pygame.compat import as_bytes
 import pygame.sndarray
 
 
+SDL2 = pygame.get_sdl_version()[0] >= 2
+
+
 class SndarrayTest (unittest.TestCase):
-    array_dtypes = {8: uint8, -8: int8, 16: uint16, -16: int16}
+    array_dtypes = {8: uint8, -8: int8, 16: uint16, -16: int16, 32: float32}
 
     def _assert_compatible(self, arr, size):
         dtype = self.array_dtypes[size]
@@ -18,7 +21,7 @@ class SndarrayTest (unittest.TestCase):
 
         def check_array(size, channels, test_data):
             try:
-                pygame.mixer.init(22050, size, channels)
+                pygame.mixer.init(22050, size, channels, allowedchanges=0)
             except pygame.error:
                 # Not all sizes are supported on all systems.
                 return
@@ -65,7 +68,7 @@ class SndarrayTest (unittest.TestCase):
 
         def check_sound(size, channels, test_data):
             try:
-                pygame.mixer.init(22050, size, channels)
+                pygame.mixer.init(22050, size, channels, allowedchanges=0)
             except pygame.error:
                 # Not all sizes are supported on all systems.
                 return
@@ -94,16 +97,15 @@ class SndarrayTest (unittest.TestCase):
         check_sound(-16, 2, [[0, -0x7fff], [-0x7fff, 0],
                              [0x7fff, 0], [0, 0x7fff]])
 
-        if pygame.get_sdl_version()[0] >= 2:
-            check_sound(32, 2, [[0.0, -1.0], [-1.0, 0],
-                                 [1.0, 0], [0, 1.0]])
+        if SDL2:
+            check_sound(32, 2, [[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]])
 
     def test_samples(self):
 
         null_byte = as_bytes('\x00')
         def check_sample(size, channels, test_data):
             try:
-                pygame.mixer.init(22050, size, channels)
+                pygame.mixer.init(22050, size, channels, allowedchanges=0)
             except pygame.error:
                 # Not all sizes are supported on all systems.
                 return
@@ -139,9 +141,8 @@ class SndarrayTest (unittest.TestCase):
         check_sample(-16, 2, [[0, -0x7fff], [-0x7fff, 0],
                              [0x7fff, 0], [0, 0x7fff]])
 
-        if pygame.get_sdl_version()[0] >= 2:
-            check_sample(32, 2, [[0.0, -1.0], [-1.0, 0],
-                                 [1.0, 0], [0, 1.0]])
+        if SDL2:
+            check_sample(32, 2, [[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]])
 
     def test_use_arraytype(self):
 
@@ -154,20 +155,19 @@ class SndarrayTest (unittest.TestCase):
         self.assertRaises(ValueError, do_use_arraytype, 'not an option')
 
 
+    @unittest.skipIf(not SDL2, 'requires SDL2')
     def test_float32(self):
         """ sized arrays work with Sounds and 32bit float arrays.
         """
-        if pygame.get_sdl_version()[0] < 2:
-            return
         try:
-            pygame.mixer.init(22050, 32, 2)
+            pygame.mixer.init(22050, 32, 2, allowedchanges=0)
         except pygame.error:
             # Not all sizes are supported on all systems.
-            return
+            self.skipTest("unsupported mixer configuration")
+
         arr = array([[0.0, -1.0], [-1.0, 0], [1.0, 0], [0, 1.0]], float32)
         newsound = pygame.mixer.Sound(array=arr)
         pygame.mixer.quit()
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This update fixes the failing sndarray tests when using SDL2.

Overview of changes:
- Fixed switch fall-through bug
- Added missing `float32` dtype
- Set `allowedchanges=0` to prevent mixer configuration changes
- Added `skipIf`/`skipTest` to notify unittest of skipped tests
- Changed SDL version check to global `bool`

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15 and 2.0.9) at 67a94cc1d0787fca9bbc5771a595cd7eec4a366d