### PR TITLE
Add keyword arguments to draw.aalines

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -402,15 +402,43 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
 .. function:: aalines
 
-   | :sl:`draw a connected sequence of antialiased lines`
-   | :sg:`aalines(Surface, color, closed, pointlist, blend=1) -> Rect`
+   | :sl:`draw multiple contiguous straight antialiased line segments`
+   | :sg:`aalines(surface, color, closed, points) -> Rect`
+   | :sg:`aalines(surface, color, closed, points, blend=1) -> Rect`
 
-   Draws a sequence on a surface. You must pass at least two points in the
-   sequence of points. The closed argument is a simple Boolean and if true, a
-   line will be draw between the first and last points. The Boolean blend
-   argument set to true will blend the shades with existing shades instead of
-   overwriting them. This function accepts floating point values for the end
-   points.
+   Draws a sequence of contiguous straight antialiased lines on the given
+   surface.
+
+   :param Surface surface: surface to draw on
+   :param color: color to draw with, the alpha value is optional if using a
+      tuple ``(RGB[A])``
+   :type color: Color or int or tuple(int, int, int, [int])
+   :param bool closed: if ``True`` an additional line segment is drawn between
+      the first and last points in the ``points`` sequence
+   :param points: a sequence of 2 or more (x, y) coordinates, where each
+      *coordinate* in the sequence must be a
+      tuple/list/:class:`pygame.math.Vector2` of 2 ints/floats and adjacent
+      coordinates will be connected by a line segment, e.g. for the
+      points ``[(x1, y1), (x2, y2), (x3, y3)]`` a line segment will be drawn
+      from ``(x1, y1)`` to ``(x2, y2)`` and from ``(x2, y2)`` to ``(x3, y3)``,
+      additionally if the ``closed`` parameter is ``True`` another line segment
+      will be drawn from ``(x3, y3)`` to ``(x1, y1)``
+   :type points: tuple(coordinate) or list(coordinate)
+   :param int blend: (optional) if non-zero (default) each line will be blended
+      with the surface's existing pixel shades, otherwise the pixels will be
+      overwritten
+
+   :returns: a rect bounding the changed pixels, if nothing is drawn the
+      bounding rect's position will be the position of the first point in the
+      ``points`` parameter (float values will be truncated) and its width and
+      height will be 0
+   :rtype: Rect
+
+   :raises ValueError: if ``len(points) < 2`` (must have at least 2 points)
+   :raises TypeError: if ``points`` is not a sequence or ``points`` does not
+      contain number pairs
+
+   .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.aalines ##
 

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -8,7 +8,7 @@
 #define DOC_PYGAMEDRAWLINE "line(surface, color, start_pos, end_pos, width) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
 #define DOC_PYGAMEDRAWLINES "lines(surface, color, closed, points) -> Rect\nlines(surface, color, closed, points, width=1) -> Rect\ndraw multiple contiguous straight line segments"
 #define DOC_PYGAMEDRAWAALINE "aaline(surface, color, start_pos, end_pos) -> Rect\naaline(surface, color, start_pos, end_pos, blend=1) -> Rect\ndraw a straight antialiased line"
-#define DOC_PYGAMEDRAWAALINES "aalines(Surface, color, closed, pointlist, blend=1) -> Rect\ndraw a connected sequence of antialiased lines"
+#define DOC_PYGAMEDRAWAALINES "aalines(surface, color, closed, points) -> Rect\naalines(surface, color, closed, points, blend=1) -> Rect\ndraw multiple contiguous straight antialiased line segments"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -59,7 +59,8 @@ pygame.draw.aaline
 draw a straight antialiased line
 
 pygame.draw.aalines
- aalines(Surface, color, closed, pointlist, blend=1) -> Rect
-draw a connected sequence of antialiased lines
+ aalines(surface, color, closed, points) -> Rect
+ aalines(surface, color, closed, points, blend=1) -> Rect
+draw multiple contiguous straight antialiased line segments
 
 */

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -31,6 +31,8 @@
 
 #include <math.h>
 
+#include <float.h>
+
 /*
     Many C libraries seem to lack the trunc call (added in C99).
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -245,53 +245,82 @@ line(PyObject *self, PyObject *arg, PyObject *kwargs)
                        pts[3] - pts[1] + 1);
 }
 
+/* Draws a series of antialiased lines on the given surface.
+ *
+ * Returns a Rect bounding the drawn area.
+ */
 static PyObject *
-aalines(PyObject *self, PyObject *arg)
+aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj, *colorobj, *closedobj, *points, *item;
-    SDL_Surface *surf;
-    float x, y;
-    float top, left, bottom, right;
-    float pts[4];
-    Uint8 rgba[4];
+    PyObject *surfobj = NULL, *colorobj = NULL, *closedobj = NULL;
+    PyObject *points = NULL, *item = NULL;
+    SDL_Surface *surf = NULL;
     Uint32 color;
