### PR TITLE
Implement buffer interface for pygame.Mask

### DIFF
--- a/src_c/include/pygame_mask.h
+++ b/src_c/include/pygame_mask.h
@@ -25,6 +25,7 @@
 typedef struct {
   PyObject_HEAD
   bitmask_t *mask;
+  void *bufdata;
 } pgMaskObject;
 
 #define pgMask_AsBitmap(x) (((pgMaskObject*)x)->mask)

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1744,6 +1744,9 @@ pgMask_GetBuffer(pgMaskObject *self, Py_buffer *view, int flags)
     view->internal = bufinfo;
     view->shape = bufinfo->shape;
     view->strides = bufinfo->strides;
+    if (flags & PyBUF_FORMAT) {
+        view->format = "L"; /* L = unsigned long */
+    }
 
     Py_INCREF(self);
     view->obj = self;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1767,6 +1767,9 @@ pgMask_ReleaseBuffer(pgMaskObject *self, Py_buffer *view)
 }
 
 static PyBufferProcs pgMask_BufferProcs = {
+#if PY2
+    NULL, NULL, NULL, NULL,
+#endif
     (getbufferproc)pgMask_GetBuffer,
     (releasebufferproc)pgMask_ReleaseBuffer
 };
@@ -1790,7 +1793,12 @@ static PyTypeObject pgMask_Type = {
     0L,                   /* tp_getattro */
     0L,                   /* tp_setattro */
     &pgMask_BufferProcs,  /* tp_as_buffer */
+#if PY3
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+#else /* PY2 */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+        Py_TPFLAGS_HAVE_NEWBUFFER, /* tp_flags */
+#endif /* PY2 */
     DOC_PYGAMEMASKMASK, /* Documentation string */
     0,                  /* tp_traverse */
     0,                  /* tp_clear */

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1721,7 +1721,7 @@ pgMask_GetBuffer(pgMaskObject *self, Py_buffer *view, int flags)
     mask_bufinfo *bufinfo = (mask_bufinfo*)self->bufdata;
 
     if (bufinfo == NULL) {
-        bufinfo = malloc(sizeof(mask_bufinfo));
+        bufinfo = PyMem_Malloc(sizeof(mask_bufinfo));
         bufinfo->numbufs = 1;
 
         bufinfo->shape[0] = (m->w - 1) / BITMASK_W_LEN + 1;
@@ -1761,7 +1761,7 @@ pgMask_ReleaseBuffer(pgMaskObject *self, Py_buffer *view)
 
     bufinfo->numbufs--;
     if (bufinfo->numbufs == 0) {
-        free(bufinfo);
+        PyMem_Free(bufinfo);
         self->bufdata = NULL;
     }
 }

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1708,6 +1708,7 @@ mask_init(PyObject *self, PyObject *args, PyObject *kwargs)
     return 0;
 }
 
+#if PY3
 typedef struct {
     int numbufs;
     Py_ssize_t shape[2];
@@ -1767,12 +1768,11 @@ pgMask_ReleaseBuffer(pgMaskObject *self, Py_buffer *view)
 }
 
 static PyBufferProcs pgMask_BufferProcs = {
-#if PY2
-    NULL, NULL, NULL, NULL,
-#endif
     (getbufferproc)pgMask_GetBuffer,
     (releasebufferproc)pgMask_ReleaseBuffer
 };
