### PR TITLE
Deploy to pypi for releases from appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -146,13 +146,22 @@ artifacts:
 # For uploading releases to github.
 # https://www.appveyor.com/docs/deployment/github/
 deploy:
-  provider: GitHub
-  auth_token:
-    secure: lPFSARNb+pYeLKJUzLfSZ9OcSw74R/0vvAjYAkj7OcXOooeHIhIWjNoYDlXZL6hs # your encrypted token from GitHub
-  artifact: pypiartifacts
-  draft: true
-  prerelease: false
-  force_update: true
+  - provider: GitHub
+    auth_token:
+      secure: lPFSARNb+pYeLKJUzLfSZ9OcSw74R/0vvAjYAkj7OcXOooeHIhIWjNoYDlXZL6hs # your encrypted token from GitHub
+    artifact: pypiartifacts
+    draft: true
+    prerelease: false
+    force_update: true
+    on:
+      # branch: master               # release from master branch only
+      appveyor_repo_tag: true        # deploy on tag push only
+
+deploy_script:
+  TWINE_USERNAME: pygameci
+  TWINE_PASSWORD:
+    secure: FtHM0I+wubit/UWOzHsykHayL06KImKRZQznRUHUfzM=
+  ps: "%PYTHON% -m pip install twine; %PYTHON% -m twine upload --skip-existing dist/*"
   on:
     # branch: master               # release from master branch only
     appveyor_repo_tag: true        # deploy on tag push only


### PR DESCRIPTION
When we push a release tag, the .whl files will be uploaded to pypi.