### PR TITLE
Fix a mixer.c compiler warning

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1729,8 +1729,11 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
         chunk = Mix_LoadWAV_RW(rw, 1);
         Py_END_ALLOW_THREADS;
         if (chunk == NULL) {
-            if (obj)
-                return RAISE(pgExc_SDLError, SDL_GetError());
+            if (obj) {
+                RAISE(pgExc_SDLError, SDL_GetError());
+                return -1;
+            }
+
             obj = pg_EncodeString(file, NULL, NULL, NULL);
             if (obj == Py_None) {
                 RAISE(pgExc_SDLError, SDL_GetError());


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at 90344c4c9c64f9ecdbe3c62837a41e17a43a1274