### PR TITLE
Add python version to startup printout

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -394,7 +394,9 @@ copy_reg.pickle(Color, __color_reduce, __color_constructor)
 
 # Thanks for supporting pygame. Without support now, there won't be pygame later.
 if 'PYGAME_HIDE_SUPPORT_PROMPT' not in os.environ:
-    print('pygame {} (SDL {}.{}.{})'.format(ver, *get_sdl_version()))
+    print('pygame {} (SDL {}.{}.{}, python {}.{}.{})'.format(
+        ver, *get_sdl_version() + sys.version_info[0:3]
+    ))
     print('Hello from the pygame community. https://www.pygame.org/contribute.html')
 
 


### PR DESCRIPTION
Adds the python version to the startup printout (see #980).

tested in python 3.6.7 and 2.7.15
pygame: 2.0.0.dev0 with sdl 1.2.15

At first I tried `.format(ver, *get_sdl_version(), *sys.version_info[0:3]))` which works in python 3 but throws a syntax error in python 2. This is why I "+" the two version tuples before unpacking.