### PR TITLE
Fix the SystemError when no type specific clipboard content exists

### DIFF
--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -203,7 +203,6 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
     char *scrap = NULL;
     PyObject *retval;
     char *scrap_type;
-    PyObject *val;
     unsigned long count;
 
     PYGAME_SCRAP_INIT_CHECK();
@@ -212,20 +211,48 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
         return NULL;
 
     if (!pygame_scrap_lost()) {
-        /* We are still the active one. */
+        /* Still own the clipboard. */
+        PyObject *scrap_dict = NULL;
+        PyObject *key = NULL;
+        PyObject *val = NULL;
+
         switch (_currentmode) {
             case SCRAP_SELECTION:
-                val = PyDict_GetItemString(_selectiondata, scrap_type);
+                scrap_dict = _selectiondata;
                 break;
+
             case SCRAP_CLIPBOARD:
             default:
-                val = PyDict_GetItemString(_clipdata, scrap_type);
+                scrap_dict = _clipdata;
                 break;
         }
 
-        if (!val) {
+#if PY3
+        key = PyUnicode_FromString(scrap_type);
+        if (NULL == key) {
+            return PyErr_Format(PyExc_ValueError,
+                                "invalid scrap data type identifier (%s)",
+                                scrap_type);
+        }
+
+        val = PyDict_GetItemWithError(scrap_dict, key);
+        Py_DECREF(key);
+
+        if (NULL == val) {
+            if (PyErr_Occurred()) {
+                return PyErr_Format(PyExc_SystemError,
+                                    "pygame.scrap internal error (key=%s)",
+                                    scrap_type);
+            }
+
             Py_RETURN_NONE;
         }
+#else  /* !PY3 */
+        val = PyDict_GetItemString(scrap_dict, scrap_type);
+        if (NULL == val) {
+            Py_RETURN_NONE;
+        }
+#endif /* !PY3 */
 
         Py_INCREF(val);
         return val;

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -222,7 +222,12 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
                 val = PyDict_GetItemString(_clipdata, scrap_type);
                 break;
         }
-        Py_XINCREF(val);
+
+        if (!val) {
+            Py_RETURN_NONE;
+        }
+
+        Py_INCREF(val);
         return val;
     }
 

--- a/test/scrap_test.py
+++ b/test/scrap_test.py
@@ -41,9 +41,6 @@ class ScrapModuleTest(unittest.TestCase):
         """Ensures get works as expected."""
         self.fail()
 
-    # The @unittest.expectedFailure decorator can be removed when issue #915
-    # is resolved.
-    @unittest.expectedFailure
     def test_get__owned_empty_type(self):
         """Ensures get works when there is no data of the requested type
         in the clipboard and the clipboard is owned by the pygame application.


### PR DESCRIPTION
This update fixes the `SystemError` that was raised when retrieving a data type that has no clipboard content.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 3c4af5613285cf10dd36ef20bc0e79e0c898ce4b

Resolves #915.