### PR TITLE
Add support for Mask subclassing

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -71,6 +71,8 @@ Starting from pygame 1.9.5 masks with width or height 0 are supported.
    .. versionadded:: 1.9.5 Named parameter ``size`` (previously it was an
       unnamed positional parameter) and the optional keyword parameter
       ``fill``.
+   .. versionadded:: 2.0.0 Subclassing support added. The ``Mask`` class
+      can be used as a base class.
 
    .. method:: get_size
 

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -67,12 +67,15 @@ class MaskTypeTest(unittest.TestCase):
         """Ensure masks are created correctly without fill parameter."""
         expected_count = 0
         expected_size = (11, 23)
+
         mask1 = pygame.mask.Mask(expected_size)
         mask2 = pygame.mask.Mask(size=expected_size)
 
+        self.assertIsInstance(mask1, pygame.mask.Mask)
         self.assertEqual(mask1.count(), expected_count)
         self.assertEqual(mask1.get_size(), expected_size)
 
+        self.assertIsInstance(mask2, pygame.mask.Mask)
         self.assertEqual(mask2.count(), expected_count)
         self.assertEqual(mask2.get_size(), expected_size)
 
@@ -93,6 +96,7 @@ class MaskTypeTest(unittest.TestCase):
 
             mask = pygame.mask.Mask(expected_size, fill=fill)
 
+            self.assertIsInstance(mask, pygame.mask.Mask, msg)
             self.assertEqual(mask.count(), expected_count, msg)
             self.assertEqual(mask.get_size(), expected_size, msg)
 
@@ -107,6 +111,7 @@ class MaskTypeTest(unittest.TestCase):
 
             mask = pygame.mask.Mask(expected_size, fill)
 
+            self.assertIsInstance(mask, pygame.mask.Mask, msg)
             self.assertEqual(mask.count(), expected_count, msg)
             self.assertEqual(mask.get_size(), expected_size, msg)
 
@@ -122,6 +127,8 @@ class MaskTypeTest(unittest.TestCase):
             mask1 = pygame.mask.Mask(fill=fill, size=expected_size)
             mask2 = pygame.mask.Mask(size=expected_size, fill=fill)
 
+            self.assertIsInstance(mask1, pygame.mask.Mask, msg)
+            self.assertIsInstance(mask2, pygame.mask.Mask, msg)
             self.assertEqual(mask1.count(), expected_count, msg)
             self.assertEqual(mask2.count(), expected_count, msg)
             self.assertEqual(mask1.get_size(), expected_size, msg)
@@ -548,6 +555,7 @@ class MaskTypeTest(unittest.TestCase):
 
                 overlap_mask = mask1.overlap_mask(mask2, offset)
 
+                self.assertIsInstance(overlap_mask, pygame.mask.Mask, msg)
                 self._assertMaskEqual(overlap_mask, expected_mask, msg)
 
                 # Ensure mask1/mask2 unchanged.
@@ -604,6 +612,7 @@ class MaskTypeTest(unittest.TestCase):
 
             overlap_mask = mask1.overlap_mask(mask2, offset)
 
+            self.assertIsInstance(overlap_mask, pygame.mask.Mask, msg)
             self.assertEqual(overlap_mask.count(), expected_count, msg)
             self.assertEqual(overlap_mask.get_size(), expected_size, msg)
 
@@ -635,6 +644,7 @@ class MaskTypeTest(unittest.TestCase):
 
             overlap_mask = mask1.overlap_mask(mask2, offset)
 
+            self.assertIsInstance(overlap_mask, pygame.mask.Mask, msg)
             self.assertEqual(overlap_mask.count(), expected_count, msg)
             self.assertEqual(overlap_mask.get_size(), expected_size, msg)
 
@@ -780,6 +790,7 @@ class MaskTypeTest(unittest.TestCase):
 
                     mask = original_mask.scale(expected_size)
 
+                    self.assertIsInstance(mask, pygame.mask.Mask, msg)
                     self.assertEqual(mask.count(), expected_count, msg)
                     self.assertEqual(mask.get_size(), expected_size)
 
@@ -1134,6 +1145,9 @@ class MaskTypeTest(unittest.TestCase):
             for s2 in sizes:
                 m2 = pygame.Mask(s2)
                 o = m1.convolve(m2)
+
+                self.assertIsInstance(o, pygame.mask.Mask)
+
                 for i in (0,1):
                     self.assertEqual(o.get_size()[i],
                                      m1.get_size()[i] + m2.get_size()[i] - 1)
