### PR TITLE
fixed wrong variable array index. closes #1179

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -210,8 +210,8 @@ time_set_timer(PyObject *self, PyObject *arg)
 
     /*stop original timer*/
     if (event_timers[index]) {
-        SDL_RemoveTimer(event_timers[event]);
-        event_timers[event] = 0;
+        SDL_RemoveTimer(event_timers[index]);
+        event_timers[index] = 0;
     }
 
     if (ticks <= 0)


### PR DESCRIPTION
So turns out `size_t` and `SDL_EventType` are both int, so it compiled just fine, but we really want to use `index` here, not `event`