### PR TITLE
Add static assertions

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -2250,13 +2250,11 @@ MODINIT_DEFINE(_freetype)
     DEC_CONST(BBOX_PIXEL_GRIDFIT);
 
     /* export the c api */
-#if PYGAMEAPI_FREETYPE_NUMSLOTS != 2
-#error Mismatch between number of api slots and actual exports.
-#endif
     c_api[0] = &pgFont_Type;
     c_api[1] = &pgFont_New;
 
-    apiobj = encapsulate_api(c_api, "freetype");
+    _encapsulate_api_safe(&apiobj, c_api, freetype, FREETYPE,
+                          PgFREETYPE_C_API);
     if (!apiobj) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -178,6 +178,8 @@ struct pgSubSurface_Data {
     int offsetx, offsety;
 };
 
+#include "pgimport.h"
+
 /*
  * include public API
  */

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2185,20 +2185,15 @@ MODINIT_DEFINE(base)
     c_api[17] = pgDict_AsBuffer;
     c_api[18] = pgExc_BufferError;
 #if IS_SDLv1
-#define FILLED_SLOTS 19
 #else /* IS_SDLv2 */
     c_api[19] = pg_GetDefaultWindow;
     c_api[20] = pg_SetDefaultWindow;
     c_api[21] = pg_GetDefaultWindowSurface;
     c_api[22] = pg_SetDefaultWindowSurface;
-#define FILLED_SLOTS 23
 #endif /* IS_SDLv2 */
 
-#if PYGAMEAPI_BASE_NUMSLOTS != FILLED_SLOTS
-#error export slot count mismatch
-#endif
 
-    apiobj = encapsulate_api(c_api, "base");
+    encapsulate_api_safe(&apiobj, c_api, base, BASE);
     if (apiobj == NULL) {
         Py_XDECREF(atexit_register);
         Py_DECREF(pgExc_BufferError);

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -885,14 +885,12 @@ MODINIT_DEFINE(bufferproxy)
         DECREF_MOD(module);
         MODINIT_ERROR;
     }
-#if PYGAMEAPI_BUFPROXY_NUMSLOTS != 4
-#error export slot count mismatch
-#endif
     c_api[0] = &pgBufproxy_Type;
     c_api[1] = pgBufproxy_New;
     c_api[2] = pgBufproxy_GetParent;
     c_api[3] = pgBufproxy_Trip;
-    apiobj = encapsulate_api(c_api, PROXY_MODNAME);
+    encapsulate_api_safe(&apiobj, c_api, bufferproxy, BUFPROXY,
+                         PgBUFPROXY_C_API);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -889,8 +889,8 @@ MODINIT_DEFINE(bufferproxy)
     c_api[1] = pgBufproxy_New;
     c_api[2] = pgBufproxy_GetParent;
     c_api[3] = pgBufproxy_Trip;
-    encapsulate_api_safe(&apiobj, c_api, bufferproxy, BUFPROXY,
-                         PgBUFPROXY_C_API);
+    _encapsulate_api_safe(&apiobj, c_api, bufferproxy, BUFPROXY,
+                          PgBUFPROXY_C_API);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/cdrom.c
+++ b/src_c/cdrom.c
@@ -645,7 +645,7 @@ MODINIT_DEFINE(cdrom)
     /* export the c api */
     c_api[0] = &pgCD_Type;
     c_api[1] = pgCD_New;
-    apiobj = encapsulate_api(c_api, "cdrom");
+    encapsulate_api_safe(&apiobj, c_api, cdrom, CDROM);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -2043,7 +2043,7 @@ MODINIT_DEFINE(color)
     c_api[2] = pg_RGBAFromColorObj;
     c_api[3] = pgColor_NewLength;
 
