### PR TITLE
Add keyword arguments to draw.lines

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -318,15 +318,50 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
 .. function:: lines
 
-   | :sl:`draw multiple contiguous line segments`
-   | :sg:`lines(Surface, color, closed, pointlist, width=1) -> Rect`
+   | :sl:`draw multiple contiguous straight line segments`
+   | :sg:`lines(surface, color, closed, points) -> Rect`
+   | :sg:`lines(surface, color, closed, points, width=1) -> Rect`
 
-   Draw a sequence of lines on a Surface. The pointlist argument is a series of
-   points that are connected by a line. If the closed argument is true an
-   additional line segment is drawn between the first and last points.
+   Draws a sequence of contiguous straight lines on the given surface. There are
+   no endcaps or miter joints. For thick lines the ends are squared off.
+   Drawing thick lines with sharp corners can have undesired looking results.
 
-   This does not draw any endcaps or miter joints. Lines with sharp corners and
-   wide line widths can have improper looking corners.
+   :param Surface surface: surface to draw on
+   :param color: color to draw with, the alpha value is optional if using a
+      tuple ``(RGB[A])``
+   :type color: Color or int or tuple(int, int, int, [int])
+   :param bool closed: if ``True`` an additional line segment is drawn between
+      the first and last points in the ``points`` sequence
+   :param points: a sequence of 2 or more (x, y) coordinates, where each
+      *coordinate* in the sequence must be a
+      tuple/list/:class:`pygame.math.Vector2` of 2 ints/floats and adjacent
+      coordinates will be connected by a line segment, e.g. for the
+      points ``[(x1, y1), (x2, y2), (x3, y3)]`` a line segment will be drawn
+      from ``(x1, y1)`` to ``(x2, y2)`` and from ``(x2, y2)`` to ``(x3, y3)``,
+      additionally if the ``closed`` parameter is ``True`` another line segment
+      will be drawn from ``(x3, y3)`` to ``(x1, y1)``
+   :type points: tuple(coordinate) or list(coordinate)
+   :param int width: (optional) used for line thickness
+
+         | if width >= 1, used for line thickness (default is 1)
+         | if width < 1, nothing will be drawn
+         |
+
+         .. note::
+            When using ``width`` values ``> 1`` refer to the ``width`` notes
+            of :func:`line` for details on how thick lines grow.
+
+   :returns: a rect bounding the changed pixels, if nothing is drawn the
+      bounding rect's position will be the position of the first point in the
+      ``points`` parameter (float values will be truncated) and its width and
+      height will be 0
+   :rtype: Rect
+
+   :raises ValueError: if ``len(points) < 2`` (must have at least 2 points)
+   :raises TypeError: if ``points`` is not a sequence or ``points`` does not
+      contain number pairs
+
+   .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.lines ##
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -6,7 +6,7 @@
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
 #define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
 #define DOC_PYGAMEDRAWLINE "line(surface, color, start_pos, end_pos, width) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
-#define DOC_PYGAMEDRAWLINES "lines(Surface, color, closed, pointlist, width=1) -> Rect\ndraw multiple contiguous line segments"
+#define DOC_PYGAMEDRAWLINES "lines(surface, color, closed, points) -> Rect\nlines(surface, color, closed, points, width=1) -> Rect\ndraw multiple contiguous straight line segments"
 #define DOC_PYGAMEDRAWAALINE "aaline(surface, color, start_pos, end_pos) -> Rect\naaline(surface, color, start_pos, end_pos, blend=1) -> Rect\ndraw a straight antialiased line"
 #define DOC_PYGAMEDRAWAALINES "aalines(Surface, color, closed, pointlist, blend=1) -> Rect\ndraw a connected sequence of antialiased lines"
 
@@ -49,8 +49,9 @@ pygame.draw.line
 draw a straight line
 
 pygame.draw.lines
