### PR TITLE
Fix invalid escape sequences in string literals

### DIFF
--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -49,7 +49,7 @@ class Dependency(object):
         self.lib_dir = None
         self.find_header = find_header
         if not find_lib and libs:
-            self.find_lib = "%s\.(a|lib)" % re.escape(libs[0])
+            self.find_lib = r"%s\.(a|lib)" % re.escape(libs[0])
         else:
             self.find_lib = find_lib
         self.libs = libs
@@ -387,20 +387,20 @@ def setup(sdl2):
 
     if not sdl2:
         DEPS.add('SDL', 'SDL', ['SDL-[1-9].*'], r'(lib){0,1}SDL\.dll$', required=1,
-                 find_header='SDL\.h')
+                 find_header=r'SDL\.h')
         DEPS.add('FONT', 'SDL_ttf', ['SDL_ttf-[2-9].*'], r'(lib){0,1}SDL_ttf\.dll$', ['SDL', 'z'],
-                 find_header='SDL_ttf\.h')
+                 find_header=r'SDL_ttf\.h')
         DEPS.add('IMAGE', 'SDL_image', ['SDL_image-[1-9].*'], r'(lib){0,1}SDL_image\.dll$',
-                 ['SDL', 'jpeg', 'png', 'tiff'], 0, find_header='SDL_image\.h'),
+                 ['SDL', 'jpeg', 'png', 'tiff'], 0, find_header=r'SDL_image\.h'),
         DEPS.add('MIXER', 'SDL_mixer', ['SDL_mixer-[1-9].*'], r'(lib){0,1}SDL_mixer\.dll$',
-                 ['SDL', 'vorbisfile'], find_header='SDL_mixer\.h')
+                 ['SDL', 'vorbisfile'], find_header=r'SDL_mixer\.h')
         DEPS.add('PNG', 'png', ['libpng-[1-9].*'], r'(png|libpng)[-0-9]*\.dll$', ['z'])
         DEPS.add('JPEG', 'jpeg', ['jpeg-[6-9]*'], r'(lib){0,1}jpeg[-0-9]*\.dll$')
-        DEPS.add('PORTMIDI', 'portmidi', ['portmidi'], r'portmidi\.dll$', find_header='portmidi\.h')
+        DEPS.add('PORTMIDI', 'portmidi', ['portmidi'], r'portmidi\.dll$', find_header=r'portmidi\.h')
         #DEPS.add('PORTTIME', 'porttime', ['porttime'], r'porttime\.dll$')
         DEPS.add_dummy('PORTTIME')
         DEPS.add('FREETYPE', 'freetype', ['freetype-[1-9].*'], r'(lib){0,1}freetype[-0-9]*\.dll$',
-                 find_header='ft2build\.h', find_lib='(lib)?freetype[-0-9]*\.lib')
+                 find_header=r'ft2build\.h', find_lib=r'(lib)?freetype[-0-9]*\.lib')
         DEPS.configure()
         DEPS.add_dll(r'(lib){0,1}tiff[-0-9]*\.dll$', 'tiff', ['tiff-[3-9].*'], ['jpeg', 'z'])
         DEPS.add_dll(r'(z|zlib1)\.dll$', 'z', ['zlib-[1-9].*'])
@@ -414,20 +414,20 @@ def setup(sdl2):
         DEPS.configure()
     else:
         DEPS.add('SDL', 'SDL2', ['SDL2-[1-9].*'], r'(lib){0,1}SDL2\.dll$', required=1)
