### PR TITLE
Update scrap tests

### DIFF
--- a/test/scrap_test.py
+++ b/test/scrap_test.py
@@ -13,7 +13,116 @@ class ScrapModuleTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        pygame.init()
+        pygame.display.init()
+        pygame.display.set_mode((1, 1))
+        scrap.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        # scrap.quit()  # Does not exist!
+        pygame.display.quit()
+
+    def test_init(self):
+        """Ensures scrap module still initialized after multiple init calls."""
+        scrap.init()
+        scrap.init()
+
+        self.assertTrue(scrap.get_init())
+
+    def test_get_init(self):
+        """Ensures get_init gets the init state."""
+        self.assertTrue(scrap.get_init())
+
+    def todo_test_contains(self):
+        """Ensures contains works as expected."""
+        self.fail()
+
+    def todo_test_get(self):
+        """Ensures get works as expected."""
+        self.fail()
+
+    # The @unittest.expectedFailure decorator can be removed when issue #915
+    # is resolved.
+    @unittest.expectedFailure
+    def test_get__owned_empty_type(self):
+        """Ensures get works when there is no data of the requested type
+        in the clipboard and the clipboard is owned by the pygame application.
+        """
+        # Use a unique data type identifier to ensure there is no preexisting
+        # data.
+        DATA_TYPE = 'test_get__owned_empty_type'
+
+        if scrap.lost():
+            # Try to acquire the clipboard.
+            scrap.put(pygame.SCRAP_TEXT, b'text to clipboard')
+
+            if scrap.lost():
+                self.skipTest('requires the pygame application to own the '
+                              'clipboard')
+
+        data = scrap.get(DATA_TYPE)
+
+        self.assertIsNone(data)
+
+    def todo_test_get_types(self):
+        """Ensures get_types works as expected."""
+        self.fail()
+
+    def todo_test_lost(self):
+        """Ensures lost works as expected."""
+        self.fail()
+
+    def test_set_mode(self):
+        """Ensures set_mode works as expected."""
+        scrap.set_mode(pygame.SCRAP_SELECTION)
+        scrap.set_mode(pygame.SCRAP_CLIPBOARD)
+
+        self.assertRaises(ValueError, scrap.set_mode, 1099)
+
+    def test_put__text(self):
+        """Ensures put can place text into the clipboard."""
+        scrap.put(pygame.SCRAP_TEXT, as_bytes("Hello world"))
+
+        self.assertEqual(scrap.get(pygame.SCRAP_TEXT), as_bytes("Hello world"))
+
+        scrap.put(pygame.SCRAP_TEXT, as_bytes("Another String"))
+
+        self.assertEqual(scrap.get(pygame.SCRAP_TEXT),
+                         as_bytes("Another String"))
+
+    @unittest.skipIf('pygame.image' not in sys.modules,
+                     'requires pygame.image module')
+    def test_put__bmp_image(self):
+        """Ensures put can place a BMP image into the clipboard."""
+        sf = pygame.image.load(trunk_relative_path(
+            "examples/data/asprite.bmp"))
+        expected_string = pygame.image.tostring(sf, "RGBA")
+        scrap.put(pygame.SCRAP_BMP, expected_string)
+
+        self.assertEqual(scrap.get(pygame.SCRAP_BMP), expected_string)
+
+    def test_put(self):
+        """Ensures put can place data into the clipboard
+        when using a user defined type identifier.
+        """
+        DATA_TYPE = 'arbitrary buffer'
+
+        scrap.put(DATA_TYPE, as_bytes('buf'))
+        r = scrap.get(DATA_TYPE)
+
+        self.assertEqual(r, as_bytes('buf'))
+
+
+class ScrapModuleClipboardNotOwnedTest(unittest.TestCase):
+    """Test the scrap module's functionality when the pygame application is
+    not the current owner of the clipboard.
+
+    A separate class is used to prevent tests that acquire the clipboard from
+    interfering with these tests.
+    """
+    @classmethod
+    def setUpClass(cls):
+        pygame.display.init()
         pygame.display.set_mode((1, 1))
         scrap.init()
 
@@ -21,119 +130,64 @@ class ScrapModuleTest(unittest.TestCase):
     def tearDownClass(cls):
         # scrap.quit()  # Does not exist!
         pygame.quit()
+        pygame.display.quit()
 
-    def test_init(self):
-        # Test if module initialized after multiple init() calls.
-        scrap.init()
-        scrap.init()
+    def _skip_if_clipboard_owned(self):
+        # Skip test if the pygame application owns the clipboard. Currently,
+        # there is no way to give up ownership.
+        if not scrap.lost():
+            self.skipTest('requires the pygame application to not own the '
+                          'clipboard')
 
-        self.assertTrue(scrap.get_init())
+    def test_get__not_owned(self):
+        """Ensures get works when there is no data of the requested type
+        in the clipboard and the clipboard is not owned by the pygame
+        application.
+        """
+        self._skip_if_clipboard_owned()
 
-    def test_get_init(self):
-        # Test if get_init() gets the init state.
-        self.assertTrue(scrap.get_init())
+        # Use a unique data type identifier to ensure there is no preexisting
+        # data.
+        DATA_TYPE = 'test_get__not_owned'
 
