### PR TITLE
Fix deadlock in music module

### DIFF
--- a/src_c/music.c
+++ b/src_c/music.c
@@ -110,8 +110,15 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
 static PyObject *
 music_get_busy(PyObject *self, PyObject *args)
 {
+    int playing;
+
     MIXER_INIT_CHECK();
-    return PyInt_FromLong(Mix_PlayingMusic());
+
+    Py_BEGIN_ALLOW_THREADS
+    playing = Mix_PlayingMusic();
+    Py_END_ALLOW_THREADS
+
+    return PyInt_FromLong(playing);
 }
 
 static PyObject *
@@ -171,7 +178,10 @@ music_rewind(PyObject *self, PyObject *args)
 {
     MIXER_INIT_CHECK();
 
+    Py_BEGIN_ALLOW_THREADS
     Mix_RewindMusic();
+    Py_END_ALLOW_THREADS
+
     Py_RETURN_NONE;
 }
 
@@ -185,7 +195,10 @@ music_set_volume(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
+    Py_BEGIN_ALLOW_THREADS
     Mix_VolumeMusic((int)(volume * 128));
+    Py_END_ALLOW_THREADS
+
     Py_RETURN_NONE;
 }
 
@@ -202,6 +215,7 @@ music_get_volume(PyObject *self, PyObject *args)
 static PyObject *
 music_set_pos(PyObject *self, PyObject *arg)
 {
+    int position_set;
     double pos = PyFloat_AsDouble(arg);
     if (pos == -1 && PyErr_Occurred()) {
         PyErr_Clear();
@@ -210,9 +224,13 @@ music_set_pos(PyObject *self, PyObject *arg)
 
     MIXER_INIT_CHECK();
 
-    if (Mix_SetMusicPosition(pos) == -1) {
+    Py_BEGIN_ALLOW_THREADS
+    position_set = Mix_SetMusicPosition(pos);
+    Py_END_ALLOW_THREADS
+
+    if (position_set == -1)
         return RAISE(pgExc_SDLError, "set_pos unsupported for this codec");
-    }
+
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
This PR fixes deadlock between two threads holding the GIL and `mixer_lock`.

There are a few functions in `music` module that didn't release the GIL when calling SDL_mixer functions that lock the `mixer_lock`. 

### An example
There are two threads:
**Thread 1**, created using `threading` module, it plays the background music using the `pygame.mixer.music` module.
**Thread 2** was created by an external library (SDL) to play a sound effect (via `pygame.mixer.Sound.play`).

Consider  the following succession of events:
1. Thread 2 locks `mixer_lock` in `SDL_RunAudio()`in preparation to play a sound.
2. Thread 1 (running the Python interpreter and thus holding the GIL) calls `music.get_busy()`(or other function fixed in the commit).
3. Thread 1 calls `SDL_LockAudio()`, but the `mixer_lock` is already acquired, so it has to wait
4. Thread 2 calls `_Mix_channel_done_playing()` which in turn  calls pygame callback `endsound_callback()` that tries to acquire the GIL, but the GIL is owned by Thread 1 which is waiting on `mixer_lock` => **Deadlock**
