### PR TITLE
Share c_api array instead of copying it for each module

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -178,6 +178,13 @@ struct pgSubSurface_Data {
     int offsetx, offsety;
 };
 
+/*
+ * include public API
+ */
+#include "include/_pygame.h"
+
+#include "pgimport.h"
+
 /* Slot counts.
  * Remember to keep these constants up to date.
  */
@@ -200,12 +207,5 @@ struct pgSubSurface_Data {
 #define PYGAMEAPI_BASE_NUMSLOTS 23
 #define PYGAMEAPI_EVENT_NUMSLOTS 6
 #endif /* PG_API_VERSION == 2 */
-
-/*
- * include public API
- */
-#include "include/_pygame.h"
-
-#include "pgimport.h"
 
 #endif /* _PYGAME_INTERNAL_H */

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -178,9 +178,34 @@ struct pgSubSurface_Data {
     int offsetx, offsety;
 };
 
+/* Slot counts.
+ * Remember to keep these constants up to date.
+ */
+
+#define PYGAMEAPI_RECT_NUMSLOTS 4
+#define PYGAMEAPI_JOYSTICK_NUMSLOTS 2
+#define PYGAMEAPI_DISPLAY_NUMSLOTS 2
+#define PYGAMEAPI_SURFACE_NUMSLOTS 3
+#define PYGAMEAPI_SURFLOCK_NUMSLOTS 8
+#define PYGAMEAPI_RWOBJECT_NUMSLOTS 6
+#define PYGAMEAPI_PIXELARRAY_NUMSLOTS 2
+#define PYGAMEAPI_COLOR_NUMSLOTS 4
+#define PYGAMEAPI_MATH_NUMSLOTS 2
+#define PYGAMEAPI_CDROM_NUMSLOTS 2
+
+#if PG_API_VERSION == 1
+#define PYGAMEAPI_BASE_NUMSLOTS 19
+#define PYGAMEAPI_EVENT_NUMSLOTS 4
+#else /* PG_API_VERSION == 2 */
+#define PYGAMEAPI_BASE_NUMSLOTS 23
+#define PYGAMEAPI_EVENT_NUMSLOTS 6
+#endif /* PG_API_VERSION == 2 */
+
 /*
  * include public API
  */
 #include "include/_pygame.h"
+
+#include "pgimport.h"
 
 #endif /* _PYGAME_INTERNAL_H */

--- a/src_c/font.h
+++ b/src_c/font.h
@@ -10,4 +10,6 @@
 
 #include "include/pygame_font.h"
 
+#define PYGAMEAPI_FONT_NUMSLOTS 3
+
 #endif /* ~PGFONT_INTERNAL_H */

--- a/src_c/freetype.h
+++ b/src_c/freetype.h
@@ -116,4 +116,6 @@ typedef struct {
 /* import public API */
 #include "include/pygame_freetype.h"
 
+#define PYGAMEAPI_FREETYPE_NUMSLOTS 2
+
 #endif /* ~_PYGAME_FREETYPE_INTERNAL_H_ */

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -49,13 +49,6 @@
  **
  ** The base module does include some useful conversion routines
  ** that you are free to use in your own extension.
- **
- ** When making changes, it is very important to keep the
- ** FIRSTSLOT and NUMSLOT constants up to date for each
- ** section. Also be sure not to overlap any of the slots.
- ** When you do make a mistake with this, it will result
- ** is a dereferenced NULL pointer that is easier to diagnose
- ** than it could be :]
  **/
 
 #include "pgplatform.h"
@@ -111,119 +104,108 @@ typedef struct pg_bufferinfo_s {
 /*
  * BASE module
  */
-#define PYGAMEAPI_BASE_FIRSTSLOT 0
-#if PG_API_VERSION == 1
-#define PYGAMEAPI_BASE_NUMSLOTS 19
-#else /* SDL2 */
-#define PYGAMEAPI_BASE_NUMSLOTS 23
-#endif /* SDL2 */
-
 #ifndef PYGAMEAPI_BASE_INTERNAL
 #define pgExc_SDLError \
     ((PyObject *)      \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT))
+        PYGAMEAPI_GET_SLOT(base, 0))
 
 #define pg_RegisterQuit          \
     (*(void (*)(void (*)(void))) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(base, 1))
 
 #define pg_IntFromObj              \
     (*(int (*)(PyObject *, int *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 2))
+        PYGAMEAPI_GET_SLOT(base, 2))
 
 #define pg_IntFromObjIndex              \
     (*(int (*)(PyObject *, int, int *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 3))
+        PYGAMEAPI_GET_SLOT(base, 3))
 
 #define pg_TwoIntsFromObj                 \
     (*(int (*)(PyObject *, int *, int *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 4))
+        PYGAMEAPI_GET_SLOT(base, 4))
 
 #define pg_FloatFromObj \
     (*(int (*)(PyObject *, float *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 5))
+        PYGAMEAPI_GET_SLOT(base, 5))
 
 #define pg_FloatFromObjIndex              \
     (*(int (*)(PyObject *, int, float *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 6))
+        PYGAMEAPI_GET_SLOT(base, 6))
 
 #define pg_TwoFloatsFromObj                   \
     (*(int (*)(PyObject *, float *, float *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 7))
+        PYGAMEAPI_GET_SLOT(base, 7))
 
 #define pg_UintFromObj                \
     (*(int (*)(PyObject *, Uint32 *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 8))
+        PYGAMEAPI_GET_SLOT(base, 8))
 
 #define pg_UintFromObjIndex     \
     (*(int (*)(PyObject *, int, Uint32 *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 9))
+        PYGAMEAPI_GET_SLOT(base, 9))
 
 #define pgVideo_AutoQuit \
     (*(void (*)(void)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 10))
