### PR TITLE
Fix some mask.c compiler warnings

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -582,7 +582,7 @@ get_pixel_color(Uint8 *pixel, Uint8 bpp)
  *
  * Ref: src_c/draw.c set_pixel_32()
  */
-static void *
+static void
 set_pixel_color(Uint8 *pixel, Uint8 bpp, Uint32 color)
 {
     switch (bpp) {
@@ -1983,7 +1983,7 @@ pgMask_GetBuffer(pgMaskObject *self, Py_buffer *view, int flags)
     view->suboffsets = NULL;
 
     Py_INCREF(self);
-    view->obj = self;
+    view->obj = (PyObject *)self;
 
     return 0;
 }


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at 4852e681baa46b0d92f1dc1420d1802217dd4a84