### PR TITLE
simple scrap module based on SDL2 clipboard

### DIFF
--- a/buildconfig/Setup.SDL2.in
+++ b/buildconfig/Setup.SDL2.in
@@ -27,7 +27,7 @@ imageext src_c/imageext.c $(SDL) $(IMAGE) $(PNG) $(JPEG) $(DEBUG)
 font src_c/font.c $(SDL) $(FONT) $(DEBUG)
 mixer src_c/mixer.c $(SDL) $(MIXER) $(DEBUG)
 mixer_music src_c/music.c $(SDL) $(MIXER) $(DEBUG)
-#scrap src_c/scrap.c $(SDL) $(SCRAP) $(DEBUG)
+scrap src_c/scrap.c $(SDL) $(SCRAP) $(DEBUG)
 pypm src_c/pypm.c $(SDL) $(PORTMIDI) $(PORTTIME) $(DEBUG)
 
 _sdl2.sdl2 src_c/_sdl2/sdl2.c $(SDL) $(DEBUG) -Isrc_c

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -63,11 +63,16 @@ static PyObject *
 _scrap_set_mode(PyObject *self, PyObject *args);
 
 /* Determine what type of clipboard we are using */
-#if defined(__unix__) && defined(SDL_VIDEO_DRIVER_X11)
+#if IS_SDLv2
+#define SDL2_SCRAP
+#include "scrap_sdl2.c"
+
+#elif defined(__unix__) && defined(SDL_VIDEO_DRIVER_X11)
 /*!defined(__QNXNTO__) &&*/
 #define X11_SCRAP
 #include <time.h> /* Needed for clipboard timeouts. */
 #include "scrap_x11.c"
+
 #elif defined(__WIN32__)
 #define WIN_SCRAP
 #include "scrap_win.c"
@@ -114,8 +119,10 @@ _scrap_init(PyObject *self, PyObject *args)
     /* In case we've got not video surface, we won't initialize
      * anything.
      */
+#if IS_SDLv1
     if (!SDL_GetVideoSurface())
         return RAISE(pgExc_SDLError, "No display mode is set");
+#endif
     if (!pygame_scrap_init())
         return RAISE(pgExc_SDLError, SDL_GetError());
 
@@ -369,7 +376,7 @@ static PyMethodDef scrap_builtins[] = {
  * Note, the macosx stuff is done in sdlosx_main.m
  */
 #if (defined(X11_SCRAP) || defined(WIN_SCRAP) || defined(QNX_SCRAP) || \
-     defined(MAC_SCRAP))
+     defined(MAC_SCRAP) || defined(SDL2_SCRAP))
 
     {"init", _scrap_init, 1, DOC_PYGAMESCRAPINIT},
     {"get_init", _scrap_get_init, METH_NOARGS, DOC_PYGAMESCRAPGETINIT},

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -277,6 +277,10 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
         Py_RETURN_NONE;
 
     retval = Bytes_FromStringAndSize(scrap, count);
+#if defined(PYGAME_SCRAP_FREE_STRING)
+    free(scrap);
+#endif
+   
     return retval;
 }
 #endif

--- a/src_c/scrap_sdl2.c
+++ b/src_c/scrap_sdl2.c
@@ -1,30 +1,29 @@
 #include "SDL.h"
 #include "SDL_clipboard.h"
 
-char* plaintext_type= "text/plain;charset=utf-8";
+char *plaintext_type = "text/plain;charset=utf-8";
 
 int