+        PYGAMEAPI_GET_SLOT(base, 10))
 
 #define pgVideo_AutoInit \
     (*(int (*)(void))    \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 11))
+        PYGAMEAPI_GET_SLOT(base, 11))
 
 #define pg_RGBAFromObj               \
     (*(int (*)(PyObject *, Uint8 *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 12))
+        PYGAMEAPI_GET_SLOT(base, 12))
 
 #define pgBuffer_AsArrayInterface   \
     (*(PyObject * (*)(Py_buffer *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 13))
+        PYGAMEAPI_GET_SLOT(base, 13))
 
 #define pgBuffer_AsArrayStruct      \
     (*(PyObject * (*)(Py_buffer *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 14))
+        PYGAMEAPI_GET_SLOT(base, 14))
 
 #define pgObject_GetBuffer                    \
     (*(int (*)(PyObject *, pg_buffer *, int)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 15))
+        PYGAMEAPI_GET_SLOT(base, 15))
 
 #define pgBuffer_Release      \
     (*(void (*)(pg_buffer *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 16))
+        PYGAMEAPI_GET_SLOT(base, 16))
 
 #define pgDict_AsBuffer                       \
     (*(int (*)(pg_buffer *, PyObject *, int)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 17))
+        PYGAMEAPI_GET_SLOT(base, 17))
 
 #define pgExc_BufferError \
     ((PyObject *)         \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 18))
+        PYGAMEAPI_GET_SLOT(base, 18))
 
 #if PG_API_VERSION == 2
 #define pg_GetDefaultWindow     \
     (*(SDL_Window * (*)(void))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 19))
+        PYGAMEAPI_GET_SLOT(base, 19))
 
 #define pg_SetDefaultWindow    \
     (*(void (*)(SDL_Window *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 20))
+        PYGAMEAPI_GET_SLOT(base, 20))
 
 #define pg_GetDefaultWindowSurface \
     (*(PyObject * (*)(void))       \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 21))
+        PYGAMEAPI_GET_SLOT(base, 21))
 
 #define pg_SetDefaultWindowSurface \
     (*(void (*)(PyObject *))       \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_BASE_FIRSTSLOT + 22))
+        PYGAMEAPI_GET_SLOT(base, 22))
 
 #endif /* PG_API_VERSION == 2 */
 
-#define import_pygame_base() IMPORT_PYGAME_MODULE(base, BASE)
+#define import_pygame_base() IMPORT_PYGAME_MODULE(base)
 #endif /* ~PYGAMEAPI_BASE_INTERNAL */
 
 /*
  * RECT module
  */