-    apiobj = encapsulate_api(c_api, "color");
+    encapsulate_api_safe(&apiobj, c_api, color, COLOR);
     if (apiobj == NULL) {
         Py_DECREF(_COLORDICT);
         DECREF_MOD(module);

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -2178,7 +2178,7 @@ MODINIT_DEFINE(display)
     /* export the c api */
     c_api[0] = &pgVidInfo_Type;
     c_api[1] = pgVidInfo_New;
-    apiobj = encapsulate_api(c_api, "display");
+    encapsulate_api_safe(&apiobj, c_api, display, DISPLAY);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1825,7 +1825,7 @@ MODINIT_DEFINE(event)
     c_api[4] = pg_EnableKeyRepeat;
     c_api[5] = pg_GetKeyRepeat;
 #endif /* IS_SDLv2 */
-    apiobj = encapsulate_api(c_api, "event");
+    encapsulate_api_safe(&apiobj, c_api, event, EVENT);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -937,7 +937,7 @@ MODINIT_DEFINE(font)
     c_api[0] = &PyFont_Type;
     c_api[1] = PyFont_New;
     c_api[2] = &font_initialized;
-    apiobj = encapsulate_api(c_api, "font");
+    _encapsulate_api_safe(&apiobj, c_api, font, FONT, PyFont_API);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/include/pgimport.h
+++ b/src_c/include/pgimport.h
@@ -20,13 +20,6 @@
 #include "pgplatform.h"
 #include "pgcompat.h"
 
-#if PG_HAVE_CAPSULE
-#define encapsulate_api(ptr, module) \
-    PyCapsule_New(ptr, PG_CAPSULE_NAME(module), NULL)
-#else /* ~PG_HAVE_CAPSULE */
-#define encapsulate_api(ptr, module) PyCObject_FromVoidPtr(ptr, NULL)
-#endif /* ~PG_HAVE_CAPSULE */
-
 #define PYGAMEAPI_LOCAL_ENTRY "_PYGAME_C_API"
 #define PG_CAPSULE_NAME(m) (IMPPREFIX m "." PYGAMEAPI_LOCAL_ENTRY)
 

--- a/src_c/include/pgimport.h
+++ b/src_c/include/pgimport.h
@@ -63,8 +63,16 @@
 #define PYGAMEAPI_EXTERN_SLOTS(api_root, numslots) \
     extern void *api_root[(numslots)]
 
-#define PYGAMEAPI_GET_SLOT(api_root, index) \
+#define PYGAMEAPI_NUM_SLOTS(api_root) \
+    sizeof(api_root) / sizeof(void*)
+
+#define PYGAMEAPI_GET_SLOT_UNSAFE(api_root, index) \
     api_root[(index)]
+#define PYGAMEAPI_GET_SLOT(api_root, index)                           \
+    (PG_STATIC_ASSERT_EXPR( (index) < PYGAMEAPI_NUM_SLOTS(api_root) ) \
+        ? PYGAMEAPI_GET_SLOT_UNSAFE(api_root, index) : NULL)
+    /* cause a compiler error for out of range indices
+      (use with expressions known at compile-time). */
 
 /*
  * disabled API with NO_PYGAME_C_API; do nothing instead

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -37,9 +37,17 @@
 
 /* SDL needs WIN32 */
 #if !defined(WIN32) &&                                           \
-    (defined(MS_WIN32) || defined(_WIN32) ||                     \
-     defined(__WIN32) || defined(__WIN32__) || defined(_WINDOWS))
+    (defined(MS_WIN32) || defined(_WIN32) || defined(__WIN32) || \
+     defined(__WIN32__) || defined(_WINDOWS))
 #define WIN32
 #endif
+
+#include <assert.h>
+#if defined(static_assert) || defined(_MSC_VER)
+#define PG_STATIC_ASSERT(cond, msg) static_assert((cond), #msg)
+#else /* !defined(static_assert) && !defined(_MSC_VER) */
+#define PG_STATIC_ASSERT(cond, msg) \
+    typedef char static_assertion_##msg[(cond) ? 1 : -1]
+#endif /* !defined(static_assert) && !defined(_MSC_VER) */
 
 #endif /* ~PG_PLATFORM_H */

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -42,6 +42,9 @@
 #define WIN32
 #endif
 
+/*
+ * assertions
+ */
 #include <assert.h>
 #if defined(static_assert) || defined(_MSC_VER)
 #define PG_STATIC_ASSERT(cond, msg) static_assert((cond), #msg)
@@ -49,5 +52,7 @@
 #define PG_STATIC_ASSERT(cond, msg) \
     typedef char static_assertion_##msg[(cond) ? 1 : -1]
 #endif /* !defined(static_assert) && !defined(_MSC_VER) */
+
+#define PG_STATIC_ASSERT_EXPR(cond) (1 + sizeof(char[1 - 2*!( cond )]))
 
 #endif /* ~PG_PLATFORM_H */

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -502,7 +502,7 @@ MODINIT_DEFINE(joystick)
     /* export the c api */
     c_api[0] = &pgJoystick_Type;
     c_api[1] = pgJoystick_New;
-    apiobj = encapsulate_api(c_api, "joystick");
+    encapsulate_api_safe(&apiobj, c_api, joystick, JOYSTICK);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1721,7 +1721,7 @@ MODINIT_DEFINE(mask)
     }
     /* export the c api */
     c_api[0] = &pgMask_Type;
