### PR TITLE
Vector: allow chaining of in-place methods

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -16,7 +16,20 @@ number*vec, vec/number, vec//number, vec+=vec, vec-=vec, vec*=number,
 vec/=number, vec//=number. All these operations will be performed elementwise.
 In addition vec*vec will perform a scalar-product (a.k.a. dot-product). If you
 want to multiply every element from vector v with every element from vector w
-you can use the elementwise method: ``v.elementwise()`` ``\*`` w
+you can use the elementwise method: ``v.elementwise() * w``
+
+The coordinates of a vector can be retrieved or set using attributes or
+subscripts::
+
+   v = pygame.Vector3()
+
+   v.x = 5
+   v[1] = 2 * v.x
+   print(v[1]) # 10
+
+   v.x == v[0]
+   v.y == v[1]
+   v.z == v[2]
 
 .. versionadded:: 1.9.2pre
 .. versionchanged:: 1.9.4 Removed experimental notice.

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -107,10 +107,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: normalize_ip
 
       | :sl:`normalizes the vector in place so that its length is 1.`
-      | :sg:`normalize_ip() -> None`
+      | :sg:`normalize_ip() -> Vector2`
 
       Normalizes the vector so that it has length == 1. The direction of the
       vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector2.normalize_ip ##
 
@@ -125,13 +127,15 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
 
    .. method:: scale_to_length
 
-      | :sl:`scales the vector to a given length.`
-      | :sg:`scale_to_length(float) -> None`
+      | :sl:`scales the vector in place to a given length.`
+      | :sg:`scale_to_length(float) -> Vector2`
 
-      Scales the vector so that it has the given length. The direction of the
-      vector is not changed. You can also scale to length 0. If the vector is
+      Scales the vector in place so that it has the given length. The direction of
+      the vector is not changed. You can also scale to length 0. If the vector is
       the zero vector (i.e. has length 0 thus no direction) an
       ZeroDivisionError is raised.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector2.scale_to_length ##
 
@@ -149,10 +153,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: reflect_ip
 
       | :sl:`reflect the vector of a given normal in place.`
-      | :sg:`reflect_ip(Vector2) -> None`
+      | :sg:`reflect_ip(Vector2) -> Vector2`
 
       Changes the direction of self as if it would have been reflected of a
       surface with the given surface normal.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector2.reflect_ip ##
 
@@ -217,10 +223,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: rotate_ip
 
       | :sl:`rotates the vector by a given angle in degrees in place.`
-      | :sg:`rotate_ip(float) -> None`
+      | :sg:`rotate_ip(float) -> Vector2`
 
       Rotates the vector counterclockwise by the given angle in degrees. The
       length of the vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector2.rotate_ip ##
 
@@ -246,10 +254,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: from_polar
 
       | :sl:`Sets x and y from a polar coordinates tuple.`
-      | :sg:`from_polar((r, phi)) -> None`
+      | :sg:`from_polar((r, phi)) -> Vector2`
 
       Sets x and y from a tuple (r, phi) where r is the radial distance, and
       phi is the azimuthal angle.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector2.from_polar ##
 
@@ -340,10 +350,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: normalize_ip
 
       | :sl:`normalizes the vector in place so that its length is 1.`
-      | :sg:`normalize_ip() -> None`
+      | :sg:`normalize_ip() -> Vector3`
 
       Normalizes the vector so that it has length == 1. The direction of the
       vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.normalize_ip ##
 
@@ -358,13 +370,15 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
 
    .. method:: scale_to_length
 
-      | :sl:`scales the vector to a given length.`
-      | :sg:`scale_to_length(float) -> None`
+      | :sl:`scales the vector in place to a given length.`
+      | :sg:`scale_to_length(float) -> Vector3`
 
-      Scales the vector so that it has the given length. The direction of the
-      vector is not changed. You can also scale to length 0. If the vector is
+      Scales the vector in place so that it has the given length. The direction of
+      the vector is not changed. You can also scale to length 0. If the vector is
       the zero vector (i.e. has length 0 thus no direction) an
       ZeroDivisionError is raised.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.scale_to_length ##
 
