### PR TITLE
accept float values for radius in draw.circle()

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -149,8 +149,9 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       e.g. ``(x, y)``
    :type center: tuple(int or float, int or float) or
       list(int or float, int or float) or Vector2(int or float, int or float)
-   :param int radius: radius of the circle, measured from the ``center``
+   :param radius: radius of the circle, measured from the ``center``
       parameter, a radius of 0 will only draw the ``center`` pixel
+   :type radius: int or float 
    :param int width: (optional) used for line thickness or to indicate that
       the circle is to be filled
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -651,17 +651,17 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
-    PyObject *posobj;
+    PyObject *posobj, *radiusobj;
     int posx, posy, radius, t, l, b, r;
     int width = 0; /* Default width. */
     static char *keywords[] = {"surface", "color", "center",
                                "radius",  "width", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!OOi|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!OOO|i", keywords,
                           &pgSurface_Type, &surfobj,
                           &colorobj,
                           &posobj,
-                          &radius, &width))
+                          &radiusobj, &width))
         return NULL; /* Exception already set. */
 
     if (!pg_TwoIntsFromObj(posobj, &posx, &posy)) {
@@ -669,6 +669,14 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
                         "expected a pair of numbers");
         return 0;
     }
+
+    if (!pg_IntFromObj (radiusobj, &radius)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "expected a number");
+        return 0;
+    }
+
+
 
     surf = pgSurface_AsSurface(surfobj);
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -666,13 +666,13 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (!pg_TwoIntsFromObj(posobj, &posx, &posy)) {
         PyErr_SetString(PyExc_TypeError,
-                        "expected a pair of numbers");
+                        "center argument must be a pair of numbers");
         return 0;
     }
 
     if (!pg_IntFromObj (radiusobj, &radius)) {
         PyErr_SetString(PyExc_TypeError,
-                        "expected a number");
+                        "radius argument must be a number");
         return 0;
     }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -676,8 +676,6 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
         return 0;
     }
 
-
-
     surf = pgSurface_AsSurface(surfobj);
 
     if (surf->format->BytesPerPixel <= 0 || surf->format->BytesPerPixel > 4) {

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4125,6 +4125,13 @@ class DrawCircleMixin(object):
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
 
+    def test_circle__args_float(self):
+        """Ensures draw circle accepts floats for center coordinates and radius."""
+        bounds_rect = self.draw_circle(pygame.Surface((2, 2)), (0, 0, 0, 50),
+                                       (1.3, 1.3), 1.2,1)
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)    
+
     def test_circle__kwargs(self):
         """Ensures draw circle accepts the correct kwargs
         with and without a width arg.

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4123,14 +4123,7 @@ class DrawCircleMixin(object):
         bounds_rect = self.draw_circle(pygame.Surface((2, 2)), (0, 0, 0, 50),
                                        (1, 1), 1)
 
-        self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_circle__args_float(self):
-        """Ensures draw circle accepts floats for center coordinates and radius."""
-        bounds_rect = self.draw_circle(pygame.Surface((2, 2)), (0, 0, 0, 50),
-                                       (1.3, 1.3), 1.2,1)
-
-        self.assertIsInstance(bounds_rect, pygame.Rect)    
+        self.assertIsInstance(bounds_rect, pygame.Rect) 
 
     def test_circle__kwargs(self):
         """Ensures draw circle accepts the correct kwargs
@@ -4444,7 +4437,7 @@ class DrawCircleMixin(object):
             surface=pygame.Surface((4, 4)),
             color=(255, 255, 127),
             center=(1.5, 1.5),
-            radius=1,
+            radius=1.3,
             width=0,
         )
 
@@ -4452,9 +4445,11 @@ class DrawCircleMixin(object):
             surface=pygame.Surface((4, 4)),
             color=(255, 255, 127),
             center=Vector2(1.5, 1.5),
-            radius=1,
+            radius=1.3,
             width=0,
         )
+
+        draw.circle(pygame.Surface((2, 2)), (0, 0, 0, 50), (1.3, 1.3), 1.2)
 
     # This decorator can be removed when issue #1122 is resolved.
     @unittest.expectedFailure

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4242,7 +4242,7 @@ class DrawCircleMixin(object):
                        {'surface' : surface,
                         'color'   : color,
                         'center'  : center,
-                        'radius'  : 1.1,  # Invalid radius.
+                        'radius'  : "1",  # Invalid radius.
                         'width'   : width},
 
                        {'surface' : surface,


### PR DESCRIPTION
Currently (pygame-2.0.0.dev3), those are legal calls:
```
pg.draw.line(srf, color, (10.12, 10), (480.33, 280))
pg.draw.rect(srf, color, pg.rect.Rect(10.12, 10, 480.33, 280))
pg.draw.circle(prozor, boja, (20.5, 15.5), 10)
```
But the next call raises "TypeError: integer argument expected, got float":
```
pg.draw.circle(prozor, boja, (20.5, 15.5), 5.5)
```
Radius of a circle is the only remaining dimension in drawing primitives without implicit argument conversion from float to int (if we don't count line width).  Whatever was initial reasons to require mandatory int type for radius, now it is just an inconsistency. 



