### PR TITLE
Add get_rect() method to Mask class

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -146,6 +146,31 @@ to store which parts collide.
 
       .. ## Mask.get_size ##
 
+   .. method:: get_rect
+
+      | :sl:`Returns a Rect based on the size of the mask`
+      | :sg:`get_rect(\**kwargs) -> Rect`
+
+      Returns a new :func:`pygame.Rect` object based on the size of this mask.
+      The rect's default position will be ``(0, 0)`` and its default width and
+      height will be the same as this mask's. The rect's attributes can be
+      altered via :func:`pygame.Rect` attribute keyword arguments/values passed
+      into this method. As an example, ``a_mask.get_rect(center=(10, 5))`` would
+      create a :func:`pygame.Rect` based on the mask's size centered at the
+      given position.
+
+      :param dict kwargs: :func:`pygame.Rect` attribute keyword arguments/values
+         that will be applied to the rect
+
+      :returns: a new :func:`pygame.Rect` object based on the size of this mask
+         with any :func:`pygame.Rect` attribute keyword arguments/values applied
+         to it
+      :rtype: Rect
+
+      .. versionadded:: 2.0.0
+
+      .. ## Mask.get_rect ##
+
    .. method:: get_at
 
       | :sl:`Gets the bit at the given position`

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -4,6 +4,7 @@
 #define DOC_PYGAMEMASKFROMTHRESHOLD "from_threshold(Surface, color) -> Mask\nfrom_threshold(Surface, color, threshold=(0, 0, 0, 255), othersurface=None, palette_colors=1) -> Mask\nCreates a mask by thresholding Surfaces"
 #define DOC_PYGAMEMASKMASK "Mask(size=(width, height)) -> Mask\nMask(size=(width, height), fill=False) -> Mask\npygame object for representing 2D bitmasks"
 #define DOC_MASKGETSIZE "get_size() -> (width, height)\nReturns the size of the mask"
+#define DOC_MASKGETRECT "get_rect(**kwargs) -> Rect\nReturns a Rect based on the size of the mask"
 #define DOC_MASKGETAT "get_at((x, y)) -> int\nGets the bit at the given position"
 #define DOC_MASKSETAT "set_at((x, y)) -> None\nset_at((x, y), value=1) -> None\nSets the bit at the given position"
 #define DOC_MASKOVERLAP "overlap(othermask, offset) -> (x, y)\noverlap(othermask, offset) -> None\nReturns the point of intersection"
@@ -51,6 +52,10 @@ pygame object for representing 2D bitmasks
 pygame.mask.Mask.get_size
  get_size() -> (width, height)
 Returns the size of the mask
+
+pygame.mask.Mask.get_rect
+ get_rect(**kwargs) -> Rect
+Returns a Rect based on the size of the mask
 
 pygame.mask.Mask.get_at
  get_at((x, y)) -> int


### PR DESCRIPTION
Overview of changes:
- Added a `get_rect()` method to the Mask class
- Added a `get_rect()` entry to the Mask documentation
- Added `get_rect()` tests
- Changed some existing mask tests to use the new `get_rect()` method

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at bbabcd03e671ba4477d5758c128206b7f566c77a

Resolves #1072.