@@ -382,10 +396,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: reflect_ip
 
       | :sl:`reflect the vector of a given normal in place.`
-      | :sg:`reflect_ip(Vector3) -> None`
+      | :sg:`reflect_ip(Vector3) -> Vector3`
 
       Changes the direction of self as if it would have been reflected of a
       surface with the given surface normal.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.reflect_ip ##
 
@@ -450,10 +466,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: rotate_ip
 
       | :sl:`rotates the vector by a given angle in degrees in place.`
-      | :sg:`rotate_ip(Vector3, float) -> None`
+      | :sg:`rotate_ip(Vector3, float) -> Vector3`
 
       Rotates the vector counterclockwise around the given axis by the given
       angle in degrees. The length of the vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.rotate_ip ##
 
@@ -470,10 +488,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: rotate_x_ip
 
       | :sl:`rotates the vector around the x-axis by the angle in degrees in place.`
-      | :sg:`rotate_x_ip(float) -> None`
+      | :sg:`rotate_x_ip(float) -> Vector3`
 
       Rotates the vector counterclockwise around the x-axis by the given angle
       in degrees. The length of the vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.rotate_x_ip ##
 
@@ -490,10 +510,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: rotate_y_ip
 
       | :sl:`rotates the vector around the y-axis by the angle in degrees in place.`
-      | :sg:`rotate_y_ip(float) -> None`
+      | :sg:`rotate_y_ip(float) -> Vector3`
 
       Rotates the vector counterclockwise around the y-axis by the given angle
       in degrees. The length of the vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.rotate_y_ip ##
 
@@ -510,10 +532,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: rotate_z_ip
 
       | :sl:`rotates the vector around the z-axis by the angle in degrees in place.`
-      | :sg:`rotate_z_ip(float) -> None`
+      | :sg:`rotate_z_ip(float) -> Vector3`
 
       Rotates the vector counterclockwise around the z-axis by the given angle
       in degrees. The length of the vector is not changed.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.rotate_z_ip ##
 
@@ -539,10 +563,12 @@ you can use the elementwise method: ``v.elementwise()`` ``\*`` w
    .. method:: from_spherical
 
       | :sl:`Sets x, y and z from a spherical coordinates 3-tuple.`
-      | :sg:`from_spherical((r, theta, phi)) -> None`
+      | :sg:`from_spherical((r, theta, phi)) -> Vector3`
 
       Sets x, y and z from a tuple (r, theta, phi) where r is the radial
       distance, theta is the inclination angle and phi is the azimuthal angle.
+
+      .. versionchanged:: 1.9.5 The vector itself is returned instead of ``None``.
 
       .. ## Vector3.from_spherical ##
 

--- a/src_c/doc/math_doc.h
+++ b/src_c/doc/math_doc.h
@@ -8,21 +8,21 @@
 #define DOC_VECTOR2LENGTH "length() -> float\nreturns the Euclidean length of the vector."
 #define DOC_VECTOR2LENGTHSQUARED "length_squared() -> float\nreturns the squared Euclidean length of the vector."
 #define DOC_VECTOR2NORMALIZE "normalize() -> Vector2\nreturns a vector with the same direction but length 1."
-#define DOC_VECTOR2NORMALIZEIP "normalize_ip() -> None\nnormalizes the vector in place so that its length is 1."
+#define DOC_VECTOR2NORMALIZEIP "normalize_ip() -> Vector2\nnormalizes the vector in place so that its length is 1."
 #define DOC_VECTOR2ISNORMALIZED "is_normalized() -> Bool\ntests if the vector is normalized i.e. has length == 1."
-#define DOC_VECTOR2SCALETOLENGTH "scale_to_length(float) -> None\nscales the vector to a given length."
+#define DOC_VECTOR2SCALETOLENGTH "scale_to_length(float) -> Vector2\nscales the vector in place to a given length."
 #define DOC_VECTOR2REFLECT "reflect(Vector2) -> Vector2\nreturns a vector reflected of a given normal."