-        DEPS.add('PORTMIDI', 'portmidi', ['portmidi'], r'portmidi\.dll$', find_header='portmidi\.h')
+        DEPS.add('PORTMIDI', 'portmidi', ['portmidi'], r'portmidi\.dll$', find_header=r'portmidi\.h')
         #DEPS.add('PORTTIME', 'porttime', ['porttime'], r'porttime\.dll$')
         DEPS.add_dummy('PORTTIME')
         DEPS.add('MIXER', 'SDL2_mixer', ['SDL2_mixer-[1-9].*'], r'(lib){0,1}SDL2_mixer\.dll$',
                  ['SDL', 'vorbisfile'])
         DEPS.add('PNG', 'png', ['SDL2_image-[2-9].*', 'libpng-[1-9].*'], r'(png|libpng)[-0-9]*\.dll$', ['z'],
-                 find_header='png\.h', find_lib='(lib)?png1[-0-9]*\.lib')
+                 find_header=r'png\.h', find_lib=r'(lib)?png1[-0-9]*\.lib')
         DEPS.add('JPEG', 'jpeg', ['SDL2_image-[2-9].*', 'jpeg-9*'], r'(lib){0,1}jpeg-9\.dll$',
-                 find_header='jpeglib\.h', find_lib='(lib)?jpeg-9\.lib')
+                 find_header=r'jpeglib\.h', find_lib=r'(lib)?jpeg-9\.lib')
         DEPS.add('IMAGE', 'SDL2_image', ['SDL2_image-[1-9].*'], r'(lib){0,1}SDL2_image\.dll$',
                  ['SDL', 'jpeg', 'png', 'tiff'], 0)
         DEPS.add('FONT', 'SDL2_ttf', ['SDL2_ttf-[2-9].*'], r'(lib){0,1}SDL2_ttf\.dll$', ['SDL', 'z', 'freetype'])
         DEPS.add('FREETYPE', 'freetype', ['freetype-[1-9].*'], r'(lib){0,1}freetype[-0-9]*\.dll$',
-                 find_header='ft2build\.h', find_lib='(lib)?freetype[-0-9]*\.lib')
+                 find_header=r'ft2build\.h', find_lib=r'(lib)?freetype[-0-9]*\.lib')
         DEPS.configure()
         _add_sdl2_dll_deps(DEPS)
         for d in get_definitions():
@@ -453,14 +453,14 @@ def setup_prebuilt_sdl2(prebuilt_dir):
                         ['SDL', 'jpeg', 'png', 'tiff'], 0)
     mixerDep = DEPS.add('MIXER', 'SDL2_mixer', ['SDL2_mixer-[1-9].*'], r'(lib){0,1}SDL2_mixer\.dll$',
                         ['SDL', 'vorbisfile'])
-    DEPS.add('PORTMIDI', 'portmidi', ['portmidi'], r'portmidi\.dll$', find_header='portmidi\.h')
+    DEPS.add('PORTMIDI', 'portmidi', ['portmidi'], r'portmidi\.dll$', find_header=r'portmidi\.h')
     #DEPS.add('PORTTIME', 'porttime', ['porttime'], r'porttime\.dll$')
     DEPS.add_dummy('PORTTIME')
     DEPS.configure()
 
     # force use of the correct freetype DLL
     ftDep = DEPS.add('FREETYPE', 'freetype', ['SDL2_ttf-[2-9].*', 'freetype-[1-9].*'], r'(lib)?freetype[-0-9]*\.dll$',
-                     find_header='ft2build\.h', find_lib='libfreetype[-0-9]*\.lib')
+                     find_header=r'ft2build\.h', find_lib=r'libfreetype[-0-9]*\.lib')
     ftDep.path = fontDep.path
     ftDep.inc_dir = [
         os.path.join(prebuilt_dir, 'include').replace('\\', '/')
@@ -469,12 +469,12 @@ def setup_prebuilt_sdl2(prebuilt_dir):
     ftDep.found = True
 
     png = DEPS.add('PNG', 'png', ['SDL2_image-[2-9].*', 'libpng-[1-9].*'], r'(png|libpng)[-0-9]*\.dll$', ['z'],
-                   find_header='png\.h', find_lib='(lib)?png1[-0-9]*\.lib')
+                   find_header=r'png\.h', find_lib=r'(lib)?png1[-0-9]*\.lib')
     png.path = imageDep.path
     png.inc_dir = [os.path.join(prebuilt_dir, 'include').replace('\\', '/')]
     png.found = True
     jpeg = DEPS.add('JPEG', 'jpeg', ['SDL2_image-[2-9].*', 'jpeg-9*'], r'(lib){0,1}jpeg-9\.dll$',
-                   find_header='jpeglib\.h', find_lib='(lib)?jpeg-9\.lib')
+                   find_header=r'jpeglib\.h', find_lib=r'(lib)?jpeg-9\.lib')
     jpeg.path = imageDep.path
     jpeg.inc_dir = [os.path.join(prebuilt_dir, 'include').replace('\\', '/')]
     jpeg.found = True

--- a/buildconfig/vstools.py
+++ b/buildconfig/vstools.py
@@ -52,7 +52,7 @@ def find_symbols(dll):
     next(it)
 
     symbols = []
-    exp = re.compile('\w+')
+    exp = re.compile(r'\w+')
 
     for line in it:
         if not line.strip():