+
+#endif /* PY3 */
 
 static PyTypeObject pgMask_Type = {
     TYPE_HEAD(NULL, 0) "pygame.mask.Mask", /* tp_name */
@@ -1792,12 +1792,12 @@ static PyTypeObject pgMask_Type = {
     (reprfunc)NULL,       /* tp_str */
     0L,                   /* tp_getattro */
     0L,                   /* tp_setattro */
-    &pgMask_BufferProcs,  /* tp_as_buffer */
 #if PY3
+    &pgMask_BufferProcs,  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
 #else /* PY2 */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_HAVE_NEWBUFFER, /* tp_flags */
+    0L,                   /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
 #endif /* PY2 */
     DOC_PYGAMEMASKMASK, /* Documentation string */
     0,                  /* tp_traverse */

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1723,6 +1723,10 @@ pgMask_GetBuffer(pgMaskObject *self, Py_buffer *view, int flags)
 
     if (bufinfo == NULL) {
         bufinfo = PyMem_Malloc(sizeof(mask_bufinfo));
+        if (bufinfo == NULL) {
+            PyErr_NoMemory();
+            return -1;
+        }
         bufinfo->numbufs = 1;
 
         bufinfo->shape[0] = (m->w - 1) / BITMASK_W_LEN + 1;

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -2638,7 +2638,7 @@ class MaskModuleTest(unittest.TestCase):
                 rects = mask.get_bounding_rects()
                 self.assertEqual(rects, [])
 
-    @unittest.skipUnless(sys.version_info[0], 3)
+    @unittest.skipIf(sys.version_info < (3, ), "Python 3 only")
     def test_buffer_interface(self):
         size = (1000, 100)
         pixels_set = (

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -2637,5 +2637,39 @@ class MaskModuleTest(unittest.TestCase):
                 rects = mask.get_bounding_rects()
                 self.assertEqual(rects, [])
 
+    def test_buffer_interface(self):
+        size = (1000, 100)
+        pixels_set = (
+            (0, 1),
+            (100, 10),
+            (173, 90)
+        )
+        pixels_unset = (
+            (0, 0),
+            (101, 10),
+            (173, 91)
+        )
+
+        mask = pygame.Mask(size)
+        for point in pixels_set:
+            mask.set_at(point, 1)
+
+        view = memoryview(mask)
+        intwidth = 8 * view.strides[1]
+
+        for point in pixels_set:
+            x, y = point
+            col = x // intwidth
+            self.assertEqual(
+                (view[col, y] >> (x % intwidth)) & 1, 1,
+                "the pixel at {} is not set to 1".format(point))
+
+        for point in pixels_unset:
+            x, y = point
+            col = x // intwidth
+            self.assertEqual(
+                (view[col, y] >> (x % intwidth)) & 1, 0,
+                "the pixel at {} is not set to 0".format(point))
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import random
 import unittest
+import sys
 
 import pygame
 from pygame.locals import *
@@ -2637,6 +2638,7 @@ class MaskModuleTest(unittest.TestCase):
                 rects = mask.get_bounding_rects()
                 self.assertEqual(rects, [])
 
+    @unittest.skipUnless(sys.version_info[0], 3)
     def test_buffer_interface(self):
         size = (1000, 100)
         pixels_set = (


### PR DESCRIPTION
Due to how the data is stored in bitmask_t, it's not very intuitive. The pixels are stored in bits.

Example usage:

```python3
>>> m = pygame.Mask((128,128))
>>> view = memoryview(m)
>>> view.strides
(512, 4)
>>> view.shape
(4, 128)
>>> view[0, 1]
0
>>> m.set_at((0, 1))
>>> view[0, 1]
1
>>> m.set_at((100, 1))
>>> view[0, 1]
1
>>> view[3, 1] # 100 // 32 = 3
16
>>> view[0, 1] = 0
>>> m.get_at((0, 0))
0
```

The first index ranges between 0 and ``width // (8 * sizeof(long))`` (on Win64, ``8 * sizeof(long) = 32``). The second index is in the interval 0 to ``height-1``. (Both inclusive)

Think of each row between 0 and the height (128) as containing 4 long ints above (since the shape is (4, 128)). If the x coordinate is eg 50, then it must be in the second long int for that row since 32 <= x < 64. For the fifth row, that would be in the integer `view[1, 4]`.

### Why is ``view[3,1]`` equal to 16 above?

The long int that the pixel is in begins at the offset ``x = 3*32 = 96``. 100 = 96 + 4, which means that the fifth pixel/bit in that integer is set. 10000<sub>2</sub> = 2<sup>4</sup> = 16.

### Comparison to `get_array()` and `get_at()`

Looping over all pixels is still slow, but it's faster than using the other methods:

| Time (s) | Iterations | Method             |
|----------|------------|--------------------|
| 3.2      | 10         | get_at()           |
| 2.2      | 10         | get_array() (copy) |
| .92      | 10         | memoryview()       |

```python3
mask = pygame.mask.Mask((1000, 1000))

def readallpixels():
    bits1 = memoryview(mask)
    w, h = mask.get_size()
    cols = bits1.shape[0]
    intwidth = math.ceil(w/cols)

    for col in range(cols):
        for y in range(h):
            val = bits1[col, y]
            for x in range(intwidth):
                if val & (1 << x):
                    pass # pixel is set

print("array:", timeit.timeit(readallpixels, number=10))
```

### Issues

- [x] Ignores flags.
- [ ] Fix for Python 2.7.

### Related

#1057, #1029