-#define DOC_VECTOR2REFLECTIP "reflect_ip(Vector2) -> None\nreflect the vector of a given normal in place."
+#define DOC_VECTOR2REFLECTIP "reflect_ip(Vector2) -> Vector2\nreflect the vector of a given normal in place."
 #define DOC_VECTOR2DISTANCETO "distance_to(Vector2) -> float\ncalculates the Euclidean distance to a given vector."
 #define DOC_VECTOR2DISTANCESQUAREDTO "distance_squared_to(Vector2) -> float\ncalculates the squared Euclidean distance to a given vector."
 #define DOC_VECTOR2LERP "lerp(Vector2, float) -> Vector2\nreturns a linear interpolation to the given vector."
 #define DOC_VECTOR2SLERP "slerp(Vector2, float) -> Vector2\nreturns a spherical interpolation to the given vector."
 #define DOC_VECTOR2ELEMENTWISE "elementwise() -> VectorElementwiseProxy\nThe next operation will be performed elementwise."
 #define DOC_VECTOR2ROTATE "rotate(float) -> Vector2\nrotates a vector by a given angle in degrees."
-#define DOC_VECTOR2ROTATEIP "rotate_ip(float) -> None\nrotates the vector by a given angle in degrees in place."
+#define DOC_VECTOR2ROTATEIP "rotate_ip(float) -> Vector2\nrotates the vector by a given angle in degrees in place."
 #define DOC_VECTOR2ANGLETO "angle_to(Vector2) -> float\ncalculates the angle to a given vector in degrees."
 #define DOC_VECTOR2ASPOLAR "as_polar() -> (r, phi)\nreturns a tuple with radial distance and azimuthal angle."
-#define DOC_VECTOR2FROMPOLAR "from_polar((r, phi)) -> None\nSets x and y from a polar coordinates tuple."
+#define DOC_VECTOR2FROMPOLAR "from_polar((r, phi)) -> Vector2\nSets x and y from a polar coordinates tuple."
 #define DOC_PYGAMEMATHVECTOR3 "Vector3() -> Vector3\nVector3(int) -> Vector2\nVector3(float) -> Vector2\nVector3(Vector3) -> Vector3\nVector3(x, y, z) -> Vector3\nVector3((x, y, z)) -> Vector3\na 3-Dimensional Vector"
 #define DOC_VECTOR3DOT "dot(Vector3) -> float\ncalculates the dot- or scalar-product with the other vector"
 #define DOC_VECTOR3CROSS "cross(Vector3) -> Vector3\ncalculates the cross- or vector-product"
@@ -31,27 +31,27 @@
 #define DOC_VECTOR3LENGTH "length() -> float\nreturns the Euclidean length of the vector."
 #define DOC_VECTOR3LENGTHSQUARED "length_squared() -> float\nreturns the squared Euclidean length of the vector."
 #define DOC_VECTOR3NORMALIZE "normalize() -> Vector3\nreturns a vector with the same direction but length 1."
-#define DOC_VECTOR3NORMALIZEIP "normalize_ip() -> None\nnormalizes the vector in place so that its length is 1."
+#define DOC_VECTOR3NORMALIZEIP "normalize_ip() -> Vector3\nnormalizes the vector in place so that its length is 1."
 #define DOC_VECTOR3ISNORMALIZED "is_normalized() -> Bool\ntests if the vector is normalized i.e. has length == 1."
-#define DOC_VECTOR3SCALETOLENGTH "scale_to_length(float) -> None\nscales the vector to a given length."
+#define DOC_VECTOR3SCALETOLENGTH "scale_to_length(float) -> Vector3\nscales the vector in place to a given length."
 #define DOC_VECTOR3REFLECT "reflect(Vector3) -> Vector3\nreturns a vector reflected of a given normal."
