### PR TITLE
Add keyword arguments to draw.line

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -63,17 +63,9 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
          .. note::
             When using ``width`` values ``> 1``, the edge lines will grow
-            outside the original boundary of the ``rect``.
-
-            For odd ``width`` values, the thickness of each edge line
-            grows with the original line being in the center.
-
-            For even ``width`` values, the thickness of each edge
-            line grows with the original line being offset from the center
-            (as there is no exact center line drawn). As a result,
-            horizontal edge lines have 1 more pixel of thickness below the
-            original line and vertical edge lines have 1 more pixel of
-            thickness to the right of the original line.
+            outside the original boundary of the rect. For more details on
+            how the thickness for edge lines grow, refer to the ``width`` notes
+            for :func:`line`.
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the given ``rect``
@@ -116,7 +108,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
             When using ``width`` values ``> 1``, the edge lines will grow
             outside the original boundary of the polygon. For more details on
             how the thickness for edge lines grow, refer to the ``width`` notes
-            for :func:`rect`.
+            for :func:`line`.
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the first point in the
@@ -271,11 +263,52 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
 .. function:: line
 
-   | :sl:`draw a straight line segment`
-   | :sg:`line(Surface, color, start_pos, end_pos, width=1) -> Rect`
+   | :sl:`draw a straight line`
+   | :sg:`line(surface, color, start_pos, end_pos, width) -> Rect`
+   | :sg:`line(surface, color, start_pos, end_pos, width=1) -> Rect`
 
-   Draw a straight line segment on a Surface. There are no endcaps, the ends
-   are squared off for thick lines.
+   Draws a straight line on the given surface. There are no endcaps. For thick
+   lines the ends are squared off.
+
+   :param Surface surface: surface to draw on
+   :param color: color to draw with, the alpha value is optional if using a
+      tuple ``(RGB[A])``
+   :type color: Color or int or tuple(int, int, int, [int])
+   :param start_pos: start position of the line, (x, y)
+   :type start_pos: tuple(int or float, int or float) or
+      list(int or float, int or float) or Vector2(int or float, int or float)
+   :param end_pos: end position of the line, (x, y)
+   :type end_pos: tuple(int or float, int or float) or
+      list(int or float, int or float) or Vector2(int or float, int or float)
+   :param int width: (optional) used for line thickness
+
+         | if width >= 1, used for line thickness (default is 1)
+         | if width < 1, nothing will be drawn
+         |
+
+         .. note::
+            When using ``width`` values ``> 1`` lines will grow as follows.
+
+            For odd ``width`` values, the thickness of each line grows with the
+            original line being in the center.
+
+            For even ``width`` values, the thickness of each line grows with the
+            original line being offset from the center (as there is no exact
+            center line drawn). As a result, lines with a slope < 1
+            (horizontal-ish) will have 1 more pixel of thickness below the
+            original line (in the y direction). Lines with a slope >= 1
+            (vertical-ish) will have 1 more pixel of thickness to the right of
+            the original line (in the x direction).
+
+   :returns: a rect bounding the changed pixels, if nothing is drawn the
+      bounding rect's position will be the ``start_pos`` parameter (float values
+      will be truncated) and its width and height will be 0
+   :rtype: Rect
+
+   :raises TypeError: if ``start_pos`` or ``end_pos`` is not a sequence of
+      two numbers
+
+   .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.line ##
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,11 +1,11 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
 #define DOC_PYGAMEDRAWRECT "rect(surface, color, rect) -> Rect\nrect(surface, color, rect, width=0) -> Rect\ndraw a rectangle"
-#define DOC_PYGAMEDRAWPOLYGON "polygon(Surface, color, pointlist, width=0) -> Rect\ndraw a shape with any number of sides"
+#define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface, color, center, radius) -> Rect\ncircle(surface, color, center, radius, width=0) -> Rect\ndraw a circle"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
-#define DOC_PYGAMEDRAWARC "arc(Surface, color, Rect, start_angle, stop_angle, width=1) -> Rect\ndraw a partial section of an ellipse"
-#define DOC_PYGAMEDRAWLINE "line(Surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line segment"
+#define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
+#define DOC_PYGAMEDRAWLINE "line(surface, color, start_pos, end_pos, width) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
 #define DOC_PYGAMEDRAWLINES "lines(Surface, color, closed, pointlist, width=1) -> Rect\ndraw multiple contiguous line segments"
 #define DOC_PYGAMEDRAWAALINE "aaline(Surface, color, startpos, endpos, blend=1) -> Rect\ndraw fine antialiased lines"
 #define DOC_PYGAMEDRAWAALINES "aalines(Surface, color, closed, pointlist, blend=1) -> Rect\ndraw a connected sequence of antialiased lines"
@@ -44,8 +44,9 @@ pygame.draw.arc
 draw an elliptical arc
 
 pygame.draw.line
- line(Surface, color, start_pos, end_pos, width=1) -> Rect
-draw a straight line segment
+ line(surface, color, start_pos, end_pos, width) -> Rect
+ line(surface, color, start_pos, end_pos, width=1) -> Rect
+draw a straight line
 
 pygame.draw.lines
  lines(Surface, color, closed, pointlist, width=1) -> Rect


### PR DESCRIPTION
Overview of changes:
- Added keyword arguments to `draw.line`
- Added/updated some exception messages for `draw.line`
- Added tests to check `draw.line` args/kwargs
- Updated draw documentation
- Commented out `draw_py.polygon` and `draw_py.line` test cases to avoid cluttering the test output with 'skipped' messages.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev0 (SDL: 1.2.15) at 86f6a5d577ff813d58a1735ca4cfe16013893757

Resolves sub-item `pygame.draw.line` of item "Add keyword arguments to the draw functions..." of #896.
Resolves the `draw.line` item of #1040.