-#define PYGAMEAPI_RECT_FIRSTSLOT \
-    (PYGAMEAPI_BASE_FIRSTSLOT + PYGAMEAPI_BASE_NUMSLOTS)
-#define PYGAMEAPI_RECT_NUMSLOTS 4
-
 #if !defined(SDL_VERSION_ATLEAST) || PG_API_VERSION == 1
 typedef struct {
     int x, y;
@@ -242,31 +224,28 @@ typedef struct {
 #ifndef PYGAMEAPI_RECT_INTERNAL
 #define pgRect_Type    \
     (*(PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RECT_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(rect, 0))
 
 #define pgRect_Check(x) \
     ((x)->ob_type == &pgRect_Type)
 #define pgRect_New                  \
     (*(PyObject * (*)(SDL_Rect *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RECT_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(rect, 1))
 
 #define pgRect_New4                        \
     (*(PyObject * (*)(int, int, int, int)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RECT_FIRSTSLOT + 2))
+        PYGAMEAPI_GET_SLOT(rect, 2))
 
 #define pgRect_FromObject                        \
     (*(GAME_Rect * (*)(PyObject *, GAME_Rect *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RECT_FIRSTSLOT + 3))
+        PYGAMEAPI_GET_SLOT(rect, 3))
 
-#define import_pygame_rect() IMPORT_PYGAME_MODULE(rect, RECT)
+#define import_pygame_rect() IMPORT_PYGAME_MODULE(rect)
 #endif /* ~PYGAMEAPI_RECT_INTERNAL */
 
 /*
  * CDROM module
  */
-#define PYGAMEAPI_CDROM_FIRSTSLOT \
-    (PYGAMEAPI_RECT_FIRSTSLOT + PYGAMEAPI_RECT_NUMSLOTS)
-#define PYGAMEAPI_CDROM_NUMSLOTS 2
 
 typedef struct {
     PyObject_HEAD int id;
@@ -276,24 +255,20 @@ typedef struct {
 #ifndef PYGAMEAPI_CDROM_INTERNAL
 #define pgCD_Type      \
     (*(PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_CDROM_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(cdrom, 0))
 
 #define pgCD_Check(x) \
     ((x)->ob_type == &pgCD_Type)
 #define pgCD_New             \
     (*(PyObject * (*)(int))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_CDROM_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(cdrom, 1))
 
-#define import_pygame_cd() IMPORT_PYGAME_MODULE(cdrom, CDROM)
+#define import_pygame_cd() IMPORT_PYGAME_MODULE(cdrom)
 #endif
 
 /*
  * JOYSTICK module
  */
-#define PYGAMEAPI_JOYSTICK_FIRSTSLOT \
-    (PYGAMEAPI_CDROM_FIRSTSLOT + PYGAMEAPI_CDROM_NUMSLOTS)
-#define PYGAMEAPI_JOYSTICK_NUMSLOTS 2
-
 typedef struct {
     PyObject_HEAD int id;
 } pgJoystickObject;
@@ -303,15 +278,15 @@ typedef struct {
 #ifndef PYGAMEAPI_JOYSTICK_INTERNAL
 #define pgJoystick_Type \
     (*(PyTypeObject *)  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_JOYSTICK_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(joystick, 0))
 
 #define pgJoystick_Check(x) \
     ((x)->ob_type == &pgJoystick_Type)
 #define pgJoystick_New       \
     (*(PyObject * (*)(int))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_JOYSTICK_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(joystick, 1))
 
-#define import_pygame_joystick() IMPORT_PYGAME_MODULE(joystick, JOYSTICK)
+#define import_pygame_joystick() IMPORT_PYGAME_MODULE(joystick)
 #endif
 
 /*
@@ -350,14 +325,10 @@ typedef struct {
 #define pgVidInfo_AsVidInfo(x) (((pgVidInfoObject *)x)->info)
 #endif /* defined(SDL_VERSION_ATLEAST) */
 
-#define PYGAMEAPI_DISPLAY_FIRSTSLOT \
-    (PYGAMEAPI_JOYSTICK_FIRSTSLOT + PYGAMEAPI_JOYSTICK_NUMSLOTS)
-#define PYGAMEAPI_DISPLAY_NUMSLOTS 2
-
 #ifndef PYGAMEAPI_DISPLAY_INTERNAL
 #define pgVidInfo_Type \
     (*(PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_DISPLAY_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(display, 0))
 
 #define pgVidInfo_Check(x) \
     ((x)->ob_type == &pgVidInfo_Type)
@@ -365,14 +336,14 @@ typedef struct {
 #if PG_API_VERSION == 1
 #define pgVidInfo_New                   \
     (*(PyObject * (*)(SDL_VideoInfo *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_DISPLAY_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(display, 1))
 #else
 #define pgVidInfo_New                   \
     (*(PyObject * (*)(pg_VideoInfo *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_DISPLAY_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(display, 1))
 #endif
 
-#define import_pygame_display() IMPORT_PYGAME_MODULE(display, DISPLAY)
+#define import_pygame_display() IMPORT_PYGAME_MODULE(display)
 #endif /* ~PYGAMEAPI_DISPLAY_INTERNAL */
 
 /*
@@ -394,38 +365,34 @@ typedef struct {
 } pgSurfaceObject;
 #define pgSurface_AsSurface(x) (((pgSurfaceObject *)x)->surf)
 
-#define PYGAMEAPI_SURFACE_FIRSTSLOT \
-    (PYGAMEAPI_DISPLAY_FIRSTSLOT + PYGAMEAPI_DISPLAY_NUMSLOTS)
-#define PYGAMEAPI_SURFACE_NUMSLOTS 3
-
 #ifndef PYGAMEAPI_SURFACE_INTERNAL
 #define pgSurface_Type \
     (*(PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFACE_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(surface, 0))
 
 #define pgSurface_Check(x)    \
     (PyObject_IsInstance((x), (PyObject *) &pgSurface_Type))
 #if PG_API_VERSION == 1
 #define pgSurface_New                 \
     (*(PyObject * (*)(SDL_Surface *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFACE_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(surface, 1))
 
 #else /* PG_API_VERSION == 2 */
 #define pgSurface_New2                     \
     (*(PyObject * (*)(SDL_Surface *, int)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFACE_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(surface, 1))
 
 #endif /* PG_API_VERSION == 2 */
 #define pgSurface_Blit                                                  \
     (*(int (*)(PyObject *, PyObject *, GAME_Rect *, GAME_Rect *, int))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFACE_FIRSTSLOT + 2))
+        PYGAMEAPI_GET_SLOT(surface, 2))
 
-#define import_pygame_surface()                   \
-    do {                                          \
-        IMPORT_PYGAME_MODULE(surface, SURFACE);   \
-        if (PyErr_Occurred() != NULL)             \
-            break;                                \
-        IMPORT_PYGAME_MODULE(surflock, SURFLOCK); \
+#define import_pygame_surface()         \
+    do {                                \
+        IMPORT_PYGAME_MODULE(surface);  \
+        if (PyErr_Occurred() != NULL)   \
+            break;                      \
+        IMPORT_PYGAME_MODULE(surflock); \
     } while (0)
 
 #if PG_API_VERSION == 2
@@ -439,14 +406,10 @@ typedef struct {
  * SURFLOCK module
  * auto imported/initialized by surface
  */
-#define PYGAMEAPI_SURFLOCK_FIRSTSLOT \
-    (PYGAMEAPI_SURFACE_FIRSTSLOT + PYGAMEAPI_SURFACE_NUMSLOTS)
-#define PYGAMEAPI_SURFLOCK_NUMSLOTS 8
-
 #ifndef PYGAMEAPI_SURFLOCK_INTERNAL
 #define pgLifetimeLock_Type \
     (*(PyTypeObject *)      \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(surflock, 0))
 
 #define pgLifetimeLock_Check(x) \
     ((x)->ob_type == &pgLifetimeLock_Type)
@@ -454,198 +417,197 @@ typedef struct {
 #define pgSurface_Prep(x)                   \
     if (((pgSurfaceObject *)x)->subsurface) \
     (*(*(void (*)(PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 1)))(x)
+        PYGAMEAPI_GET_SLOT(surflock, 1)))(x)
 
 #define pgSurface_Unprep(x)                 \
     if (((pgSurfaceObject *)x)->subsurface) \
     (*(*(void (*)(PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 2)))(x)
+        PYGAMEAPI_GET_SLOT(surflock, 2)))(x)
 
 #define pgSurface_Lock \
     (*(int (*)(PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 3))
+        PYGAMEAPI_GET_SLOT(surflock, 3))
 
 #define pgSurface_Unlock \
     (*(int (*)(PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 4))
+        PYGAMEAPI_GET_SLOT(surflock, 4))
 
 #define pgSurface_LockBy   \
     (*(int (*)(PyObject *, PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 5))
+        PYGAMEAPI_GET_SLOT(surflock, 5))
 
 #define pgSurface_UnlockBy \
     (*(int (*)(PyObject *, PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 6))
+        PYGAMEAPI_GET_SLOT(surflock, 6))
 
 #define pgSurface_LockLifetime                 \
     (*(PyObject * (*)(PyObject *, PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_SURFLOCK_FIRSTSLOT + 7))
+        PYGAMEAPI_GET_SLOT(surflock, 7))
 #endif
 
 /*
  * EVENT module
  */
-#define PYGAMEAPI_EVENT_FIRSTSLOT \
-    (PYGAMEAPI_SURFLOCK_FIRSTSLOT + PYGAMEAPI_SURFLOCK_NUMSLOTS)
-#if PG_API_VERSION == 1
-#define PYGAMEAPI_EVENT_NUMSLOTS 4
-#else /* PG_API_VERSION == 2 */
-#define PYGAMEAPI_EVENT_NUMSLOTS 6
-#endif /* PG_API_VERSION == 2 */
-
 typedef struct pgEventObject pgEventObject;
 
 #ifndef PYGAMEAPI_EVENT_INTERNAL
 #define pgEvent_Type \
     (*(PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_EVENT_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(event, 0))
 
 #define pgEvent_Check(x) \
     ((x)->ob_type == &pgEvent_Type)
 
 #define pgEvent_New                 \
     (*(PyObject * (*)(SDL_Event *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_EVENT_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(event, 1))
 
 #define pgEvent_New2                    \
     (*(PyObject * (*)(int, PyObject *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_EVENT_FIRSTSLOT + 2))
+        PYGAMEAPI_GET_SLOT(event, 2))
 
 #define pgEvent_FillUserEvent   \
     (*(int (*)(pgEventObject *, SDL_Event *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_EVENT_FIRSTSLOT + 3))
+        PYGAMEAPI_GET_SLOT(event, 3))
 
 #if PG_API_VERSION == 2
 #define pg_EnableKeyRepeat \
     (*(int (*)(int, int)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_EVENT_FIRSTSLOT + 4))
+        PYGAMEAPI_GET_SLOT(event, 4))
 
 #define pg_GetKeyRepeat \
     (*(void (*)(int *, int *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_EVENT_FIRSTSLOT + 5))
+        PYGAMEAPI_GET_SLOT(event, 5))
 #endif /* PG_API_VERSION == 2 */
 
-#define import_pygame_event() IMPORT_PYGAME_MODULE(event, EVENT)
+#define import_pygame_event() IMPORT_PYGAME_MODULE(event)
 #endif
 
 /*
  * RWOBJECT module
  * the rwobject are only needed for C side work, not accessable from python.
  */
-#define PYGAMEAPI_RWOBJECT_FIRSTSLOT \
-    (PYGAMEAPI_EVENT_FIRSTSLOT + PYGAMEAPI_EVENT_NUMSLOTS)
-#define PYGAMEAPI_RWOBJECT_NUMSLOTS 6
 #ifndef PYGAMEAPI_RWOBJECT_INTERNAL
 #define pgRWops_FromObject           \
     (*(SDL_RWops * (*)(PyObject *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RWOBJECT_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(rwobject, 0))
 
 #define pgRWops_IsFileObject \
     (*(int (*)(SDL_RWops *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RWOBJECT_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(rwobject, 1))
 
 #define pg_EncodeFilePath                       \
     (*(PyObject * (*)(PyObject *, PyObject *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RWOBJECT_FIRSTSLOT + 2))
+        PYGAMEAPI_GET_SLOT(rwobject, 2))
 
 #define pg_EncodeString                                                     \
     (*(PyObject * (*)(PyObject *, const char *, const char *, PyObject *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RWOBJECT_FIRSTSLOT + 3))
+        PYGAMEAPI_GET_SLOT(rwobject, 3))
 
 #define pgRWops_FromFileObject       \
     (*(SDL_RWops * (*)(PyObject *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RWOBJECT_FIRSTSLOT + 4))
+        PYGAMEAPI_GET_SLOT(rwobject, 4))
 
 #define pgRWops_ReleaseObject       \
     (*(int (*)(SDL_RWops *))        \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_RWOBJECT_FIRSTSLOT + 5))
+        PYGAMEAPI_GET_SLOT(rwobject, 5))
 
-#define import_pygame_rwobject() IMPORT_PYGAME_MODULE(rwobject, RWOBJECT)
+#define import_pygame_rwobject() IMPORT_PYGAME_MODULE(rwobject)
 
 #endif
 
 /*
  * PixelArray module
  */
-#define PYGAMEAPI_PIXELARRAY_FIRSTSLOT \
-    (PYGAMEAPI_RWOBJECT_FIRSTSLOT + PYGAMEAPI_RWOBJECT_NUMSLOTS)
-#define PYGAMEAPI_PIXELARRAY_NUMSLOTS 2
 #ifndef PYGAMEAPI_PIXELARRAY_INTERNAL
 #define PyPixelArray_Type \
     ((PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_PIXELARRAY_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(pixelarray, 0))
 
 #define PyPixelArray_Check(x) \
     ((x)->ob_type == &PyPixelArray_Type)
 #define PyPixelArray_New \
     (*(PyObject * (*))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_PIXELARRAY_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(pixelarray, 1))
 
-#define import_pygame_pixelarray() IMPORT_PYGAME_MODULE(pixelarray, PIXELARRAY)
+#define import_pygame_pixelarray() IMPORT_PYGAME_MODULE(pixelarray)
 #endif /* PYGAMEAPI_PIXELARRAY_INTERNAL */
 
 /*
  * Color module
  */
-#define PYGAMEAPI_COLOR_FIRSTSLOT \
-    (PYGAMEAPI_PIXELARRAY_FIRSTSLOT + PYGAMEAPI_PIXELARRAY_NUMSLOTS)
-#define PYGAMEAPI_COLOR_NUMSLOTS 4
 #ifndef PYGAMEAPI_COLOR_INTERNAL
 #define pgColor_Type (*(PyObject *) \
-    PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_COLOR_FIRSTSLOT))
+    PYGAMEAPI_GET_SLOT(color, 0))
 
 #define pgColor_Check(x) \
     ((x)->ob_type == &pgColor_Type)
 #define pgColor_New \
     (*(PyObject * (*)(Uint8 *))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_COLOR_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(color, 1))
 
 #define pgColor_NewLength              \
     (*(PyObject * (*)(Uint8 *, Uint8)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_COLOR_FIRSTSLOT + 3))
+        PYGAMEAPI_GET_SLOT(color, 3))
 
 #define pg_RGBAFromColorObj \
     (*(int (*)(PyObject *, Uint8 *)) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_COLOR_FIRSTSLOT + 2))
+        PYGAMEAPI_GET_SLOT(color, 2))
 
-#define import_pygame_color() IMPORT_PYGAME_MODULE(color, COLOR)
+#define import_pygame_color() IMPORT_PYGAME_MODULE(color)
 #endif /* PYGAMEAPI_COLOR_INTERNAL */
 
 /*
  * Math module
  */
-#define PYGAMEAPI_MATH_FIRSTSLOT \
-    (PYGAMEAPI_COLOR_FIRSTSLOT + PYGAMEAPI_COLOR_NUMSLOTS)
-#define PYGAMEAPI_MATH_NUMSLOTS 2
 #ifndef PYGAMEAPI_MATH_INTERNAL
 #define pgVector2_Check(x) \
     ((x)->ob_type == (PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_MATH_FIRSTSLOT + 0))
+        PYGAMEAPI_GET_SLOT(math, 0))
 
 #define pgVector3_Check(x) \
     ((x)->ob_type == (PyTypeObject *) \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_MATH_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(math, 1))
 /*
 #define pgVector2_New                                             \
     (*(PyObject*(*))  \
-        PYGAMEAPI_GET_SLOT(PyGAME_C_API, PYGAMEAPI_MATH_FIRSTSLOT + 1))
+        PYGAMEAPI_GET_SLOT(PyGAME_C_API, 1))
 */
-#define import_pygame_math() IMPORT_PYGAME_MODULE(math, MATH)
+#define import_pygame_math() IMPORT_PYGAME_MODULE(math)
 #endif /* PYGAMEAPI_MATH_INTERNAL */
 
-#define IMPORT_PYGAME_MODULE(module, MODULE) \
-    _IMPORT_PYGAME_MODULE(module, MODULE, PyGAME_C_API)
-#define PYGAMEAPI_TOTALSLOTS \
-    (PYGAMEAPI_MATH_FIRSTSLOT + PYGAMEAPI_MATH_NUMSLOTS)
+#define IMPORT_PYGAME_MODULE _IMPORT_PYGAME_MODULE
 
 /*
  * base pygame API slots
  * disable slots with NO_PYGAME_C_API
  */
 #ifdef PYGAME_H
-PYGAMEAPI_DEFINE_SLOTS( PyGAME_C_API, PYGAMEAPI_TOTALSLOTS );
+PYGAMEAPI_DEFINE_SLOTS(base);
+PYGAMEAPI_DEFINE_SLOTS(rect);
+PYGAMEAPI_DEFINE_SLOTS(cdrom);
+PYGAMEAPI_DEFINE_SLOTS(joystick);
+PYGAMEAPI_DEFINE_SLOTS(display);
+PYGAMEAPI_DEFINE_SLOTS(surface);
+PYGAMEAPI_DEFINE_SLOTS(surflock);
+PYGAMEAPI_DEFINE_SLOTS(event);
+PYGAMEAPI_DEFINE_SLOTS(rwobject);
+PYGAMEAPI_DEFINE_SLOTS(pixelarray);
+PYGAMEAPI_DEFINE_SLOTS(color);
+PYGAMEAPI_DEFINE_SLOTS(math);
 #else /* ~PYGAME_H */
-PYGAMEAPI_EXTERN_SLOTS( PyGAME_C_API, PYGAMEAPI_TOTALSLOTS );
+PYGAMEAPI_EXTERN_SLOTS(base);
+PYGAMEAPI_EXTERN_SLOTS(rect);
+PYGAMEAPI_EXTERN_SLOTS(cdrom);
+PYGAMEAPI_EXTERN_SLOTS(joystick);
+PYGAMEAPI_EXTERN_SLOTS(display);
+PYGAMEAPI_EXTERN_SLOTS(surface);
+PYGAMEAPI_EXTERN_SLOTS(surflock);
+PYGAMEAPI_EXTERN_SLOTS(event);
+PYGAMEAPI_EXTERN_SLOTS(rwobject);
+PYGAMEAPI_EXTERN_SLOTS(pixelarray);
+PYGAMEAPI_EXTERN_SLOTS(color);
+PYGAMEAPI_EXTERN_SLOTS(math);
 #endif /* ~PYGAME_H */
 
 #endif /* PYGAME_H */

--- a/src_c/include/pgimport.h
+++ b/src_c/include/pgimport.h
@@ -19,20 +19,13 @@
 
 #include "pgcompat.h"
 
-#if PG_HAVE_CAPSULE
-#define encapsulate_api(ptr, module) \
-    PyCapsule_New(ptr, PG_CAPSULE_NAME(module), NULL)
-#else /* ~PG_HAVE_CAPSULE */
-#define encapsulate_api(ptr, module) PyCObject_FromVoidPtr(ptr, NULL)
-#endif /* ~PG_HAVE_CAPSULE */
-
 #define PYGAMEAPI_LOCAL_ENTRY "_PYGAME_C_API"
 #define PG_CAPSULE_NAME(m) (IMPPREFIX m "." PYGAMEAPI_LOCAL_ENTRY)
 
 /*
  * fill API slots defined by PYGAMEAPI_DEFINE_SLOTS/PYGAMEAPI_EXTERN_SLOTS
  */
-#define _IMPORT_PYGAME_MODULE(module, MODULE, api_root)                      \
+#define _IMPORT_PYGAME_MODULE(module)                                        \
     {                                                                        \
         PyObject *_module = PyImport_ImportModule(IMPPREFIX #module);        \
                                                                              \
@@ -44,29 +37,25 @@
             if (_c_api != NULL && PyCapsule_CheckExact(_c_api)) {            \
                 void **localptr = (void **)PyCapsule_GetPointer(             \
                     _c_api, PG_CAPSULE_NAME(#module));                       \
-                                                                             \
-                if (localptr != NULL) {                                      \
-                    memcpy(api_root + PYGAMEAPI_##MODULE##_FIRSTSLOT,        \
-                           localptr,                                         \
-                           sizeof(void **) * PYGAMEAPI_##MODULE##_NUMSLOTS); \
-                }                                                            \
+                _PGSLOTS_ ## module = localptr;                              \
             }                                                                \
             Py_XDECREF(_c_api);                                              \
         }                                                                    \
     }
 
+#define PYGAMEAPI_IS_IMPORTED(module) (_PGSLOTS_ ## module != NULL)
+
 /*
- * source file must include one of these in order to use _IMPORT_PYGAME_MODULE
- * this array is filled by import_pygame_*() functions
+ * source file must include one of these in order to use _IMPORT_PYGAME_MODULE.
+ * this is set by import_pygame_*() functions.
  * disable with NO_PYGAME_C_API
  */
-#define PYGAMEAPI_DEFINE_SLOTS(api_root, numslots) \
-    void *api_root[(numslots)] = {NULL}
-#define PYGAMEAPI_EXTERN_SLOTS(api_root, numslots) \
-    extern void *api_root[(numslots)]
-
-#define PYGAMEAPI_GET_SLOT(api_root, index) \
-    api_root[(index)]
+#define PYGAMEAPI_DEFINE_SLOTS(module) \
+    void ** _PGSLOTS_ ## module = NULL
+#define PYGAMEAPI_EXTERN_SLOTS(module) \
+    extern void **_PGSLOTS_ ## module
+#define PYGAMEAPI_GET_SLOT(module, index) \
+    _PGSLOTS_ ## module ## [(index)]
 
 /*
  * disabled API with NO_PYGAME_C_API; do nothing instead
@@ -76,15 +65,15 @@
 #undef PYGAMEAPI_DEFINE_SLOTS
 #undef PYGAMEAPI_EXTERN_SLOTS
 
-#define PYGAMEAPI_DEFINE_SLOTS(api_root, numslots)
-#define PYGAMEAPI_EXTERN_SLOTS(api_root, numslots)
+#define PYGAMEAPI_DEFINE_SLOTS(module)
+#define PYGAMEAPI_EXTERN_SLOTS(module)
 
 /* intentionally leave this defined to cause a compiler error *
 #define PYGAMEAPI_GET_SLOT(api_root, index)
 #undef PYGAMEAPI_GET_SLOT*/
 
 #undef _IMPORT_PYGAME_MODULE
-#define _IMPORT_PYGAME_MODULE(module, MODULE, api_root)
+#define _IMPORT_PYGAME_MODULE(module)
 
 #endif /* NO_PYGAME_C_API */
 

--- a/src_c/include/pgimport.h
+++ b/src_c/include/pgimport.h
@@ -55,7 +55,7 @@
 #define PYGAMEAPI_EXTERN_SLOTS(module) \
     extern void **_PGSLOTS_ ## module
 #define PYGAMEAPI_GET_SLOT(module, index) \
-    _PGSLOTS_ ## module ## [(index)]
+    _PGSLOTS_ ## module [(index)]
 
 /*
  * disabled API with NO_PYGAME_C_API; do nothing instead

--- a/src_c/include/pygame_bufferproxy.h
+++ b/src_c/include/pygame_bufferproxy.h
@@ -27,9 +27,6 @@
 
 #include <Python.h>
 
-#define PYGAMEAPI_BUFPROXY_NUMSLOTS 4
-#define PYGAMEAPI_BUFPROXY_FIRSTSLOT 0
-
 typedef PyObject *(*_pgbufproxy_new_t)(PyObject *, getbufferproc);
 typedef PyObject *(*_pgbufproxy_get_obj_t)(PyObject *);
 typedef int (*_pgbufproxy_trip_t)(PyObject *);
@@ -38,27 +35,24 @@ typedef int (*_pgbufproxy_trip_t)(PyObject *);
 
 #include "pgimport.h"
 
-PYGAMEAPI_DEFINE_SLOTS(PgBUFPROXY_C_API, PYGAMEAPI_BUFPROXY_NUMSLOTS);
-
-
+PYGAMEAPI_DEFINE_SLOTS(bufferproxy);
 
 #define pgBufproxy_Type (*(PyTypeObject*) \
-    PYGAMEAPI_GET_SLOT(PgBUFPROXY_C_API, 0) )
+    PYGAMEAPI_GET_SLOT(bufferproxy, 0) )
 
 #define pgBufproxy_Check(x) ((x)->ob_type == &pgBufproxy_Type)
 
 #define pgBufproxy_New (*(_pgbufproxy_new_t) \
-    PYGAMEAPI_GET_SLOT(PgBUFPROXY_C_API, 1))
+    PYGAMEAPI_GET_SLOT(bufferproxy, 1))
 
 #define pgBufproxy_GetParent \
     (*(_pgbufproxy_get_obj_t) \
-        PYGAMEAPI_GET_SLOT(PgBUFPROXY_C_API, 2))
+        PYGAMEAPI_GET_SLOT(bufferproxy, 2))
 
 #define pgBufproxy_Trip (*(_pgbufproxy_trip_t) \
-    PYGAMEAPI_GET_SLOT(PgBUFPROXY_C_API, 3))
+    PYGAMEAPI_GET_SLOT(bufferproxy, 3))
 
-#define import_pygame_bufferproxy() \
-    _IMPORT_PYGAME_MODULE(bufferproxy, BUFPROXY, PgBUFPROXY_C_API)
+#define import_pygame_bufferproxy() _IMPORT_PYGAME_MODULE(bufferproxy)
 
 #endif /* ~PYGAMEAPI_BUFPROXY_INTERNAL */
 

--- a/src_c/include/pygame_font.h
+++ b/src_c/include/pygame_font.h
@@ -23,9 +23,6 @@
 #include <Python.h>
 #include "pgplatform.h"
 
-#define PYGAMEAPI_FONT_FIRSTSLOT 0
-#define PYGAMEAPI_FONT_NUMSLOTS 3
-
 typedef struct TTF_Font;
 
 typedef struct {
@@ -39,19 +36,18 @@ typedef struct {
 
 #include "pgimport.h"
 
-PYGAMEAPI_DEFINE_SLOTS(PyFONT_C_API, PYGAMEAPI_FONT_NUMSLOTS);
+PYGAMEAPI_DEFINE_SLOTS(font);
 
 #define PyFont_Type (*(PyTypeObject*) \
-    PYGAMEAPI_GET_SLOT(PyFONT_C_API, 0))
+    PYGAMEAPI_GET_SLOT(font, 0))
 #define PyFont_Check(x) ((x)->ob_type == &PyFont_Type)
 
 #define PyFont_New (*(PyObject*(*)(TTF_Font*))\
-    PYGAMEAPI_GET_SLOT(PyFONT_C_API, 1))
+    PYGAMEAPI_GET_SLOT(font, 1))
 
 /*slot 2 taken by FONT_INIT_CHECK*/
 
-#define import_pygame_font() \
-    _IMPORT_PYGAME_MODULE(font, FONT, PyFONT_C_API)
+#define import_pygame_font() _IMPORT_PYGAME_MODULE(font)
 
 #endif
 

--- a/src_c/include/pygame_freetype.h
+++ b/src_c/include/pygame_freetype.h
@@ -24,23 +24,19 @@
 #include "pgimport.h"
 #include "pgcompat.h"
 
-#define PYGAMEAPI_FREETYPE_FIRSTSLOT 0
-#define PYGAMEAPI_FREETYPE_NUMSLOTS 2
-
 #ifndef PYGAME_FREETYPE_INTERNAL
 
-PYGAMEAPI_DEFINE_SLOTS(PgFREETYPE_C_API, PYGAMEAPI_FREETYPE_NUMSLOTS);
+PYGAMEAPI_DEFINE_SLOTS(_freetype);
 
 #define pgFont_Type (*(PyTypeObject*) \
-    PYGAMEAPI_GET_SLOT(PgFREETYPE_C_API, 0))
+    PYGAMEAPI_GET_SLOT(_freetype, 0))
 
 #define pgFont_Check(x) ((x)->ob_type == &pgFont_Type)
 
 #define pgFont_New (*(PyObject*(*)(const char*, long)) \
-    PYGAMEAPI_GET_SLOT(PgFREETYPE_C_API, 1))
+    PYGAMEAPI_GET_SLOT(_freetype, 1))
 
-#define import_pygame_freetype() \
-    _IMPORT_PYGAME_MODULE(freetype, FREETYPE, PgFREETYPE_C_API)
+#define import_pygame_freetype() _IMPORT_PYGAME_MODULE(_freetype)
 
 #endif /* PYGAME_FREETYPE_INTERNAL */
 

--- a/src_c/include/pygame_mask.h
+++ b/src_c/include/pygame_mask.h
@@ -22,9 +22,6 @@
 #include <Python.h>
 #include "bitmask.h"
 
-#define PYGAMEAPI_MASK_FIRSTSLOT 0
-#define PYGAMEAPI_MASK_NUMSLOTS 1
-
 typedef struct {
   PyObject_HEAD
   bitmask_t *mask;
@@ -36,14 +33,13 @@ typedef struct {
 
 #include "pgimport.h"
 
-PYGAMEAPI_DEFINE_SLOTS(PyMASK_C_API, PYGAMEAPI_MASK_NUMSLOTS);
+PYGAMEAPI_DEFINE_SLOTS(mask);
 
 #define pgMask_Type     (*(PyTypeObject*) \
-    PYGAMEAPI_GET_SLOT(PyMASK_C_API, 0))
+    PYGAMEAPI_GET_SLOT(mask, 0))
 #define pgMask_Check(x) ((x)->ob_type == &pgMask_Type)
 
-#define import_pygame_mask() \
-    _IMPORT_PYGAME_MODULE(mask, MASK, PyMASK_C_API)
+#define import_pygame_mask() _IMPORT_PYGAME_MODULE(mask)
 
 #endif /* ~PYGAMEAPI_MASK_INTERNAL */
 

--- a/src_c/include/pygame_mixer.h
+++ b/src_c/include/pygame_mixer.h
@@ -47,39 +47,35 @@ typedef struct {
 
 #include "pgimport.h"
 
-#define PYGAMEAPI_MIXER_FIRSTSLOT 0
-#define PYGAMEAPI_MIXER_NUMSLOTS 7
-
 #ifndef PYGAMEAPI_MIXER_INTERNAL
 
-PYGAMEAPI_DEFINE_SLOTS(pgMIXER_C_API, PYGAMEAPI_MIXER_NUMSLOTS);
+PYGAMEAPI_DEFINE_SLOTS(mixer);
 
 #define pgSound_Type (*(PyTypeObject*) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 0))
+    PYGAMEAPI_GET_SLOT(mixer, 0))
 
 #define pgSound_Check(x) ((x)->ob_type == &pgSound_Type)
 
 #define pgSound_New (*(PyObject*(*)(Mix_Chunk*)) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 1))
+    PYGAMEAPI_GET_SLOT(mixer, 1))
 
 #define pgSound_Play (*(PyObject*(*)(PyObject*, PyObject*)) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 2))
+    PYGAMEAPI_GET_SLOT(mixer, 2))
 
 #define pgChannel_Type (*(PyTypeObject*) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 3))
+    PYGAMEAPI_GET_SLOT(mixer, 3))
 #define pgChannel_Check(x) ((x)->ob_type == &pgChannel_Type)
 
 #define pgChannel_New (*(PyObject*(*)(int)) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 4))
+    PYGAMEAPI_GET_SLOT(mixer, 4))
 
 #define pgMixer_AutoInit (*(PyObject*(*)(PyObject*, PyObject*)) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 5))
+    PYGAMEAPI_GET_SLOT(mixer, 5))
 
 #define pgMixer_AutoQuit (*(void(*)(void)) \
-    PYGAMEAPI_GET_SLOT(pgMIXER_C_API, 6))
+    PYGAMEAPI_GET_SLOT(mixer, 6))
 
-#define import_pygame_mixer() \
-    _IMPORT_PYGAME_MODULE(mixer, MIXER, pgMIXER_C_API)
+#define import_pygame_mixer() _IMPORT_PYGAME_MODULE(mixer)
 
 #endif /* PYGAMEAPI_MIXER_INTERNAL */
 

--- a/src_c/mask.h
+++ b/src_c/mask.h
@@ -2,5 +2,6 @@
 #define PGMASK_INTERNAL_H
 
 #include "include/pygame_mask.h"
+#define PYGAMEAPI_MASK_NUMSLOTS 1
 
 #endif /* ~PGMASK_INTERNAL_H */

--- a/src_c/mixer.h
+++ b/src_c/mixer.h
@@ -8,6 +8,7 @@
     if(!SDL_WasInit(SDL_INIT_AUDIO)) \
         return RAISE(pgExc_SDLError, "mixer not initialized")
 
+#define PYGAMEAPI_MIXER_NUMSLOTS 7
 #include "include/pygame_mixer.h"
 
 #endif /* ~MIXER_INTERNAL_H */

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -417,8 +417,6 @@ MODINIT_DEFINE(mixer_music)
                                          NULL};
 #endif
 
-    pgMIXER_C_API[0] = pgMIXER_C_API[0]; /*clean an unused warning*/
-
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
     */

--- a/src_c/pgbufferproxy.h
+++ b/src_c/pgbufferproxy.h
@@ -1,1 +1,7 @@
+#ifndef PG_BUFPROXY_INTERNAL_H
+#define PG_BUFPROXY_INTERNAL_H
+
 #include "include/pygame_bufferproxy.h"
+#define PYGAMEAPI_BUFPROXY_NUMSLOTS 4
+
+#endif /* ~PG_BUFPROXY_INTERNAL_H */

--- a/src_c/pgimport.h
+++ b/src_c/pgimport.h
@@ -1,1 +1,13 @@
+#ifndef PGIMPORT_INTERNAL_H
+#define PGIMPORT_INTERNAL_H
+
 #include "include/pgimport.h"
+
+#if PG_HAVE_CAPSULE
+#define encapsulate_api(ptr, module) \
+    PyCapsule_New(ptr, PG_CAPSULE_NAME(module), NULL)
+#else /* ~PG_HAVE_CAPSULE */
+#define encapsulate_api(ptr, module) PyCObject_FromVoidPtr(ptr, NULL)
+#endif /* ~PG_HAVE_CAPSULE */
+
+#endif /* PGIMPORT_INTERNAL_H */

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -4053,7 +4053,7 @@ static PyMethodDef _surface_methods[] = {{NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(surface)
 {
-    PyObject *module, *dict, *apiobj, *lockmodule;
+    PyObject *module, *dict, *apiobj;
     int ecode;
     static void *c_api[PYGAMEAPI_SURFACE_NUMSLOTS];
 
@@ -4088,24 +4088,8 @@ MODINIT_DEFINE(surface)
     if (PyErr_Occurred()) {
         MODINIT_ERROR;
     }
-
-    /* import the surflock module manually */
-    lockmodule = PyImport_ImportModule(IMPPREFIX "surflock");
-    if (lockmodule != NULL) {
-        PyObject *_dict = PyModule_GetDict(lockmodule);
-        PyObject *_c_api = PyDict_GetItemString(_dict, PYGAMEAPI_LOCAL_ENTRY);
-
-        if (PyCapsule_CheckExact(_c_api)) {
-            int i;
-            void **localptr = (void *)PyCapsule_GetPointer(
-                _c_api, PG_CAPSULE_NAME("surflock"));
-
-            for (i = 0; i < PYGAMEAPI_SURFLOCK_NUMSLOTS; ++i)
-                PyGAME_C_API[i + PYGAMEAPI_SURFLOCK_FIRSTSLOT] = localptr[i];
-        }
-        Py_DECREF(lockmodule);
-    }
-    else {
+    _IMPORT_PYGAME_MODULE(surflock);
+    if (PyErr_Occurred()) {
         MODINIT_ERROR;
     }
 


### PR DESCRIPTION
Makes one of the changes mentioned earlier. Using a shared c_api[] array instead of copying it for each import.
* More readable headers.
* Uses slighly less memory. If there were about 10 slots on average per module and 30 modules, each slot taking up about 4 bytes (a void* pointer), it took up about 35 KB of memory. Now there is roughly one pointer to each other module and a single array for each, so it should use about 1/10 of that. Insignificant in practice, I guess.

The import_pygame_*() macros are backward compatible.

Error is due to #967