### PR TITLE
Add a draw.rect test

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1531,7 +1531,7 @@ class DrawRectMixin(object):
                   'rect'    : None,
                   'width'   : 0}
         rects = (pygame.Rect(pos, (1, 1)), (pos, (2, 2)),
-                 (pos[0], pos[1], 3, 3))
+                 (pos[0], pos[1], 3, 3), [pos, (2.1, 2.2)])
 
         for rect in rects:
             surface.fill(surface_color)  # Clear for each test.
@@ -1541,6 +1541,22 @@ class DrawRectMixin(object):
 
             self.assertEqual(surface.get_at(pos), expected_color)
             self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_rect__invalid_rect_formats(self):
+        """Ensures draw rect handles invalid rect formats correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 4)),
+                  'color'   : pygame.Color('red'),
+                  'rect'    : None,
+                  'width'   : 0}
+
+        invalid_fmts = ([], [1], [1, 2], [1, 2, 3], [1, 2, 3, 4, 5],
+                        set([1, 2, 3, 4]), [1, 2, 3, '4'])
+
+        for rect in invalid_fmts:
+            kwargs['rect'] = rect
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_rect(**kwargs)
 
     def test_rect__valid_color_formats(self):
         """Ensures draw rect accepts different color formats."""


### PR DESCRIPTION
Overview of changes:
- Added a `draw.rect` test to ensure invalid rect formats are handled correctly
- Changed a `draw.rect` test to check another valid rect format

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at 27a588c1f6c27e4784fea49ca49446c2de098862