### PR TITLE
Fix to_surface incorrectly using width values

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1843,7 +1843,7 @@ draw_to_surface(SDL_Surface *surf, bitmask_t *bitmask, int draw_setbits,
             for (x = 0; x < w; ++x, pixel += bpp) {
                 if (bitmask_getbit(bitmask, x, y)) {
                     if (draw_setbits) {
-                        if (use_setsurf && setsurf->w) {
+                        if (use_setsurf && setsurf->w > x) {
                             set_pixel_color(pixel, bpp,
                                             get_pixel_color(setpixel, bpp));
                         }
@@ -1853,7 +1853,7 @@ draw_to_surface(SDL_Surface *surf, bitmask_t *bitmask, int draw_setbits,
                     }
                 }
                 else if (draw_unsetbits) {
-                    if (use_unsetsurf && unsetsurf->w) {
+                    if (use_unsetsurf && unsetsurf->w > x) {
                         set_pixel_color(pixel, bpp,
                                         get_pixel_color(unsetpixel, bpp));
                     }


### PR DESCRIPTION
Overview of changes:
- Fixed to_surface incorrectly using the `setsurface` and `unsetsurface` width values in some instances
- Added some `to_surface` tests
- Removed a debug `print()` from a test
- Added a parameter to a helper function

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev2 (SDL: 2.0.9) at 458e3928af4971dfa04af05099897061acf7133d

Related to #1070.