### PR TITLE
Fix SCALED for existing windows and improve test

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -486,4 +486,16 @@ required).
 
    .. ## pygame.display.get_num_displays ##
 
+.. function:: get_window_size
+
+   | :sl:`Return the size of the window or screen`
+   | :sg:`get_window_size() -> tuple`
+
+   Returns the size of the window initialized with :func:`pygame.set_mode()`.
+   This may differ from the size of the display surface if ``SCALED`` is used.
+
+   .. versionadded:: 2.0
+
+   .. ## pygame.display.get_window_size ##
+
 .. ## pygame.display ##

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -881,7 +881,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
             if (flags & PGS_SCALED && !(flags & PGS_FULLSCREEN)) {
                 SDL_DisplayMode dm;
                 int xscale, yscale;
-                if (SDL_GetCurrentDisplayMode(0, &dm) != 0) {
+                if (SDL_GetDesktopDisplayMode(display, &dm) != 0) {
                     return RAISE(pgExc_SDLError, SDL_GetError());
                 }
                 xscale = dm.w / w;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1356,8 +1356,8 @@ pg_window_size(PyObject *self, PyObject *args)
         return RAISE(pgExc_SDLError, "No open window");
     }
     return Py_BuildValue("(ii)",
-        pgDisplaySurfaceObject->w,
-        pgDisplaySurfaceObject->h);
+        pgSurface_AsSurface(pgDisplaySurfaceObject)->w,
+        pgSurface_AsSurface(pgDisplaySurfaceObject)->h);
 }
 
 /* SDL1 mode_ok. Note, there is a separate SDL2 version of this. */

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -887,6 +887,8 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                 xscale = dm.w / w;
                 yscale = dm.h / h;
                 scale = xscale < yscale ? xscale : yscale;
+                if (scale < 1)
+                    scale = 1;
             }
             w_1 = w * scale;
             h_1 = h * scale;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -2126,7 +2126,7 @@ static PyMethodDef _pg_display_methods[] = {
     {"get_wm_info", pg_get_wm_info, METH_NOARGS, DOC_PYGAMEDISPLAYGETWMINFO},
     {"Info", pgInfo, METH_NOARGS, DOC_PYGAMEDISPLAYINFO},
     {"get_surface", pg_get_surface, METH_NOARGS, DOC_PYGAMEDISPLAYGETSURFACE},
-    {"get_window_size", pg_window_size, METH_NOARGS, NULL}, /* TODO: add docs */
+    {"get_window_size", pg_window_size, METH_NOARGS, DOC_PYGAMEDISPLAYGETWINDOWSIZE},
 
     {"set_mode", (PyCFunction)pg_set_mode, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYSETMODE},
     {"mode_ok", (PyCFunction)pg_mode_ok, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYMODEOK},

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1071,6 +1071,17 @@ _pg_get_default_display_masks(int bpp,
 }
 
 static PyObject *
+pg_window_size(PyObject *self, PyObject *args)
+{
+    SDL_Window *win = pg_GetDefaultWindow();
+    int w, h;
+    if (!win)
+        return RAISE(pgExc_SDLError, "No open window");
+    SDL_GetWindowSize(win, &w, &h);
+    return Py_BuildValue("(ii)", w, h);
+}
+
+static PyObject *
 pg_mode_ok(PyObject *self, PyObject *args, PyObject *kwds)
 {
     SDL_DisplayMode desired, closest;
@@ -1336,6 +1347,17 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 #endif
     Py_INCREF(pgDisplaySurfaceObject);
     return pgDisplaySurfaceObject;
+}
+
+static PyObject *
+pg_window_size(PyObject *self, PyObject *args)
+{
+    if (!pgDisplaySurfaceObject) {
+        return RAISE(pgExc_SDLError, "No open window");
+    }
+    return Py_BuildValue("(ii)",
+        pgDisplaySurfaceObject->w,
+        pgDisplaySurfaceObject->h);
 }
 
 /* SDL1 mode_ok. Note, there is a separate SDL2 version of this. */
@@ -2104,6 +2126,7 @@ static PyMethodDef _pg_display_methods[] = {
     {"get_wm_info", pg_get_wm_info, METH_NOARGS, DOC_PYGAMEDISPLAYGETWMINFO},
     {"Info", pgInfo, METH_NOARGS, DOC_PYGAMEDISPLAYINFO},
     {"get_surface", pg_get_surface, METH_NOARGS, DOC_PYGAMEDISPLAYGETSURFACE},
+    {"get_window_size", pg_window_size, METH_NOARGS, NULL}, /* TODO: add docs */
 
     {"set_mode", (PyCFunction)pg_set_mode, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYSETMODE},
     {"mode_ok", (PyCFunction)pg_mode_ok, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDISPLAYMODEOK},

--- a/src_c/doc/display_doc.h
+++ b/src_c/doc/display_doc.h
@@ -24,6 +24,7 @@
 #define DOC_PYGAMEDISPLAYGETCAPTION "get_caption() -> (title, icontitle)\nGet the current window caption"
 #define DOC_PYGAMEDISPLAYSETPALETTE "set_palette(palette=None) -> None\nSet the display color palette for indexed displays"
 #define DOC_PYGAMEDISPLAYGETNUMDISPLAYS "get_num_displays() -> int\nReturn the number of displays"
+#define DOC_PYGAMEDISPLAYGETWINDOWSIZE "get_window_size() -> tuple\nReturn the size of the window or screen"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -129,5 +130,9 @@ Set the display color palette for indexed displays
 pygame.display.get_num_displays
  get_num_displays() -> int
 Return the number of displays
+
+pygame.display.get_window_size
+ get_window_size() -> tuple
+Return the size of the window or screen
 
 */

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -361,7 +361,13 @@ class DisplayModuleTest(unittest.TestCase):
 
 
     def test_set_mode_scaled(self):
-        pygame.display.set_mode(size=(1, 1), flags=pygame.SCALED, depth=0, display=0)
+        surf = pygame.display.set_mode(size=(1, 1), flags=pygame.SCALED, depth=0, display=0)
+        winsize = pygame.display.get_window_size()
+        self.assertEqual(winsize[0] % surf.get_size()[0], 0,
+            "window width should be a multiple of the surface width")
+        self.assertEqual(winsize[1] % surf.get_size()[1], 0,
+            "window height should be a multiple of the surface height")
+        self.assertEqual(winsize[0] / surf.get_size()[0], winsize[1] / surf.get_size()[1])
 
     def todo_test_set_palette(self):
 


### PR DESCRIPTION
* Makes SCALED set the right size for existing windows.
* Added `display.get_window_size()`. For SDL1 (in case there's ever another release...), it's equal to the display surface size. For SDL2, it equals the window size (which may differ for SCALED).
* Test SCALED using window size.

- [x] Test it to make sure it works before merging.

Possible issue: `display.get_window_size()` does not work using pygame 1.9.6.