### PR TITLE
Make mask offset boundary checking consistent

### DIFF
--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -207,8 +207,9 @@ bitmask_overlap(const bitmask_t *a, const bitmask_t *b, int xoffset,
     const BITMASK_W *ap, *app, *bp;
     unsigned int shift, rshift, i, astripes, bstripes;
 
-    if ((xoffset >= a->w) || (yoffset >= a->h) || (b->h + yoffset <= 0) ||
-        (b->w + xoffset <= 0) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
+    /* Return if no overlap or one mask has a width/height of 0. */
+    if ((xoffset >= a->w) || (yoffset >= a->h) || (yoffset <= -b->h) ||
+        (xoffset <= -b->w) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
         return 0;
     }
 
@@ -309,8 +310,9 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
     const BITMASK_W *a_entry, *a_end, *b_entry, *ap, *bp;
     unsigned int shift, rshift, i, astripes, bstripes, xbase;
 
+    /* Return if no overlap or one mask has a width/height of 0. */
     if ((xoffset >= a->w) || (yoffset >= a->h) || (yoffset <= -b->h) ||
-        (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
+        (xoffset <= -b->w) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
         return 0;
     }
 
@@ -426,10 +428,12 @@ bitmask_overlap_area(const bitmask_t *a, const bitmask_t *b, int xoffset,
     unsigned int shift, rshift, i, astripes, bstripes;
     unsigned int count = 0;
 
-    if ((xoffset >= a->w) || (yoffset >= a->h) || (b->h + yoffset <= 0) ||
-        (b->w + xoffset <= 0) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
+    /* Return if no overlap or one mask has a width/height of 0. */
+    if ((xoffset >= a->w) || (yoffset >= a->h) || (yoffset <= -b->h) ||
+        (xoffset <= -b->w) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
         return 0;
     }
+
     if (xoffset >= 0) {
     swapentry:
         if (yoffset >= 0) {
@@ -509,8 +513,9 @@ bitmask_overlap_mask(const bitmask_t *a, const bitmask_t *b, bitmask_t *c,
     BITMASK_W *c_entry, *c_end, *cp;
     int shift, rshift, i, astripes, bstripes;
 
+    /* Return if no overlap or one mask has a width/height of 0. */
     if ((xoffset >= a->w) || (yoffset >= a->h) || (yoffset <= -b->h) ||
-        (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
+        (xoffset <= -b->w) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
         return;
     }
 
@@ -676,8 +681,9 @@ bitmask_draw(bitmask_t *a, const bitmask_t *b, int xoffset, int yoffset)
     const BITMASK_W *b_entry, *b_end, *bp;
     int shift, rshift, i, astripes, bstripes;
 
+    /* Return if no overlap or one mask has a width/height of 0. */
     if ((xoffset >= a->w) || (yoffset >= a->h) || (yoffset <= -b->h) ||
-        (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
+        (xoffset <= -b->w) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
         return;
     }
 
@@ -821,8 +827,9 @@ bitmask_erase(bitmask_t *a, const bitmask_t *b, int xoffset, int yoffset)
     const BITMASK_W *b_entry, *b_end, *bp;
     int shift, rshift, i, astripes, bstripes;
 
+    /* Return if no overlap or one mask has a width/height of 0. */
     if ((xoffset >= a->w) || (yoffset >= a->h) || (yoffset <= -b->h) ||
-        (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
+        (xoffset <= -b->w) || (!a->h) || (!a->w) || (!b->h) || (!b->w)) {
         return;
     }
 

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -345,6 +345,34 @@ class MaskTypeTest(unittest.TestCase):
             self.assertEqual(mask2.get_size(), mask2_size, msg)
             self.assertEqual(mask2.get_at(set_pos), 1, msg)
 
+    def test_overlap__offset_boundary(self):
+        """Ensures overlap handles offsets and boundaries correctly."""
+        mask1 = pygame.mask.Mask((13, 3), fill=True)
+        mask2 = pygame.mask.Mask((7, 5), fill=True)
+        mask1_count = mask1.count()
+        mask2_count = mask2.count()
+        mask1_size = mask1.get_size()
+        mask2_size = mask2.get_size()
+
+        # Check the 4 boundaries.
+        offsets = ((mask1_size[0], 0),   # off right
+                   (0, mask1_size[1]),   # off bottom
+                   (-mask2_size[0], 0),  # off left
+                   (0, -mask2_size[1]))  # off top
+
+        for offset in offsets:
+            msg = 'offset={}'.format(offset)
+
+            overlap_pos = mask1.overlap(mask2, offset)
+
+            self.assertIsNone(overlap_pos, msg)
+
+            # Ensure mask1/mask2 unchanged.
+            self.assertEqual(mask1.count(), mask1_count, msg)
+            self.assertEqual(mask2.count(), mask2_count, msg)
+            self.assertEqual(mask1.get_size(), mask1_size, msg)
+            self.assertEqual(mask2.get_size(), mask2_size, msg)
+
     def test_overlap__invalid_mask_arg(self):
         """Ensure overlap handles invalid mask arguments correctly."""
         size = (5, 3)
@@ -418,6 +446,35 @@ class MaskTypeTest(unittest.TestCase):
             rect2.topleft = offset
             overlap_rect = rect1.clip(rect2)
             expected_count = overlap_rect.w * overlap_rect.h
+
+            overlap_count = mask1.overlap_area(mask2, offset)
+
+            self.assertEqual(overlap_count, expected_count, msg)
+
+            # Ensure mask1/mask2 unchanged.
+            self.assertEqual(mask1.count(), mask1_count, msg)
+            self.assertEqual(mask2.count(), mask2_count, msg)
+            self.assertEqual(mask1.get_size(), mask1_size, msg)
+            self.assertEqual(mask2.get_size(), mask2_size, msg)
+
+    def test_overlap_area__offset_boundary(self):
+        """Ensures overlap_area handles offsets and boundaries correctly."""
+        mask1 = pygame.mask.Mask((11, 3), fill=True)
+        mask2 = pygame.mask.Mask((5, 7), fill=True)
+        mask1_count = mask1.count()
+        mask2_count = mask2.count()
+        mask1_size = mask1.get_size()
+        mask2_size = mask2.get_size()
+        expected_count = 0
+
+        # Check the 4 boundaries.
+        offsets = ((mask1_size[0], 0),   # off right
+                   (0, mask1_size[1]),   # off bottom
+                   (-mask2_size[0], 0),  # off left
+                   (0, -mask2_size[1]))  # off top
+
+        for offset in offsets:
+            msg = 'offset={}'.format(offset)
 
             overlap_count = mask1.overlap_area(mask2, offset)
 
@@ -540,6 +597,37 @@ class MaskTypeTest(unittest.TestCase):
             self.assertEqual(mask1.count(), mask1_count, msg)
             self.assertEqual(mask2.count(), mask2_count, msg)
             self.assertEqual(mask1.get_size(), expected_size, msg)
+            self.assertEqual(mask2.get_size(), mask2_size, msg)
+
+    def test_overlap_mask__offset_boundary(self):
+        """Ensures overlap_mask handles offsets and boundaries correctly."""
+        mask1 = pygame.mask.Mask((9, 3), fill=True)
+        mask2 = pygame.mask.Mask((11, 5), fill=True)
+        mask1_count = mask1.count()
+        mask2_count = mask2.count()
+        mask1_size = mask1.get_size()
+        mask2_size = mask2.get_size()
+        expected_count = 0
+        expected_size = mask1_size
+
+        # Check the 4 boundaries.
+        offsets = ((mask1_size[0], 0),   # off right
+                   (0, mask1_size[1]),   # off bottom
+                   (-mask2_size[0], 0),  # off left
+                   (0, -mask2_size[1]))  # off top
+
+        for offset in offsets:
+            msg = 'offset={}'.format(offset)
+
+            overlap_mask = mask1.overlap_mask(mask2, offset)
+
+            self.assertEqual(overlap_mask.count(), expected_count, msg)
+            self.assertEqual(overlap_mask.get_size(), expected_size, msg)
+
+            # Ensure mask1/mask2 unchanged.
+            self.assertEqual(mask1.count(), mask1_count, msg)
+            self.assertEqual(mask2.count(), mask2_count, msg)
+            self.assertEqual(mask1.get_size(), mask1_size, msg)
             self.assertEqual(mask2.get_size(), mask2_size, msg)
 
     def test_overlap_mask__invalid_mask_arg(self):
@@ -760,6 +848,32 @@ class MaskTypeTest(unittest.TestCase):
             self.assertEqual(mask2.count(), mask2_count, msg)
             self.assertEqual(mask2.get_size(), mask2_size, msg)
 
+    def test_draw__offset_boundary(self):
+        """Ensures draw handles offsets and boundaries correctly."""
+        mask1 = pygame.mask.Mask((13, 5))
+        mask2 = pygame.mask.Mask((7, 3), fill=True)
+        mask1_count = mask1.count()
+        mask2_count = mask2.count()
+        mask1_size = mask1.get_size()
+        mask2_size = mask2.get_size()
+
+        # Check the 4 boundaries.
+        offsets = ((mask1_size[0], 0),   # off right
+                   (0, mask1_size[1]),   # off bottom
+                   (-mask2_size[0], 0),  # off left
+                   (0, -mask2_size[1]))  # off top
+
+        for offset in offsets:
+            msg = 'offset={}'.format(offset)
+
+            mask1.draw(mask2, offset)
+
+            # Ensure mask1/mask2 unchanged.
+            self.assertEqual(mask1.count(), mask1_count, msg)
+            self.assertEqual(mask2.count(), mask2_count, msg)
+            self.assertEqual(mask1.get_size(), mask1_size, msg)
+            self.assertEqual(mask2.get_size(), mask2_size, msg)
+
     def test_draw__invalid_mask_arg(self):
         """Ensure draw handles invalid mask arguments correctly."""
         size = (7, 3)
@@ -840,6 +954,32 @@ class MaskTypeTest(unittest.TestCase):
 
             # Ensure mask2 unchanged.
             self.assertEqual(mask2.count(), mask2_count, msg)
+            self.assertEqual(mask2.get_size(), mask2_size, msg)
+
+    def test_erase__offset_boundary(self):
+        """Ensures erase handles offsets and boundaries correctly."""
+        mask1 = pygame.mask.Mask((7, 11), fill=True)
+        mask2 = pygame.mask.Mask((3, 13), fill=True)
+        mask1_count = mask1.count()
+        mask2_count = mask2.count()
+        mask1_size = mask1.get_size()
+        mask2_size = mask2.get_size()
+
+        # Check the 4 boundaries.
+        offsets = ((mask1_size[0], 0),   # off right
+                   (0, mask1_size[1]),   # off bottom
+                   (-mask2_size[0], 0),  # off left
+                   (0, -mask2_size[1]))  # off top
+
+        for offset in offsets:
+            msg = 'offset={}'.format(offset)
+
+            mask1.erase(mask2, offset)
+
+            # Ensure mask1/mask2 unchanged.
+            self.assertEqual(mask1.count(), mask1_count, msg)
+            self.assertEqual(mask2.count(), mask2_count, msg)
+            self.assertEqual(mask1.get_size(), mask1_size, msg)
             self.assertEqual(mask2.get_size(), mask2_size, msg)
 
     def test_erase__invalid_mask_arg(self):


### PR DESCRIPTION
Overview of changes:
- Made the offset boundary checking consistent across bitmask functions
- Added some offset boundary tests

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 1.9.5.dev1 (SDL: 1.2.15) at a84b461f646b007a12c92c7157f595ec68a065a3

Resolves the "Provide consistent boundary checking in `bitmask.c`" item of #800.