### PR TITLE
Add SDL version info to startup greeting string

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -394,7 +394,7 @@ copy_reg.pickle(Color, __color_reduce, __color_constructor)
 
 # Thanks for supporting pygame. Without support now, there won't be pygame later.
 if 'PYGAME_HIDE_SUPPORT_PROMPT' not in os.environ:
-    print('pygame %s' % ver)
+    print('pygame {} (SDL {}.{}.{})'.format(ver, *get_sdl_version()))
     print('Hello from the pygame community. https://www.pygame.org/contribute.html')
 
 


### PR DESCRIPTION
Overview of changes:
- Added the SDL version info to the startup greeting string

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15 and SDL: 2.0.9) at aca3e36ed1b24886548a7919414a2516aa63dd9a

Resolves #938.