### PR TITLE
Fix draw.line bounding rect

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -557,9 +557,6 @@ class LineMixin(object):
                 self.assertEqual(surface.get_at(pos), expected_color,
                                  'pos={}'.format(pos))
 
-    # This decorator can be removed when the draw.line bounding rect issue is
-    # resolved (#895).
-    @unittest.expectedFailure
     def test_line__bounding_rect(self):
         """Ensures draw line returns the correct bounding rect.
 


### PR DESCRIPTION
Overview of changes:
- Fixed the bounding rect returned from `pygame.draw.line` so it encloses the changed area
- Removed the expected failure decorator from the now passing test

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at ad681aee16958f0ecfdf2a402166fa718cec236b

Resolves the "Fix bounding rects for `pygame.draw.line`" item of #895.