-#define DOC_VECTOR3REFLECTIP "reflect_ip(Vector3) -> None\nreflect the vector of a given normal in place."
+#define DOC_VECTOR3REFLECTIP "reflect_ip(Vector3) -> Vector3\nreflect the vector of a given normal in place."
 #define DOC_VECTOR3DISTANCETO "distance_to(Vector3) -> float\ncalculates the Euclidean distance to a given vector."
 #define DOC_VECTOR3DISTANCESQUAREDTO "distance_squared_to(Vector3) -> float\ncalculates the squared Euclidean distance to a given vector."
 #define DOC_VECTOR3LERP "lerp(Vector3, float) -> Vector3\nreturns a linear interpolation to the given vector."
 #define DOC_VECTOR3SLERP "slerp(Vector3, float) -> Vector3\nreturns a spherical interpolation to the given vector."
 #define DOC_VECTOR3ELEMENTWISE "elementwise() -> VectorElementwiseProxy\nThe next operation will be performed elementwise."
 #define DOC_VECTOR3ROTATE "rotate(Vector3, float) -> Vector3\nrotates a vector by a given angle in degrees."
-#define DOC_VECTOR3ROTATEIP "rotate_ip(Vector3, float) -> None\nrotates the vector by a given angle in degrees in place."
+#define DOC_VECTOR3ROTATEIP "rotate_ip(Vector3, float) -> Vector3\nrotates the vector by a given angle in degrees in place."
 #define DOC_VECTOR3ROTATEX "rotate_x(float) -> Vector3\nrotates a vector around the x-axis by the angle in degrees."
-#define DOC_VECTOR3ROTATEXIP "rotate_x_ip(float) -> None\nrotates the vector around the x-axis by the angle in degrees in place."
+#define DOC_VECTOR3ROTATEXIP "rotate_x_ip(float) -> Vector3\nrotates the vector around the x-axis by the angle in degrees in place."
 #define DOC_VECTOR3ROTATEY "rotate_y(float) -> Vector3\nrotates a vector around the y-axis by the angle in degrees."
-#define DOC_VECTOR3ROTATEYIP "rotate_y_ip(float) -> None\nrotates the vector around the y-axis by the angle in degrees in place."
+#define DOC_VECTOR3ROTATEYIP "rotate_y_ip(float) -> Vector3\nrotates the vector around the y-axis by the angle in degrees in place."
 #define DOC_VECTOR3ROTATEZ "rotate_z(float) -> Vector3\nrotates a vector around the z-axis by the angle in degrees."
-#define DOC_VECTOR3ROTATEZIP "rotate_z_ip(float) -> None\nrotates the vector around the z-axis by the angle in degrees in place."
+#define DOC_VECTOR3ROTATEZIP "rotate_z_ip(float) -> Vector3\nrotates the vector around the z-axis by the angle in degrees in place."
 #define DOC_VECTOR3ANGLETO "angle_to(Vector3) -> float\ncalculates the angle to a given vector in degrees."
 #define DOC_VECTOR3ASSPHERICAL "as_spherical() -> (r, theta, phi)\nreturns a tuple with radial distance, inclination and azimuthal angle."
-#define DOC_VECTOR3FROMSPHERICAL "from_spherical((r, theta, phi)) -> None\nSets x, y and z from a spherical coordinates 3-tuple."
+#define DOC_VECTOR3FROMSPHERICAL "from_spherical((r, theta, phi)) -> Vector3\nSets x, y and z from a spherical coordinates 3-tuple."
 #define DOC_PYGAMEMATHENABLESWIZZLING "enable_swizzling() -> None\nglobally enables swizzling for vectors."
 #define DOC_PYGAMEMATHDISABLESWIZZLING "disable_swizzling() -> None\nglobally disables swizzling for vectors."
 
@@ -101,7 +101,7 @@ pygame.math.Vector2.normalize
 returns a vector with the same direction but length 1.
 
 pygame.math.Vector2.normalize_ip
- normalize_ip() -> None
+ normalize_ip() -> Vector2
 normalizes the vector in place so that its length is 1.
 
 pygame.math.Vector2.is_normalized
@@ -109,15 +109,15 @@ pygame.math.Vector2.is_normalized
 tests if the vector is normalized i.e. has length == 1.
 
 pygame.math.Vector2.scale_to_length