- lines(Surface, color, closed, pointlist, width=1) -> Rect
-draw multiple contiguous line segments
+ lines(surface, color, closed, points) -> Rect
+ lines(surface, color, closed, points, width=1) -> Rect
+draw multiple contiguous straight line segments
 
 pygame.draw.aaline
  aaline(surface, color, start_pos, end_pos) -> Rect

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -331,56 +331,80 @@ aalines(PyObject *self, PyObject *arg)
                        (int)(bottom - top + 2));
 }
 
+/* Draws a series of lines on the given surface.
+ *
+ * Returns a Rect bounding the drawn area.
+ */
 static PyObject *
-lines(PyObject *self, PyObject *arg)
+lines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj, *colorobj, *closedobj, *points, *item;
-    SDL_Surface *surf;
-    int x, y;
-    int top, left, bottom, right;
-    int pts[4], width = 1;
-    Uint8 rgba[4];
+    PyObject *surfobj = NULL, *colorobj = NULL, *closedobj = NULL;
+    PyObject *points = NULL, *item = NULL;
+    SDL_Surface *surf = NULL;
     Uint32 color;
-    int closed;
-    int result, loop, length;
-    int *xlist, *ylist;
+    Uint8 rgba[4];
+    int pts[4];
+    int x, y, closed, result, loop, length;
+    int top = INT_MAX, left = INT_MAX;
+    int bottom = INT_MIN, right = INT_MIN;
+    int *xlist = NULL, *ylist = NULL;
+    int width = 1; /* Default width. */
+    static char *keywords[] = {"surface", "color", "closed",
+                               "points",  "width", NULL};
 
-    /*get all the arguments*/
-    if (!PyArg_ParseTuple(arg, "O!OOO|i", &pgSurface_Type, &surfobj, &colorobj,
-                          &closedobj, &points, &width))
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|i", keywords,
+                                     &pgSurface_Type, &surfobj, &colorobj,
+                                     &closedobj, &points, &width)) {
+        return NULL; /* Exception already set. */
+    }
+
     surf = pgSurface_AsSurface(surfobj);
 
-    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4)
-        return RAISE(PyExc_ValueError, "unsupport bit depth for line draw");
+    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+        return PyErr_Format(PyExc_ValueError,
+                            "unsupported surface bit depth (%d) for drawing",
+                            surf->format->BytesPerPixel);
+    }
 
     CHECK_LOAD_COLOR(colorobj)
 
     closed = PyObject_IsTrue(closedobj);
 
-    if (!PySequence_Check(points))
+    if (-1 == closed) {
+        return RAISE(PyExc_TypeError, "closed argument is invalid");
+    }
+
+    if (!PySequence_Check(points)) {
         return RAISE(PyExc_TypeError,
                      "points argument must be a sequence of number pairs");
-    length = PySequence_Length(points);
-    if (length < 2)
-        return RAISE(PyExc_ValueError,
-                     "points argument must contain more than 1 points");
+    }
 
-    left = top = 10000;
-    right = bottom = -10000;
+    length = PySequence_Length(points);
+
+    if (length < 2) {
+        return RAISE(PyExc_ValueError,
+                     "points argument must contain 2 or more points");
+    }
 
     xlist = PyMem_New(int, length);
     ylist = PyMem_New(int, length);
