### PR TITLE
Add keyword arguments to draw.polygon

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -91,14 +91,46 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
 .. function:: polygon
 
-   | :sl:`draw a shape with any number of sides`
-   | :sg:`polygon(Surface, color, pointlist, width=0) -> Rect`
+   | :sl:`draw a polygon`
+   | :sg:`polygon(surface=Surface, color=Color, points=points) -> Rect`
+   | :sg:`polygon(surface=Surface, color=Color, points=points, width=0) -> Rect`
 
-   Draws a polygonal shape on the Surface. The pointlist argument is the
-   vertices of the polygon. The width argument is the thickness to draw the
-   outer edge. If width is zero then the polygon will be filled.
+   Draws a polygon on the given surface.
 
-   For aapolygon, use aalines with the 'closed' parameter.
+   :param Surface surface: surface to draw on
+   :param color: color to draw with, the alpha value is optional if using a
+      tuple ``(RGB[A])``
+   :type color: Color or int or tuple(int, int, int, [int])
+   :param points: a sequence of 3 or more points that make up the vertices of
+      the polygon
+   :type points: tuple(int, int) or list(int, int)
+   :param int width: (optional) used for line thickness or to indicate that
+      the polygon is to be filled
+
+         | if width == 0, (default) fill the polygon
+         | if width > 0, used for line thickness
+         | if width < 0, nothing will be drawn
+         |
+
+         .. note::
+            When using ``width`` values ``> 1``, the edge lines will grow
+            outside the original boundary of the polygon. For more details on
+            how the thickness for edge lines grow, refer to the ``width`` notes
+            for :func:`rect`.
+
+   :returns: a rect bounding the changed pixels, if nothing is drawn the
+      bounding rect's position will be the position of the first point in the
+      ``points`` parameter and its width and height will be 0
+   :rtype: Rect
+
+   :raises ValueError: if ``len(points) < 3`` (must have at least 3 points)
+   :raises TypeError: if ``points`` is not a sequence or ``points`` does not
+      contain number pairs
+
+   .. note::
+       For an aapolygon, use :func:`aalines()` with ``closed=True``.
+
+   .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.polygon ##
 

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -92,8 +92,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 .. function:: polygon
 
    | :sl:`draw a polygon`
-   | :sg:`polygon(surface=Surface, color=Color, points=points) -> Rect`
-   | :sg:`polygon(surface=Surface, color=Color, points=points, width=0) -> Rect`
+   | :sg:`polygon(surface, color, points) -> Rect`
+   | :sg:`polygon(surface, color, points, width=0) -> Rect`
 
    Draws a polygon on the given surface.
 
@@ -102,8 +102,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       tuple ``(RGB[A])``
    :type color: Color or int or tuple(int, int, int, [int])
    :param points: a sequence of 3 or more points that make up the vertices of
-      the polygon
-   :type points: tuple(int, int) or list(int, int)
+      the polygon, each point/vertex must be a tuple/list of 2 numbers
+   :type points: tuple or list
    :param int width: (optional) used for line thickness or to indicate that
       the polygon is to be filled
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
 #define DOC_PYGAMEDRAWRECT "rect(surface=Surface, color=Color, rect=Rect) -> Rect\nrect(surface=Surface, color=Color, rect=Rect, width=0) -> Rect\ndraw a rectangle"
-#define DOC_PYGAMEDRAWPOLYGON "polygon(surface=Surface, color=Color, points=points) -> Rect\npolygon(surface=Surface, color=Color, points=points, width=0) -> Rect\ndraw a polygon"
+#define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface=Surface, color=Color, center=(x, y), radius=radius) -> Rect\ncircle(surface=Surface, color=Color, center=(x, y), radius=radius, width=0) -> Rect\ndraw a circle"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(Surface, color, Rect, width=0) -> Rect\ndraw a round shape inside a rectangle"
 #define DOC_PYGAMEDRAWARC "arc(Surface, color, Rect, start_angle, stop_angle, width=1) -> Rect\ndraw a partial section of an ellipse"
@@ -24,8 +24,8 @@ pygame.draw.rect
 draw a rectangle
 
 pygame.draw.polygon
- polygon(surface=Surface, color=Color, points=points) -> Rect
- polygon(surface=Surface, color=Color, points=points, width=0) -> Rect
+ polygon(surface, color, points) -> Rect
+ polygon(surface, color, points, width=0) -> Rect
 draw a polygon
 
 pygame.draw.circle

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
 #define DOC_PYGAMEDRAWRECT "rect(surface=Surface, color=Color, rect=Rect) -> Rect\nrect(surface=Surface, color=Color, rect=Rect, width=0) -> Rect\ndraw a rectangle"