-    apiobj = encapsulate_api(c_api, "mask");
+    _encapsulate_api_safe(&apiobj, c_api, mask, MASK, PyMASK_C_API);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3761,7 +3761,7 @@ MODINIT_DEFINE(math)
     c_api[3] = pgVector_NEW;
     c_api[4] = pgVectorCompatible_Check;
     */
-    apiobj = encapsulate_api(c_api, "math");
+    encapsulate_api_safe(&apiobj, c_api, math, MATH);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1933,7 +1933,8 @@ MODINIT_DEFINE(mixer)
     c_api[4] = pgChannel_New;
     c_api[5] = pgMixer_AutoInit;
     c_api[6] = pgMixer_AutoQuit;
-    apiobj = encapsulate_api(c_api, "mixer");
+    _encapsulate_api_safe(&apiobj, c_api, mixer, MIXER,
+                          pgMIXER_C_API);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/pgimport.h
+++ b/src_c/pgimport.h
@@ -11,20 +11,6 @@
     PyCObject_FromVoidPtr(array, NULL)
 #endif /* ~PG_HAVE_CAPSULE */
 
-#if 0
-#ifndef NO_PYGAME_C_API
-#define _PG_ASSERT_ROOT_SIZE(MODULE, api_root)                     \
-        PG_STATIC_ASSERT(                                          \
-            PYGAMEAPI_##MODULE##_FIRSTSLOT +                       \
-            PYGAMEAPI_##MODULE##_NUMSLOTS                          \
-            <= PYGAMEAPI_NUM_SLOTS(api_root), api_root_too_small)
-#else /* NO_PYGAME_C_API */
-#define _PG_ASSERT_ROOT_SIZE(MODULE, api_root)
-#endif /* NO_PYGAME_C_API */
-#endif
-
-#define _PG_ASSERT_ROOT_SIZE(MODULE, api_root)
-
 #define _encapsulate_api_safe(retptr, array,                       \
                               module, MODULE,                      \
                               api_root)                            \
@@ -32,7 +18,6 @@
         PG_STATIC_ASSERT( sizeof(array) / sizeof(void*) ==         \
                           PYGAMEAPI_##MODULE##_NUMSLOTS,           \
                           encapsulate_wrong_size );                \
-        _PG_ASSERT_ROOT_SIZE(MODULE, api_root);                    \
         *retptr = encapsulate_api(array, #module);                 \
     } while(0)
 

--- a/src_c/pgimport.h
+++ b/src_c/pgimport.h
@@ -1,1 +1,42 @@
+#ifndef PGIMPORT_INTERNAL_H
+#define PGIMPORT_INTERNAL_H
+
 #include "include/pgimport.h"
