### PR TITLE
Fix pygame.mixer.music.queue() not queuing sound

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -178,12 +178,14 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
 
 .. function:: queue
 
-   | :sl:`queue a music file to follow the current`
+   | :sl:`queue a sound file to follow the current`
    | :sg:`queue(filename) -> None`
 
-   This will load a music file and queue it. A queued music file will begin as
-   soon as the current music naturally ends. If the current music is ever
-   stopped or changed, the queued song will be lost.
+   This will load a sound file and queue it. A queued sound file will begin as
+   soon as the current sound naturally ends. Only one sound can be queued at a
+   time. Queuing a new sound while another sound is queued will result in the
+   new sound becoming the queued sound. Also, if the current sound is ever
+   stopped or changed, the queued sound will be lost.
 
    The following example will play music by Bach six times, then play music by
    Mozart once:

--- a/src_c/doc/music_doc.h
+++ b/src_c/doc/music_doc.h
@@ -13,7 +13,7 @@
 #define DOC_PYGAMEMIXERMUSICGETBUSY "get_busy() -> bool\ncheck if the music stream is playing"
 #define DOC_PYGAMEMIXERMUSICSETPOS "set_pos(pos) -> None\nset position to play from"
 #define DOC_PYGAMEMIXERMUSICGETPOS "get_pos() -> time\nget the music play time"
-#define DOC_PYGAMEMIXERMUSICQUEUE "queue(filename) -> None\nqueue a music file to follow the current"
+#define DOC_PYGAMEMIXERMUSICQUEUE "queue(filename) -> None\nqueue a sound file to follow the current"
 #define DOC_PYGAMEMIXERMUSICSETENDEVENT "set_endevent() -> None\nset_endevent(type) -> None\nhave the music send an event when playback stops"
 #define DOC_PYGAMEMIXERMUSICGETENDEVENT "get_endevent() -> type\nget the event a channel sends when playback stops"
 
@@ -80,7 +80,7 @@ get the music play time
 
 pygame.mixer.music.queue
  queue(filename) -> None
-queue a music file to follow the current
+queue a sound file to follow the current
 
 pygame.mixer.music.set_endevent
  set_endevent() -> None

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -97,17 +97,39 @@ class MixerMusicModuleTest(unittest.TestCase):
         finally:
             os.remove(tmppath)
 
-    def test_queue(self):
-        """Ensures queue() can be called with different file types.
+    @unittest.skipIf('Darwin' in platform.system(),
+                     'SDL2_mixer issue with mp3 files on Travis CI')
+    def test_queue_mp3(self):
+        """Ensures queue() accepts mp3 files.
 
-        This also tests that queue() can be called multiple times.
+        |tags:music|
         """
-        mp3_file = example_path(os.path.join('data', 'house_lo.mp3'))
+        filename = example_path(os.path.join('data', 'house_lo.mp3'))
+        pygame.mixer.music.queue(filename)
+
+    def test_queue_ogg(self):
+        """Ensures queue() accepts ogg files.
+
+        |tags:music|
+        """
+        filename = example_path(os.path.join('data', 'house_lo.ogg'))
+        pygame.mixer.music.queue(filename)
+
+    def test_queue_wav(self):
+        """Ensures queue() accepts wav files.
+
+        |tags:music|
+        """
+        filename = example_path(os.path.join('data', 'house_lo.wav'))
+        pygame.mixer.music.queue(filename)
+
+    def test_queue__multiple_calls(self):
+        """Ensures queue() can be called multiple times."""
         ogg_file = example_path(os.path.join('data', 'house_lo.ogg'))
         wav_file = example_path(os.path.join('data', 'house_lo.wav'))
 
-        for filename in (mp3_file, ogg_file, wav_file):
-            pygame.mixer.music.queue(filename)
+        pygame.mixer.music.queue(ogg_file)
+        pygame.mixer.music.queue(wav_file)
 
     def test_queue__no_file(self):
         """Ensures queue() correctly handles missing the file argument."""

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -97,22 +97,34 @@ class MixerMusicModuleTest(unittest.TestCase):
         finally:
             os.remove(tmppath)
 
-    def todo_test_queue(self):
+    def test_queue(self):
+        """Ensures queue() can be called with different file types.
 
-        # __doc__ (as of 2008-08-02) for pygame.mixer_music.queue:
+        This also tests that queue() can be called multiple times.
+        """
+        mp3_file = example_path(os.path.join('data', 'house_lo.mp3'))
+        ogg_file = example_path(os.path.join('data', 'house_lo.ogg'))
+        wav_file = example_path(os.path.join('data', 'house_lo.wav'))
 
-          # This will load a music file and queue it. A queued music file will
-          # begin as soon as the current music naturally ends. If the current
-          # music is ever stopped or changed, the queued song will be lost.
-          #
-          # The following example will play music by Bach six times, then play
-          # music by Mozart once:
-          #
-          #     pygame.mixer.music.load('bach.ogg')
-          #     pygame.mixer.music.play(5)        # Plays six times, not five!
-          #     pygame.mixer.music.queue('mozart.ogg')
+        for filename in (mp3_file, ogg_file, wav_file):
+            pygame.mixer.music.queue(filename)
 
-        self.fail()
+    def test_queue__no_file(self):
+        """Ensures queue() correctly handles missing the file argument."""
+        with self.assertRaises(TypeError):
+            pygame.mixer.music.queue()
+
+    def test_queue__invalid_sound_type(self):
+        """Ensures queue() correctly handles invalid file types."""
+        not_a_sound_file = example_path(os.path.join('data', 'city.png'))
+
+        with self.assertRaises(pygame.error):
+            pygame.mixer.music.queue(not_a_sound_file)
+
+    def test_queue__invalid_filename(self):
+        """Ensures queue() correctly handles invalid filenames."""
+        with self.assertRaises(pygame.error):
+            pygame.mixer.music.queue('')
 
     def todo_test_stop(self):
 


### PR DESCRIPTION
Overview of changes:
- Fixed `pygame.mixer.music.queue()` not queuing sound
- Fixed queued music still playing after `stop()` or `fadeout()` being called
- Updated `queue()` documentation
- Added some `queue()` tests

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.9) at c8c9e8236cb8ad4178594badb1f29e95ff0c0708

Resolves #1193.