+
+    if (NULL == xlist || NULL == ylist) {
+        return RAISE(PyExc_MemoryError,
+                     "cannot allocate memory to draw lines");
+    }
 
     for (loop = 0; loop < length; ++loop) {
         item = PySequence_GetItem(points, loop);
         result = pg_TwoIntsFromObj(item, &x, &y);
         Py_DECREF(item);
+
         if (!result) {
             PyMem_Del(xlist);
             PyMem_Del(ylist);
             return RAISE(PyExc_TypeError, "points must be number pairs");
         }
+
         xlist[loop] = x;
         ylist[loop] = y;
         left = MIN(x, left);
@@ -398,7 +422,7 @@ lines(PyObject *self, PyObject *arg)
     if (!pgSurface_Lock(surfobj)) {
         PyMem_Del(xlist);
         PyMem_Del(ylist);
-        return NULL;
+        return RAISE(PyExc_RuntimeError, "error locking surface");
     }
 
     for (loop = 1; loop < length; ++loop) {
@@ -408,6 +432,7 @@ lines(PyObject *self, PyObject *arg)
         pts[3] = ylist[loop];
         clip_and_draw_line_width(surf, &surf->clip_rect, color, width, pts);
     }
+
     if (closed && length > 2) {
         pts[0] = xlist[length - 1];
         pts[1] = ylist[length - 1];
@@ -418,10 +443,12 @@ lines(PyObject *self, PyObject *arg)
 
     PyMem_Del(xlist);
     PyMem_Del(ylist);
-    if (!pgSurface_Unlock(surfobj))
-        return NULL;
 
-    /*compute return rect*/
+    if (!pgSurface_Unlock(surfobj)) {
+        return RAISE(PyExc_RuntimeError, "error unlocking surface");
+    }
+
+    /* Compute return rect. */
     return pgRect_New4(left, top, right - left + 1, bottom - top + 1);
 }
 
@@ -681,7 +708,7 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
             return NULL; /* Exception already set. */
         }
 
-        ret = lines(NULL, args);
+        ret = lines(NULL, args, NULL);
         Py_DECREF(args);
         return ret;
     }
