### PR TITLE
Add default surface support to Mask's to_surface()

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -568,12 +568,17 @@ to store which parts collide.
    .. method:: to_surface
 
       | :sl:`Returns a surface with the mask drawn on it`
-      | :sg:`to_surface(surface)) -> Surface`
-      | :sg:`to_surface(surface, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface`
+      | :sg:`to_surface() -> Surface`
+      | :sg:`to_surface(surface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface`
 
       Draws this mask on the given surface.
 
-      :param Surface surface: Surface to draw mask onto
+      :param surface: (optional) Surface to draw mask onto, if no surface is
+         provided one will be created (default is ``None``, which will cause a
+         surface with the parameters
+         ``Surface(size=mask.get_size(), flags=SRCALPHA, depth=32)`` to be
+         created, drawn on, and returned
+      :type surface: Surface or None
       :param setcolor: (optional) color to draw set bits (bits set to 1),
          (default is ``(255, 255, 255, 255)``, white), use ``None`` to skip
          drawing the set bits
@@ -585,7 +590,8 @@ to store which parts collide.
       :type unsetcolor: Color or int or tuple(int, int, int, [int]) or
          list(int, int, int, [int]) or None
 
-      :returns: the ``surface`` parameter with this mask drawn on it
+      :returns: the ``surface`` parameter (or a newly created surface if no
+         ``surface`` parameter was provided) with this mask drawn on it
       :rtype: Surface
 
       .. versionadded:: 2.0.0

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -25,7 +25,7 @@
 #define DOC_MASKCONNECTEDCOMPONENT "connected_component() -> Mask\nconnected_component((x, y)) -> Mask\nReturns a mask containing a connected component"
 #define DOC_MASKCONNECTEDCOMPONENTS "connected_components() -> [Mask, ...]\nconnected_components(min=0) -> [Mask, ...]\nReturns a list of masks of connected components"
 #define DOC_MASKGETBOUNDINGRECTS "get_bounding_rects() -> [Rect, ...]\nReturns a list of bounding rects of connected components"
-#define DOC_MASKTOSURFACE "to_surface(surface)) -> Surface\nto_surface(surface, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface\nReturns a surface with the mask drawn on it"
+#define DOC_MASKTOSURFACE "to_surface() -> Surface\nto_surface(surface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface\nReturns a surface with the mask drawn on it"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -145,8 +145,8 @@ pygame.mask.Mask.get_bounding_rects
 Returns a list of bounding rects of connected components
 
 pygame.mask.Mask.to_surface
- to_surface(surface)) -> Surface
- to_surface(surface, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface
+ to_surface() -> Surface
+ to_surface(surface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface
 Returns a surface with the mask drawn on it
 
 */


### PR DESCRIPTION
Overview of changes:
- Added support for creating a default surface to Mask's `to_surface()`
- Updated Mask documentation
- Added/updated some `to_surface()` tests
- Renamed a helper method

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 2.0.9) at eb8bd8653114783bdf2d9b5f0471ccd57b0025aa

Resolves sub-items "code" and "documentation" of item "support for creating a new surface, i.e. when `surface=None`" of #1070.