### PR TITLE
Fix some event related compiler warnings

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1753,7 +1753,8 @@ static PyMethodDef _event_methods[] = {
      "auto initialize for event module"},
 #endif /* IS_SDLv2 */
 
-    {"Event", pg_Event, 3, DOC_PYGAMEEVENTEVENT},
+    {"Event", (PyCFunction)pg_Event, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEEVENTEVENT},
     {"event_name", event_name, METH_VARARGS, DOC_PYGAMEEVENTEVENTNAME},
 
     {"set_grab", set_grab, METH_VARARGS, DOC_PYGAMEEVENTSETGRAB},

--- a/src_c/fastevents.c
+++ b/src_c/fastevents.c
@@ -168,7 +168,11 @@ FE_Init()
     }
 
     eventTimer = SDL_AddTimer(10, timerCallback, NULL);
+#if IS_SDLv1
     if (NULL == eventTimer) {
+#else /* !IS_SDLv1 */
+    if (0 == eventTimer) {
+#endif /* IS_SDLv1 */
         setError("FE: can't add a timer");
         return -1;
     }


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev1 (SDL: 2.0.9) at eb8bd8653114783bdf2d9b5f0471ccd57b0025aa