### PR TITLE
Fix SDL1 compile issue

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -1934,7 +1934,14 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
     if (Py_None == surfobj) {
         surfobj =
             PyObject_CallFunction((PyObject *)&pgSurface_Type, "(ii)ii",
-                                  bitmask->w, bitmask->h, PGS_SRCALPHA, 32);
+                                  bitmask->w, bitmask->h,
+#if IS_SDLv1
+                                  SDL_SRCALPHA,
+#else
+                                  PGS_SRCALPHA,
+#endif
+                                  32);
+
         if (NULL == surfobj) {
             if (!PyErr_Occurred()) {
                 return RAISE(PyExc_RuntimeError, "unable to create surface");


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.9 and SDL 1.2.15) at d14a5bfdabcc601bcf828cc0b3e58c040dd085cb