### PR TITLE
Add attributes to pygame.version.vernum

### DIFF
--- a/buildconfig/version.py.in
+++ b/buildconfig/version.py.in
@@ -27,10 +27,16 @@ The python version information should always compare greater than any previous
 releases. (hmm, until we get to versions > 10)
 """
 
-import collections
-
-class PygameVersion(collections.namedtuple('PygameVersion', 'major minor patch')):
+class PygameVersion(tuple):
     __slots__ = ()
-
+    fields = 'major', 'minor', 'patch'
+    def __new__(cls, major, minor, patch):
+        return tuple.__new__(cls, (major, minor, patch))
+    def __repr__(self):
+        fields = ('{}={}'.format(fld, val) for fld, val in zip(self.fields, self))
+        return '{}({})'.format(str(self.__class__.__name__), ', '.join(fields))
     def __str__(self):
         return '{}.{}.{}'.format(*self)
+    major = property(lambda self: self[0])
+    minor = property(lambda self: self[1])
+    patch = property(lambda self: self[2])

--- a/buildconfig/version.py.in
+++ b/buildconfig/version.py.in
@@ -27,46 +27,10 @@ The python version information should always compare greater than any previous
 releases. (hmm, until we get to versions > 10)
 """
 
-class VersionInfo(object):
-    def __init__(self, major, minor, patch):
-        self._version = (major, minor, patch)
+import collections
 
-    @property
-    def major(self):
-        return self[0]
-
-    @property
-    def minor(self):
-        return self[1]
-
-    @property
-    def patch(self):
-        return self[2]
-
-    def __repr__(self):
-        return "pygame.version.vernum(major={}, minor={}, patch={})" \
-            .format(*self._version)
+class PygameVersion(collections.namedtuple('PygameVersion', 'major minor patch')):
+    __slots__ = ()
 
     def __str__(self):
-        return "{}.{}.{}".format(*self._version)
-
-    def __getitem__(self, key):
-        return self._version[key]
-
-    def __len__(self):
-        return len(self._version)
-
-    def __lt__(self, other):
-        return self._version < other
-
-    def __le__(self, other):
-        return self._version <= other
-
-    def __eq__(self, other):
-        return self._version == other
-
-    def __gt__(self, other):
-        return self._version > other
-
-    def __ge__(self, other):
-        return self._version >= other
+        return '{}.{}.{}'.format(*self)

