### PR TITLE
Use SDL_RWops instead of pg_FopenUTF8.

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -373,9 +373,9 @@ typedef struct {
 
 #define PYGAMEAPI_BASE_FIRSTSLOT 0
 #if IS_SDLv1
-#define PYGAMEAPI_BASE_NUMSLOTS 20
+#define PYGAMEAPI_BASE_NUMSLOTS 19
 #else /* IS_SDLv2 */
-#define PYGAMEAPI_BASE_NUMSLOTS 24
+#define PYGAMEAPI_BASE_NUMSLOTS 23
 #endif /* IS_SDLv2 */
 #ifndef PYGAMEAPI_BASE_INTERNAL
 #define pgExc_SDLError ((PyObject *)PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT])
@@ -445,22 +445,18 @@ typedef struct {
 #define pgExc_BufferError \
     ((PyObject *)PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 18])
 
-#define pg_FopenUTF8                          \
-    (*(FILE* (*)(const char *, const char *)) \
-                 PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 19])
-
 #if IS_SDLv2
 #define pg_GetDefaultWindow \
-    (*(SDL_Window * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 20])
+    (*(SDL_Window * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 19])
 
 #define pg_SetDefaultWindow \
-    (*(void (*)(SDL_Window *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 21])
+    (*(void (*)(SDL_Window *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 20])
 
 #define pg_GetDefaultWindowSurface \
-    (*(PyObject * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 22])
+    (*(PyObject * (*)(void)) PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 21])
 
 #define pg_SetDefaultWindowSurface \
-    (*(void (*)(PyObject *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 23])
+    (*(void (*)(PyObject *))PyGAME_C_API[PYGAMEAPI_BASE_FIRSTSLOT + 22])
 
 #endif /* IS_SDLv2 */
 

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -188,109 +188,6 @@ static void
 pg_SetDefaultWindowSurface(PyObject *);
 #endif /* IS_SDLv2 */
 
-
-#include <errno.h>
-#ifdef WIN32
-
-static char*
-_new_win_error_msg_utf8() {
-    /* must be free()'d by the caller */
-    size_t utf8_len;
-    char *utf8_buf = NULL;
-    size_t nwritten;
-    wchar_t* buffer = NULL;
-    DWORD numChars =
-        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM |
-                       FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                       FORMAT_MESSAGE_IGNORE_INSERTS,
-                       NULL,
-                       GetLastError(),
-                       0,
-                       (wchar_t*)&buffer,
-                       0, 0);
-    if (!numChars)
-        goto leave;
-    utf8_len =
-        WideCharToMultiByte(CP_UTF8, 0,
-                            buffer, numChars,
-                            NULL, 0,
-                            NULL, NULL);
-    if (!utf8_len)
-        goto leave;
-    utf8_buf = malloc(utf8_len + 1);
-    if (!utf8_buf)
-        goto leave;
-    nwritten =
-        WideCharToMultiByte(CP_UTF8, 0,
-                            buffer, numChars,
-                            utf8_buf, utf8_len,
-                            NULL, NULL);
-    if (!nwritten) {
-        free(utf8_buf);
-        utf8_buf = NULL;
-        goto leave;
-    }
-    utf8_buf[nwritten] = 0;
-
-leave:
-    LocalFree(buffer);
-    return utf8_buf;
-}
-
-static FILE*
-pg_FopenUTF8(const char *filename, const char *mode) {
-    FILE *fp = NULL;
-    static wchar_t modebuf[24];
-    size_t nameInputSize = strlen(filename) + 1;
-    size_t namebuf_chars = MultiByteToWideChar(CP_UTF8, 0, filename, nameInputSize, 0, 0);
-    wchar_t* namebuf;
-    if (namebuf_chars == 0)
-        return NULL;
-    namebuf = malloc(namebuf_chars * sizeof(wchar_t));
-    if (!namebuf)
-        goto leave;
-
-    if (MultiByteToWideChar(CP_UTF8, 0, filename, nameInputSize,
-                            namebuf, namebuf_chars) == 0) {
-        char *utf8_buf = _new_win_error_msg_utf8();
-        if (utf8_buf) {
-            SDL_SetError("Cannot open file %s: %s.", filename, utf8_buf);
-            free(utf8_buf);
-        } else {
-            SDL_SetError("Cannot open file %s.", filename);
-        }
-        goto leave;
-    }
-    if (MultiByteToWideChar(CP_UTF8, 0, mode, -1,
-                            modebuf, sizeof(modebuf) / sizeof(wchar_t)) == 0) {
-        char *utf8_buf = _new_win_error_msg_utf8();
-        if (utf8_buf) {
-            SDL_SetError("Cannot open file %s: %s.", filename, utf8_buf);
-            free(utf8_buf);
-        } else {
-            SDL_SetError("Cannot open file %s.", filename);
-        }
-        goto leave;
-    }
-
-    fp = _wfopen(namebuf, modebuf);
-    if (!fp)
-        SDL_SetError("Cannot open file %s. %s", filename, strerror(errno));
-
-leave:
-    free(namebuf);
-    return fp;
-}
-#else /* !WIN32 */
-static FILE*
-pg_FopenUTF8(const char *filename, const char *mode) {
-    FILE *fp = fopen(filename, mode);
-    if (!fp)
-        SDL_SetError("Cannot open file %s. %s", filename, strerror(errno));
-    return fp;
-}
-#endif /* !WIN32 */
-
 static int
 pg_CheckSDLVersions(void) /*compare compiled to linked*/
 {
@@ -2287,15 +2184,14 @@ MODINIT_DEFINE(base)
     c_api[16] = pgBuffer_Release;
     c_api[17] = pgDict_AsBuffer;
     c_api[18] = pgExc_BufferError;
-    c_api[19] = pg_FopenUTF8;
 #if IS_SDLv1
-#define FILLED_SLOTS 20
+#define FILLED_SLOTS 19
 #else /* IS_SDLv2 */
-    c_api[20] = pg_GetDefaultWindow;
-    c_api[21] = pg_SetDefaultWindow;
-    c_api[22] = pg_GetDefaultWindowSurface;
-    c_api[23] = pg_SetDefaultWindowSurface;
-#define FILLED_SLOTS 24
+    c_api[19] = pg_GetDefaultWindow;
+    c_api[20] = pg_SetDefaultWindow;
+    c_api[21] = pg_GetDefaultWindowSurface;
+    c_api[22] = pg_SetDefaultWindowSurface;
+#define FILLED_SLOTS 23
 #endif /* IS_SDLv2 */
 
 #if PYGAMEAPI_BASE_NUMSLOTS != FILLED_SLOTS


### PR DESCRIPTION
This removes pg_FopenUTF8 in favor of SDL_RWFromFile. It was only used in imageext.c.

One issue is that the RWops API lacks a flush function, so I had to remove those. It seems to work fine without explicit flushing, though. SDL_image does more or less the same thing.

- [ ] Manually test the image saving functions.