### PR TITLE
Close open cursor files

### DIFF
--- a/src_py/cursors.py
+++ b/src_py/cursors.py
@@ -255,10 +255,19 @@ should work with typical XBM files.
             b = num&(1<<x) != 0
             val = val<<1 | b
         return val
-    if type(curs) is type(''): curs = open(curs)
-    if type(mask) is type(''): mask = open(mask)
-    curs = curs.readlines()
-    mask = mask.readlines()
+
+    if type(curs) is type(''):
+        with open(curs) as cursor_f:
+            curs = cursor_f.readlines()
+    else:
+        curs = curs.readlines()
+
+    if type(mask) is type(''):
+        with open(mask) as mask_f:
+            mask = mask_f.readlines()
+    else:
+        mask = mask.readlines()
+
     #avoid comments
     for line in range(len(curs)):
         if curs[line].startswith("#define"):


### PR DESCRIPTION
This update ensures the cursor files opened by `pygame.cursors.load_xbm` are closed.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 736c2e9d383da9f3383d8d1185bb9f76ca22658e