-#define DOC_PYGAMEDRAWPOLYGON "polygon(Surface, color, pointlist, width=0) -> Rect\ndraw a shape with any number of sides"
+#define DOC_PYGAMEDRAWPOLYGON "polygon(surface=Surface, color=Color, points=points) -> Rect\npolygon(surface=Surface, color=Color, points=points, width=0) -> Rect\ndraw a polygon"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface=Surface, color=Color, center=(x, y), radius=radius) -> Rect\ncircle(surface=Surface, color=Color, center=(x, y), radius=radius, width=0) -> Rect\ndraw a circle"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(Surface, color, Rect, width=0) -> Rect\ndraw a round shape inside a rectangle"
 #define DOC_PYGAMEDRAWARC "arc(Surface, color, Rect, start_angle, stop_angle, width=1) -> Rect\ndraw a partial section of an ellipse"
@@ -24,8 +24,9 @@ pygame.draw.rect
 draw a rectangle
 
 pygame.draw.polygon
- polygon(Surface, color, pointlist, width=0) -> Rect
-draw a shape with any number of sides
+ polygon(surface=Surface, color=Color, points=points) -> Rect
+ polygon(surface=Surface, color=Color, points=points, width=0) -> Rect
+draw a polygon
 
 pygame.draw.circle
  circle(surface=Surface, color=Color, center=(x, y), radius=radius) -> Rect

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -577,26 +577,34 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-polygon(PyObject *self, PyObject *arg)
+polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj, *colorobj, *points, *item;
-    SDL_Surface *surf;
+    PyObject *surfobj = NULL, *colorobj = NULL, *points = NULL, *item = NULL;
+    SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
-    int width = 0, length, loop;
-    int *xlist, *ylist;
-    int x, y, top, left, bottom, right, result;
+    int *xlist = NULL, *ylist = NULL;
+    int width = 0; /* Default width. */
+    int top = INT_MAX, left = INT_MAX;
+    int bottom = INT_MIN, right = INT_MIN;
+    int x, y, result, length, loop;
+    static char *keywords[] = {"surface", "color", "points", "width", NULL};
 
-    /*get all the arguments*/
-    if (!PyArg_ParseTuple(arg, "O!OO|i", &pgSurface_Type, &surfobj, &colorobj,
-                          &points, &width))
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OO|i", keywords,
+                                     &pgSurface_Type, &surfobj, &colorobj,
+                                     &points, &width)) {
+        return NULL; /* Exception already set. */
+    }
 
     if (width) {
-        PyObject *args, *ret;
-        args = Py_BuildValue("(OOiOi)", surfobj, colorobj, 1, points, width);
-        if (!args)
-            return NULL;
+        PyObject *ret = NULL;
+        PyObject *args =
+            Py_BuildValue("(OOiOi)", surfobj, colorobj, 1, points, width);
+
+        if (!args) {
+            return NULL; /* Exception already set. */
+        }
+
         ret = lines(NULL, args);
         Py_DECREF(args);
         return ret;
@@ -604,21 +612,25 @@ polygon(PyObject *self, PyObject *arg)
 
     surf = pgSurface_AsSurface(surfobj);
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
-        return RAISE(PyExc_ValueError, "unsupport bit depth for line draw");
+    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+        return PyErr_Format(PyExc_ValueError,
+                            "unsupported surface bit depth (%d) for drawing",
+                            surf->format->BytesPerPixel);
+    }
 
     CHECK_LOAD_COLOR(colorobj)
 
-    if (!PySequence_Check(points))
+    if (!PySequence_Check(points)) {
         return RAISE(PyExc_TypeError,
                      "points argument must be a sequence of number pairs");
+    }
+
     length = PySequence_Length(points);
-    if (length < 3)
+
+    if (length < 3) {
         return RAISE(PyExc_ValueError,
                      "points argument must contain more than 2 points");
-
-    left = top = 10000;
-    right = bottom = -10000;
+    }
 
     xlist = PyMem_New(int, length);
     ylist = PyMem_New(int, length);
@@ -627,11 +639,13 @@ polygon(PyObject *self, PyObject *arg)
         item = PySequence_GetItem(points, loop);
         result = pg_TwoIntsFromObj(item, &x, &y);
         Py_DECREF(item);
