### PR TITLE
Fix incorrect memory deallocation for Overlay

### DIFF
--- a/src_c/overlay.c
+++ b/src_c/overlay.c
@@ -42,7 +42,7 @@ overlay_dealloc(PyGameOverlay *self)
     if (SDL_WasInit(SDL_INIT_VIDEO) && self->cOverlay)
         SDL_FreeYUVOverlay(self->cOverlay);
 
-    PyObject_Free((PyObject *)self);
+    Py_TYPE(self)->tp_free(self);
 }
 
 static PyObject *


### PR DESCRIPTION
This update changes `Overlay`'s deallocation function to call the type's `tp_free()` function instead of calling `PyObject_Free()`. A subclassed `Overlay` object is not freed properly ([ref](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_dealloc)) by calling `PyObject_Free()` directly (memory leaks and sometimes segmentation faults occur).

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at 38779ec6ece565f013b6b3a64ecf57e0d1f05459