### PR TITLE
Fix some Py_ssize_t conversion to int compiler warnings

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -266,7 +266,7 @@ static PyObject *
 pg_init(PyObject *self, PyObject *args)
 {
     PyObject *allmodules, *moduleslist, *dict, *func, *result, *mod;
-    int loop, num;
+    Py_ssize_t loop, num;
 
     int success = 0, fail = 0;
 
@@ -372,7 +372,7 @@ _pg_quit(void)
 {
     PyObject *quit;
     PyObject *privatefuncs;
-    int num;
+    Py_ssize_t num;
 
     pg_is_init = 0;  // Considered uninitialized at this point?
 
@@ -526,7 +526,7 @@ pg_UintFromObjIndex(PyObject *obj, int _index, Uint32 *val)
 static int
 pg_RGBAFromObj(PyObject *obj, Uint8 *RGBA)
 {
-    int length;
+    Py_ssize_t length;
     Uint32 val;
 
     if (PyTuple_Check(obj) && PyTuple_Size(obj) == 1) {
@@ -1594,8 +1594,7 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
 {
     Py_ssize_t ndim = PyTuple_GET_SIZE(shape);
     pgViewInternals *internal_p;
-    Py_ssize_t sz;
-    int i;
+    Py_ssize_t sz, i;
 
     assert(ndim > 0);
     view_p->obj = 0;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1569,7 +1569,8 @@ pg_update(PyObject *self, PyObject *arg)
     else {
         PyObject *seq;
         PyObject *r;
-        int loop, num, count;
+        Py_ssize_t loop, num;
+        int count;
         SDL_Rect *rects;
         if (PyTuple_Size(arg) != 1)
             return RAISE(

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -120,7 +120,7 @@ static GAME_Rect *
 pgRect_FromObject(PyObject *obj, GAME_Rect *temp)
 {
     int val;
-    int length;
+    Py_ssize_t length;
 
     if (pgRect_Check(obj)) {
         return &((pgRectObject *)obj)->r;
@@ -342,7 +342,7 @@ static PyObject *
 pg_rect_unionall(pgRectObject *self, PyObject *args)
 {
     GAME_Rect *argrect, temp;
-    int loop, size;
+    Py_ssize_t loop, size;
     PyObject *list, *obj;
     int t, l, b, r;
 
@@ -389,7 +389,7 @@ static PyObject *
 pg_rect_unionall_ip(pgRectObject *self, PyObject *args)
 {
     GAME_Rect *argrect, temp;
-    int loop, size;
+    Py_ssize_t loop, size;
     PyObject *list, *obj;
     int t, l, b, r;
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -459,7 +459,8 @@ pgRWops_ReleaseObject(SDL_RWops *context)
 
         pgRWHelper *helper = (pgRWHelper *)context->hidden.unknown.data1;
         PyObject *fileobj = helper->file;
-        int filerefcnt = Py_REFCNT(fileobj) - 1 - 5 /* 5 helper functions */;
+        /* 5 helper functions */
+        Py_ssize_t filerefcnt = Py_REFCNT(fileobj) - 1 - 5;
 
         if (filerefcnt) {
             Py_XDECREF(helper->seek);


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 1.2.15) at 7bff9307aecf56cae6b250d6476f9193be2ede1c