### PR TITLE
Debian/Raspberry arm config improvements. Mixer devicename fix (again).

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -109,6 +109,7 @@ class Dependency:
             self.found = 1
         else:
             print (self.name + '        '[len(self.name):] + ': not found')
+            print(self.name, self.checkhead, self.checklib, incdirs, libdirs)
 
 
 class DependencyPython:
@@ -150,10 +151,12 @@ def main(sdl2=False):
     if sdl2:
         origincdirs = ['/include', '/include/SDL2']
         origlibdirs = ['/lib','/lib64','/X11R6/lib',
-                       '/lib/i386-linux-gnu', '/lib/x86_64-linux-gnu']
+                       '/lib/i386-linux-gnu', '/lib/x86_64-linux-gnu',
+                       '/lib/arm-linux-gnueabihf/']
+
     else:
         origincdirs = ['/include', '/include/SDL', '/include/SDL']
-        origlibdirs = ['/lib','/lib64','/X11R6/lib']
+        origlibdirs = ['/lib','/lib64','/X11R6/lib', '/lib/arm-linux-gnueabihf/']
     if 'ORIGLIBDIRS' in os.environ and os.environ['ORIGLIBDIRS'] != "":
         origlibdirs = os.environ['ORIGLIBDIRS'].split(":")
 
@@ -231,7 +234,7 @@ def main(sdl2=False):
     DEPS.append(find_freetype())
 
     if not DEPS[0].found:
-        sys.exit('Unable to run "sdl-config". Please make sure a development version of SDL is installed.')
+        raise RuntimeError('Unable to run "sdl-config". Please make sure a development version of SDL is installed.')
 
     incdirs = []
     libdirs = []

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,9 @@ def compilation_help():
     if the_system == 'Linux':
         if hasattr(platform, 'linux_distribution'):
             distro = platform.linux_distribution()
-            if distro[0] == 'Ubuntu':
+            if distro[0].lower() == 'ubuntu':
                 the_system = 'Ubuntu'
-            elif distro[0] == 'Debian':
+            elif distro[0].lower() == 'debian':
                 the_system = 'Debian'
 
     help_urls = {
@@ -49,18 +49,18 @@ def compilation_help():
     }
 
     default = 'https://www.pygame.org/wiki/Compilation'
-    url = help_urls.get(platform.system(), default)
+    url = help_urls.get(the_system, default)
 
     is_pypy = '__pypy__' in sys.builtin_module_names
     if is_pypy:
         url += '\n    https://www.pygame.org/wiki/CompilePyPy'
 
-    print ('---')
+    print ('\n---')
     print ('For help with compilation see:')
     print ('    %s' % url)
     print ('To contribute to pygame development see:')
     print ('    https://www.pygame.org/contribute.html')
-    print ('---')
+    print ('---\n')
 
 
 
@@ -191,7 +191,11 @@ if len(sys.argv) == 1 and sys.stdout.isatty():
 if AUTO_CONFIG or not os.path.isfile('Setup'):
     print ('\n\nWARNING, No "Setup" File Exists, Running "buildconfig/config.py"')
     import buildconfig.config
-    buildconfig.config.main(AUTO_CONFIG)
+    try:
+        buildconfig.config.main(AUTO_CONFIG)
+    except:
+        compilation_help()
+        raise
     if '-config' in sys.argv:
         sys.exit(0)
     print ('\nContinuing With "setup.py"')

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -454,9 +454,13 @@ _init(int freq, int size, int channels, int chunk, char *devicename, int allowed
         if (SDL_InitSubSystem(SDL_INIT_AUDIO) == -1)
             return PyInt_FromLong(0);
 
-#ifdef Mix_OpenAudioDevice
+#if SDL_MIXER_MAJOR_VERSION >= 2 && SDL_MIXER_MINOR_VERSION >= 0 && SDL_MIXER_PATCHLEVEL >= 2
         if (Mix_OpenAudioDevice(freq, fmt, channels, chunk, devicename,
                                 allowedchanges) == -1) {
+            /* mixer.init swallows errors, tell user a reason via a log. */
+            if(devicename) {
+                SDL_Log("Failed to open devicename:%s: with error :%s:", devicename, SDL_GetError());
+            }
             SDL_QuitSubSystem(SDL_INIT_AUDIO);
             return PyInt_FromLong(0);
         }


### PR DESCRIPTION
- Added arm-linux-gnueabihf to lib search path.
- Help if buildconfig.config.main fails. Detect debian properly. 
- Mixer devicename fix (again).

Probably `pkg-config libjpeg --libs` is better for this these days. Not sure how portable that is though.