### PR TITLE
Use round() in Color.lerp

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -45,6 +45,13 @@
 
 #include <ctype.h>
 
+
+#if (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L) && !defined(round)
+#define pg_round(d) (((d < 0) ? (ceil((d)-0.5)) : (floor((d)+0.5))))
+#else
+#define pg_round(d) round(d)
+#endif
+
 typedef enum { TRISTATE_SUCCESS, TRISTATE_FAIL, TRISTATE_ERROR } tristate;
 
 static PyObject *_COLORDICT = NULL;
@@ -868,10 +875,10 @@ _color_lerp(pgColorObject *self, PyObject *args, PyObject *kw)
                         "Argument 2 must be in range [0, 1]");
     }
 
-    new_rgba[0] = (Uint8)round(self->data[0] * (1 - amt) + rgba[0] * amt);
-    new_rgba[1] = (Uint8)round(self->data[1] * (1 - amt) + rgba[1] * amt);
-    new_rgba[2] = (Uint8)round(self->data[2] * (1 - amt) + rgba[2] * amt);
-    new_rgba[3] = (Uint8)round(self->data[3] * (1 - amt) + rgba[3] * amt);
+    new_rgba[0] = (Uint8)pg_round(self->data[0] * (1 - amt) + rgba[0] * amt);
+    new_rgba[1] = (Uint8)pg_round(self->data[1] * (1 - amt) + rgba[1] * amt);
+    new_rgba[2] = (Uint8)pg_round(self->data[2] * (1 - amt) + rgba[2] * amt);
+    new_rgba[3] = (Uint8)pg_round(self->data[3] * (1 - amt) + rgba[3] * amt);
 
     return (PyObject *)_color_new_internal(Py_TYPE(self), new_rgba);
 }

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -868,10 +868,10 @@ _color_lerp(pgColorObject *self, PyObject *args, PyObject *kw)
                         "Argument 2 must be in range [0, 1]");
     }
 
-    new_rgba[0] = (Uint8)(self->data[0] * (1 - amt) + rgba[0] * amt);
-    new_rgba[1] = (Uint8)(self->data[1] * (1 - amt) + rgba[1] * amt);
-    new_rgba[2] = (Uint8)(self->data[2] * (1 - amt) + rgba[2] * amt);
-    new_rgba[3] = (Uint8)(self->data[3] * (1 - amt) + rgba[3] * amt);
+    new_rgba[0] = (Uint8)round(self->data[0] * (1 - amt) + rgba[0] * amt);
+    new_rgba[1] = (Uint8)round(self->data[1] * (1 - amt) + rgba[1] * amt);
+    new_rgba[2] = (Uint8)round(self->data[2] * (1 - amt) + rgba[2] * amt);
+    new_rgba[3] = (Uint8)round(self->data[3] * (1 - amt) + rgba[3] * amt);
 
     return (PyObject *)_color_new_internal(Py_TYPE(self), new_rgba);
 }

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -1104,7 +1104,7 @@ class ColorTypeTest (unittest.TestCase):
         # common value testing
         self.assertEqual(color1.lerp(color2, 0.5), Color(64, 64, 64, 64))
         self.assertEqual(color1.lerp(color2, 0.5), Color(64, 64, 64, 64))
-        self.assertEqual(color2.lerp(color3, 0.5), Color(191, 191, 191, 191))
+        self.assertEqual(color2.lerp(color3, 0.5), Color(192, 192, 192, 192))
         self.assertEqual(color1.lerp(color3, 0.5), Color(127, 127, 127, 127))
 
         # testing extremes
@@ -1201,45 +1201,6 @@ class SubclassTest(unittest.TestCase):
         self.assertTrue(isinstance(mc2, self.MyColor))
         self.assertRaises(AttributeError, getattr, mc2, 'an_attribute')
 