- scale_to_length(float) -> None
-scales the vector to a given length.
+ scale_to_length(float) -> Vector2
+scales the vector in place to a given length.
 
 pygame.math.Vector2.reflect
  reflect(Vector2) -> Vector2
 returns a vector reflected of a given normal.
 
 pygame.math.Vector2.reflect_ip
- reflect_ip(Vector2) -> None
+ reflect_ip(Vector2) -> Vector2
 reflect the vector of a given normal in place.
 
 pygame.math.Vector2.distance_to
@@ -145,7 +145,7 @@ pygame.math.Vector2.rotate
 rotates a vector by a given angle in degrees.
 
 pygame.math.Vector2.rotate_ip
- rotate_ip(float) -> None
+ rotate_ip(float) -> Vector2
 rotates the vector by a given angle in degrees in place.
 
 pygame.math.Vector2.angle_to
@@ -157,7 +157,7 @@ pygame.math.Vector2.as_polar
 returns a tuple with radial distance and azimuthal angle.
 
 pygame.math.Vector2.from_polar
- from_polar((r, phi)) -> None
+ from_polar((r, phi)) -> Vector2
 Sets x and y from a polar coordinates tuple.
 
 pygame.math.Vector3
@@ -198,7 +198,7 @@ pygame.math.Vector3.normalize
 returns a vector with the same direction but length 1.
 
 pygame.math.Vector3.normalize_ip
- normalize_ip() -> None
+ normalize_ip() -> Vector3
 normalizes the vector in place so that its length is 1.
 
 pygame.math.Vector3.is_normalized
@@ -206,15 +206,15 @@ pygame.math.Vector3.is_normalized
 tests if the vector is normalized i.e. has length == 1.
 
 pygame.math.Vector3.scale_to_length
- scale_to_length(float) -> None
-scales the vector to a given length.
+ scale_to_length(float) -> Vector3
+scales the vector in place to a given length.
 
 pygame.math.Vector3.reflect
  reflect(Vector3) -> Vector3
 returns a vector reflected of a given normal.
 
 pygame.math.Vector3.reflect_ip
- reflect_ip(Vector3) -> None
+ reflect_ip(Vector3) -> Vector3
 reflect the vector of a given normal in place.
 
 pygame.math.Vector3.distance_to
@@ -242,7 +242,7 @@ pygame.math.Vector3.rotate
 rotates a vector by a given angle in degrees.
 
 pygame.math.Vector3.rotate_ip
- rotate_ip(Vector3, float) -> None
+ rotate_ip(Vector3, float) -> Vector3
 rotates the vector by a given angle in degrees in place.
 
 pygame.math.Vector3.rotate_x
@@ -250,7 +250,7 @@ pygame.math.Vector3.rotate_x
 rotates a vector around the x-axis by the angle in degrees.
 
 pygame.math.Vector3.rotate_x_ip
- rotate_x_ip(float) -> None
+ rotate_x_ip(float) -> Vector3
 rotates the vector around the x-axis by the angle in degrees in place.
 
 pygame.math.Vector3.rotate_y
@@ -258,7 +258,7 @@ pygame.math.Vector3.rotate_y
 rotates a vector around the y-axis by the angle in degrees.
 
 pygame.math.Vector3.rotate_y_ip
- rotate_y_ip(float) -> None
+ rotate_y_ip(float) -> Vector3
 rotates the vector around the y-axis by the angle in degrees in place.
 
 pygame.math.Vector3.rotate_z
@@ -266,7 +266,7 @@ pygame.math.Vector3.rotate_z
 rotates a vector around the z-axis by the angle in degrees.
 
 pygame.math.Vector3.rotate_z_ip
- rotate_z_ip(float) -> None
+ rotate_z_ip(float) -> Vector3
 rotates the vector around the z-axis by the angle in degrees in place.
 
 pygame.math.Vector3.angle_to
@@ -278,7 +278,7 @@ pygame.math.Vector3.as_spherical
 returns a tuple with radial distance, inclination and azimuthal angle.
 
 pygame.math.Vector3.from_spherical
