### PR TITLE
pg_SetDefaultWindowSurface() would not destroy owned surfaces

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1931,7 +1931,6 @@ pg_SetDefaultWindowSurface(PyObject *screen)
     }
     Py_XINCREF(screen);
     if (pg_default_screen) {
-        pgSurface_AsSurface(pg_default_screen) = NULL;
         Py_DECREF(pg_default_screen);
     }
     pg_default_screen = screen;


### PR DESCRIPTION
If pg_default_screen owned its surface, this would not destroy it (the 'fake' surface created for GL windows):
```c
static void
pg_SetDefaultWindowSurface(PyObject *screen)
{
    /*a screen surface can be replaced with itself*/
    if (screen == pg_default_screen) {
        return;
    }
    Py_XINCREF(screen);
    if (pg_default_screen) {
        pgSurface_AsSurface(pg_default_screen) = NULL;
        Py_DECREF(pg_default_screen);
    }
    pg_default_screen = screen;
}
```
I'm not sure if there was a reason for setting the SDL_Surface pointer to NULL?