@@ -1144,8 +1158,15 @@ class MaskTypeTest(unittest.TestCase):
         k = pygame.Mask((1,1))
         k.set_at((0,0))
 
-        self._assertMaskEqual(m, m.convolve(k))
-        self._assertMaskEqual(m, k.convolve(k.convolve(m)))
+        convolve_mask = m.convolve(k)
+
+        self.assertIsInstance(convolve_mask, pygame.mask.Mask)
+        self._assertMaskEqual(m, convolve_mask)
+
+        convolve_mask = k.convolve(k.convolve(m))
+
+        self.assertIsInstance(convolve_mask, pygame.mask.Mask)
+        self._assertMaskEqual(m, convolve_mask)
 
     def test_convolve__with_output(self):
         """checks that convolution modifies only the correct portion of the output"""
@@ -1159,6 +1180,8 @@ class MaskTypeTest(unittest.TestCase):
 
         m.convolve(k,o)
         test.draw(m,(1,1))
+
+        self.assertIsInstance(o, pygame.mask.Mask)
         self._assertMaskEqual(o, test)
 
         o.clear()
@@ -1166,15 +1189,20 @@ class MaskTypeTest(unittest.TestCase):
 
         m.convolve(k,o, (10,10))
         test.draw(m,(11,11))
+
+        self.assertIsInstance(o, pygame.mask.Mask)
         self._assertMaskEqual(o, test)
 
     def test_convolve__out_of_range(self):
         full = pygame.Mask((2, 2), fill=True)
+        # Tuple of points (out of range) and the expected count for each.
+        pts_data = (((0, 3), 0), ((0, 2), 3), ((-2, -2), 1), ((-3, -3), 0))
 
-        self.assertEqual(full.convolve(full, None, ( 0,  3)).count(), 0)
-        self.assertEqual(full.convolve(full, None, ( 0,  2)).count(), 3)
-        self.assertEqual(full.convolve(full, None, (-2, -2)).count(), 1)
-        self.assertEqual(full.convolve(full, None, (-3, -3)).count(), 0)
+        for pt, expected_count in pts_data:
+            convolve_mask = full.convolve(full, None, pt)
+
+            self.assertIsInstance(convolve_mask, pygame.mask.Mask)
+            self.assertEqual(convolve_mask.count(), expected_count)
 
     def test_convolve(self):
         """Tests the definition of convolution"""
@@ -1182,6 +1210,7 @@ class MaskTypeTest(unittest.TestCase):
         m2 = random_mask((100,100))
         conv = m1.convolve(m2)
 