+
         if (!result) {
             PyMem_Del(xlist);
             PyMem_Del(ylist);
             return RAISE(PyExc_TypeError, "points must be number pairs");
         }
+
         xlist[loop] = x;
         ylist[loop] = y;
         left = MIN(x, left);
@@ -643,15 +657,16 @@ polygon(PyObject *self, PyObject *arg)
     if (!pgSurface_Lock(surfobj)) {
         PyMem_Del(xlist);
         PyMem_Del(ylist);
-        return NULL;
+        return RAISE(PyExc_RuntimeError, "error locking surface");
     }
 
     draw_fillpoly(surf, xlist, ylist, length, color);
-
     PyMem_Del(xlist);
     PyMem_Del(ylist);
-    if (!pgSurface_Unlock(surfobj))
-        return NULL;
+
+    if (!pgSurface_Unlock(surfobj)) {
+        return RAISE(PyExc_RuntimeError, "error unlocking surface");
+    }
 
     left = MAX(left, surf->clip_rect.x);
     top = MAX(top, surf->clip_rect.y);
@@ -691,7 +706,7 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL; /* Exception already set. */
     }
 
-    ret = polygon(NULL, poly_args);
+    ret = polygon(NULL, poly_args, NULL);
     Py_DECREF(poly_args);
     return ret;
 }
