### PR TITLE
Tests to NULL check API slots

### DIFF
--- a/test/api_test.py
+++ b/test/api_test.py
@@ -37,7 +37,7 @@ class ModuleEntryTest(unittest.TestCase):
             for line in f:
                 match = capture_numslots(line)
                 if match:
-                    numslots = int(match[1])
+                    numslots = int(match.group(1))
                     break
         return numslots
 
@@ -67,7 +67,7 @@ class ModuleEntryTest(unittest.TestCase):
             mod = __import__('.'.join(('pygame', modulestr)))
             self.check_module(getattr(pygame, modulestr),
                               header, macronameFunc)
-        except ModuleNotFoundError:
+        except ImportError:
             unittest.skip('module unavailable')
 
 

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -1,0 +1,98 @@
+import unittest
+import ctypes
+import pygame
+import os.path
+import re
+
+
+pgheader = os.path.join('src_c', '_pygame.h')
+local_entry = '_PYGAME_C_API'
+
+ctypes.pythonapi.PyCapsule_GetName.restype = ctypes.c_char_p
+ctypes.pythonapi.PyCapsule_GetPointer.restype = \
+    ctypes.POINTER(ctypes.c_void_p)
+
+
+class ModuleEntryTest(unittest.TestCase):
+    """ensure that C API slots have been initialized"""
+
+    @staticmethod
+    def numslots_for(module, macroname=None,
+                     header=pgheader):
+        """number of C API slots or -1 if it cannot be found"""
+        if not macroname:
+            macroname = 'PYGAMEAPI_{}_NUMSLOTS'.format(
+                module.__name__.split('.')[-1].upper())
+        capture_numslots_expr = \
+            re.compile('\s*#define.*{}.*(\d+)'
+                .format(macroname))
+        capture_numslots = capture_numslots_expr.match
+
+        numslots = -1
+        with open(header) as f:
+            for line in f:
+                match = capture_numslots(line)
+                if match:
+                    numslots = int(match[1])
+                    break
+        return numslots
+
+    def check_module(self, module, header=pgheader):
+        """NULL check module's (zero-initialized) API slot entries"""
+        capsule = getattr(module, local_entry)
+        capsuleobj = ctypes.py_object(capsule)
+        name = ctypes.pythonapi.PyCapsule_GetName(capsuleobj)
+
+        # find number of slots
+        macroname = 'PYGAMEAPI_{}_NUMSLOTS'.format(
+            module.__name__.split('.')[-1].upper())
+        numslots = self.numslots_for(module, macroname=macroname,
+                                     header=header)
+        self.assertNotEqual(numslots, -1,
+            "cannot find {} in {}".format(macroname, header))
+
+        # void *moduletable[] = { ... };
+        moduletable = ctypes.pythonapi.PyCapsule_GetPointer(
+            capsuleobj, name)
+        for entryind in range(numslots):
+            self.assertIsNotNone(moduletable[entryind],
+                'API slot {} is NULL'.format(entryind))
+
+
+@unittest.skipIf(not os.path.isfile(pgheader),
+                 "Skipping because we cannot find _pygame.h")
+class BaseModuleEntryTest(ModuleEntryTest):
+    pass
+
+#
+# add tests for the base modules
+#
+base_modules = [
+    'base',
+    'rect',
+    'cdrom',
+    'joystick',
+    'display',
+    'surface',
+    'surflock',
+    'event',
+    'rwobject',
+    'pixelarray',
+    'color',
+    'math',
+    ]
+if pygame.version.vernum[0] == 2:
+    # display has no API with SDL 2
+    base_modules.remove('display')
+base_modules = [getattr(pygame, modname) for modname in base_modules if modname in pygame.__dict__]
+
+def _makechecker(test, mod):
+    def ret(test):
+        BaseModuleEntryTest.check_module(test, mod)
+    return ret
+
+for mod in base_modules:
+    modname = mod.__name__.split('.')[-1]
+    setattr(BaseModuleEntryTest,
+            "test_{}".format(modname),
+            _makechecker(BaseModuleEntryTest, mod))


### PR DESCRIPTION
Ensures that the "c_api" arrays are initialized. Eg if you forget to set a slot,
```c
c_api[0] = &pgSurface_Type;
c_api[2] = pgSurface_Blit;
```
then you get an error like this:

```
loading test.api_test
........F
======================================================================
FAIL: test_surface (test.api_test.BaseModuleEntryTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\David\Documents\dev\pygame\test\api_test.py", line 86, in ret
    BaseModuleEntryTest.check_module(test, mod)
  File "C:\Users\David\Documents\dev\pygame\test\api_test.py", line 59, in check_module
    'API slot {} is NULL'.format(entryind))
AssertionError: unexpectedly None : API slot 1 is NULL

----------------------------------------------------------------------
Ran 9 tests in 0.037s

FAILED (failures=1)
```
I made it a test because it didn't have to be a runtime check.