### PR TITLE
Drawing ellipse/circle/arc with negative width value

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -157,7 +157,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
          | if ``width == 0``, (default) fill the circle
          | if ``width > 0``, used for line thickness
-         | if ``width < 0``, raises a ``ValueError``
+         | if ``width < 0``, nothing will be drawn
          |
 
          .. note::
@@ -169,7 +169,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       values will be truncated) and its width and height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``radius < 0`` or ``width < 0`` or ``width > radius``
+   :raises ValueError: if ``radius < 0`` or ``width > radius``
 
    .. versionchanged:: 2.0.0 Added support for keyword arguments.
 

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -196,7 +196,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
          | if ``width == 0``, (default) fill the ellipse
          | if ``width > 0``, used for line thickness
-         | if ``width < 0``, raises a ``ValueError``
+         | if ``width < 0``, nothing will be drawn
          |
 
          .. note::
@@ -208,8 +208,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       parameter and its width and height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``width < 0`` or ``width > rect.w / 2`` or
-      ``width > rect.h / 2``
+   :raises ValueError: if ``width > rect.w / 2`` or ``width > rect.h / 2``
 
    .. versionchanged:: 2.0.0 Added support for keyword arguments.
 

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -253,8 +253,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
          | if ``width == 0``, nothing will be drawn
          | if ``width > 0``, (default is 1) used for line thickness
-         | if ``width < 0``, raises a ``ValueError``
-         |
+         | if ``width < 0``, same as ``width == 0``
 
          .. note::
             When using ``width`` values ``> 1``, the edge lines will only grow
@@ -265,7 +264,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       parameter and its width and height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``width < 0`` or ``width > rect.w / 2`` or
+   :raises ValueError: if ``width > rect.w / 2`` or
       ``width > rect.h / 2``
 
    .. versionchanged:: 2.0.0 Added support for keyword arguments.

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -613,7 +613,7 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
     CHECK_LOAD_COLOR(colorobj)
 
     if (width < 0) {
-        return RAISE(PyExc_ValueError, "negative width");
+        return pgRect_New4(rect->x, rect->y, 0, 0);
     }
 
     if (width > rect->w / 2 || width > rect->h / 2) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -543,7 +543,7 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
     CHECK_LOAD_COLOR(colorobj)
 
     if (width < 0) {
-        return RAISE(PyExc_ValueError, "negative width");
+        return pgRect_New4(rect->x, rect->y, 0, 0);
     }
 
     if (width > rect->w / 2 || width > rect->h / 2) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -695,7 +695,7 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (width < 0) {
-        return pgRect_New4(posx - radius, posy - radius, 0, 0);
+        return pgRect_New4(posx, posy, 0, 0);
     }
 
     if (width > radius) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -695,7 +695,7 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (width < 0) {
-        return RAISE(PyExc_ValueError, "negative width");
+        return pgRect_New4(posx - radius, posy - radius, 0, 0);
     }
 
     if (width > radius) {

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4672,6 +4672,14 @@ class DrawArcMixin(object):
                                     pygame.Rect((0, 0), (2, 2)), 1.1, 2.1)
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
+        
+    def test_arc__args_with_negative_width(self):
+        """Ensures draw arc accepts the args with negative width."""
+        bounds_rect = self.draw_arc(pygame.Surface((3, 3)),
+            (10, 10, 50, 50), (1, 1, 2, 2), 0, 1, -1)
+    
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+        self.assertEqual(bounds_rect, pygame.Rect(1, 1, 0, 0))
 
     def test_arc__kwargs(self):
         """Ensures draw arc accepts the correct kwargs

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -192,6 +192,14 @@ class DrawEllipseMixin(object):
                                         pygame.Rect((1, 1), (1, 1)))
 
         self.assertIsInstance(bounds_rect, pygame.Rect)
+    
+    def test_ellipse__args_with_negative_width(self):
+        """Ensures draw ellipse accepts the args with negative width."""
+        bounds_rect = self.draw_ellipse(pygame.Surface((3, 3)),
+            (0, 10, 0, 50), pygame.Rect((2, 3), (3, 2)), -1)
+        
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+        self.assertEqual(bounds_rect, pygame.Rect(2, 3, 0, 0))
 
     def test_ellipse__kwargs(self):
         """Ensures draw ellipse accepts the correct kwargs

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4206,6 +4206,14 @@ class DrawCircleMixin(object):
 
         self.assertIsInstance(bounds_rect, pygame.Rect) 
 
+    def test_circle__args_with_negative_width(self):
+        """Ensures draw circle accepts the args with negative width."""
+        bounds_rect = self.draw_circle(pygame.Surface((2, 2)), (0, 0, 0, 50),
+                                       (1, 1), 1, -1)
+
+        self.assertIsInstance(bounds_rect, pygame.Rect) 
+        self.assertEqual(bounds_rect, pygame.Rect(0, 0, 0, 0))
+
     def test_circle__kwargs(self):
         """Ensures draw circle accepts the correct kwargs
         with and without a width arg.

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4212,7 +4212,7 @@ class DrawCircleMixin(object):
                                        (1, 1), 1, -1)
 
         self.assertIsInstance(bounds_rect, pygame.Rect) 
-        self.assertEqual(bounds_rect, pygame.Rect(0, 0, 0, 0))
+        self.assertEqual(bounds_rect, pygame.Rect(1, 1, 0, 0))
 
     def test_circle__kwargs(self):
         """Ensures draw circle accepts the correct kwargs


### PR DESCRIPTION
Closes #975 : drawing an ellipse/arc/circle with negative `width` value would raise `ValueError`. 

Now the behavior is the same as when drawing a rect with a negative width value (draw nothing and return a bounding rect with the position set to that of the `rect` argument and its width and height set to zero). 

This PR has 3 parts.

- [x] Accept negative width values for pygame.draw.arc (also add relevant tests and update documentation)  
- [x] Accept negative width values for pygame.draw.circle (also add relevant tests and update documentation)
- [x] Accept negative width values for pygame.draw.ellipse (also add relevant tests and update documentation)
