### PR TITLE
Fix scrap.init memory leak

### DIFF
--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -45,8 +45,8 @@ static int _scrapinitialized = 0;
  * Currently active Clipboard object.
  */
 static ScrapClipType _currentmode;
-static PyObject *_selectiondata;
-static PyObject *_clipdata;
+static PyObject *_selectiondata = NULL;
+static PyObject *_clipdata = NULL;
 
 /* Forward declarations. */
 static PyObject *
@@ -103,8 +103,13 @@ static PyObject *
 _scrap_init(PyObject *self, PyObject *args)
 {
     VIDEO_INIT_CHECK();
-    _clipdata = PyDict_New();
-    _selectiondata = PyDict_New();
+
+    if (!pygame_scrap_initialized()) {
+        Py_XDECREF(_clipdata);
+        Py_XDECREF(_selectiondata);
+        _clipdata = PyDict_New();
+        _selectiondata = PyDict_New();
+    }
 
     /* In case we've got not video surface, we won't initialize
      * anything.

--- a/test/scrap_test.py
+++ b/test/scrap_test.py
@@ -29,6 +29,16 @@ class ScrapModuleTest(unittest.TestCase):
 
         self.assertTrue(scrap.get_init())
 
+    def test_init__reinit(self):
+        """Ensures reinitializing the scrap module doesn't clear its data."""
+        data_type = pygame.SCRAP_TEXT
+        expected_data = as_bytes('test_init__reinit')
+        scrap.put(data_type, expected_data)
+
+        scrap.init()
+
+        self.assertEqual(scrap.get(data_type), expected_data)
+
     def test_get_init(self):
         """Ensures get_init gets the init state."""
         self.assertTrue(scrap.get_init())


### PR DESCRIPTION
Overview of changes:
- Fixed the `scrap.init` memory leak
- Added a scrap test

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at 9d55b5fd7d589cbfaf1def4925d41b077397ecc0

Resolves #921.