### PR TITLE
Add copy() method to Mask class

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -129,6 +129,9 @@ to store which parts collide.
    :returns: a newly created :class:`Mask` object
    :rtype: Mask
 
+   .. versionchanged:: 2.0.0
+      Shallow copy support added. The :class:`Mask` class supports the special
+      method ``__copy__()`` and shallow copying via ``copy.copy(mask)``.
    .. versionchanged:: 2.0.0 Subclassing support added. The :class:`Mask` class
       can be used as a base class.
    .. versionchanged:: 1.9.5 Added support for keyword arguments.

--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -136,6 +136,33 @@ to store which parts collide.
    .. versionchanged:: 1.9.5 Added support for masks with a width and/or a
       height of 0.
 
+   .. method:: copy
+
+      | :sl:`Returns a new copy of the mask`
+      | :sg:`copy() -> Mask`
+
+      :returns: a new copy of this mask, the new mask will have the same width,
+         height, and set/unset bits as the original
+      :rtype: Mask
+
+      .. note::
+         If a mask subclass needs to copy any instance specific attributes
+         then it should override the ``__copy__()`` method. The overridden
+         ``__copy__()`` method needs to call ``super().__copy__()`` and then
+         copy the required data as in the following example code.
+
+         ::
+
+            class SubMask(pygame.mask.Mask):
+                def __copy__(self):
+                    new_mask = super().__copy__()
+                    # Do any SubMask attribute copying here.
+                    return new_mask
+
+      .. versionadded:: 2.0.0
+
+      .. ## Mask.copy ##
+
    .. method:: get_size
 
       | :sl:`Returns the size of the mask`

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -118,6 +118,36 @@ bitmask_free(bitmask_t *m)
     free(m);
 }
 
+/* Create a copy of the given bitmask.
+ *
+ * Returns:
+ *     bitmask if successful, otherwise NULL
+ */
+bitmask_t *
+bitmask_copy(bitmask_t *mask) {
+    bitmask_t *mask_copy = NULL;
+
+    if (mask->w < 0 || mask->h < 0) {
+        return NULL;
+    }
+
+    mask_copy = bitmask_create(mask->w, mask->h);
+
+    if (NULL == mask_copy) {
+        return NULL;
+    }
+
+    /* Nothing to copy if width or height is 0. */
+    if (!mask->w || !mask->h) {
+        return mask_copy;
+    }
+
+    memcpy(mask_copy->bits, mask->bits,
+           mask->h * ((mask->w - 1) / BITMASK_W_LEN + 1) * sizeof(BITMASK_W));
+
+    return mask_copy;
+}
+
 void
 bitmask_clear(bitmask_t *m)
 {

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -124,7 +124,8 @@ bitmask_free(bitmask_t *m)
  *     bitmask if successful, otherwise NULL
  */
 bitmask_t *
-bitmask_copy(bitmask_t *mask) {
+bitmask_copy(bitmask_t *mask)
+{
     bitmask_t *mask_copy = NULL;
 
     if (mask->w < 0 || mask->h < 0) {

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -3,6 +3,7 @@
 #define DOC_PYGAMEMASKFROMSURFACE "from_surface(Surface) -> Mask\nfrom_surface(Surface, threshold=127) -> Mask\nCreates a Mask from the given surface"
 #define DOC_PYGAMEMASKFROMTHRESHOLD "from_threshold(Surface, color) -> Mask\nfrom_threshold(Surface, color, threshold=(0, 0, 0, 255), othersurface=None, palette_colors=1) -> Mask\nCreates a mask by thresholding Surfaces"
 #define DOC_PYGAMEMASKMASK "Mask(size=(width, height)) -> Mask\nMask(size=(width, height), fill=False) -> Mask\npygame object for representing 2D bitmasks"
+#define DOC_MASKCOPY "copy() -> Mask\nReturns a new copy of the mask"
 #define DOC_MASKGETSIZE "get_size() -> (width, height)\nReturns the size of the mask"
 #define DOC_MASKGETRECT "get_rect(**kwargs) -> Rect\nReturns a Rect based on the size of the mask"
 #define DOC_MASKGETAT "get_at((x, y)) -> int\nGets the bit at the given position"
@@ -48,6 +49,10 @@ pygame.mask.Mask
  Mask(size=(width, height)) -> Mask
  Mask(size=(width, height), fill=False) -> Mask
 pygame object for representing 2D bitmasks
+
+pygame.mask.Mask.copy
+ copy() -> Mask
+Returns a new copy of the mask
 
 pygame.mask.Mask.get_size
  get_size() -> (width, height)

--- a/src_c/include/bitmask.h
+++ b/src_c/include/bitmask.h
@@ -62,6 +62,9 @@ bitmask_t *bitmask_create(int w, int h);
 /* Frees all the memory allocated by bitmask_create for m. */
 void bitmask_free(bitmask_t *m);
 
+/* Create a copy of the given bitmask. */
+bitmask_t *bitmask_copy(bitmask_t *m);
+
 /* Clears all bits in the mask */
 void bitmask_clear(bitmask_t *m);
 


### PR DESCRIPTION
Overview of changes:
- Added a `copy()` method to the `Mask` class
- Added a `copy()` entry to the `Mask` documentation
- Added `copy()` tests
- Renamed a `mask.c` function to get rid of leading underscore
- Converted a `MaskTypeTest` method into a general function to allow other testcases to use it

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at 90344c4c9c64f9ecdbe3c62837a41e17a43a1274

Resolves #1086.