### PR TITLE
pygame.event.apost: async event posting, safe for main thread calling

### DIFF
--- a/src_c/doc/event_doc.h
+++ b/src_c/doc/event_doc.h
@@ -13,6 +13,9 @@
 #define DOC_PYGAMEEVENTSETGRAB "set_grab(bool) -> None\ncontrol the sharing of input devices with other applications"
 #define DOC_PYGAMEEVENTGETGRAB "get_grab() -> bool\ntest if the program is sharing input devices"
 #define DOC_PYGAMEEVENTPOST "post(Event) -> None\nplace a new event on the queue"
+
+#define DOC_PYGAMEEVENTAPOST "apost(Event) -> None\nplace a new event on the queue asynchronously (via SDL thread)"
+
 #define DOC_PYGAMEEVENTEVENT "Event(type, dict) -> EventType instance\nEvent(type, **attributes) -> EventType instance\ncreate a new event object"
 #define DOC_PYGAMEEVENTEVENTTYPE "pygame object for representing events"
 #define DOC_EVENTTYPETYPE "type -> int\nevent type identifier."
@@ -83,6 +86,10 @@ test if the program is sharing input devices
 
 pygame.event.post
  post(Event) -> None
+place a new event on the queue
+
+pygame.event.apost
+ apost(Event) -> None
 place a new event on the queue
 
 pygame.event.Event


### PR DESCRIPTION
Calling pygame.event.post from Python signal handlers (which execute in the main thread) was found to be unsafe (can deadlock). This solution, which is using serialized threads to push the events, was tested on the following buildroot python-pygame (buildroot's latest):

PYTHON_PYGAME_VERSION = d61ea8eabd56
PYTHON_PYGAME_SOURCE = pygame-$(PYTHON_PYGAME_VERSION).tar.gz
PYTHON_PYGAME_SITE = https://bitbucket.org/pygame/pygame
PYTHON_PYGAME_SITE_METHOD = hg

The patch was adapted to the latest pygame code in the hope that it would find someone to test it in a different environment.

Thanks, Enoch.