### PR TITLE
Add pygame.Color slice assignment

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -180,13 +180,14 @@ struct pgSubSurface_Data {
     int offsetx, offsety;
 };
 
-
-typedef struct {
+/*
+ * color module internals
+ */
+struct pgColorObject {
     PyObject_HEAD
-    /* RGBA */
     Uint8 data[4];
     Uint8 len;
-} pgColorObject;
+};
 
 /*
  * include public API

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -536,6 +536,8 @@ typedef struct pgEventObject pgEventObject;
 /*
  * Color module
  */
+typedef struct pgColorObject pgColorObject;
+
 #ifndef PYGAMEAPI_COLOR_INTERNAL
 #define pgColor_Type (*(PyObject *) \
     PYGAMEAPI_GET_SLOT(color, 0))


### PR DESCRIPTION
Assigning sequences:

```python3
>>> c=pygame.Color(1,2,3,4)
>>> c[0:2] = 5,6
>>> c
(5, 6, 3, 4)
```

```python3
>>> c=pygame.Color(1,2,3,4)
>>> c[3:0:-1] = 1,2,3
>>> c
(1, 3, 2, 1)
```

This can be used to copy another color:

```python3
>>> c2=pygame.Color(10,11,12,13)
>>> c[:] = c2
>>> c
(10, 11, 12, 13)
```

Close #1050.