### PR TITLE
pygame.time.set_timer can now do something just once.

### DIFF
--- a/docs/reST/ref/time.rst
+++ b/docs/reST/ref/time.rst
@@ -53,6 +53,7 @@ resolution, in milliseconds, is given in the ``TIMER_RESOLUTION`` constant.
 
    | :sl:`repeatedly create an event on the event queue`
    | :sg:`set_timer(eventid, milliseconds) -> None`
+   | :sg:`set_timer(eventid, milliseconds, once) -> None`
 
    Set an event type to appear on the event queue every given number of
    milliseconds. The first event will not appear until the amount of time has
@@ -62,6 +63,10 @@ resolution, in milliseconds, is given in the ``TIMER_RESOLUTION`` constant.
    the value between ``pygame.USEREVENT`` and ``pygame.NUMEVENTS``.
 
    To disable the timer for an event, set the milliseconds argument to 0.
+
+   If the once argument is True, then only send the timer once.
+
+   .. versionadded:: 2.0.0.dev3 once argument added.
 
    .. ## pygame.time.set_timer ##
 
@@ -106,7 +111,7 @@ resolution, in milliseconds, is given in the ``TIMER_RESOLUTION`` constant.
       If you pass the optional framerate argument the function will delay to
       keep the game running slower than the given ticks per second. This can be
       used to help limit the runtime speed of a game. By calling
-      ``Clock.tick_busy_loop(40)`` once per frame, the program will never run at 
+      ``Clock.tick_busy_loop(40)`` once per frame, the program will never run at
       more than 40 frames per second.
 
       Note that this function uses :func:`pygame.time.delay`, which uses lots

--- a/src_c/doc/time_doc.h
+++ b/src_c/doc/time_doc.h
@@ -3,7 +3,7 @@
 #define DOC_PYGAMETIMEGETTICKS "get_ticks() -> milliseconds\nget the time in milliseconds"
 #define DOC_PYGAMETIMEWAIT "wait(milliseconds) -> time\npause the program for an amount of time"
 #define DOC_PYGAMETIMEDELAY "delay(milliseconds) -> time\npause the program for an amount of time"
-#define DOC_PYGAMETIMESETTIMER "set_timer(eventid, milliseconds) -> None\nrepeatedly create an event on the event queue"
+#define DOC_PYGAMETIMESETTIMER "set_timer(eventid, milliseconds) -> None\nset_timer(eventid, milliseconds, once) -> None\nrepeatedly create an event on the event queue"
 #define DOC_PYGAMETIMECLOCK "Clock() -> Clock\ncreate an object to help track time"
 #define DOC_CLOCKTICK "tick(framerate=0) -> milliseconds\nupdate the clock"
 #define DOC_CLOCKTICKBUSYLOOP "tick_busy_loop(framerate=0) -> milliseconds\nupdate the clock"
@@ -33,6 +33,7 @@ pause the program for an amount of time
 
 pygame.time.set_timer
  set_timer(eventid, milliseconds) -> None
+ set_timer(eventid, milliseconds, once) -> None
 repeatedly create an event on the event queue
 
 pygame.time.Clock

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -79,6 +79,7 @@ enumerate_event(Uint32 type)
 }
 #endif /* IS_SDLv2 */
 
+
 static Uint32
 timer_callback(Uint32 interval, void *param)
 {
@@ -90,6 +91,13 @@ timer_callback(Uint32 interval, void *param)
     }
     return interval;
 }
+
+static Uint32
+timer_callback_once(Uint32 interval, void *param)
+{
+    return timer_callback(0, param);
+}
+
 
 static int
 accurate_delay(int ticks)
@@ -190,9 +198,10 @@ time_set_timer(PyObject *self, PyObject *arg)
 {
     SDL_TimerID newtimer;
     int ticks = 0;
+    int once = 0;
     SDL_EventType event;
     size_t index;
-    if (!PyArg_ParseTuple(arg, "ii", &event, &ticks))
+    if (!PyArg_ParseTuple(arg, "ii|i", &event, &ticks, &once))
         return NULL;
 
     index = enumerate_event(event);
@@ -214,7 +223,11 @@ time_set_timer(PyObject *self, PyObject *arg)
             return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
-    newtimer = SDL_AddTimer(ticks, timer_callback, (void *)event);
+    if (once) {
+        newtimer = SDL_AddTimer(ticks, timer_callback_once, (void *)event);
+    } else {
+        newtimer = SDL_AddTimer(ticks, timer_callback, (void *)event);
+    }
     if (!newtimer)
         return RAISE(pgExc_SDLError, SDL_GetError());
     event_timers[index] = newtimer;
@@ -227,8 +240,9 @@ time_set_timer(PyObject *self, PyObject *arg)
 {
     SDL_TimerID newtimer;
     int ticks = 0;
+    int once = 0;
     intptr_t event = SDL_NOEVENT;
-    if (!PyArg_ParseTuple(arg, "ii", &event, &ticks))
+    if (!PyArg_ParseTuple(arg, "ii|i", &event, &ticks, &once))
         return NULL;
 
     if (event <= SDL_NOEVENT || event >= SDL_NUMEVENTS)
@@ -250,7 +264,11 @@ time_set_timer(PyObject *self, PyObject *arg)
             return RAISE(pgExc_SDLError, SDL_GetError());
     }
 
-    newtimer = SDL_AddTimer(ticks, timer_callback, (void *)event);
+    if (once) {
+        newtimer = SDL_AddTimer(ticks, timer_callback_once, (void *)event);
+    } else {
+        newtimer = SDL_AddTimer(ticks, timer_callback, (void *)event);
+    }
     if (!newtimer)
         return RAISE(pgExc_SDLError, SDL_GetError());
     event_timers[event] = newtimer;


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/1149

Post the event 1 second later, and do not repeat it.
```
pygame.time.set_timer(EVENT, 1000, 1)
```
