### PR TITLE
Add keyword arguments to draw.rect

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -59,6 +59,21 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
          | if width == 0, (default) fill the rectangle
          | if width > 0, used for line thickness
          | if width < 0, nothing will be drawn
+         |
+
+         .. note::
+            When using ``width`` values ``> 1``, the edge lines will grow
+            outside the original boundary of the ``rect``.
+
+            For odd ``width`` values, the thickness of each edge line
+            grows with the original line being in the center.
+
+            For even ``width`` values, the thickness of each edge
+            line grows with the original line being offset from the center
+            (as there is no exact center line drawn). As a result,
+            horizontal edge lines have 1 more pixel of thickness below the
+            original line and vertical edge lines have 1 more pixel of
+            thickness to the right of the original line.
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the given ``rect``
@@ -69,6 +84,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       The :func:`pygame.Surface.fill()` method works just as well for drawing
       filled rectangles and can be hardware accelerated on some platforms with
       both software and hardware display modes.
+
+   .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.rect ##
 

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -8,40 +8,67 @@
 
 | :sl:`pygame module for drawing shapes`
 
-Draw several simple shapes to a Surface. These functions will work for
-rendering to any format of Surface. Rendering to hardware Surfaces will be
-slower than regular software Surfaces.
+Draw several simple shapes to a surface. These functions will work for
+rendering to any format of surface. Rendering to hardware surfaces will be
+slower than regular software surfaces.
 
 Most of the functions take a width argument to represent the size of stroke
-around the edge of the shape. If a width of 0 is passed the function will
-actually solid fill the entire shape.
+(thickness) around the edge of the shape. If a width of 0 is passed the shape
+will be filled (solid).
 
-All the drawing functions respect the clip area for the Surface, and will be
+All the drawing functions respect the clip area for the surface and will be
 constrained to that area. The functions return a rectangle representing the
-bounding area of changed pixels.
+bounding area of changed pixels. This bounding rectangle is the 'minimum'
+bounding box that encloses the affected area.
 
-Most of the arguments accept a color argument that is an ``RGB`` triplet. These
-can also accept an ``RGBA`` quadruplet. The alpha value will be written
-directly into the Surface if it contains pixel alphas, but the draw function
-will not draw transparently. The color argument can also be an integer pixel
-value that is already mapped to the Surface's pixel format.
+All the drawing functions accept a color argument that can be one of the
+following formats:
 
-These functions must temporarily lock the Surface they are operating on. Many
-sequential drawing calls can be sped up by locking and unlocking the Surface
-object around the draw calls.
+   - a :mod:`pygame.Color` object
+   - an ``(RGB)`` triplet (tuple/list)
+   - an ``(RGBA)`` quadruplet (tuple/list)
+   - an integer value that has been mapped to the surface's pixel format
+     (see :func:`pygame.Surface.map_rgb` and :func:`pygame.Surface.map_rgb`).
+
+A color's alpha value will be written directly into the surface (if the
+surface contains pixel alphas), but the draw function will not draw
+transparently.
+
+These functions temporarily lock the surface they are operating on. Many
+sequential drawing calls can be sped up by locking and unlocking the surface
+object around the draw calls (see :func:`pygame.Surface.lock` and
+:func:`pygame.Surface.lock`).
 
 .. function:: rect
 
-   | :sl:`draw a rectangle shape`
-   | :sg:`rect(Surface, color, Rect, width=0) -> Rect`
+   | :sl:`draw a rectangle`
+   | :sg:`rect(surface=Surface, color=Color, rect=Rect) -> Rect`
+   | :sg:`rect(surface=Surface, color=Color, rect=Rect, width=0) -> Rect`
 
-   Draws a rectangular shape on the Surface. The given Rect is the area of the
-   rectangle. The width argument is the thickness to draw the outer edge. If
-   width is zero then the rectangle will be filled.
+   Draws a rectangle on the given surface.
 
