### PR TITLE
Fix zero sized mask convolve segmentation fault

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -66,7 +66,7 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
    :type size: tuple(int, int) or list[int, int]
    :param bool fill: create mask unfilled (``False`` - default) or filled
       (``True``)
-   :rtype: ``Mask`` object
+   :rtype: Mask
 
    .. versionadded:: 1.9.5 Named parameter ``size`` (previously it was an
       unnamed positional parameter) and the optional keyword parameter
@@ -244,15 +244,26 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
    .. method:: convolve
 
       | :sl:`Return the convolution of self with another mask.`
-      | :sg:`convolve(othermask, outputmask = None, offset = (0,0)) -> Mask`
+      | :sg:`convolve(othermask) -> Mask`
+      | :sg:`convolve(othermask, outputmask=None, offset=(0,0)) -> Mask`
 
-      Returns a mask with the (i-offset[0],j-offset[1]) bit set if shifting
-      othermask so that its lower right corner pixel is at (i,j) would cause
-      it to overlap with self.
+      Convolve self with the given ``othermask``.
 
-      If an outputmask is specified, the output is drawn onto outputmask and
-      outputmask is returned. Otherwise a mask of size ``self.get_size()`` +
-      ``othermask.get_size()`` - (1,1) is created.
+      :param Mask othermask: mask to convolve with self
+      :param outputmask: mask for output, default is None
+      :type outputmask: Mask or None
+      :param offset: offset used in convolution of masks, default is (0, 0)
+      :type offset: tuple(int, int) or list[int, int]
+
+      :returns: A mask with the ``(i - offset[0], j - offset[1])`` bit set, if
+         shifting ``othermask`` (such that its bottom right corner pixel is at
+         ``(i, j)``) causes it to overlap with self.
+
+         If an ``outputmask`` is specified, the output is drawn onto it and
+         it is returned. Otherwise a mask of size ``(MAX(0, width + othermask's
+         width - 1), MAX(0, height + othermask's height - 1))`` is created and
+         returned.
+      :rtype: Mask
 
       .. ## Mask.convolve ##
 

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -88,7 +88,13 @@ bitmask_create(int w, int h)
     bitmask_t *temp;
     size_t size;
 
+    /* Guard against negative parameters. */
+    if (w < 0 || h < 0) {
+        return 0;
+    }
+
     size = offsetof(bitmask_t, bits);
+
     if (w && h) {
         size += h * ((w - 1) / BITMASK_W_LEN + 1) * sizeof(BITMASK_W);
     }
@@ -98,9 +104,11 @@ bitmask_create(int w, int h)
     if (!temp) {
         return 0;
     }
+
     temp->w = w;
     temp->h = h;
     bitmask_clear(temp);
+
     return temp;
 }
 
@@ -978,19 +986,20 @@ bitmask_scale(const bitmask_t *m, int w, int h)
 }
 
 void
-bitmask_convolve(const bitmask_t *a, const bitmask_t *b, bitmask_t *o,
+bitmask_convolve(const bitmask_t *a, const bitmask_t *b, bitmask_t *output,
                  int xoffset, int yoffset)
 {
     int x, y;
 
-    if (!a->h || !a->w || !b->h || !b->w) {
+    if (!a->h || !a->w || !b->h || !b->w || !output->h || !output->w) {
         return;
     }
 
     xoffset += b->w - 1;
     yoffset += b->h - 1;
+
     for (y = 0; y < b->h; y++)
         for (x = 0; x < b->w; x++)
             if (bitmask_getbit(b, x, y))
-                bitmask_draw(o, a, xoffset - x, yoffset - y);
+                bitmask_draw(output, a, xoffset - x, yoffset - y);
 }

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -19,7 +19,7 @@
 #define DOC_MASKCENTROID "centroid() -> (x, y)\nReturns the centroid of the pixels in a Mask"
 #define DOC_MASKANGLE "angle() -> theta\nReturns the orientation of the pixels"
 #define DOC_MASKOUTLINE "outline(every = 1) -> [(x,y), (x,y) ...]\nlist of points outlining an object"
-#define DOC_MASKCONVOLVE "convolve(othermask, outputmask = None, offset = (0,0)) -> Mask\nReturn the convolution of self with another mask."
+#define DOC_MASKCONVOLVE "convolve(othermask) -> Mask\nconvolve(othermask, outputmask=None, offset=(0,0)) -> Mask\nReturn the convolution of self with another mask."
 #define DOC_MASKCONNECTEDCOMPONENT "connected_component((x,y) = None) -> Mask\nReturns a mask of a connected region of pixels."
 #define DOC_MASKCONNECTEDCOMPONENTS "connected_components(min = 0) -> [Masks]\nReturns a list of masks of connected regions of pixels."
 #define DOC_MASKGETBOUNDINGRECTS "get_bounding_rects() -> Rects\nReturns a list of bounding rects of regions of set pixels."
@@ -110,7 +110,8 @@ pygame.mask.Mask.outline
 list of points outlining an object
 
 pygame.mask.Mask.convolve
- convolve(othermask, outputmask = None, offset = (0,0)) -> Mask
+ convolve(othermask) -> Mask
+ convolve(othermask, outputmask=None, offset=(0,0)) -> Mask
 Return the convolution of self with another mask.
 
 pygame.mask.Mask.connected_component

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -1577,7 +1577,6 @@ class MaskTypeTest(unittest.TestCase):
             self.assertListEqual(points, expected_points,
                                  'size={}'.format(size))
 
-    @unittest.skip('can cause segmentation fault')
     def test_zero_mask_convolve(self):
         """Ensures convolve correctly handles zero sized masks.
 


### PR DESCRIPTION
This update fixes the segmentation fault caused by calling `pygame.mask.Mask.convolve` on a zero sized mask.

Overview of changes:
- Changed `convolve` to work correctly with zero sized masks and added some error checking
- Added negative size check to `bitmask_create`
- Removed `@unittest.skip` decorator from the now passing test
- Updated the mask documentation

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at adac292a8be6708b3ef833ec0813638871d754d5

Resolves #890.