-pygame_scrap_contains(char *type){
-    return (strcmp(type, plaintext_type) == 0)
-        && SDL_HasClipboardText();
+pygame_scrap_contains(char *type)
+{
+    return (strcmp(type, plaintext_type) == 0) && SDL_HasClipboardText();
 }
 
-char*
-pygame_scrap_get(char *type, unsigned long *count){
+char *
+pygame_scrap_get(char *type, unsigned long *count)
+{
     char *retval = NULL;
     char *clipboard = NULL;
-
 
     if (!pygame_scrap_initialized()) {
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
         return NULL;
     }
 
-    if  (strcmp(type, plaintext_type) == 0){
-        printf("type OK\n");
+    if (strcmp(type, plaintext_type) == 0) {
         clipboard = SDL_GetClipboardText();
-        if (clipboard != NULL){
-            *count=strlen(clipboard);
+        if (clipboard != NULL) {
+            *count = strlen(clipboard);
             retval = strdup(clipboard);
             SDL_free(clipboard);
             return retval;
@@ -33,9 +32,10 @@ pygame_scrap_get(char *type, unsigned long *count){
     return NULL;
 }
 
-char**
-pygame_scrap_get_types(void){
-    char** types;
+char **
+pygame_scrap_get_types(void)
+{
+    char **types;
     types = malloc(sizeof(char *) * 2);
     if (!types)
         return NULL;
@@ -47,24 +47,27 @@ pygame_scrap_get_types(void){
 }
 
 int
-pygame_scrap_init(void){
+pygame_scrap_init(void)
+{
     SDL_Init(SDL_INIT_VIDEO);
     _scrapinitialized = 1;
     return _scrapinitialized;
 }
 
 int
-pygame_scrap_lost(void){
+pygame_scrap_lost(void)
+{
     return 1;
 }
 
 int
-pygame_scrap_put(char *type, int srclen, char *src){
+pygame_scrap_put(char *type, int srclen, char *src)
+{
     if (!pygame_scrap_initialized()) {
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
         return 0;
     }
-    if (strcmp(type, plaintext_type) == 0){
+    if (strcmp(type, plaintext_type) == 0) {
         if (SDL_SetClipboardText(src) == 0) {
             return 1;
         }

--- a/src_c/scrap_sdl2.c
+++ b/src_c/scrap_sdl2.c
@@ -1,0 +1,73 @@
+#include "SDL.h"
+#include "SDL_clipboard.h"
+
+char* plaintext_type= "text/plain;charset=utf-8";
+
+int
+pygame_scrap_contains(char *type){
+    return (strcmp(type, plaintext_type) == 0)
+        && SDL_HasClipboardText();
+}
+
+char*
+pygame_scrap_get(char *type, unsigned long *count){
+    char *retval = NULL;
+    char *clipboard = NULL;
+
+
+    if (!pygame_scrap_initialized()) {
+        PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
+        return NULL;
+    }
+
+    if  (strcmp(type, plaintext_type) == 0){
+        printf("type OK\n");
+        clipboard = SDL_GetClipboardText();
+        if (clipboard != NULL){
+            *count=strlen(clipboard);
+            retval = strdup(clipboard);
+            SDL_free(clipboard);
+            return retval;
+        }
+    }
+    return NULL;
+}
+
+char**
+pygame_scrap_get_types(void){
+    char** types;
+    types = malloc(sizeof(char *) * 2);
+    if (!types)
+        return NULL;
+
+    types[0] = strdup(plaintext_type);
+    types[1] = NULL;
+
+    return types;
+}
+
+int
+pygame_scrap_init(void){
+    SDL_Init(SDL_INIT_VIDEO);
+    _scrapinitialized = 1;
+    return _scrapinitialized;
+}
+
+int
+pygame_scrap_lost(void){
+    return 1;
+}
+
+int
+pygame_scrap_put(char *type, int srclen, char *src){
+    if (!pygame_scrap_initialized()) {
+        PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
+        return 0;
+    }
+    if (strcmp(type, plaintext_type) == 0){
+        if (SDL_SetClipboardText(src) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Currently the master branch doesn't build the scrap module when you compile with SDL2. This is a simple replacement for the platform-specific scrap modules based on the cross-platform SDL2 clipboard functions. It can only handle utf-8 plaintext and nothing else.

Can somebody look at the code and tell me whether I have to used memcpy instead of strdup? I'm not sure if mixing null-terminated strings and length fields breaks anything besides wasting a single byte of memory.