### PR TITLE
Fix range check and example for _sdl2.video

### DIFF
--- a/examples/video.py
+++ b/examples/video.py
@@ -11,7 +11,7 @@ data_dir = os.path.join(os.path.split(os.path.abspath(__file__))[0],
 from pygame._sdl2 import (
     Window,
     Texture,
-    SubTexture,
+    Image,
     Renderer,
     get_drivers,
     messagebox,
@@ -60,7 +60,7 @@ del tex2
 
 full = 0
 
-tex = SubTexture(tex, (0, 0, tex.width, tex.height))
+tex = Image(tex, (0, 0, tex.width, tex.height))
 
 while running:
     for event in pygame.event.get():
@@ -93,7 +93,7 @@ while running:
                 renderer.draw_color = backgrounds[bg_index]
 
     renderer.clear()
-    tex.draw(dstrect=(x, y, tex.width, tex.height))
+    tex.draw(dstrect=(x, y))
     renderer.present()
 
     clock.tick(60)

--- a/src_c/_sdl2/video.pyx
+++ b/src_c/_sdl2/video.pyx
@@ -713,11 +713,10 @@ cdef class Image:
         if srcrect is not None:
             if pgRect_FromObject(srcrect, &temp) == NULL:
                 raise error('srcrect must be None or a rectangle')
-            if temp.x < 0 or temp.x >= self.srcrect.w or \
-                temp.y < 0 or temp.y >= self.srcrect.h or \
+            if temp.x < 0 or temp.y < 0 or \
                 temp.w < 0 or temp.h < 0 or \
-                temp.x + temp.w >= self.srcrect.w or \
-                temp.y + temp.h >= self.srcrect.h:
+                temp.x + temp.w > self.srcrect.w or \
+                temp.y + temp.h > self.srcrect.h:
                 raise ValueError('rect values are out of range')
             temp.x += self.srcrect.x
             temp.y += self.srcrect.y


### PR DESCRIPTION
* Fix video example
* Fix range check for `srcrect` in the constructor of Image