+        self.assertIsInstance(conv, pygame.mask.Mask)
         for i in range(conv.get_size()[0]):
             for j in range(conv.get_size()[1]):
                 self.assertEqual(conv.get_at((i,j)) == 0,
@@ -1277,6 +1306,7 @@ class MaskTypeTest(unittest.TestCase):
 
         mask = original_mask.connected_component()
 
+        self.assertIsInstance(mask, pygame.mask.Mask)
         self.assertEqual(mask.count(), expected_count)
         self.assertEqual(mask.get_size(), expected_size)
         self.assertEqual(mask.overlap_area(expected_pattern, expected_offset),
@@ -1299,6 +1329,7 @@ class MaskTypeTest(unittest.TestCase):
 
         mask = original_mask.connected_component()
 
+        self.assertIsInstance(mask, pygame.mask.Mask)
         self.assertEqual(mask.count(), expected_count)
         self.assertEqual(mask.get_size(), expected_size)
 
@@ -1316,6 +1347,7 @@ class MaskTypeTest(unittest.TestCase):
 
         mask = original_mask.connected_component()
 
+        self.assertIsInstance(mask, pygame.mask.Mask)
         self.assertEqual(mask.count(), expected_count)
         self.assertEqual(mask.get_size(), expected_size)
 
@@ -1342,6 +1374,7 @@ class MaskTypeTest(unittest.TestCase):
 
         mask = original_mask.connected_component(set_pos)
 
+        self.assertIsInstance(mask, pygame.mask.Mask)
         self.assertEqual(mask.count(), expected_count)
         self.assertEqual(mask.get_size(), expected_size)
         self.assertEqual(mask.overlap_area(expected_pattern, expected_offset),
@@ -1376,6 +1409,7 @@ class MaskTypeTest(unittest.TestCase):
 
         mask = original_mask.connected_component(set_pos)
 
+        self.assertIsInstance(mask, pygame.mask.Mask)
         self.assertEqual(mask.count(), expected_count)
         self.assertEqual(mask.get_size(), expected_size)
         self.assertEqual(mask.overlap_area(expected_pattern, expected_offset),
@@ -1401,6 +1435,7 @@ class MaskTypeTest(unittest.TestCase):
 
         mask = original_mask.connected_component(unset_pos)
 
+        self.assertIsInstance(mask, pygame.mask.Mask)
         self.assertEqual(mask.count(), expected_count)
         self.assertEqual(mask.get_size(), expected_size)
 
@@ -1464,6 +1499,9 @@ class MaskTypeTest(unittest.TestCase):
         self.assertEqual(len(comps1), 2)
         self.assertEqual(len(comps2), 1)
         self.assertEqual(len(comps3), 0)
+
+        for mask in comps:
+            self.assertIsInstance(mask, pygame.mask.Mask)
 
     def test_get_bounding_rects(self):
         """Ensures get_bounding_rects works correctly."""
@@ -1560,14 +1598,15 @@ class MaskTypeTest(unittest.TestCase):
                                  expected_rects, 'size={}'.format(size))
 
     def test_zero_mask(self):
-        mask = pygame.mask.Mask((0, 0))
-        self.assertEqual(mask.get_size(), (0, 0))
+        """Ensures masks can be created with zero sizes."""
+        for size in ((100, 0), (0, 100), (0, 0)):
+            for fill in (True, False):
+                msg = 'size={}, fill={}'.format(size, fill)
 
-        mask = pygame.mask.Mask((100, 0))
-        self.assertEqual(mask.get_size(), (100, 0))
+                mask = pygame.mask.Mask(size, fill=fill)
 
-        mask = pygame.mask.Mask((0, 100))
-        self.assertEqual(mask.get_size(), (0, 100))
+                self.assertIsInstance(mask, pygame.mask.Mask, msg)
+                self.assertEqual(mask.get_size(), size, msg)
 
     def test_zero_mask_get_size(self):
         """Ensures get_size correctly handles zero sized masks."""
@@ -1622,6 +1661,8 @@ class MaskTypeTest(unittest.TestCase):
             overlap_mask = mask.overlap_mask(mask2, (0, 0))
             overlap_mask2 = mask2.overlap_mask(mask, (0, 0))
 
+            self.assertIsInstance(mask, pygame.mask.Mask)
+            self.assertIsInstance(mask2, pygame.mask.Mask)
             self.assertEqual(mask.get_size(), overlap_mask.get_size())
             self.assertEqual(mask2.get_size(), overlap_mask2.get_size())
 
@@ -1654,6 +1695,8 @@ class MaskTypeTest(unittest.TestCase):
         for size in sizes:
             mask = pygame.mask.Mask(size)
             mask2 = mask.scale((2, 3))
+
+            self.assertIsInstance(mask2, pygame.mask.Mask)
             self.assertEqual(mask2.get_size(), (2, 3))
 
     def test_zero_mask_draw(self):
@@ -1740,6 +1783,7 @@ class MaskTypeTest(unittest.TestCase):
 
                 mask = mask1.convolve(mask2)
 
+                self.assertIsInstance(mask, pygame.mask.Mask, msg)
                 self.assertIsNot(mask, mask2, msg)
                 self.assertEqual(mask.get_size(), expected_size, msg)
 
@@ -1761,6 +1805,7 @@ class MaskTypeTest(unittest.TestCase):
 
                     mask = mask1.convolve(mask2, output_mask)
 
+                    self.assertIsInstance(mask, pygame.mask.Mask, msg)
                     self.assertIs(mask, output_mask, msg)
                     self.assertEqual(mask.get_size(), output_size, msg)
 
@@ -1769,13 +1814,14 @@ class MaskTypeTest(unittest.TestCase):
         expected_count = 0
 
         for size in ((81, 0), (0, 80), (0, 0)):
+            msg = 'size={}'.format(size)
             mask = pygame.mask.Mask(size)
 
             cc_mask = mask.connected_component()
 
+            self.assertIsInstance(cc_mask, pygame.mask.Mask, msg)
             self.assertEqual(cc_mask.get_size(), size)
-            self.assertEqual(cc_mask.count(), expected_count,
-                             'size={}'.format(size))
+            self.assertEqual(cc_mask.count(), expected_count, msg)
 
     def test_zero_mask_connected_component__indexed(self):
         """Ensures connected_component correctly handles zero sized masks
@@ -1809,6 +1855,282 @@ class MaskTypeTest(unittest.TestCase):
 
             self.assertListEqual(bounding_rects, expected_bounding_rects,
                                  'size={}'.format(size))
+
+
+class SubMask(pygame.mask.Mask):
+    """Subclass of the Mask class to help test subclassing."""
+    def __init__(self, *args, **kwargs):
+        super(SubMask, self).__init__(*args, **kwargs)
+        self.test_attribute = True
+
+
+class MaskSubclassTest(unittest.TestCase):
+    """Test subclassed Masks."""
+    def test_subclass_mask(self):
+        """Ensures the Mask class can be subclassed."""
+        mask = SubMask((5, 3), fill=True)
+
+        self.assertIsInstance(mask, pygame.mask.Mask)
+        self.assertIsInstance(mask, SubMask)
+        self.assertTrue(mask.test_attribute)
+
+    def test_subclass_get_size(self):
+        """Ensures get_size works for subclassed Masks."""
+        expected_size = (2, 3)
+        mask = SubMask(expected_size)
+
+        size = mask.get_size()
+
+        self.assertEqual(size, expected_size)
+
+    def test_subclass_get_at(self):
+        """Ensures get_at works for subclassed Masks."""
+        expected_bit = 1
+        mask = SubMask((3, 2), fill=True)
+
+        bit = mask.get_at((0, 0))
+
+        self.assertEqual(bit, expected_bit)
+
+    def test_subclass_set_at(self):
+        """Ensures set_at works for subclassed Masks."""
+        expected_bit = 1
+        expected_count = 1
+        pos = (0, 0)
+        mask = SubMask(fill=False, size=(4, 2))
+
+        mask.set_at(pos)
+
+        self.assertEqual(mask.get_at(pos), expected_bit)
+        self.assertEqual(mask.count(), expected_count)
+
+    def test_subclass_overlap(self):
+        """Ensures overlap works for subclassed Masks."""
+        expected_pos = (0, 0)
+        mask_size = (2, 3)
+        masks = (pygame.mask.Mask(fill=True, size=mask_size),
+                 SubMask(mask_size, True))
+        arg_masks = (pygame.mask.Mask(fill=True, size=mask_size),
+                     SubMask(mask_size, True))
+
+        # Test different combinations of subclassed and non-subclassed Masks.
+        for mask in masks:
+            for arg_mask in arg_masks:
+                overlap_pos = mask.overlap(arg_mask, (0, 0))
+
+                self.assertEqual(overlap_pos, expected_pos)
+
+    def test_subclass_overlap_area(self):
+        """Ensures overlap_area works for subclassed Masks."""
+        mask_size = (3, 2)
+        expected_count = mask_size[0] * mask_size[1]
+        masks = (pygame.mask.Mask(fill=True, size=mask_size),
+                 SubMask(mask_size, True))
+        arg_masks = (pygame.mask.Mask(fill=True, size=mask_size),
+                     SubMask(mask_size, True))
+
+        # Test different combinations of subclassed and non-subclassed Masks.
+        for mask in masks:
+            for arg_mask in arg_masks:
+                overlap_count = mask.overlap_area(arg_mask, (0, 0))
+
+                self.assertEqual(overlap_count, expected_count)
+
+    def test_subclass_overlap_mask(self):
+        """Ensures overlap_mask works for subclassed Masks."""
+        expected_size = (4, 5)
+        expected_count = expected_size[0] * expected_size[1]
+        masks = (pygame.mask.Mask(fill=True, size=expected_size),
+                 SubMask(expected_size, True))
+        arg_masks = (pygame.mask.Mask(fill=True, size=expected_size),
+                     SubMask(expected_size, True))
+
+        # Test different combinations of subclassed and non-subclassed Masks.
+        for mask in masks:
+            for arg_mask in arg_masks:
+                overlap_mask = mask.overlap_mask(arg_mask, (0, 0))
+
+                self.assertIsInstance(overlap_mask, pygame.mask.Mask)
+                self.assertNotIsInstance(overlap_mask, SubMask)
+                self.assertEqual(overlap_mask.count(), expected_count)
+                self.assertEqual(overlap_mask.get_size(), expected_size)
+
+    def test_subclass_fill(self):
+        """Ensures fill works for subclassed Masks."""
+        mask_size = (2, 4)
+        expected_count = mask_size[0] * mask_size[1]
+        mask = SubMask(fill=False, size=mask_size)
+
+        mask.fill()
+
+        self.assertEqual(mask.count(), expected_count)
+
+    def test_subclass_clear(self):
+        """Ensures clear works for subclassed Masks."""
+        mask_size = (4, 3)
+        expected_count = 0
+        mask = SubMask(mask_size, True)
+
+        mask.clear()
+
+        self.assertEqual(mask.count(), expected_count)
+
+    def test_subclass_invert(self):
+        """Ensures invert works for subclassed Masks."""
+        mask_size = (1, 4)
+        expected_count = mask_size[0] * mask_size[1]
+        mask = SubMask(fill=False, size=mask_size)
+
+        mask.invert()
+
+        self.assertEqual(mask.count(), expected_count)
+
+    def test_subclass_scale(self):
+        """Ensures scale works for subclassed Masks."""
+        expected_size = (5, 2)
+        mask = SubMask((1, 4))
+
+        scaled_mask = mask.scale(expected_size)
+
+        self.assertIsInstance(scaled_mask, pygame.mask.Mask)
+        self.assertNotIsInstance(scaled_mask, SubMask)
+        self.assertEqual(scaled_mask.get_size(), expected_size)
+
+    def test_subclass_draw(self):
+        """Ensures draw works for subclassed Masks."""
+        mask_size = (5, 4)
+        expected_count = mask_size[0] * mask_size[1]
+        arg_masks = (pygame.mask.Mask(fill=True, size=mask_size),
+                     SubMask(mask_size, True))
+
+        # Test different combinations of subclassed and non-subclassed Masks.
+        for mask in (pygame.mask.Mask(mask_size), SubMask(mask_size)):
+            for arg_mask in arg_masks:
+                mask.clear() # Clear for each test.
+
+                mask.draw(arg_mask, (0, 0))
+
+                self.assertEqual(mask.count(), expected_count)
+
+    def test_subclass_erase(self):
+        """Ensures erase works for subclassed Masks."""
+        mask_size = (3, 4)
+        expected_count = 0
+        masks = (pygame.mask.Mask(mask_size, True), SubMask(mask_size, True))
+        arg_masks = (pygame.mask.Mask(mask_size, True),
+                     SubMask(mask_size, True))
+
+        # Test different combinations of subclassed and non-subclassed Masks.
+        for mask in masks:
+            for arg_mask in arg_masks:
+                mask.fill() # Fill for each test.
+
+                mask.erase(arg_mask, (0, 0))
+
+                self.assertEqual(mask.count(), expected_count)
+
+    def test_subclass_count(self):
+        """Ensures count works for subclassed Masks."""
+        mask_size = (5, 2)
+        expected_count = mask_size[0] * mask_size[1] - 1
+        mask = SubMask(fill=True, size=mask_size)
+        mask.set_at((1, 1), 0)
+
+        count = mask.count()
+
+        self.assertEqual(count, expected_count)
+
+    def test_subclass_centroid(self):
+        """Ensures centroid works for subclassed Masks."""
+        expected_centroid = (0, 0)
+        mask_size = (3, 2)
+        mask = SubMask((3, 2))
+
+        centroid = mask.centroid()
+
+        self.assertEqual(centroid, expected_centroid)
+
+    def test_subclass_angle(self):
+        """Ensures angle works for subclassed Masks."""
+        expected_angle = 0.0
+        mask = SubMask(size=(5, 4))
+
+        angle = mask.angle()
+
+        self.assertAlmostEqual(angle, expected_angle)
+
+    def test_subclass_outline(self):
+        """Ensures outline works for subclassed Masks."""
+        expected_outline = []
+        mask = SubMask((3, 4))
+
+        outline = mask.outline()
+
+        self.assertListEqual(outline, expected_outline)
+
+    def test_subclass_convolve(self):
+        """Ensures convolve works for subclassed Masks."""
+        width, height = 7, 5
+        mask_size = (width, height)
+        expected_count = 0
+        expected_size = (max(0, width * 2 - 1), max(0, height * 2 - 1))
+
+        arg_masks = (pygame.mask.Mask(mask_size), SubMask(mask_size))
+        output_masks = (pygame.mask.Mask(mask_size), SubMask(mask_size))
+
+        # Test different combinations of subclassed and non-subclassed Masks.
+        for mask in (pygame.mask.Mask(mask_size), SubMask(mask_size)):
+            for arg_mask in arg_masks:
+                convolve_mask = mask.convolve(arg_mask)
+
+                self.assertIsInstance(convolve_mask, pygame.mask.Mask)
+                self.assertNotIsInstance(convolve_mask, SubMask)
+                self.assertEqual(convolve_mask.count(), expected_count)
+                self.assertEqual(convolve_mask.get_size(), expected_size)
+
+                # Test subclassed masks for the output_mask as well.
+                for output_mask in output_masks:
+                    convolve_mask = mask.convolve(arg_mask, output_mask)
+
+                    self.assertIsInstance(convolve_mask, pygame.mask.Mask)
+                    self.assertEqual(convolve_mask.count(), expected_count)
+                    self.assertEqual(convolve_mask.get_size(), mask_size)
+
+                    if isinstance(output_mask, SubMask):
+                        self.assertIsInstance(convolve_mask, SubMask)
+                    else:
+                        self.assertNotIsInstance(convolve_mask, SubMask)
+
+    def test_subclass_connected_component(self):
+        """Ensures connected_component works for subclassed Masks."""
+        expected_count = 0
+        expected_size = (3, 4)
+        mask = SubMask(expected_size)
+
+        cc_mask = mask.connected_component()
+
+        self.assertIsInstance(cc_mask, pygame.mask.Mask)
+        self.assertNotIsInstance(cc_mask, SubMask)
+        self.assertEqual(cc_mask.count(), expected_count)
+        self.assertEqual(cc_mask.get_size(), expected_size)
+
+    def test_subclass_connected_components(self):
+        """Ensures connected_components works for subclassed Masks."""
+        expected_ccs = []
+        mask = SubMask((5, 4))
+
+        ccs = mask.connected_components()
+
+        self.assertListEqual(ccs, expected_ccs)
+
+    def test_subclass_get_bounding_rects(self):
+        """Ensures get_bounding_rects works for subclassed Masks."""
+        expected_bounding_rects = []
+        mask = SubMask((3, 2))
+
+        bounding_rects = mask.get_bounding_rects()
+
+        self.assertListEqual(bounding_rects, expected_bounding_rects)
 
 
 class MaskModuleTest(unittest.TestCase):
@@ -1859,6 +2181,7 @@ class MaskModuleTest(unittest.TestCase):
 
                     mask = pygame.mask.from_surface(surface, threshold)
 
+                    self.assertIsInstance(mask, pygame.mask.Mask, msg)
                     self.assertEqual(mask.get_size(), expected_size, msg)
                     self.assertEqual(mask.count(), expected_count, msg)
 
@@ -1893,6 +2216,7 @@ class MaskModuleTest(unittest.TestCase):
 
             mask = pygame.mask.from_surface(surface, threshold)
 
+            self.assertIsInstance(mask, pygame.mask.Mask, msg)
             self.assertEqual(mask.get_size(), expected_size, msg)
             self.assertEqual(mask.count(), expected_count, msg)
             self.assertEqual(mask.overlap_area(expected_mask, offset),
@@ -1978,6 +2302,7 @@ class MaskModuleTest(unittest.TestCase):
 
                 mask = pygame.mask.from_surface(surface, threshold)
 
+                self.assertIsInstance(mask, pygame.mask.Mask, msg)
                 self.assertEqual(mask.get_size(), expected_size, msg)
                 self.assertEqual(mask.count(), expected_count, msg)
                 self.assertEqual(mask.overlap_area(expected_mask, offset),
@@ -2013,6 +2338,7 @@ class MaskModuleTest(unittest.TestCase):
             surf2.fill((100,100,100), (40,40,10,10))
             mask = pygame.mask.from_threshold(surf, (0,0,0,0), (10,10,10,255), surf2)
 
+            self.assertIsInstance(mask, pygame.mask.Mask)
             self.assertEqual(mask.count(), 100)
             self.assertEqual(mask.get_bounding_rects(), [pygame.Rect((40,40,10,10))])
 
@@ -2048,6 +2374,7 @@ class MaskModuleTest(unittest.TestCase):
                 surf2.fill((100, 100, 100), (40, 40, 10, 10))
                 mask = pygame.mask.from_threshold(surf, (0, 0, 0, 0), (10, 10, 10, 255), surf2)
 
+                self.assertIsInstance(mask, pygame.mask.Mask)
                 self.assertEqual(mask.count(), 0)
 
                 rects = mask.get_bounding_rects()


### PR DESCRIPTION
Overview of changes:
- Added support to allow the `Mask` class to be subclassed
- Added/updated tests
- Updated documentation

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at aca3e36

Resolves the "Add support to allow the `Mask` class to be subclassed." item of #800.