### PR TITLE
VULKAN not supported on SDL 2.0.5 and below (used by raspberian).

### DIFF
--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -79,6 +79,13 @@
 
 #include "pgcompat.h"
 
+#if defined(SDL_VERSION_ATLEAST)
+#ifndef SDL_WINDOW_VULKAN
+#define SDL_WINDOW_VULKAN 0
+#endif
+#endif
+
+
 /* Flag indicating a pg_buffer; used for assertions within callbacks */
 #ifndef NDEBUG
 #define PyBUF_PYGAME 0x4000


### PR DESCRIPTION
Commenting it out for now. ifdef in cython is hard.