### PR TITLE
Fix LayeredDirty's inconsistent use of its source rect

### DIFF
--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1098,20 +1098,27 @@ class LayeredDirty(LayeredUpdates):
                 if 1 > spr.dirty:
                     if spr._visible:
                         # sprite not dirty; blit only the intersecting part
-                        _spr_rect = spr.rect
-                        _spr_rect_clip = _spr_rect.clip
-                        source_rect_offset_x = 0
-                        source_rect_offset_y = 0
                         if spr.source_rect is not None:
-                            source_rect_offset_x = spr.source_rect[0]
-                            source_rect_offset_y = spr.source_rect[1]
+                            # For possible future speed up, source_rect's data
+                            # can be prefetched outside of this loop.
+                            _spr_rect = _rect(spr.rect.topleft,
+                                              spr.source_rect.size)
+                            rect_offset_x = spr.source_rect[0] - _spr_rect[0]
+                            rect_offset_y = spr.source_rect[1] - _spr_rect[1]
+                        else:
+                            _spr_rect = spr.rect
+                            rect_offset_x = -_spr_rect[0]
+                            rect_offset_y = -_spr_rect[1]
+
+                        _spr_rect_clip = _spr_rect.clip
+
                         for idx in _spr_rect.collidelistall(_update):
                             # clip
                             clip = _spr_rect_clip(_update[idx])
                             _surf_blit(spr.image,
                                        clip,
-                                       (clip[0] - _spr_rect[0] + source_rect_offset_x,
-                                        clip[1] - _spr_rect[1] + source_rect_offset_y,
+                                       (clip[0] + rect_offset_x,
+                                        clip[1] + rect_offset_y,
                                         clip[2],
                                         clip[3]),
                                        spr.blendmode)

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -1088,7 +1088,6 @@ class LayeredDirtyTypeTest__DirtySprite(LayeredGroupBase, unittest.TestCase):
         """
         self._nondirty_intersections_redrawn()
 
-    @unittest.expectedFailure
     def test_nondirty_intersections_redrawn__with_source_rect(self):
         """Ensure non-dirty sprites using source_rects are correctly redrawn
         when dirty sprites intersect with them.


### PR DESCRIPTION
This update changes `LayeredDirty` so the use of its `source_rect` is consistent.

Overview of changes:
- Changed `LayeredDirty` so the use of its `source_rect` is consistent
- Removed `@unittest.expectedFailure` decorator from the now passing test

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev0 (SDL: 1.2.15) at 883dacca377160da2483db85e7482d27126b94b0

Related: #899, #900, #919.