### PR TITLE
Fix incorrect inheritance for draw line test classes

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -560,7 +560,7 @@ class LineMixin(object):
                 self.assertEqual(color, expected_color, 'pos={}'.format(pos))
 
 
-class PythonDrawLineTest(LineMixin, DrawTestCase):
+class PythonDrawLineTest(LineMixin, PythonDrawTestCase):
     """Test draw_py module functions: line, lines, aaline, and aalines.
 
     This class inherits the general tests from LineMixin. It is also the class
@@ -568,7 +568,7 @@ class PythonDrawLineTest(LineMixin, DrawTestCase):
     """
 
 
-class DrawLineTest(LineMixin, PythonDrawTestCase):
+class DrawLineTest(LineMixin, DrawTestCase):
     """Test draw module functions: line, lines, aaline, and aalines.
 
     This class inherits the general tests from LineMixin. It is also the class


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at aca3e36ed1b24886548a7919414a2516aa63dd9a