--- a/setup.py
+++ b/setup.py
@@ -337,16 +337,16 @@ add_datafiles(data_files, 'pygame/docs',
 #generate the version module
 def parse_version(ver):
     from re import findall
-    return ', '.join(s for s in findall('\d+', ver)[0:3])
+    return ', '.join(s for s in findall(r'\d+', ver)[0:3])
 
 def parse_source_version():
     pgh_major = -1
     pgh_minor = -1
     pgh_patch = -1
     import re
-    major_exp_search = re.compile('define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
-    minor_exp_search = re.compile('define\s+PG_MINOR_VERSION\s+([0-9]+)').search
-    patch_exp_search = re.compile('define\s+PG_PATCH_VERSION\s+([0-9]+)').search
+    major_exp_search = re.compile(r'define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
+    minor_exp_search = re.compile(r'define\s+PG_MINOR_VERSION\s+([0-9]+)').search
+    patch_exp_search = re.compile(r'define\s+PG_PATCH_VERSION\s+([0-9]+)').search
     pg_header = os.path.join('src_c', 'include', '_pygame.h')
     with open(pg_header) as f:
         for line in f:

--- a/test/test_utils/run_tests.py
+++ b/test/test_utils/run_tests.py
@@ -134,7 +134,7 @@ def run(*args, **kwds):
     # Compile a list of test modules. If fake, then compile list of fake
     # xxxx_test.py from run_tests__tests
 
-    TEST_MODULE_RE = re.compile('^(.+_test)\.py$')
+    TEST_MODULE_RE = re.compile(r'^(.+_test)\.py$')
 
     test_mods_pkg_name = test_pkg_name
 

--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -41,7 +41,7 @@ main_dir, test_subdir, fake_test_subdir = prepare_test_env()
 
 TAG_PAT = r'-?[a-zA-Z0-9_]+'
 TAG_RE = re.compile(TAG_PAT)
-EXCLUDE_RE = re.compile("(%s,?\s*)+$" % (TAG_PAT,))
+EXCLUDE_RE = re.compile(r"(%s,?\s*)+$" % (TAG_PAT,))
 
 def exclude_callback(option, opt, value, parser):
     if EXCLUDE_RE.match(value) is None:

--- a/test/util/relative_indentation.py
+++ b/test/util/relative_indentation.py
@@ -7,7 +7,7 @@ import re
 def strip_common_preceding_space(input_str):
     "Strips preceding common space so only relative indentation remains"
 
-    preceding_whitespace = re.compile("^(?:(\s*?)\S)?")
+    preceding_whitespace = re.compile(r"^(?:(\s*?)\S)?")
     common_start = len(input_str)
 
     split = input_str.split("\n")
@@ -23,7 +23,7 @@ def pad_secondary_lines(input_str, padding):
 
 ################################################################################
 
-ph_re = re.compile("\${(.*?)}")
+ph_re = re.compile(r"\${(.*?)}")
 multi_line_re = re.MULTILINE | re.DOTALL
 
 ################################################################################
@@ -69,7 +69,7 @@ class Template(object):
         for ph_name, replacement in replacements.items():
             ph_offset = self.ph_offsets[ph_name]
     
-            ph_search = re.search ("\${%s}" % ph_name, template, multi_line_re)
+            ph_search = re.search (r"\${%s}" % ph_name, template, multi_line_re)
             
             ph_start, ph_end = ph_search.span()
             

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -14,9 +14,9 @@ class VersionTest(unittest.TestCase):
         pgh_minor = -1
         pgh_patch = -1
         import re
-        major_exp_search = re.compile('define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
-        minor_exp_search = re.compile('define\s+PG_MINOR_VERSION\s+([0-9]+)').search
-        patch_exp_search = re.compile('define\s+PG_PATCH_VERSION\s+([0-9]+)').search
+        major_exp_search = re.compile(r'define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
+        minor_exp_search = re.compile(r'define\s+PG_MINOR_VERSION\s+([0-9]+)').search
+        patch_exp_search = re.compile(r'define\s+PG_PATCH_VERSION\s+([0-9]+)').search
         with open(pg_header) as f:
             for line in f:
                 if pgh_major == -1:


### PR DESCRIPTION
Python 3.8 emits a SyntaxWarning when it encounters a backslash followed by an unknown letter or character inside a string literal:

    $ python3.8
    Python 3.8.0a4+ (heads/master:d8b7551672, May 29 2019, 14:21:13)
    [GCC 8.3.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> 'aaa\.b'
    <stdin>:1: SyntaxWarning: invalid escape sequence \.
    'aaa\\.b'