### PR TITLE
[DOC]Changing buffersize to buffer

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -106,7 +106,7 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
 .. function:: pre_init
 
    | :sl:`preset the mixer init arguments`
-   | :sg:`pre_init(frequency=22050, size=-16, channels=2, buffersize=4096, devicename=None) -> None`
+   | :sg:`pre_init(frequency=22050, size=-16, channels=2, buffer=4096, devicename=None) -> None`
 
    Call pre_init to change the defaults used when the real
    ``pygame.mixer.init()`` is called. Keyword arguments are accepted. The best


### PR DESCRIPTION
Quoting [Ian Mallett's comment](https://www.pygame.org/docs/ref/mixer.html#comment_pygame_mixer_pre_init).

    Should be "buffer", not "buffersize"

Not sure to which branch I should PR, let me know if this is the right one.