### PR TITLE
Build 64-bit Linux wheels with manylinux2010 

### DIFF
--- a/buildconfig/manylinux-build/Makefile
+++ b/buildconfig/manylinux-build/Makefile
@@ -1,7 +1,7 @@
 REPO_ROOT = $(abspath ../..)
 
 wheels-x64:
-	docker run --rm -v ${REPO_ROOT}:/io pygame/manylinux1_base_x86_64 /io/buildconfig/manylinux-build/build-wheels.sh
+	docker run --rm -v ${REPO_ROOT}:/io:z pygame/manylinux2010_base_x86_64 /io/buildconfig/manylinux-build/build-wheels.sh
 
 wheels-x86:
 	docker run --rm -v ${REPO_ROOT}:/io pygame/manylinux1_base_i686 /io/buildconfig/manylinux-build/build-wheels.sh
@@ -9,7 +9,7 @@ wheels-x86:
 wheels: wheels-x64 wheels-x86
 
 base-image-x64:
-	docker build -t pygame/manylinux1_base_x86_64 -f docker_base/Dockerfile-x86_64 docker_base
+	docker build -t pygame/manylinux2010_base_x86_64 -f docker_base/Dockerfile-x86_64 docker_base
 
 base-image-x86:
 	docker build -t pygame/manylinux1_base_i686 -f docker_base/Dockerfile-i686 docker_base

--- a/buildconfig/manylinux-build/Makefile
+++ b/buildconfig/manylinux-build/Makefile
@@ -1,33 +1,41 @@
 REPO_ROOT = $(abspath ../..)
 
 wheels-x64:
-	docker run --rm -v ${REPO_ROOT}:/io:z pygame/manylinux2010_base_x86_64 /io/buildconfig/manylinux-build/build-wheels.sh
+	docker run --rm -v ${REPO_ROOT}:/io pygame/manylinux2010_base_x86_64 /io/buildconfig/manylinux-build/build-wheels.sh
 
 wheels-x86:
+	echo "No build image available for manylinux2010_i686"
+	exit 1
 	docker run --rm -v ${REPO_ROOT}:/io pygame/manylinux1_base_i686 /io/buildconfig/manylinux-build/build-wheels.sh
 
-wheels: wheels-x64 wheels-x86
+wheels: wheels-x64
 
 base-image-x64:
 	docker build -t pygame/manylinux2010_base_x86_64 -f docker_base/Dockerfile-x86_64 docker_base
 
 base-image-x86:
+	echo "No build image available for manylinux2010_i686"
+	exit 1
 	docker build -t pygame/manylinux1_base_i686 -f docker_base/Dockerfile-i686 docker_base
 
-base-images: base-image-x64 base-image-x86
+base-images: base-image-x64
 
 push-x64:
-	docker push pygame/manylinux1_base_x86_64
+	docker push pygame/manylinux2010_base_x86_64
 
 push-x86:
+	echo "No build image available for manylinux2010_i686"
+	exit 1
 	docker push pygame/manylinux1_base_i686
 
-push: push-x64 push-x86
+push: push-x64
 
 pull-x64:
-	docker pull pygame/manylinux1_base_x86_64
+	docker pull pygame/manylinux2010_base_x86_64
 
 pull-x86:
+	echo "No build image available for manylinux2010_i686"
+	exit 1
 	docker pull pygame/manylinux1_base_i686
 
