### PR TITLE
Add links between gfxdraw and draw docs

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -39,6 +39,10 @@ sequential drawing calls can be sped up by locking and unlocking the surface
 object around the draw calls (see :func:`pygame.Surface.lock` and
 :func:`pygame.Surface.unlock`).
 
+.. note ::
+   See the :mod:`pygame.gfxdraw` module for alternative draw methods.
+
+
 .. function:: rect
 
    | :sl:`draw a rectangle`

--- a/docs/reST/ref/gfxdraw.rst
+++ b/docs/reST/ref/gfxdraw.rst
@@ -43,8 +43,11 @@ The pygame.gfxdraw module differs from the draw module in the API it uses, and
 also the different functions available to draw.  It also wraps the primitives 
 from the library called SDL_gfx, rather than using modified versions.
 
+.. note ::
+   See the :mod:`pygame.draw` module for alternative draw methods.
 
 .. versionadded:: 1.9.0
+
 
 .. function:: pixel
 


### PR DESCRIPTION
Resolves sub-item "Add a link to `pygame.gfxdraw` as an alternative to `pygame.draw`." of item "Update the `pygame.draw` documentation. " of #896.