### PR TITLE
Fix mixer cleanup and init

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -338,6 +338,17 @@ pgMixer_AutoQuit(void)
     }
 }
 
+static PyObject*
+import_music()
+{
+    PyObject *music = PyImport_ImportModule(IMPPREFIX "mixer_music");
+    if (music == NULL) {
+        PyErr_Clear();
+        music = PyImport_ImportModule(RELATIVE_MODULE("mixer_music"));
+    }
+    return music;
+}
+
 static PyObject *
 _init(int freq, int size, int channels, int chunk, char *devicename, int allowedchanges)
 {
@@ -458,6 +469,28 @@ _init(int freq, int size, int channels, int chunk, char *devicename, int allowed
 
         Mix_VolumeMusic(127);
     }
+
+    PyObject *music = import_music();
+    if (music != NULL) {
+        PyObject *ptr, *_dict;
+        _dict = PyModule_GetDict(music);
+        ptr = PyDict_GetItemString(_dict, "_MUSIC_POINTER");
+        current_music =
+            (Mix_Music **)PyCapsule_GetPointer(ptr,
+                                               "pygame.music_mixer."
+                                               "_MUSIC_POINTER");
+        ptr = PyDict_GetItemString(_dict, "_QUEUE_POINTER");
+        queue_music = (Mix_Music **)PyCapsule_GetPointer(ptr,
+                                                         "pygame.music_mixer."
+                                                         "_QUEUE_POINTER");
+        Py_DECREF(music);
+    }
+    else {
+        current_music = NULL;
+        queue_music = NULL;
+        PyErr_Clear();
+    }
+
     return PyInt_FromLong(1);
 }
 
@@ -1945,39 +1978,15 @@ MODINIT_DEFINE(mixer)
         MODINIT_ERROR;
     }
 
-    music = PyImport_ImportModule(IMPPREFIX "mixer_music");
-    if (music == NULL) {
-        PyErr_Clear();
-        /* try loading it under this name...
-         */
-        music = PyImport_ImportModule(RELATIVE_MODULE("mixer_music"));
-        /*printf("NOTE3: here in mixer.c...\n");
-         */
-    }
-
+    music = import_music();
     if (music != NULL) {
-        PyObject *ptr, *_dict;
-        /* printf("NOTE: failed loading pygame.mixer_music in src/mixer.c\n");
-         */
         if (PyModule_AddObject(module, "music", music) < 0) {
             DECREF_MOD(module);
             Py_DECREF(music);
             MODINIT_ERROR;
         }
-        _dict = PyModule_GetDict(music);
-        ptr = PyDict_GetItemString(_dict, "_MUSIC_POINTER");
-        current_music =
-            (Mix_Music **)PyCapsule_GetPointer(ptr,
-                                               "pygame.music_mixer."
-                                               "_MUSIC_POINTER");
-        ptr = PyDict_GetItemString(_dict, "_QUEUE_POINTER");
-        queue_music = (Mix_Music **)PyCapsule_GetPointer(ptr,
-                                                         "pygame.music_mixer."
-                                                         "_QUEUE_POINTER");
     }
-    else /*music module not compiled? cleanly ignore*/
-    {
-        current_music = NULL;
+    else {
         PyErr_Clear();
     }
     MODINIT_RETURN(module);

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -255,5 +255,21 @@ class MixerMusicModuleTest(unittest.TestCase):
 
         self.fail()
 
+    def test_init(self):
+        """issue #955. unload music whenever mixer.quit() is called"""
+        import tempfile
+        import shutil
+        testfile = example_path(os.path.join('data', 'house_lo.wav'))
+        tempcopy = os.path.join(tempfile.gettempdir(), 'tempfile.wav')
+
+        for i in range(10):
+            pygame.mixer.init()
+            try:
+                shutil.copy2(testfile, tempcopy)
+                pygame.mixer.music.load(tempcopy)
+                pygame.mixer.quit()
+            finally:
+                os.remove(tempcopy)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Close #955. Obtain `current_music` and `queue_music` every time mixer.init() is called instead of only when the module is initialized, or else mixer.quit() would only unload music the first time it was called.