+
+#if PG_HAVE_CAPSULE
+#define encapsulate_api(array, module) \
+    PyCapsule_New(array, PG_CAPSULE_NAME(module), NULL)
+#else /* ~PG_HAVE_CAPSULE */
+#define encapsulate_api(array, module) \
+    PyCObject_FromVoidPtr(array, NULL)
+#endif /* ~PG_HAVE_CAPSULE */
+
+#if 0
+#ifndef NO_PYGAME_C_API
+#define _PG_ASSERT_ROOT_SIZE(MODULE, api_root)                     \
+        PG_STATIC_ASSERT(                                          \
+            PYGAMEAPI_##MODULE##_FIRSTSLOT +                       \
+            PYGAMEAPI_##MODULE##_NUMSLOTS                          \
+            <= PYGAMEAPI_NUM_SLOTS(api_root), api_root_too_small)
+#else /* NO_PYGAME_C_API */
+#define _PG_ASSERT_ROOT_SIZE(MODULE, api_root)
+#endif /* NO_PYGAME_C_API */
+#endif
+
+#define _PG_ASSERT_ROOT_SIZE(MODULE, api_root)
+
+#define _encapsulate_api_safe(retptr, array,                       \
+                              module, MODULE,                      \
+                              api_root)                            \
+    do {                                                           \
+        PG_STATIC_ASSERT( sizeof(array) / sizeof(void*) ==         \
+                          PYGAMEAPI_##MODULE##_NUMSLOTS,           \
+                          encapsulate_wrong_size );                \
+        _PG_ASSERT_ROOT_SIZE(MODULE, api_root);                    \
+        *retptr = encapsulate_api(array, #module);                 \
+    } while(0)
+
+#define encapsulate_api_safe(retptr, array, module, MODULE) \
+    _encapsulate_api_safe(retptr, array, module, MODULE, PyGAME_C_API)
+
+#endif /* ~PGIMPORT_INTERNAL_H */

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1998,7 +1998,7 @@ MODINIT_DEFINE(pixelarray)
 
     c_api[0] = &pgPixelArray_Type;
     c_api[1] = pgPixelArray_New;
-    apiobj = encapsulate_api(c_api, "pixelarray");
+    encapsulate_api_safe(&apiobj, c_api, pixelarray, PIXELARRAY);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1782,7 +1782,7 @@ MODINIT_DEFINE(rect)
     c_api[1] = pgRect_New;
     c_api[2] = pgRect_New4;
     c_api[3] = pgRect_FromObject;
-    apiobj = encapsulate_api(c_api, "rect");
+    encapsulate_api_safe(&apiobj, c_api, rect, RECT);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -761,7 +761,7 @@ MODINIT_DEFINE(rwobject)
     c_api[3] = pg_EncodeString;
     c_api[4] = pgRWops_FromFileObject;
     c_api[5] = pgRWops_ReleaseObject;
-    apiobj = encapsulate_api(c_api, "rwobject");
+    encapsulate_api_safe(&apiobj, c_api, rwobject, RWOBJECT);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -4140,7 +4140,7 @@ MODINIT_DEFINE(surface)
     c_api[0] = &pgSurface_Type;
     c_api[1] = pgSurface_New;
     c_api[2] = pgSurface_Blit;
-    apiobj = encapsulate_api(c_api, "surface");
+    encapsulate_api_safe(&apiobj, c_api, surface, SURFACE);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -297,7 +297,7 @@ MODINIT_DEFINE(surflock)
     c_api[5] = pgSurface_LockBy;
     c_api[6] = pgSurface_UnlockBy;
     c_api[7] = pgSurface_LockLifetime;
-    apiobj = encapsulate_api(c_api, "surflock");
+    encapsulate_api_safe(&apiobj, c_api, surflock, SURFLOCK);
     if (apiobj == NULL) {
         DECREF_MOD(module);
         MODINIT_ERROR;


### PR DESCRIPTION
This branch derives from #990.

Additions:
* Static bounds check for `PYGAMEAPI_GET_SLOT()`. If the number is greater than the size of the array declared with `PYGAMEAPI_DEFINE_SLOTS()`/`PYGAMEAPI_EXTERN_SLOTS()` it causes a compiler error.
* Safer encapsulation of the c_api[] slot arrays. If size of the array doesn't match PYGAMEAPI_<MODULENAME>_NUMSLOTS, it causes a static assertion fail with the message "encapsulate_wrong_size".
* Static checks import_pygame_*(). If the imported slots can't fit inside the array declared with `PYGAMEAPI_DEFINE_SLOTS()`/`PYGAMEAPI_EXTERN_SLOTS()`, it causes a static assertion fail with the message "api_root_too_small".

Other stuff:
* Also, running import_pygame_xyz() more than once has no effect now.
* Moved encapsulation code to private pgimport.h.

Possible issues:
* Maybe overly complicated
* Maybe the import_pygame_*() checks are unnecessary since the encapsulation checks pretty much do the same thing (and not repeatedly).
* Not sure how portable the `PG_STATIC_ASSERT()` macro is. It definitely works for C99.
* Not entirely sure if `PG_STATIC_ASSERT_EXPR()` works as intended, but probably. It evaluates to a non-zero integer if the assertion succeeds, so for `(PG_STATIC_ASSERT_EXPR(...) ? dostuff() : NULL)`, any compiler should remove the if statement since it's always true.