### PR TITLE
Fix invalid Color values not being detected

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -390,7 +390,7 @@ _get_color(PyObject *val, Uint32 *color)
 #if !PY3
     if (PyInt_Check(val)) {
         long intval = PyInt_AsLong(val);
-        if (intval == -1 && PyErr_Occurred()) {
+        if ((intval == -1 && PyErr_Occurred()) || (intval > 0xFFFFFFFF)) {
             PyErr_SetString(PyExc_ValueError, "invalid color argument");
             return 0;
         }
@@ -400,7 +400,7 @@ _get_color(PyObject *val, Uint32 *color)
 #endif
     if (PyLong_Check(val)) {
         unsigned long longval = PyLong_AsUnsignedLong(val);
-        if (PyErr_Occurred()) {
+        if (PyErr_Occurred() || (longval > 0xFFFFFFFF)) {
             PyErr_SetString(PyExc_ValueError, "invalid color argument");
             return 0;
         }

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -399,8 +399,6 @@ class ColorTypeTest (unittest.TestCase):
             self.assertEqual(color.b, (value >> 8) & 0xFF)
             self.assertEqual(color.a, value & 0xFF)
 
-    # The skip decorator can be removed when issue #1060 is resolved.
-    @unittest.skip('invalid int value not detected on some platforms')
     def test_color__int_arg_invalid(self):
         """Ensures invalid int values are detected when creating Color objects.
         """


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at bbabcd03e671ba4477d5758c128206b7f566c77a

Resolves #1060.