@@ -1807,7 +1822,8 @@ static PyMethodDef _draw_methods[] = {
     {"arc", arc, METH_VARARGS, DOC_PYGAMEDRAWARC},
     {"circle", (PyCFunction)circle, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDRAWCIRCLE},
-    {"polygon", polygon, METH_VARARGS, DOC_PYGAMEDRAWPOLYGON},
+    {"polygon", (PyCFunction)polygon, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEDRAWPOLYGON},
     {"rect", (PyCFunction)rect, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDRAWRECT},
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1183,6 +1183,305 @@ class DrawPolygonMixin(object):
     def setUp(self):
         self.surface = pygame.Surface((20, 20))
 
+    def test_polygon__args(self):
+        """Ensures draw polygon accepts the correct args."""
+        bounds_rect = self.draw_polygon(pygame.Surface((3, 3)), (0, 10, 0, 50),
+                                        ((0, 0), (1, 1), (2, 2)), 1)
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__args_without_width(self):
+        """Ensures draw polygon accepts the args without a width."""
+        bounds_rect = self.draw_polygon(pygame.Surface((2, 2)), (0, 0, 0, 50),
+                                       ((0, 0), (1, 1), (2, 2)))
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__kwargs(self):
+        """Ensures draw polygon accepts the correct kwargs
+        with and without a width arg.
+        """
+        surface = pygame.Surface((4, 4))
+        color = pygame.Color('yellow')
+        points = ((0, 0), (1, 1), (2, 2))
+        kwargs_list = [{'surface' : surface,
+                        'color'   : color,
+                        'points'  : points,
+                        'width'   : 1},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'points'  : points}]
+
+        for kwargs in kwargs_list:
+            bounds_rect = self.draw_polygon(**kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__kwargs_order_independent(self):
+        """Ensures draw polygon's kwargs are not order dependent."""
+        bounds_rect = self.draw_polygon(color=(10, 20, 30),
+                                        surface=pygame.Surface((3, 2)),
+                                        width=0,
+                                        points=((0, 1), (1, 2), (2, 3)))
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__args_missing(self):
+        """Ensures draw polygon detects any missing required args."""
+        surface = pygame.Surface((1, 1))
+        color = pygame.Color('blue')
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_polygon(surface, color)
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_polygon(surface)
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_polygon()
+
+    def test_polygon__kwargs_missing(self):
+        """Ensures draw polygon detects any missing required kwargs."""
+        kwargs = {'surface' : pygame.Surface((1, 2)),
+                  'color'   : pygame.Color('red'),
+                  'points'  : ((2, 1), (2, 2), (2, 3)),
+                  'width'   : 1}
+
+        for name in ('points', 'color', 'surface'):
+            invalid_kwargs = dict(kwargs)
+            invalid_kwargs.pop(name)  # Pop from a copy.
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_polygon(**invalid_kwargs)
+
+    def test_polygon__arg_invalid_types(self):
+        """Ensures draw polygon detects invalid arg types."""
+        surface = pygame.Surface((2, 2))
+        color = pygame.Color('blue')
+        points = ((0, 1), (1, 2), (1, 3))
+
+        with self.assertRaises(TypeError):
+            # Invalid width.
+            bounds_rect = self.draw_polygon(surface, color, points, '1')
+
+        with self.assertRaises(TypeError):
+            # Invalid points.
+            bounds_rect = self.draw_polygon(surface, color, (1, 2, 3))
+
+        with self.assertRaises(TypeError):
+            # Invalid color.
+            bounds_rect = self.draw_polygon(surface, 'blue', points)
+
+        with self.assertRaises(TypeError):
+            # Invalid surface.
+            bounds_rect = self.draw_polygon((1, 2, 3, 4), color, points)
+
+    def test_polygon__kwarg_invalid_types(self):
+        """Ensures draw polygon detects invalid kwarg types."""
+        surface = pygame.Surface((3, 3))
+        color = pygame.Color('green')
+        points = ((0, 0), (1, 0), (2, 0))
+        width = 1
+        kwargs_list = [{'surface' : pygame.Surface,  # Invalid surface.
+                        'color'   : color,
+                        'points'  : points,
+                        'width'   : width},
+
+                       {'surface' : surface,
+                        'color'   : 'green',  # Invalid color.
+                        'points'  : points,
+                        'width'   : width},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'points'  : ((1,), (1,), (1,)),  # Invalid points.
+                        'width'   : width},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'points'  : points,
+                        'width'   : 1.2}]  # Invalid width.
+
+        for kwargs in kwargs_list:
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_polygon(**kwargs)
+
+    def test_polygon__kwarg_invalid_name(self):
+        """Ensures draw polygon detects invalid kwarg names."""
+        surface = pygame.Surface((2, 3))
+        color = pygame.Color('cyan')
+        points = ((1, 1), (1, 2), (1, 3))
+        kwargs_list = [{'surface' : surface,
+                        'color'   : color,
+                        'points'  : points,
+                        'width'   : 1,
+                        'invalid' : 1},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'points'  : points,
+                        'invalid' : 1}]
+
+        for kwargs in kwargs_list:
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_polygon(**kwargs)
+
+    def test_polygon__args_and_kwargs(self):
+        """Ensures draw polygon accepts a combination of args/kwargs"""
+        surface = pygame.Surface((3, 1))
+        color = (255, 255, 0, 0)
+        points = ((0, 1), (1, 2), (2, 3))
+        width = 0
+        kwargs = {'surface' : surface,
+                  'color'   : color,
+                  'points'  : points,
+                  'width'   : width}
+
+        for name in ('surface', 'color', 'points', 'width'):
+            kwargs.pop(name)
+
+            if 'surface' == name:
+                bounds_rect = self.draw_polygon(surface, **kwargs)
+            elif 'color' == name:
+                bounds_rect = self.draw_polygon(surface, color, **kwargs)
+            elif 'points' == name:
+                bounds_rect = self.draw_polygon(surface, color, points,
+                                                **kwargs)
+            else:
+                bounds_rect = self.draw_polygon(surface, color, points, width,
+                                                **kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__valid_width_values(self):
+        """Ensures draw polygon accepts different width values."""
+        surface_color = pygame.Color('white')
+        surface = pygame.Surface((3, 4))
+        color = (10, 20, 30, 255)
+        kwargs = {'surface' : surface,
+                  'color'   : color,
+                  'points'  : ((1, 1), (2, 1), (2, 2), (1, 2)),
+                  'width'   : None}
+        pos = kwargs['points'][0]
+
+        for width in (-100, -10, -1, 0, 1, 10, 100):
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['width'] = width
+            expected_color = color if width >= 0 else surface_color
+
+            bounds_rect = self.draw_polygon(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__valid_points_format(self):
+        """Ensures draw polygon accepts different points formats."""
+        expected_color = (10, 20, 30, 255)
+        surface_color = pygame.Color('white')
+        surface = pygame.Surface((3, 4))
+        kwargs = {'surface' : surface,
+                  'color'   : expected_color,
+                  'points'  : None,
+                  'width'   : 0}
+
+        points_fmts = (((1, 1), (2, 1), (2, 2), (1, 2)),
+                       ([1, 1], [2, 1], [2, 2], [1, 2]),
+                       ([1, 1], (2, 1), [2, 2], (1, 2)),
+                       ([1, 1], (2.2, 1), [2.2, 2.2], (1, 2.1)))
+
+        for points in points_fmts:
+            for seq_type in (tuple, list):  # Test as tuples and lists.
+                surface.fill(surface_color)  # Clear for each test.
+                pos = points[0]
+                kwargs['points'] = seq_type(points)
+
+                bounds_rect = self.draw_polygon(**kwargs)
+
+                self.assertEqual(surface.get_at(pos), expected_color)
+                self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__invalid_points_formats(self):
+        """Ensures draw polygon handles invalid points formats correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 4)),
+                  'color'   : pygame.Color('red'),
+                  'points'  : None,
+                  'width'   : 0}
+
+        points_fmts = (((1, 1), (2, 1), (2,)),      # Too few coords.
+                       ((1, 1), (2, 1), (2, 2, 2)), # Too many coords.
+                       ((1, 1), (2, 1), (2, '2')),    # Wrong type.
+                       ((1, 1), (2, 1), set([2, 3])), # Wrong type.
+                       ((1, 1), (2, 1), dict(((2, 2), (3, 3)))), # Wrong type.
+                       set(((1, 1), (2, 1), (2, 2), (1, 2))),    # Wrong type.
+                       dict(((1, 1), (2, 2), (3, 3), (4, 4))))   # Wrong type.
+
+        for points in points_fmts:
+            kwargs['points'] = points
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_polygon(**kwargs)
+
+    def test_polygon__invalid_points_values(self):
+        """Ensures draw polygon handles invalid points values correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 4)),
+                  'color'   : pygame.Color('red'),
+                  'points'  : None,
+                  'width'   : 0}
+
+        points_fmts = (tuple(),          # Too few points.
+                       ((1, 1),),        # Too few points.
+                       ((1, 1), (2, 1))) # Too few points.
+
+        for points in points_fmts:
+            for seq_type in (tuple, list):  # Test as tuples and lists.
+                kwargs['points'] = seq_type(points)
+
+                with self.assertRaises(ValueError):
+                    bounds_rect = self.draw_polygon(**kwargs)
+
+    def test_polygon__valid_color_formats(self):
+        """Ensures draw polygon accepts different color formats."""
+        green_color = pygame.Color('green')
+        surface_color = pygame.Color('black')
+        surface = pygame.Surface((3, 4))
+        kwargs = {'surface' : surface,
+                  'color'   : None,
+                  'points'  : ((1, 1), (2, 1), (2, 2), (1, 2)),
+                  'width'   : 0}
+        pos = kwargs['points'][0]
+        greens = ((0, 255, 0), (0, 255, 0, 255), surface.map_rgb(green_color),
+                  green_color)
+
+        for color in greens:
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['color'] = color
+
+            if isinstance(color, int):
+                expected_color = surface.unmap_rgb(color)
+            else:
+                expected_color = green_color
+
+            bounds_rect = self.draw_polygon(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_polygon__invalid_color_formats(self):
+        """Ensures draw polygon handles invalid color formats correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 3)),
+                  'color'   : None,
+                  'points'  : ((1, 1), (2, 1), (2, 2), (1, 2)),
+                  'width'   : 0}
+
+        # These color formats are currently not supported (it would be
+        # nice to eventually support them).
+        for expected_color in ('green', '#00FF00FF', '0x00FF00FF'):
+            kwargs['color'] = expected_color
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_polygon(**kwargs)
+
     def test_draw_square(self):
         self.draw_polygon(self.surface, RED, SQUARE, 0)
         # note : there is a discussion (#234) if draw.polygon should include or
@@ -1319,6 +1618,7 @@ class DrawPolygonTest(DrawPolygonMixin, DrawTestCase):
     """
 
 
+@unittest.skip('draw_py.draw_rect not fully supported yet')
 class PythonDrawPolygonTest(DrawPolygonMixin, PythonDrawTestCase):
     """Test draw_py module function draw_polygon.
 
@@ -1615,7 +1915,7 @@ class DrawCircleMixin(object):
     def test_circle__args(self):
         """Ensures draw circle accepts the correct args."""
         bounds_rect = self.draw_circle(pygame.Surface((3, 3)), (0, 10, 0, 50),
-                                                      (0, 0), 3, 1)
+                                       (0, 0), 3, 1)
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 


### PR DESCRIPTION
Overview of changes:
- Added keyword arguments to `draw.polygon`
- Added/updated some exception messages for `draw.polygon`
- Added tests to check `draw.polygon` args/kwargs
- Updated draw documentation
- Added a `unittest.skip` decorator to the `PythonDrawPolygonTest` class

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at 27a588c1f6c27e4784fea49ca49446c2de098862

Resolves sub-item `pygame.draw.polygon` of item "Add keyword arguments to the draw functions..." of #896.