### PR TITLE
WIP: Z buffering

### DIFF
--- a/examples/zbuffer.py
+++ b/examples/zbuffer.py
@@ -1,0 +1,25 @@
+import pygame
+pygame.init()
+screen=pygame.display.set_mode((320,240), pygame.SCALED)
+screen.fill((255,255,255))
+pygame.display.flip()
+
+z_buf = pygame.Surface((320,240), depth=8)
+z_buf.fill(255)
+
+sprit = pygame.Surface((20,20))
+sprit.fill((255,0,255))
+sprit.set_colorkey((255,0,255))
+pygame.draw.circle(sprit, (100,100,100), (10,10), 8, 2)
+
+screen.blit(sprit, (20,20))
+
+pygame.draw.circle(sprit, (100,200,200), (10,10), 8, 2)
+screen.depth_blit(sprit, (20,25), z_buf, 8)
+
+pygame.draw.circle(sprit, (200,100,100), (10,10), 8, 2)
+screen.depth_blit(sprit, (25,25), z_buf, 9)
+
+pygame.display.flip()
+
+input()


### PR DESCRIPTION
I propose the method `Surface.depth_blit(source, position, z_buffer, depth)`. It draws the source surface at the position only where the depth (or distance) is lower than the value in the depth buffer. If it is lower, the depth buffer is updated.

Due to performance considerations, this functionality needs to be written in C and not Python. It can't be written as a series of blits, only by iterating over the pixels. Due to the nature of Z-buffering, alpha blending is not possible and only color key surfaces can be drawn.

Right now, this implementation is very incomplete, and I'm not sure whether using a Surface as the depth buffer is a good idea, or whether the depth buffer should consist of 32-bit floats. 