-pull: pull-x64 pull-x86
+pull: pull-x64

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -16,7 +16,7 @@ done
 
 # Bundle external shared libraries into the wheels
 for whl in wheelhouse/*.whl; do
-    auditwheel repair $whl -w /io/buildconfig/manylinux-build/wheelhouse/
+    auditwheel repair --plat manylinux2010_x86_64 $whl -w /io/buildconfig/manylinux-build/wheelhouse/
 done
 
 # Dummy options for headless testing

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
@@ -1,8 +1,8 @@
 FROM quay.io/pypa/manylinux2010_x86_64
 
 # Set up repoforge
-COPY RPM-GPG-KEY.dag.txt /tmp/
-RUN rpm --import /tmp/RPM-GPG-KEY.dag.txt
+#COPY RPM-GPG-KEY.dag.txt /tmp/
+#RUN rpm --import /tmp/RPM-GPG-KEY.dag.txt
 
 #ENV RPMFORGE_FILE "rpmforge-release-0.5.3-1.el5.rf.x86_64.rpm"
 #ADD "https://repoforge.cu.be/redhat/el5/en/x86_64/dag/RPMS/${RPMFORGE_FILE}" /tmp/${RPMFORGE_FILE}

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
@@ -12,7 +12,7 @@ FROM quay.io/pypa/manylinux2010_x86_64
 # Install SDL and portmidi dependencies
 RUN yum install -y zlib-devel libjpeg-devel libX11-devel\
     mesa-libGLU-devel audiofile-devel \
-    cmake libtiff-devel \
+    cmake libtiff-devel dejavu-sans-fonts fontconfig \
     mikmod-devel smpeg-devel giflib-devel libsndfile-devel dbus-devel \
     pulseaudio-libs-devel xz
 

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
@@ -12,7 +12,7 @@ FROM quay.io/pypa/manylinux2010_x86_64
 # Install SDL and portmidi dependencies
 RUN yum install -y zlib-devel libjpeg-devel libX11-devel\
     mesa-libGLU-devel audiofile-devel \
-    cmake java-1.7.0-openjdk-devel jpackage-utils libtiff-devel \
+    cmake libtiff-devel \
     mikmod-devel smpeg-devel giflib-devel libsndfile-devel dbus-devel \
     pulseaudio-libs-devel xz
 

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux1_x86_64
+FROM quay.io/pypa/manylinux2010_x86_64
 
 # Set up repoforge
 COPY RPM-GPG-KEY.dag.txt /tmp/

--- a/buildconfig/manylinux-build/docker_base/portmidi/build-portmidi.sh
+++ b/buildconfig/manylinux-build/docker_base/portmidi/build-portmidi.sh
@@ -9,19 +9,6 @@ curl -sL http://downloads.sourceforge.net/project/portmedia/portmidi/217/${SRC_Z
 sha512sum -c portmidi.sha512
 unzip $SRC_ZIP
 
-if [ "$(uname -i)" = "x86_64" ]; then
-    export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk.x86_64
-    JRE_LIB_DIR=amd64
-else
-    export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk
-    JRE_LIB_DIR=i386
-fi
-ls ${JAVA_HOME}
-ls ${JAVA_HOME}/jre
-ls ${JAVA_HOME}/jre/lib
-ls ${JAVA_HOME}/jre/lib/$JRE_LIB_DIR
-ls ${JAVA_HOME}/jre/lib/$JRE_LIB_DIR/server
-
 cd portmidi/
 patch -p1 < ../no-java.patch
 #cmake -DJAVA_JVM_LIBRARY=${JAVA_HOME}/jre/lib/${JRE_LIB_DIR}/server/libjvm.so .

--- a/buildconfig/manylinux-build/docker_base/portmidi/build-portmidi.sh
+++ b/buildconfig/manylinux-build/docker_base/portmidi/build-portmidi.sh
@@ -23,6 +23,7 @@ ls ${JAVA_HOME}/jre/lib/$JRE_LIB_DIR
 ls ${JAVA_HOME}/jre/lib/$JRE_LIB_DIR/server
 
 cd portmidi/
+patch -p1 < ../no-java.patch
 #cmake -DJAVA_JVM_LIBRARY=${JAVA_HOME}/jre/lib/${JRE_LIB_DIR}/server/libjvm.so .
 cmake -DCMAKE_BUILD_TYPE=Release .
 make

--- a/buildconfig/manylinux-build/docker_base/portmidi/no-java.patch
+++ b/buildconfig/manylinux-build/docker_base/portmidi/no-java.patch
@@ -1,5 +1,8 @@
---- portmidi.orig/CMakeLists.txt	2019-04-11 12:42:33.397314863 +0100
-+++ portmidi/CMakeLists.txt 2019-04-11 12:42:48.315175169 +0100
+Allow portmidi to build without its Java interface.
+
+diff -rupN portmidi.orig/CMakeLists.txt portmidi/CMakeLists.txt
+--- portmidi.orig/CMakeLists.txt	2019-04-12 14:13:22.542505935 +0100
++++ portmidi/CMakeLists.txt	2019-04-12 14:13:56.612622878 +0100
 @@ -73,5 +73,5 @@ add_subdirectory(pm_test)
  add_subdirectory(pm_dylib)
  
@@ -7,3 +10,60 @@
 -add_subdirectory(pm_java)
 +#add_subdirectory(pm_java)
  
+diff -rupN portmidi.orig/pm_common/CMakeLists.txt portmidi/pm_common/CMakeLists.txt
+--- portmidi.orig/pm_common/CMakeLists.txt	2019-04-12 14:13:22.543505938 +0100
++++ portmidi/pm_common/CMakeLists.txt	2019-04-12 14:18:34.351576295 +0100
+@@ -67,14 +67,14 @@ if(UNIX)
+     message(STATUS "SYSROOT: " ${CMAKE_OSX_SYSROOT})
+   else(APPLE)
+     # LINUX settings...
+-    include(FindJNI)
+-    message(STATUS "JAVA_JVM_LIB_PATH is " ${JAVA_JVM_LIB_PATH})
+-    message(STATUS "JAVA_INCLUDE_PATH is " ${JAVA_INCLUDE_PATH})
+-    message(STATUS "JAVA_INCLUDE_PATH2 is " ${JAVA_INCLUDE_PATH2})
+-    message(STATUS "JAVA_JVM_LIBRARY is " ${JAVA_JVM_LIBRARY})
+-    set(JAVA_INCLUDE_PATHS ${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
++    #include(FindJNI)
++    #message(STATUS "JAVA_JVM_LIB_PATH is " ${JAVA_JVM_LIB_PATH})
++    #message(STATUS "JAVA_INCLUDE_PATH is " ${JAVA_INCLUDE_PATH})
++    #message(STATUS "JAVA_INCLUDE_PATH2 is " ${JAVA_INCLUDE_PATH2})
++    #message(STATUS "JAVA_JVM_LIBRARY is " ${JAVA_JVM_LIBRARY})
++    #set(JAVA_INCLUDE_PATHS ${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
+     # libjvm.so is found relative to JAVA_INCLUDE_PATH:
+-    set(JAVAVM_LIB ${JAVA_JVM_LIBRARY}/libjvm.so)
++    #set(JAVAVM_LIB ${JAVA_JVM_LIBRARY}/libjvm.so)
+ 
+     set(LINUXSRC pmlinuxalsa pmlinux finddefault)
+     prepend_path(LIBSRC ../pm_linux/ ${LINUXSRC})
+@@ -99,7 +99,7 @@ else(UNIX)
+     set(PM_NEEDED_LIBS winmm.lib)
+   endif(WIN32)
+ endif(UNIX)
+-set(JNI_EXTRA_LIBS ${PM_NEEDED_LIBS} ${JAVA_JVM_LIBRARY})
++#set(JNI_EXTRA_LIBS ${PM_NEEDED_LIBS} ${JAVA_JVM_LIBRARY})
+ 
+ # this completes the list of library sources by adding shared code
+ list(APPEND LIBSRC pmutil portmidi)
+@@ -110,16 +110,16 @@ set_target_properties(portmidi-static PR
+ target_link_libraries(portmidi-static ${PM_NEEDED_LIBS})
+ 
+ # define the jni library
+-include_directories(${JAVA_INCLUDE_PATHS})
++#include_directories(${JAVA_INCLUDE_PATHS})
+ 
+-set(JNISRC ${LIBSRC} ../pm_java/pmjni/pmjni.c)
+-add_library(pmjni SHARED ${JNISRC})
+-target_link_libraries(pmjni ${JNI_EXTRA_LIBS})
+-set_target_properties(pmjni PROPERTIES EXECUTABLE_EXTENSION "jnilib")
++#set(JNISRC ${LIBSRC} ../pm_java/pmjni/pmjni.c)
++#add_library(pmjni SHARED ${JNISRC})
++#target_link_libraries(pmjni ${JNI_EXTRA_LIBS})
++#set_target_properties(pmjni PROPERTIES EXECUTABLE_EXTENSION "jnilib")
+ 
+ # install the libraries (Linux and Mac OS X command line)
+ if(UNIX)
+-  INSTALL(TARGETS portmidi-static pmjni
++  INSTALL(TARGETS portmidi-static
+     LIBRARY DESTINATION /usr/local/lib
+     ARCHIVE DESTINATION /usr/local/lib)
+ # .h files installed by pm_dylib/CMakeLists.txt, so don't need them here

--- a/buildconfig/manylinux-build/docker_base/portmidi/no-java.patch
+++ b/buildconfig/manylinux-build/docker_base/portmidi/no-java.patch
@@ -1,0 +1,9 @@
+--- portmidi.orig/CMakeLists.txt	2019-04-11 12:42:33.397314863 +0100
++++ portmidi/CMakeLists.txt 2019-04-11 12:42:48.315175169 +0100
+@@ -73,5 +73,5 @@ add_subdirectory(pm_test)
+ add_subdirectory(pm_dylib)
+ 
+ # Cannot figure out how to make an xcode Java application with CMake
+-add_subdirectory(pm_java)
++#add_subdirectory(pm_java)
+ 

--- a/buildconfig/manylinux-build/docker_base/sdl_libs/build-sdl-libs.sh
+++ b/buildconfig/manylinux-build/docker_base/sdl_libs/build-sdl-libs.sh
@@ -18,6 +18,8 @@ sha512sum -c sdl.sha512
 # Build SDL
 tar xzf ${SDL}.tar.gz
 cd $SDL
+patch -p1 < ../libsdl-1.2-fix-compilation-libX11.patch
+./autogen.sh
 ./configure --enable-png --disable-png-shared --enable-jpg --disable-jpg-shared
 make
 make install

--- a/buildconfig/manylinux-build/docker_base/sdl_libs/libsdl-1.2-fix-compilation-libX11.patch
+++ b/buildconfig/manylinux-build/docker_base/sdl_libs/libsdl-1.2-fix-compilation-libX11.patch
@@ -1,0 +1,59 @@
+# From: https://bugzilla-attachments.libsdl.org/attachment.cgi?id=1166
+# See:  https://bugzilla.libsdl.org/show_bug.cgi?id=1769
+# HG changeset patch
+# User Azamat H. Hackimov <azamat.hackimov@gmail.com>
+# Date 1370184533 -21600
+# Branch SDL-1.2
+# Node ID 91ad7b43317a6387e115ecdf63a49137f47e42c8
+# Parent  f7fd5c3951b9ed922fdf696f7182e71b58a13268
+Fix compilation with libX11 >= 1.5.99.902.
+
+These changes fixes bug #1769 for SDL 1.2
+(http://bugzilla.libsdl.org/show_bug.cgi?id=1769).
+
+diff -r f7fd5c3951b9 -r 91ad7b43317a configure.in
+--- a/configure.in	Wed Apr 17 00:56:53 2013 -0700
++++ b/configure.in	Sun Jun 02 20:48:53 2013 +0600
+@@ -1169,6 +1169,17 @@
+             if test x$definitely_enable_video_x11_xrandr = xyes; then
+                 AC_DEFINE(SDL_VIDEO_DRIVER_X11_XRANDR)
+             fi
++            AC_MSG_CHECKING(for const parameter to _XData32)
++            have_const_param_xdata32=no
++            AC_TRY_COMPILE([
++              #include <X11/Xlibint.h>
++              extern int _XData32(Display *dpy,register _Xconst long *data,unsigned len);
++            ],[
++            ],[
++            have_const_param_xdata32=yes
++            AC_DEFINE(SDL_VIDEO_DRIVER_X11_CONST_PARAM_XDATA32)
++            ])
++            AC_MSG_RESULT($have_const_param_xdata32)
+         fi
+     fi
+ }
+diff -r f7fd5c3951b9 -r 91ad7b43317a include/SDL_config.h.in
+--- a/include/SDL_config.h.in	Wed Apr 17 00:56:53 2013 -0700
++++ b/include/SDL_config.h.in	Sun Jun 02 20:48:53 2013 +0600
+@@ -283,6 +283,7 @@
+ #undef SDL_VIDEO_DRIVER_WINDIB
+ #undef SDL_VIDEO_DRIVER_WSCONS
+ #undef SDL_VIDEO_DRIVER_X11
++#undef SDL_VIDEO_DRIVER_X11_CONST_PARAM_XDATA32
+ #undef SDL_VIDEO_DRIVER_X11_DGAMOUSE
+ #undef SDL_VIDEO_DRIVER_X11_DYNAMIC
+ #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT
+diff -r f7fd5c3951b9 -r 91ad7b43317a src/video/x11/SDL_x11sym.h
+--- a/src/video/x11/SDL_x11sym.h	Wed Apr 17 00:56:53 2013 -0700
++++ b/src/video/x11/SDL_x11sym.h	Sun Jun 02 20:48:53 2013 +0600
+@@ -165,7 +165,11 @@
+  */
+ #ifdef LONG64
+ SDL_X11_MODULE(IO_32BIT)
++#if SDL_VIDEO_DRIVER_X11_CONST_PARAM_XDATA32
++SDL_X11_SYM(int,_XData32,(Display *dpy,register _Xconst long *data,unsigned len),(dpy,data,len),return)
++#else
+ SDL_X11_SYM(int,_XData32,(Display *dpy,register long *data,unsigned len),(dpy,data,len),return)
++#endif
+ SDL_X11_SYM(void,_XRead32,(Display *dpy,register long *data,long len),(dpy,data,len),)
+ #endif

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -90,7 +90,7 @@ class FontModuleTest( unittest.TestCase ):
         for name in fnts:
             # note, on ubuntu 2.6 they are all unicode strings.
 
-            self.assertTrue(isinstance(name, name_types), name)
+            self.assertIsInstance(name, name_types)
             # Font names can be comprised of only numeric characters, so
             # just checking name.islower() will not work as expected here.
             self.assertFalse(any(c.isupper() for c in name))


### PR DESCRIPTION
This updates the manylinux build to use the newer manylinux2010 tag based on CentOS 6. The base images are only available for 64-bit architectures at the moment, so I've disabled the machinery to build 32-bit wheels, but left it there in case it's wanted again in the future.

The built packages currently fail some tests, however.