- from_spherical((r, theta, phi)) -> None
+ from_spherical((r, theta, phi)) -> Vector3
 Sets x, y and z from a spherical coordinates 3-tuple.
 
 pygame.math.enable_swizzling

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1244,7 +1244,7 @@ vector_normalize_ip(pgVector *self, PyObject *args)
     for (i = 0; i < self->dim; ++i)
         self->coords[i] /= length;
 
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -1295,7 +1295,7 @@ vector_scale_to_length(pgVector *self, PyObject *length)
     for (i = 0; i < self->dim; ++i)
         self->coords[i] *= fraction;
 
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -1459,7 +1459,7 @@ vector_reflect_ip(pgVector *self, PyObject *normal)
         return NULL;
     }
     memcpy(self->coords, tmp_coords, self->dim * sizeof(tmp_coords[0]));
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static double
@@ -1987,7 +1987,7 @@ vector2_rotate_ip(pgVector *self, PyObject *args)
     if (!_vector2_rotate_helper(self->coords, tmp, angle, self->epsilon)) {
         return NULL;
     }
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -2050,7 +2050,7 @@ vector2_from_polar(pgVector *self, PyObject *args)
     self->coords[0] = r * cos(phi);
     self->coords[1] = r * sin(phi);
 
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 static PyObject *
 vector_getsafepickle(pgRectObject *self, void *closure)
@@ -2455,7 +2455,7 @@ vector3_rotate_ip(pgVector *self, PyObject *args)
                                 self->epsilon)) {
         return NULL;
     }
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -2499,7 +2499,7 @@ vector3_rotate_x_ip(pgVector *self, PyObject *angleObject)
 
     self->coords[1] = tmp_coords[1] * cosValue - tmp_coords[2] * sinValue;
     self->coords[2] = tmp_coords[1] * sinValue + tmp_coords[2] * cosValue;
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -2544,7 +2544,7 @@ vector3_rotate_y_ip(pgVector *self, PyObject *angleObject)
 
     self->coords[0] = tmp_coords[0] * cosValue + tmp_coords[2] * sinValue;
     self->coords[2] = -tmp_coords[0] * sinValue + tmp_coords[2] * cosValue;
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -2589,7 +2589,7 @@ vector3_rotate_z_ip(pgVector *self, PyObject *angleObject)
 
     self->coords[0] = tmp_coords[0] * cosValue - tmp_coords[1] * sinValue;
     self->coords[1] = tmp_coords[0] * sinValue + tmp_coords[1] * cosValue;
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 static PyObject *
@@ -2691,7 +2691,7 @@ vector3_from_spherical(pgVector *self, PyObject *args)
     self->coords[1] = r * sin(theta) * sin(phi);
     self->coords[2] = r * cos(theta);
 
-    Py_RETURN_NONE;
+    return Py_INCREF(self), self;
 }
 
 /* For pickling. */

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -310,7 +310,7 @@ class Vector2TypeTest(unittest.TestCase):
 
     def test_rotate_ip(self):
         v = Vector2(1, 0)
-        self.assertEqual(v.rotate_ip(90), None)
+        self.assertEqual(v.rotate_ip(90), v)
         self.assertEqual(v.x, 0)
         self.assertEqual(v.y, 1)
         v = Vector2(-1, -1)
@@ -334,7 +334,7 @@ class Vector2TypeTest(unittest.TestCase):
         # v has length != 1 before normalizing
         self.assertNotEqual(v.x * v.x + v.y * v.y, 1.)
         # inplace operations should return None
-        self.assertEqual(v.normalize_ip(), None)
+        self.assertEqual(v.normalize_ip(), v)
         # length is 1
         self.assertAlmostEqual(v.x * v.x + v.y * v.y, 1.)
         # v2 is paralell to v1
@@ -381,7 +381,7 @@ class Vector2TypeTest(unittest.TestCase):
         v.scale_to_length(2.5)
         self.assertEqual(v, Vector2(2.5, 2.5) / math.sqrt(2))
         self.assertRaises(ValueError, lambda : self.zeroVec.scale_to_length(1))
-        self.assertEqual(v.scale_to_length(0), None)
+        self.assertEqual(v.scale_to_length(0), v)
         self.assertEqual(v, self.zeroVec)
 
     def test_length(self):
