### PR TITLE
Enable DPI awareness on Windows.

### DIFF
--- a/buildconfig/Setup.SDL1.in
+++ b/buildconfig/Setup.SDL1.in
@@ -17,6 +17,7 @@ SCRAP = -lX11
 PORTMIDI = -lportmidi
 PORTTIME = -lporttime
 FREETYPE = -lfreetype
+BASE =
 #--EndConfig
 
 DEBUG = 
@@ -43,7 +44,7 @@ _freetype src_c/freetype/ft_cache.c src_c/freetype/ft_wrap.c src_c/freetype/ft_r
 #these modules are required for pygame to run. they only require
 #SDL as a dependency. these should not be altered
 
-base src_c/base.c $(SDL) $(DEBUG)
+base src_c/base.c $(SDL) $(DEBUG) $(BASE)
 cdrom src_c/cdrom.c $(SDL) $(DEBUG)
 color src_c/color.c $(SDL) $(DEBUG)
 constants src_c/constants.c $(SDL) $(DEBUG)

--- a/buildconfig/Setup.SDL2.in
+++ b/buildconfig/Setup.SDL2.in
@@ -15,6 +15,7 @@ SCRAP = -lX11
 PORTMIDI = -lportmidi
 PORTTIME = -lporttime
 FREETYPE = -lfreetype
+BASE =
 #--EndConfig
 
 DEBUG =
@@ -48,7 +49,7 @@ _freetype src_c/freetype/ft_cache.c src_c/freetype/ft_wrap.c src_c/freetype/ft_r
 #these modules are required for pygame to run. they only require
 #SDL as a dependency. these should not be altered
 
-base src_c/base.c $(SDL) $(DEBUG)
+base src_c/base.c $(SDL) $(DEBUG) $(BASE)
 color src_c/color.c $(SDL) $(DEBUG)
 constants src_c/constants.c $(SDL) $(DEBUG)
 display src_c/display.c $(SDL) $(DEBUG)

--- a/buildconfig/Setup_Win_Common.in
+++ b/buildconfig/Setup_Win_Common.in
@@ -1,2 +1,3 @@
 # Windows specific flags for Pygame modules.
 SCRAP = -luser32 -lgdi32
+BASE = -lShcore

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -41,6 +41,9 @@
 #include <windows.h>
 extern int
 SDL_RegisterApp(char *, Uint32, void *);
+#if WINVER >= 0x0602
+#include <shellscalingapi.h>
+#endif /* Windows 8+ */
 #endif
 
 #if defined(macintosh)
@@ -616,6 +619,10 @@ pgVideo_AutoInit(void)
 {
     if (!SDL_WasInit(SDL_INIT_VIDEO)) {
         int status;
+#if WINVER >= 0x0602
+        /* disable DPI scaling */
+        SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+#endif /* Windows 8+ */
 #if defined(__APPLE__) && defined(darwin)
         PyObject *module = PyImport_ImportModule("pygame.macosx");
         PyObject *rval;


### PR DESCRIPTION
This patch enables DPI awareness on Windows. Before, `SDL_GetDesktopDisplayMode()` reported my resolution to be 1536x864, but it's actually 1920x1080. This meant that `pygame.SCALED` didn't scale the window maximally.

Platform: Windows 10

Related: #1046 