-   Keep in mind the ``Surface.fill()`` method works just as well for drawing
-   filled rectangles. In fact the ``Surface.fill()`` can be hardware
-   accelerated on some platforms with both software and hardware display modes.
+   :param Surface surface: surface to draw on
+   :param color: color to draw with, the alpha value is optional if using a
+      tuple ``(RGB[A])``
+   :type color: Color or int or tuple(int, int, int, [int])
+   :param Rect rect: rectangle to draw, position and dimensions
+   :param int width: (optional) used for line thickness or to indicate that
+      the rectangle is to be filled (not to be confused with the width value
+      of the ``rect`` parameter)
+
+         | if width == 0, (default) fill the rectangle
+         | if width > 0, used for line thickness
+         | if width < 0, nothing will be drawn
+
+   :returns: a rect bounding the changed pixels, if nothing is drawn the
+      bounding rect's position will be the position of the given ``rect``
+      parameter and its width and height will be 0
+   :rtype: Rect
+
+   .. note::
+      The :func:`pygame.Surface.fill()` method works just as well for drawing
+      filled rectangles and can be hardware accelerated on some platforms with
+      both software and hardware display modes.
 
    .. ## pygame.draw.rect ##
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,6 +1,6 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
-#define DOC_PYGAMEDRAWRECT "rect(Surface, color, Rect, width=0) -> Rect\ndraw a rectangle shape"
+#define DOC_PYGAMEDRAWRECT "rect(surface=Surface, color=Color, rect=Rect) -> Rect\nrect(surface=Surface, color=Color, rect=Rect, width=0) -> Rect\ndraw a rectangle"
 #define DOC_PYGAMEDRAWPOLYGON "polygon(Surface, color, pointlist, width=0) -> Rect\ndraw a shape with any number of sides"
 #define DOC_PYGAMEDRAWCIRCLE "circle(Surface, color, pos, radius, width=0) -> Rect\ndraw a circle around a point"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(Surface, color, Rect, width=0) -> Rect\ndraw a round shape inside a rectangle"
@@ -19,8 +19,9 @@ pygame.draw
 pygame module for drawing shapes
 
 pygame.draw.rect