@@ -406,7 +406,7 @@ class Vector2TypeTest(unittest.TestCase):
         v1 = Vector2(1, -1)
         v2 = Vector2(v1)
         n = Vector2(0, 1)
-        self.assertEqual(v2.reflect_ip(n), None)
+        self.assertEqual(v2.reflect_ip(n), v2)
         self.assertEqual(v2, Vector2(1, 1))
         v2 = Vector2(v1)
         v2.reflect_ip(3*n)
@@ -1089,7 +1089,7 @@ class Vector3TypeTest(unittest.TestCase):
     def test_rotate_ip(self):
         v = Vector3(1, 0, 0)
         axis = Vector3(0, 1, 0)
-        self.assertEqual(v.rotate_ip(90, axis), None)
+        self.assertEqual(v.rotate_ip(90, axis), v)
         self.assertEqual(v.x, 0)
         self.assertEqual(v.y, 0)
         self.assertEqual(v.z, -1)
@@ -1128,7 +1128,7 @@ class Vector3TypeTest(unittest.TestCase):
 
     def test_rotate_x_ip(self):
         v = Vector3(1, 0, 0)
-        self.assertEqual(v.rotate_x_ip(90), None)
+        self.assertEqual(v.rotate_x_ip(90), v)
         self.assertEqual(v.x, 1)
         self.assertEqual(v.y, 0)
         self.assertEqual(v.z, 0)
@@ -1167,7 +1167,7 @@ class Vector3TypeTest(unittest.TestCase):
 
     def test_rotate_y_ip(self):
         v = Vector3(1, 0, 0)
-        self.assertEqual(v.rotate_y_ip(90), None)
+        self.assertEqual(v.rotate_y_ip(90), v)
         self.assertAlmostEqual(v.x, 0)
         self.assertEqual(v.y, 0)
         self.assertAlmostEqual(v.z, -1)
@@ -1206,7 +1206,7 @@ class Vector3TypeTest(unittest.TestCase):
 
     def test_rotate_z_ip(self):
         v = Vector3(1, 0, 0)
-        self.assertEqual(v.rotate_z_ip(90), None)
+        self.assertEqual(v.rotate_z_ip(90), v)
         self.assertAlmostEqual(v.x, 0)
         self.assertAlmostEqual(v.y, 1)
         self.assertEqual(v.z, 0)
@@ -1236,7 +1236,7 @@ class Vector3TypeTest(unittest.TestCase):
         # v has length != 1 before normalizing
         self.assertNotEqual(v.x * v.x + v.y * v.y + v.z * v.z, 1.)
         # inplace operations should return None
-        self.assertEqual(v.normalize_ip(), None)
+        self.assertEqual(v.normalize_ip(), v)
         # length is 1
         self.assertAlmostEqual(v.x * v.x + v.y * v.y + v.z * v.z, 1.)
         # v2 is paralell to v1 (tested via cross product)
@@ -1289,7 +1289,7 @@ class Vector3TypeTest(unittest.TestCase):
         v.scale_to_length(2.5)
         self.assertEqual(v, Vector3(2.5, 2.5, 2.5) / math.sqrt(3))
         self.assertRaises(ValueError, lambda : self.zeroVec.scale_to_length(1))
-        self.assertEqual(v.scale_to_length(0), None)
+        self.assertEqual(v.scale_to_length(0), v)
         self.assertEqual(v, self.zeroVec)
 
     def test_length(self):
@@ -1314,7 +1314,7 @@ class Vector3TypeTest(unittest.TestCase):
         v1 = Vector3(1, -1, 1)
         v2 = Vector3(v1)
         n = Vector3(0, 1, 0)
-        self.assertEqual(v2.reflect_ip(n), None)
+        self.assertEqual(v2.reflect_ip(n), v2)
         self.assertEqual(v2, Vector3(1, 1, 1))
         v2 = Vector3(v1)
         v2.reflect_ip(3*n)


### PR DESCRIPTION
Return `self` from in-place methods like rotate_ip, allowing you to chain methods, eg `v.rotate_ip(123).scale_to_length(30)`.