-    def todo_test_contains(self):
+        data = scrap.get(DATA_TYPE)
 
-        # __doc__ (as of 2008-08-02) for pygame.scrap.contains:
+        self.assertIsNone(data)
 
-          # scrap.contains (type) -> bool
-          # Checks, whether a certain type is available in the clipboard.
-          #
-          # Returns True, if data for the passed type is available in the
-          # clipboard, False otherwise.
-          #
-          #   if pygame.scrap.contains (SCRAP_TEXT):
-          #       print "There is text in the clipboard."
-          #   if pygame.scrap.contains ("own_data_type"):
-          #       print "There is stuff in the clipboard."
+    def test_get_types__not_owned(self):
+        """Ensures get_types works when the clipboard is not owned
+        by the pygame application.
+        """
+        self._skip_if_clipboard_owned()
 
-        self.fail()
+        data_types = scrap.get_types()
 
-    def todo_test_get(self):
+        self.assertIsInstance(data_types, list)
 
-        # __doc__ (as of 2008-08-02) for pygame.scrap.get:
+    def test_contains__not_owned(self):
+        """Ensures contains works when the clipboard is not owned
+        by the pygame application.
+        """
+        self._skip_if_clipboard_owned()
 
-          # scrap.get (type) -> string
-          # Gets the data for the specified type from the clipboard.
-          #
-          # Returns the data for the specified type from the clipboard. The data
-          # is returned as string and might need further processing. If no data
-          # for the passed type is available, None is returned.
-          #
-          #   text = pygame.scrap.get (SCRAP_TEXT)
-          #   if text:
-          #       # Do stuff with it.
-          #   else:
-          #       print "There does not seem to be text in the clipboard."
+        # Use a unique data type identifier to ensure there is no preexisting
+        # data.
+        DATA_TYPE = 'test_contains__not_owned'
 
-        self.fail()
+        contains = scrap.contains(DATA_TYPE)
 
-    def todo_test_get_types(self):
+        self.assertFalse(contains)
 
-        # __doc__ (as of 2008-08-02) for pygame.scrap.get_types:
+    def test_lost__not_owned(self):
+        """Ensures lost works when the clipboard is not owned
+        by the pygame application.
+        """
+        self._skip_if_clipboard_owned()
 
-          # scrap.get_types () -> list
-          # Gets a list of the available clipboard types.
-          #
-          # Gets a list of strings with the identifiers for the available
-          # clipboard types. Each identifier can be used in the scrap.get()
-          # method to get the clipboard content of the specific type. If there
-          # is no data in the clipboard, an empty list is returned.
-          #
-          #   types = pygame.scrap.get_types ()
-          #   for t in types:
-          #       if "text" in t:
-          #           # There is some content with the word "text" in it. It's
-          #           # possibly text, so print it.
-          #           print pygame.scrap.get (t)
+        lost = scrap.lost()
 
-        self.fail()
+        self.assertTrue(lost)
 
-    def todo_test_lost(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.scrap.lost:
-
-          # scrap.lost() -> bool
-          # Checks whether the clipboard is currently owned by the application.
-          #
-          # Returns True, if the clipboard is currently owned by the pygame
-          # application, False otherwise.
-          #
-          #   if pygame.scrap.lost ():
-          #      print "No content from me anymore. The clipboard is used by someone else."
-
-        self.fail()
-
-    def test_set_mode (self):
-        scrap.set_mode (pygame.SCRAP_SELECTION)
-        scrap.set_mode (pygame.SCRAP_CLIPBOARD)
-        self.assertRaises (ValueError, scrap.set_mode, 1099)
-
-    def test_scrap_put_text (self):
-        scrap.put (pygame.SCRAP_TEXT, as_bytes("Hello world"))
-        self.assertEqual(scrap.get(pygame.SCRAP_TEXT), as_bytes("Hello world"))
-        scrap.put (pygame.SCRAP_TEXT, as_bytes("Another String"))
-
-        self.assertEqual(scrap.get(pygame.SCRAP_TEXT),
-                         as_bytes("Another String"))
-
-    def test_scrap_put_image (self):
-        if 'pygame.image' not in sys.modules:
-            return
-        sf = pygame.image.load (
-            trunk_relative_path("examples/data/asprite.bmp")
-        )
-        expected_string = pygame.image.tostring(sf, "RGBA")
-        scrap.put(pygame.SCRAP_BMP, expected_string)
-
-        self.assertEqual(scrap.get(pygame.SCRAP_BMP), expected_string)
-
-    def test_put (self):
-        scrap.put ("arbitrary buffer", as_bytes("buf"))
-        r = scrap.get ("arbitrary buffer")
-
-        self.assertEqual(r, as_bytes("buf"))
 
 class X11InteractiveTest(unittest.TestCase):
     __tags__ = ['ignore', 'subprocess_ignore']


### PR DESCRIPTION
Overview of changes:
- Added some new tests (`test_get__acquired_empty_type` reproduces issue #915)
- Changed `pygame.init`/`quit` to `pygame.display.init`/`quit` for speed up
- Added a `skipIf` decorator to notify unittest when the test is skipped
- General refactoring (docstrings/comments/renaming/etc)

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 15b1c1fd97682f5cdcbe6c24d55ab0c829a5c743