-    def test_lerp(self):
-        # setup
-        Color = self.MyColor
-
-        color1 = Color(0, 0, 0, 0)
-        color2 = Color(128, 128, 128, 128)
-        color3 = Color(255, 255, 255, 255)
-        color4 = Color(100, 100, 100, 100)
-
-        # type checking
-        self.assertTrue(isinstance(color1.lerp(color2, 0.5), Color))
-
-        # common value testing
-        self.assertEqual(color1.lerp(color2, 0.5), Color(64, 64, 64, 64))
-        self.assertEqual(color1.lerp(color2, 0.5), Color(64, 64, 64, 64))
-        self.assertEqual(color2.lerp(color3, 0.5), Color(191, 191, 191, 191))
-        self.assertEqual(color1.lerp(color3, 0.5), Color(127, 127, 127, 127))
-
-        # testing extremes
-        self.assertEqual(color1.lerp(color4, 0), color1)
-        self.assertEqual(color1.lerp(color4, 0.01), Color(1, 1, 1, 1))
-        self.assertEqual(color1.lerp(color4, 0.99), Color(99, 99, 99, 99))
-        self.assertEqual(color1.lerp(color4, 1), color4)
-
-        # kwarg testing
-        self.assertEqual(color1.lerp(color=color4,
-                                     amount=0.5),
-                         Color(50, 50, 50, 50))
-        self.assertEqual(color1.lerp(amount=0.5,
-                                     color=color4),
-                         Color(50, 50, 50, 50))
-
-        # invalid input testing
-        self.assertRaises(ValueError, lambda: color1.lerp(color2, 2.5))
-        self.assertRaises(ValueError, lambda: color1.lerp(color2, -0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((256, 0, 0, 0), 0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((0, 256, 0, 0), 0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((0, 0, 256, 0), 0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((0, 0, 0, 256), 0.5))
 
 ################################################################################
 

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -1093,41 +1093,41 @@ class ColorTypeTest (unittest.TestCase):
         # setup
         Color = pygame.color.Color
 
-        color1 = Color(0, 0, 0, 0)
-        color2 = Color(128, 128, 128, 128)
-        color3 = Color(255, 255, 255, 255)
-        color4 = Color(100, 100, 100, 100)
+        color0 = Color(0, 0, 0, 0)
+        color128 = Color(128, 128, 128, 128)
+        color255 = Color(255, 255, 255, 255)
+        color100 = Color(100, 100, 100, 100)
 
         # type checking
-        self.assertTrue(isinstance(color1.lerp(color2, 0.5), Color))
+        self.assertTrue(isinstance(color0.lerp(color128, 0.5), Color))
 
         # common value testing
-        self.assertEqual(color1.lerp(color2, 0.5), Color(64, 64, 64, 64))
-        self.assertEqual(color1.lerp(color2, 0.5), Color(64, 64, 64, 64))
-        self.assertEqual(color2.lerp(color3, 0.5), Color(192, 192, 192, 192))
-        self.assertEqual(color1.lerp(color3, 0.5), Color(127, 127, 127, 127))
+        self.assertEqual(color0.lerp(color128, 0.5), Color(64, 64, 64, 64))
+        self.assertEqual(color0.lerp(color128, 0.5), Color(64, 64, 64, 64))
+        self.assertEqual(color128.lerp(color255, 0.5), Color(192, 192, 192, 192))
+        self.assertEqual(color0.lerp(color255, 0.5), Color(128, 128, 128, 128))
 
         # testing extremes
-        self.assertEqual(color1.lerp(color4, 0), color1)
-        self.assertEqual(color1.lerp(color4, 0.01), Color(1, 1, 1, 1))
-        self.assertEqual(color1.lerp(color4, 0.99), Color(99, 99, 99, 99))
-        self.assertEqual(color1.lerp(color4, 1), color4)
+        self.assertEqual(color0.lerp(color100, 0), color0)
+        self.assertEqual(color0.lerp(color100, 0.01), Color(1, 1, 1, 1))
+        self.assertEqual(color0.lerp(color100, 0.99), Color(99, 99, 99, 99))
+        self.assertEqual(color0.lerp(color100, 1), color100)
 
         # kwarg testing
-        self.assertEqual(color1.lerp(color=color4,
+        self.assertEqual(color0.lerp(color=color100,
                                      amount=0.5),
                          Color(50, 50, 50, 50))
-        self.assertEqual(color1.lerp(amount=0.5,
-                                     color=color4),
+        self.assertEqual(color0.lerp(amount=0.5,
+                                     color=color100),
                          Color(50, 50, 50, 50))
 
         # invalid input testing
-        self.assertRaises(ValueError, lambda: color1.lerp(color2, 2.5))
-        self.assertRaises(ValueError, lambda: color1.lerp(color2, -0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((256, 0, 0, 0), 0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((0, 256, 0, 0), 0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((0, 0, 256, 0), 0.5))
-        self.assertRaises(TypeError, lambda: color1.lerp((0, 0, 0, 256), 0.5))
+        self.assertRaises(ValueError, lambda: color0.lerp(color128, 2.5))
+        self.assertRaises(ValueError, lambda: color0.lerp(color128, -0.5))
+        self.assertRaises(TypeError, lambda: color0.lerp((256, 0, 0, 0), 0.5))
+        self.assertRaises(TypeError, lambda: color0.lerp((0, 256, 0, 0), 0.5))
+        self.assertRaises(TypeError, lambda: color0.lerp((0, 0, 256, 0), 0.5))
+        self.assertRaises(TypeError, lambda: color0.lerp((0, 0, 0, 256), 0.5))
 
 
 class SubclassTest(unittest.TestCase):


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/574

This makes the math a bit closer to python, and a tiny bit more consistent over different C compilers/platforms.

There were some issues with `round()`. 
- not available on old msvc.
- being declared by python in pymath, but not exposing it publicly.

The workaround was to define it as pg_round. Which seems to work.