@@ -1895,7 +1922,8 @@ static PyMethodDef _draw_methods[] = {
     {"line", (PyCFunction)line, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDRAWLINE},
     {"aalines", aalines, METH_VARARGS, DOC_PYGAMEDRAWAALINES},
-    {"lines", lines, METH_VARARGS, DOC_PYGAMEDRAWLINES},
+    {"lines", (PyCFunction)lines, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEDRAWLINES},
     {"ellipse", (PyCFunction)ellipse, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDRAWELLIPSE},
     {"arc", (PyCFunction)arc, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEDRAWARC},

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -79,6 +79,12 @@ def border_pos_and_color(surface):
         yield pos, surface.get_at(pos)
 
 
+class InvalidBool(object):
+    """To help test invalid bool values."""
+    __nonzero__ = None
+    __bool__ = None
+
+
 class DrawTestCase(unittest.TestCase):
     """Base class to test draw module functions."""
     draw_rect    = staticmethod(draw.rect)
@@ -1365,6 +1371,354 @@ class LinesMixin(BaseLineMixin):
 
     This class contains all the general lines drawing tests.
     """
+    def test_lines__args(self):
+        """Ensures draw lines accepts the correct args."""
+        bounds_rect = self.draw_lines(pygame.Surface((3, 3)), (0, 10, 0, 50),
+                                      False, ((0, 0), (1, 1)), 1)
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__args_without_width(self):
+        """Ensures draw lines accepts the args without a width."""
+        bounds_rect = self.draw_lines(pygame.Surface((2, 2)), (0, 0, 0, 50),
+                                      False, ((0, 0), (1, 1)))
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__kwargs(self):
+        """Ensures draw lines accepts the correct kwargs
+        with and without a width arg.
+        """
+        surface = pygame.Surface((4, 4))
+        color = pygame.Color('yellow')
+        points = ((0, 0), (1, 1), (2, 2))
+        kwargs_list = [{'surface' : surface,
+                        'color'   : color,
+                        'closed'  : False,
+                        'points'  : points,
+                        'width'   : 1},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'closed'  : False,
+                        'points'  : points}]
+
+        for kwargs in kwargs_list:
+            bounds_rect = self.draw_lines(**kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__kwargs_order_independent(self):
+        """Ensures draw lines's kwargs are not order dependent."""
+        bounds_rect = self.draw_lines(closed=1,
+                                      points=((0, 0), (1, 1), (2, 2)),
+                                      width=2,
+                                      color=(10, 20, 30),
+                                      surface=pygame.Surface((3, 2)))
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__args_missing(self):
+        """Ensures draw lines detects any missing required args."""
+        surface = pygame.Surface((1, 1))
+        color = pygame.Color('blue')
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_lines(surface, color, 0)
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_lines(surface, color)
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_lines(surface)
+
+        with self.assertRaises(TypeError):
+            bounds_rect = self.draw_lines()
+
+    def test_lines__kwargs_missing(self):
+        """Ensures draw lines detects any missing required kwargs."""
+        kwargs = {'surface' : pygame.Surface((3, 2)),
+                  'color'   : pygame.Color('red'),
+                  'closed'  : 1,
+                  'points'  : ((2, 2), (1, 1)),
+                  'width'   : 1}
+
+        for name in ('points', 'closed', 'color', 'surface'):
+            invalid_kwargs = dict(kwargs)
+            invalid_kwargs.pop(name)  # Pop from a copy.
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_lines(**invalid_kwargs)
+
+    def test_lines__arg_invalid_types(self):
+        """Ensures draw lines detects invalid arg types."""
+        surface = pygame.Surface((2, 2))
+        color = pygame.Color('blue')
+        closed = 0
+        points = ((1, 2), (2, 1))
+
+        with self.assertRaises(TypeError):
+            # Invalid width.
+            bounds_rect = self.draw_lines(surface, color, closed, points, '1')
+
+        with self.assertRaises(TypeError):
+            # Invalid points.
+            bounds_rect = self.draw_lines(surface, color, closed, (1, 2, 3))
+
+        with self.assertRaises(TypeError):
+            # Invalid closed.
+            bounds_rect = self.draw_lines(surface, color, InvalidBool(),
+                                          points)
+
+        with self.assertRaises(TypeError):
+            # Invalid color.
+            bounds_rect = self.draw_lines(surface, 'blue', closed, points)
+
+        with self.assertRaises(TypeError):
+            # Invalid surface.
+            bounds_rect = self.draw_lines((1, 2, 3, 4), color, closed, points)
+
+    def test_lines__kwarg_invalid_types(self):
+        """Ensures draw lines detects invalid kwarg types."""
+        valid_kwargs = {'surface' : pygame.Surface((3, 3)),
+                        'color'   : pygame.Color('green'),
+                        'closed'  : False,
+                        'points'  : ((1, 2), (2, 1)),
+                        'width'   : 1}
+
+        invalid_kwargs = {'surface' : pygame.Surface,
+                          'color'   : 'green',
+                          'closed'  : InvalidBool(),
+                          'points'  : (0, 0, 0),
+                          'width'   : 1.2}
+
+        for kwarg in ('surface', 'color', 'closed', 'points', 'width'):
+            kwargs = dict(valid_kwargs)
+            kwargs[kwarg] = invalid_kwargs[kwarg]
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_lines(**kwargs)
+
+    def test_lines__kwarg_invalid_name(self):
+        """Ensures draw lines detects invalid kwarg names."""
+        surface = pygame.Surface((2, 3))
+        color = pygame.Color('cyan')
+        closed = 1
+        points = ((1, 2), (2, 1))
+        kwargs_list = [{'surface' : surface,
+                        'color'   : color,
+                        'closed'  : closed,
+                        'points'  : points,
+                        'width'   : 1,
+                        'invalid' : 1},
+
+                       {'surface' : surface,
+                        'color'   : color,
+                        'closed'  : closed,
+                        'points'  : points,
+                        'invalid' : 1}]
+
+        for kwargs in kwargs_list:
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_lines(**kwargs)
+
+    def test_lines__args_and_kwargs(self):
+        """Ensures draw lines accepts a combination of args/kwargs"""
+        surface = pygame.Surface((3, 2))
+        color = (255, 255, 0, 0)
+        closed = 0
+        points = ((1, 2), (2, 1))
+        width = 1
+        kwargs = {'surface' : surface,
+                  'color'   : color,
+                  'closed'  : closed,
+                  'points'  : points,
+                  'width'   : width}
+
+        for name in ('surface', 'color', 'closed', 'points', 'width'):
+            kwargs.pop(name)
+
+            if 'surface' == name:
+                bounds_rect = self.draw_lines(surface, **kwargs)
+            elif 'color' == name:
+                bounds_rect = self.draw_lines(surface, color, **kwargs)
+            elif 'closed' == name:
+                bounds_rect = self.draw_lines(surface, color, closed, **kwargs)
+            elif 'points' == name:
+                bounds_rect = self.draw_lines(surface, color, closed, points,
+                                              **kwargs)
+            else:
+                bounds_rect = self.draw_lines(surface, color, closed, points,
+                                              width, **kwargs)
+
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__valid_width_values(self):
+        """Ensures draw lines accepts different width values."""
+        line_color = pygame.Color('yellow')
+        surface_color = pygame.Color('white')
+        surface = pygame.Surface((3, 4))
+        pos = (1, 1)
+        kwargs = {'surface' : surface,
+                  'color'   : line_color,
+                  'closed'  : False,
+                  'points'  : (pos, (2, 1)),
+                  'width'   : None}
+
+        for width in (-100, -10, -1, 0, 1, 10, 100):
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['width'] = width
+            expected_color = line_color if width > 0 else surface_color
+
+            bounds_rect = self.draw_lines(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__valid_points_format(self):
+        """Ensures draw lines accepts different points formats."""
+        expected_color = (10, 20, 30, 255)
+        surface_color = pygame.Color('white')
+        surface = pygame.Surface((3, 4))
+        kwargs = {'surface' : surface,
+                  'color'   : expected_color,
+                  'closed'  : False,
+                  'points'  : None,
+                  'width'   : 1}
+
+        # The point type can be a tuple/list/Vector2.
+        point_types = ((tuple, tuple, tuple, tuple), # all tuples
+                       (list, list, list, list),     # all lists
+                       (Vector2, Vector2, Vector2, Vector2), # all Vector2s
+                       (list, Vector2, tuple, Vector2))      # mix
+
+        # The point values can be ints or floats.
+        point_values = (((1, 1), (2, 1), (2, 2), (1, 2)),
+                        ((1, 1), (2.2, 1), (2.1, 2.2), (1, 2.1)))
+
+        # Each sequence of points can be a tuple or a list.
+        seq_types = (tuple, list)
+
+        for point_type in point_types:
+            for values in point_values:
+                check_pos = values[0]
+                points = [point_type[i](pt) for i, pt in enumerate(values)]
+
+                for seq_type in seq_types:
+                    surface.fill(surface_color)  # Clear for each test.
+                    kwargs['points'] = seq_type(points)
+
+                    bounds_rect = self.draw_lines(**kwargs)
+
+                    self.assertEqual(surface.get_at(check_pos), expected_color)
+                    self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__invalid_points_formats(self):
+        """Ensures draw lines handles invalid points formats correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 4)),
+                  'color'   : pygame.Color('red'),
+                  'closed'  : False,
+                  'points'  : None,
+                  'width'   : 1}
+
+        points_fmts = (((1, 1), (2,)),          # Too few coords.
+                       ((1, 1), (2, 2, 2)),     # Too many coords.
+                       ((1, 1), (2, '2')),      # Wrong type.
+                       ((1, 1), set([2, 3])),   # Wrong type.
+                       ((1, 1), dict(((2, 2), (3, 3)))), # Wrong type.
+                       set(((1, 1), (1, 2))),   # Wrong type.
+                       dict(((1, 1), (4, 4))))  # Wrong type.
+
+        for points in points_fmts:
+            kwargs['points'] = points
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_lines(**kwargs)
+
+    def test_lines__invalid_points_values(self):
+        """Ensures draw lines handles invalid points values correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 4)),
+                  'color'   : pygame.Color('red'),
+                  'closed'  : False,
+                  'points'  : None,
+                  'width'   : 1}
+
+        for points in ([], ((1, 1),)):  # Too few points.
+            for seq_type in (tuple, list):  # Test as tuples and lists.
+                kwargs['points'] = seq_type(points)
+
+                with self.assertRaises(ValueError):
+                    bounds_rect = self.draw_lines(**kwargs)
+
+    def test_lines__valid_closed_values(self):
+        """Ensures draw lines accepts different closed values."""
+        line_color = pygame.Color('blue')
+        surface_color = pygame.Color('white')
+        surface = pygame.Surface((3, 4))
+        pos = (1, 2)
+        kwargs = {'surface' : surface,
+                  'color'   : line_color,
+                  'closed'  : None,
+                  'points'  : ((1, 1), (3, 1), (3, 3), (1, 3)),
+                  'width'   : 1}
+
+        true_values = (-7, 1, 10, '2', 3.1, (4,), [5], True)
+        false_values = (None, '', 0, (), [], False)
+
+        for closed in true_values + false_values:
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['closed'] = closed
+            expected_color = line_color if closed else surface_color
+
+            bounds_rect = self.draw_lines(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__valid_color_formats(self):
+        """Ensures draw lines accepts different color formats."""
+        green_color = pygame.Color('green')
+        surface_color = pygame.Color('black')
+        surface = pygame.Surface((3, 4))
+        pos = (1, 1)
+        kwargs = {'surface' : surface,
+                  'color'   : None,
+                  'closed'  : False,
+                  'points'  : (pos, (2, 1)),
+                  'width'   : 3}
+        greens = ((0, 255, 0), (0, 255, 0, 255), surface.map_rgb(green_color),
+                  green_color)
+
+        for color in greens:
+            surface.fill(surface_color)  # Clear for each test.
+            kwargs['color'] = color
+
+            if isinstance(color, int):
+                expected_color = surface.unmap_rgb(color)
+            else:
+                expected_color = green_color
+
+            bounds_rect = self.draw_lines(**kwargs)
+
+            self.assertEqual(surface.get_at(pos), expected_color)
+            self.assertIsInstance(bounds_rect, pygame.Rect)
+
+    def test_lines__invalid_color_formats(self):
+        """Ensures draw lines handles invalid color formats correctly."""
+        kwargs = {'surface' : pygame.Surface((4, 3)),
+                  'color'   : None,
+                  'closed'  : False,
+                  'points'  : ((1, 1), (1, 2)),
+                  'width'   : 1}
+
+        # These color formats are currently not supported (it would be
+        # nice to eventually support them).
+        for expected_color in ('green', '#00FF00FF', '0x00FF00FF'):
+            kwargs['color'] = expected_color
+
+            with self.assertRaises(TypeError):
+                bounds_rect = self.draw_lines(**kwargs)
+
     def test_lines__color(self):
         """Tests if the lines drawn are the correct color.
 
@@ -1406,12 +1760,14 @@ class LinesMixin(BaseLineMixin):
         self.fail()
 
 
-class PythonDrawLinesTest(LinesMixin, PythonDrawTestCase):
-    """Test draw_py module function lines.
-
-    This class inherits the general tests from LinesMixin. It is also the class
-    to add any draw_py.draw_lines specific tests to.
-    """
+# Commented out to avoid cluttering the test output. Add back in if draw_py
+# ever fully supports drawing lines.
+#class PythonDrawLinesTest(LinesMixin, PythonDrawTestCase):
+#    """Test draw_py module function lines.
+#
+#    This class inherits the general tests from LinesMixin. It is also the
+#    class to add any draw_py.draw_lines specific tests to.
+#    """
 
 
 class DrawLinesTest(LinesMixin, DrawTestCase):


### PR DESCRIPTION
Overview of changes:
- Added keyword arguments to `draw.lines`
- Added/updated some exception messages for `draw.lines`
- Added tests to check `draw.lines` args/kwargs
- Updated draw documentation
- Commented out `draw_py.lines` test cases to avoid cluttering the test output with 'skipped' messages

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at 4852e681baa46b0d92f1dc1420d1802217dd4a84

Resolves sub-item `pygame.draw.lines` of item "Add keyword arguments to the draw functions..." of #896.
Resolves the `draw.lines` item of #1040.