-    int closed, blend=1;
-    int result, loop, length;
+    Uint8 rgba[4];
+    float pts[4];
     float *xlist, *ylist;
+    float x, y;
+    float top = FLT_MAX, left = FLT_MAX;
+    float bottom = FLT_MIN, right = FLT_MIN;
+    int result, loop, length;
+    int closed = 0; /* Default closed. */
+    int blend = 1;  /* Default blend. */
+    static char *keywords[] = {"surface", "color", "closed",
+                               "points",  "blend", NULL};
 
-    /*get all the arguments*/
-    if (!PyArg_ParseTuple(arg, "O!OOO|i", &pgSurface_Type, &surfobj, &colorobj,
-                          &closedobj, &points, &blend))
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|i", keywords,
+                                     &pgSurface_Type, &surfobj, &colorobj,
+                                     &closedobj, &points, &blend)) {
+        return NULL; /* Exception already set. */
+    }
+
     surf = pgSurface_AsSurface(surfobj);
+
+    if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {
+        return PyErr_Format(PyExc_ValueError,
+                            "unsupported surface bit depth (%d) for drawing",
+                            surf->format->BytesPerPixel);
+    }
 
     CHECK_LOAD_COLOR(colorobj)
 
     closed = PyObject_IsTrue(closedobj);
 
-    if (!PySequence_Check(points))
+    if (-1 == closed) {
+        return RAISE(PyExc_TypeError, "closed argument is invalid");
+    }
+
+    if (!PySequence_Check(points)) {
         return RAISE(PyExc_TypeError,
                      "points argument must be a sequence of number pairs");
+    }
+
     length = PySequence_Length(points);
-    if (length < 2)
+
+    if (length < 2) {
         return RAISE(PyExc_ValueError,
-                     "points argument must contain more than 1 points");
+                     "points argument must contain 2 or more points");
+    }
 
     xlist = PyMem_New(float, length);
     ylist = PyMem_New(float, length);
 
-    left = top = 10000;
-    right = bottom = -10000;
+    if (NULL == xlist || NULL == ylist) {
+        return RAISE(PyExc_MemoryError,
+                     "cannot allocate memory to draw aalines");
+    }
 
     for (loop = 0; loop < length; ++loop) {
         item = PySequence_GetItem(points, loop);
         result = pg_TwoFloatsFromObj(item, &x, &y);
         Py_DECREF(item);
+
         if (!result) {
             PyMem_Del(xlist);
             PyMem_Del(ylist);
             return RAISE(PyExc_TypeError, "points must be number pairs");
         }
+
         xlist[loop] = x;
         ylist[loop] = y;
         left = MIN(x, left);
@@ -303,7 +332,7 @@ aalines(PyObject *self, PyObject *arg)
     if (!pgSurface_Lock(surfobj)) {
         PyMem_Del(xlist);
         PyMem_Del(ylist);
-        return NULL;
+        return RAISE(PyExc_RuntimeError, "error locking surface");
     }
 
     for (loop = 1; loop < length; ++loop) {
@@ -323,10 +352,12 @@ aalines(PyObject *self, PyObject *arg)
 
     PyMem_Del(xlist);
     PyMem_Del(ylist);
-    if (!pgSurface_Unlock(surfobj))
-        return NULL;
 
-    /*compute return rect*/
+    if (!pgSurface_Unlock(surfobj)) {
+        return RAISE(PyExc_RuntimeError, "error unlocking surface");
+    }
+
+    /* Compute return rect. */
     return pgRect_New4((int)left, (int)top, (int)(right - left + 2),
                        (int)(bottom - top + 2));
 }
@@ -1926,7 +1957,8 @@ static PyMethodDef _draw_methods[] = {
      DOC_PYGAMEDRAWAALINE},
     {"line", (PyCFunction)line, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDRAWLINE},
-    {"aalines", aalines, METH_VARARGS, DOC_PYGAMEDRAWAALINES},
+    {"aalines", (PyCFunction)aalines, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEDRAWAALINES},
     {"lines", (PyCFunction)lines, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDRAWLINES},
     {"ellipse", (PyCFunction)ellipse, METH_VARARGS | METH_KEYWORDS,


### PR DESCRIPTION
Overview of changes:
- Added keyword arguments to `draw.aalines`
- Added/updated some exception messages for `draw.aalines`
- Added tests to check `draw.aalines` args/kwargs
- Updated draw documentation
- Commented out `draw_py.aalines` test cases to avoid cluttering the test output with 'skipped' messages
- Minor change to an existing aaline test

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev2 (SDL: 2.0.9) at 3d286457f48f5ac8a4f8cf219ea029a2393783e7

Resolves sub-item `pygame.draw.aalines` of item "Add keyword arguments to the draw functions..." of #896.
Resolves #1040 (resolved the last item: `draw.aalines`).