--- a/buildconfig/version.py.in
+++ b/buildconfig/version.py.in
@@ -27,3 +27,46 @@ The python version information should always compare greater than any previous
 releases. (hmm, until we get to versions > 10)
 """
 
+class VersionInfo(object):
+    def __init__(self, major, minor, patch):
+        self._version = (major, minor, patch)
+
+    @property
+    def major(self):
+        return self[0]
+
+    @property
+    def minor(self):
+        return self[1]
+
+    @property
+    def patch(self):
+        return self[2]
+
+    def __repr__(self):
+        return "pygame.version.vernum(major={}, minor={}, patch={})" \
+            .format(*self._version)
+
+    def __str__(self):
+        return "{}.{}.{}".format(*self._version)
+
+    def __getitem__(self, key):
+        return self._version[key]
+
+    def __len__(self):
+        return len(self._version)
+
+    def __lt__(self, other):
+        return self._version < other
+
+    def __le__(self, other):
+        return self._version <= other
+
+    def __eq__(self, other):
+        return self._version == other
+
+    def __gt__(self, other):
+        return self._version > other
+
+    def __ge__(self, other):
+        return self._version >= other

--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -232,7 +232,7 @@ variables to check with version of pygame has been imported.
 
    .. versionchanged:: 2.0 str(vernum) returns a string like "2.0.0" instead of "(2, 0, 0)".
 
-   .. versionchanged:: 2.0 repr(vernum) returns a string like "pygame.version.vernum(major=2, minor=0, patch=0)" instead of "(2, 0, 0)".
+   .. versionchanged:: 2.0 repr(vernum) returns a string like "PygameVersion(major=2, minor=0, patch=0)" instead of "(2, 0, 0)".
 
    .. ## pygame.version.vernum ##
 

--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -222,7 +222,7 @@ variables to check with version of pygame has been imported.
            print 'Warning, older version of pygame (%s)' %  pygame.version.ver
            disable_advanced_features = True
 
-   .. versionadded:: 2.0 Attributes ``major``, ``minor``, and ``patch``.
+   .. versionadded:: 1.9.6 Attributes ``major``, ``minor``, and ``patch``.
 
    ::
 
@@ -230,9 +230,9 @@ variables to check with version of pygame has been imported.
       vernum.minor == vernum[1]
       vernum.patch == vernum[2]
 
-   .. versionchanged:: 2.0 str(vernum) returns a string like "2.0.0" instead of "(2, 0, 0)".
+   .. versionchanged:: 1.9.6 str(vernum) returns a string like "2.0.0" instead of "(2, 0, 0)".
 
-   .. versionchanged:: 2.0 repr(vernum) returns a string like "PygameVersion(major=2, minor=0, patch=0)" instead of "(2, 0, 0)".
+   .. versionchanged:: 1.9.6 repr(vernum) returns a string like "PygameVersion(major=2, minor=0, patch=0)" instead of "(2, 0, 0)".
 
    .. ## pygame.version.vernum ##
 

--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -222,6 +222,18 @@ variables to check with version of pygame has been imported.
            print 'Warning, older version of pygame (%s)' %  pygame.version.ver
            disable_advanced_features = True
 
+   .. versionadded:: 2.0 Attributes ``major``, ``minor``, and ``patch``.
+
+   ::
+
+      vernum.major == vernum[0]
+      vernum.minor == vernum[1]
+      vernum.patch == vernum[2]
+
+   .. versionchanged:: 2.0 str(vernum) returns a string like "2.0.0" instead of "(2, 0, 0)".
+
+   .. versionchanged:: 2.0 repr(vernum) returns a string like "pygame.version.vernum(major=2, minor=0, patch=0)" instead of "(2, 0, 0)".
+
    .. ## pygame.version.vernum ##
 
 .. data:: rev

--- a/setup.py
+++ b/setup.py
@@ -374,7 +374,7 @@ def write_version_module(pygame_version, revision):
     with open(os.path.join('src_py', 'version.py'), 'w') as version_file:
         version_file.write(header)
         version_file.write('ver = "' + pygame_version + '"\n')
-        version_file.write('vernum = VersionInfo(%s)\n' % vernum)
+        version_file.write('vernum = PygameVersion(%s)\n' % vernum)
         version_file.write('rev = "' + revision + '"\n')
 
 write_version_module(METADATA['version'], revision)

--- a/setup.py
+++ b/setup.py
@@ -374,7 +374,7 @@ def write_version_module(pygame_version, revision):
     with open(os.path.join('src_py', 'version.py'), 'w') as version_file:
         version_file.write(header)
         version_file.write('ver = "' + pygame_version + '"\n')
-        version_file.write('vernum = ' + vernum + '\n')
+        version_file.write('vernum = VersionInfo(%s)\n' % vernum)
         version_file.write('rev = "' + revision + '"\n')
 
 write_version_module(METADATA['version'], revision)


### PR DESCRIPTION
Make pygame.version.vernum a named tuple, so its fields can be referred to with attributes as well:

```python3
pygame.version.vernum[0] == pygame.version.vernum.major
pygame.version.vernum[1] == pygame.version.vernum.minor
pygame.version.vernum[2] == pygame.version.vernum.patch
```

Update `repr(vernum)`:

```
PygameVersion(major=2, minor=0, patch=0)
```

This is similar to Python's sys.version_info: `sys.version_info(major=3, minor=7, micro=2, releaselevel='final', serial=0)`

Update `str(vernum)`: `'2.0.0'`