- rect(Surface, color, Rect, width=0) -> Rect
-draw a rectangle shape
+ rect(surface=Surface, color=Color, rect=Rect) -> Rect
+ rect(surface=Surface, color=Color, rect=Rect, width=0) -> Rect
+draw a rectangle
 
 pygame.draw.polygon
  polygon(Surface, color, pointlist, width=0) -> Rect

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1211,9 +1211,258 @@ class DrawRectMixin(object):
 
     This class contains all the general rect drawing tests.
     """
+    def test_rect__args(self):
+        """Ensures draw rect accepts the correct args."""
+        bounds_rect = self.draw_rect(pygame.Surface((2, 2)), (20, 10, 20, 150),
+                                     pygame.Rect((0, 0), (1, 1)), 2)
 
-    def todo_test_circle(self):
-        self.fail()
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__args_without_width(self):
+        """Ensures draw rect accepts the args without a width."""
+        bounds_rect = self.draw_rect(pygame.Surface((3, 5)), (0, 0, 0, 255),
+                                     pygame.Rect((0, 0), (1, 1)))
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__kwargs(self):
+        """Ensures draw rect accepts the correct kwargs
+        with and without a width arg.
+        """
+        kwargs_list = [{'surface' : pygame.Surface((5, 5)),
+                        'color'   : pygame.Color('red'),
+                        'rect'    : pygame.Rect((0, 0), (1, 2)),
+                        'width'   : 1 },
+
+                       {'surface' : pygame.Surface((1, 2)),
+                        'color'   : (0, 100, 200),
+                        'rect'    : (0, 0, 1, 1)}]
+
+        for kwargs in kwargs_list:
+            bounds_rect = self.draw_rect(**kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__kwargs_order_independent(self):
+        """Ensures draw rect's kwargs are not order dependent."""
+        bounds_rect = self.draw_rect(color=(0, 1, 2),
+                                     surface=pygame.Surface((2, 3)),
+                                     width=-2,
+                                     rect=pygame.Rect((0, 0), (0, 0)))
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__args_missing(self):
+        """Ensures draw rect detects any missing required args."""
+        surface = pygame.Surface((1, 1))
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_rect(surface, pygame.Color('white'))
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_rect(surface)
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_rect()
+
+    def test_rect__kwargs_missing(self):
+        """Ensures draw rect detects any missing required kwargs."""
+        kwargs = {'surface' : pygame.Surface((1, 3)),
+                  'color'   : pygame.Color('red'),
+                  'rect'    : pygame.Rect((0, 0), (2, 2)),
+                  'width'   : 5}
+
+        for name in ('rect', 'color', 'surface'):
+            invalid_kwargs = dict(kwargs)
+            invalid_kwargs.pop(name)  # Pop from a copy.
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_rect(**invalid_kwargs)
+
+    def test_rect__arg_invalid_types(self):
+        """Ensures draw rect detects invalid arg types."""
+        surface = pygame.Surface((3, 3))
+        color = pygame.Color('white')
+        rect = pygame.Rect((1, 1), (1, 1))
+
+        with self.assertRaises(TypeError):
+            # Invalid width.
+            bounds_rect = self.draw_rect(surface, color, rect, '2')
+
+        with self.assertRaises(TypeError):
+            # Invalid rect.
+            bounds_rect = self.draw_rect(surface, color, (1, 2, 3), 2)
+
+        with self.assertRaises(TypeError):
+            # Invalid color.
+            bounds_rect = self.draw_rect(surface, 'yellow', rect, 3)
+
+        with self.assertRaises(TypeError):
+            # Invalid surface.
+            bounds_rect = self.draw_rect(rect, color, rect, 4)
+
+    def test_rect__kwarg_invalid_types(self):
+        """Ensures draw rect detects invalid kwarg types."""
+        surface = pygame.Surface((2, 3))
+        color = pygame.Color('red')
+        rect = pygame.Rect((0, 0), (1, 1))
+        kwargs_list = [{'surface' : pygame.Surface,  # Invalid surface.
+                        'color'   : color,
+                        'rect'    : rect,
+                        'width'   : 1 },
+
+                       {'surface' : surface,
+                        'color'   : 'red',  # Invalid color.
+                        'rect'    : rect,
+                        'width'   : 1 },
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'rect'    : (1, 1, 2),  # Invalid rect.
+                        'width'   : 1 },
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'rect'    : rect,
+                        'width'   : 1.1 }]  # Invalid width.
+
+        for kwargs in kwargs_list:
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_rect(**kwargs)
+
+    def test_rect__kwarg_invalid_name(self):
+        """Ensures draw rect detects invalid kwarg names."""
+        surface = pygame.Surface((2, 1))
+        color = pygame.Color('green')
+        rect = pygame.Rect((0, 0), (3, 3))
+        kwargs_list = [{'surface' : surface,
+                        'color'   : color,
+                        'rect'    : rect,
+                        'width'   : 1,
+                        'invalid' : 1},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'rect'    : rect,
+                        'invalid' : 1 }]
+
+        for kwargs in kwargs_list:
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_rect(**kwargs)
+
+    def test_rect__args_and_kwargs(self):
+        """Ensures draw rect accepts a combination of args/kwargs"""
+        surface = pygame.Surface((3, 1))
+        color = (255, 255, 255, 0)
+        rect = pygame.Rect((1, 0), (2, 5))
+        width = 0
+        kwargs = {'surface' : surface,
+                  'color'   : color,
+                  'rect'    : rect,
+                  'width'   : width}
+
+        for name in ('surface', 'color', 'rect', 'width'):
+            kwargs.pop(name)
+
+            if 'surface' == name:
+                bounds_rect = self.draw_rect(surface, **kwargs)
+            elif 'color' == name:
+                bounds_rect = self.draw_rect(surface, color, **kwargs)
+            elif 'rect' == name:
+                bounds_rect = self.draw_rect(surface, color, rect, **kwargs)
+            else:
+                bounds_rect = self.draw_rect(surface, color, rect, width,
+                                             **kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__valid_width_values(self):
+        """Ensures draw rect accepts different width values."""
+        pos = (1, 1)
+        surface_color = pygame.Color('black')
+        surface = pygame.Surface((3, 4))
+        color = (1, 2, 3, 255)
+        kwargs = {'surface' : surface,
+                  'color'   : color,
+                  'rect'    : pygame.Rect(pos, (2, 2)),
+                  'width'   : None}
+
+        for width in (-1000, -10, -1, 0, 1, 10, 1000):
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['width'] = width
+            expected_color = color if width >= 0 else surface_color
+
+            bounds_rect = self.draw_rect(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__valid_rect_formats(self):
+        """Ensures draw rect accepts different rect formats."""
+        pos = (1, 1)
+        expected_color = pygame.Color('yellow')
+        surface_color = pygame.Color('black')
+        surface = pygame.Surface((3, 4))
+        kwargs = {'surface' : surface,
+                  'color'   : expected_color,
+                  'rect'    : None,
+                  'width'   : 0}
+        rects = (pygame.Rect(pos, (1, 1)), (pos, (2, 2)),
+                 (pos[0], pos[1], 3, 3))
+
+        for rect in rects:
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['rect'] = rect
+
+            bounds_rect = self.draw_rect(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__valid_color_formats(self):
+        """Ensures draw rect accepts different color formats."""
+        pos = (1, 1)
+        red_color = pygame.Color('red')
+        surface_color = pygame.Color('black')
+        surface = pygame.Surface((3, 4))
+        kwargs = {'surface' : surface,
+                  'color'   : None,
+                  'rect'    : pygame.Rect(pos, (1, 1)),
+                  'width'   : 3}
+        reds = ((255, 0, 0), (255, 0, 0, 255), surface.map_rgb(red_color),
+                red_color)
+
+        for color in reds:
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['color'] = color
+
+            if isinstance(color, int):
+                expected_color = surface.unmap_rgb(color)
+            else:
+                expected_color = red_color
+
+            bounds_rect = self.draw_rect(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__invalid_color_formats(self):
+        """Ensures draw rect handles invalid color formats correctly."""
+        pos = (1, 1)
+        surface_color = pygame.Color('black')
+        surface = pygame.Surface((3, 4))
+        kwargs = {'surface' : surface,
+                  'color'   : None,
+                  'rect'    : pygame.Rect(pos, (1, 1)),
+                  'width'   : 1}
+
+        # These color formats are currently not supported (it would be
+        # nice to eventually support them).
+        for expected_color in ('red', '#FF0000FF', '0xFF0000FF'):
+            kwargs['color'] = expected_color
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_rect(**kwargs)
 
 
 class DrawRectTest(DrawRectMixin, DrawTestCase):
@@ -1224,6 +1473,7 @@ class DrawRectTest(DrawRectMixin, DrawTestCase):
     """
 
 
+@unittest.skip('draw_py.draw_rect not supported yet')
 class PythonDrawRectTest(DrawRectMixin, PythonDrawTestCase):
     """Test draw_py module function draw_rect.
 
@@ -1241,6 +1491,7 @@ class DrawCircleMixin(object):
     """
 
     def todo_test_circle(self):
+        """Ensure draw circle works correctly."""
         self.fail()
 
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):
@@ -1251,6 +1502,7 @@ class DrawCircleTest(DrawCircleMixin, DrawTestCase):
     """
 
 
+@unittest.skip('draw_py.draw_circle not supported yet')
 class PythonDrawCircleTest(DrawCircleMixin, PythonDrawTestCase):
     """Test draw_py module function draw_circle."
 
@@ -1268,6 +1520,7 @@ class DrawArcMixin(object):
     """
 
     def todo_test_arc(self):
+        """Ensure draw arc works correctly."""
         self.fail()
 
 
@@ -1279,6 +1532,7 @@ class DrawArcTest(DrawArcMixin, DrawTestCase):
     """
 
 
+@unittest.skip('draw_py.draw_arc not supported yet')
 class PythonDrawArcTest(DrawArcMixin, PythonDrawTestCase):
     """Test draw_py module function draw_arc.
 


### PR DESCRIPTION
Overview of changes:
- Added keyword arguments to `draw.rect`
- Updated draw documentation
- Added tests to check `draw.rect`'s args/kwargs

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at 56949ca1096874d69d25df15c2b67d73113dc722

Resolves:
- sub-item `pygame.draw.rect` of item "Add keyword arguments to the draw functions..." of #896.
- sub-item "Clarify the bounding rectangle definition..." of item "Update the pygame.draw documentation." of #896.