### PR TITLE
Add function to get SDL mixer version

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -262,6 +262,8 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    .. note::
       The linked and compile version numbers should be the same.
 
+   .. versionadded:: 2.0.0
+
    .. ## pygame.mixer.get_sdl_mixer_version ##
 
 .. class:: Sound

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -245,6 +245,25 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
 
    .. ## pygame.mixer.get_busy ##
 
+.. function:: get_sdl_mixer_version
+
+   | :sl:`get the mixer's SDL version`
+   | :sg:`get_sdl_mixer_version() -> (major, minor, patch)`
+   | :sg:`get_sdl_mixer_version(linked=True) -> (major, minor, patch)`
+
+   :param bool linked: if ``True`` (default) the linked version number is
+      returned, otherwise the compiled version number is returned
+
+   :returns: the mixer's SDL library version number (linked or compiled
+      depending on the ``linked`` parameter) as a tuple of 3 integers
+      ``(major, minor, patch)``
+   :rtype: tuple
+
+   .. note::
+      The linked and compile version numbers should be the same.
+
+   .. ## pygame.mixer.get_sdl_mixer_version ##
+
 .. class:: Sound
 
    | :sl:`Create a new Sound object from a file or buffer object`

--- a/src_c/doc/mixer_doc.h
+++ b/src_c/doc/mixer_doc.h
@@ -13,6 +13,7 @@
 #define DOC_PYGAMEMIXERSETRESERVED "set_reserved(count) -> None\nreserve channels from being automatically used"
 #define DOC_PYGAMEMIXERFINDCHANNEL "find_channel(force=False) -> Channel\nfind an unused channel"
 #define DOC_PYGAMEMIXERGETBUSY "get_busy() -> bool\ntest if any sound is being mixed"
+#define DOC_PYGAMEMIXERGETSDLMIXERVERSION "get_sdl_mixer_version() -> (major, minor, patch)\nget_sdl_mixer_version(linked=True) -> (major, minor, patch)\nget the mixer's SDL version"
 #define DOC_PYGAMEMIXERSOUND "Sound(filename) -> Sound\nSound(file=filename) -> Sound\nSound(buffer) -> Sound\nSound(buffer=buffer) -> Sound\nSound(object) -> Sound\nSound(file=object) -> Sound\nSound(array=object) -> Sound\nCreate a new Sound object from a file or buffer object"
 #define DOC_SOUNDPLAY "play(loops=0, maxtime=0, fade_ms=0) -> Channel\nbegin sound playback"
 #define DOC_SOUNDSTOP "stop() -> None\nstop sound playback"
@@ -96,6 +97,11 @@ find an unused channel
 pygame.mixer.get_busy
  get_busy() -> bool
 test if any sound is being mixed
+
+pygame.mixer.get_sdl_mixer_version
+ get_sdl_mixer_version() -> (major, minor, patch)
+ get_sdl_mixer_version(linked=True) -> (major, minor, patch)
+get the mixer's SDL version
 
 pygame.mixer.Sound
  Sound(filename) -> Sound

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -37,6 +37,13 @@ CONFIG = {'frequency' : 22050, 'size' : -16, 'channels' : 2} # base config
 if pygame.get_sdl_version()[0] >= 2:
     CONFIG = {'frequency' : 44100, 'size' : 32, 'channels' : 2} # base config
 
+
+class InvalidBool(object):
+    """To help test invalid bool values."""
+    __nonzero__ = None
+    __bool__ = None
+
+
 ############################## MODULE LEVEL TESTS ##############################
 
 class MixerModuleTest(unittest.TestCase):
@@ -544,6 +551,69 @@ class MixerModuleTest(unittest.TestCase):
           # This will resume all active sound channels after they have been paused.
 
         self.fail()
+
+    def test_get_sdl_mixer_version(self):
+        """Ensures get_sdl_mixer_version works correctly with no args."""
+        expected_length = 3
+        expected_type = tuple
+        expected_item_type = int
+
+        version = pygame.mixer.get_sdl_mixer_version()
+
+        self.assertIsInstance(version, expected_type)
+        self.assertEqual(len(version), expected_length)
+
+        for item in version:
+            self.assertIsInstance(item, expected_item_type)
+
+    def test_get_sdl_mixer_version__args(self):
+        """Ensures get_sdl_mixer_version works correctly using args."""
+        expected_length = 3
+        expected_type = tuple
+        expected_item_type = int
+
+        for value in (True, False):
+            version = pygame.mixer.get_sdl_mixer_version(value)
+
+            self.assertIsInstance(version, expected_type)
+            self.assertEqual(len(version), expected_length)
+
+            for item in version:
+                self.assertIsInstance(item, expected_item_type)
+
+    def test_get_sdl_mixer_version__kwargs(self):
+        """Ensures get_sdl_mixer_version works correctly using kwargs."""
+        expected_length = 3
+        expected_type = tuple
+        expected_item_type = int
+
+        for value in (True, False):
+            version = pygame.mixer.get_sdl_mixer_version(linked=value)
+
+            self.assertIsInstance(version, expected_type)
+            self.assertEqual(len(version), expected_length)
+
+            for item in version:
+                self.assertIsInstance(item, expected_item_type)
+
+    def test_get_sdl_mixer_version__invalid_args_kwargs(self):
+        """Ensures get_sdl_mixer_version handles invalid args and kwargs."""
+        invalid_bool = InvalidBool()
+
+        with self.assertRaises(TypeError):
+            version = pygame.mixer.get_sdl_mixer_version(invalid_bool)
+
+        with self.assertRaises(TypeError):
+            version = pygame.mixer.get_sdl_mixer_version(linked=invalid_bool)
+
+    def test_get_sdl_mixer_version__linked_equals_compiled(self):
+        """Ensures get_sdl_mixer_version's linked/compiled versions are equal.
+        """
+        linked_version = pygame.mixer.get_sdl_mixer_version(linked=True)
+        complied_version = pygame.mixer.get_sdl_mixer_version(linked=False)
+
+        self.assertTupleEqual(linked_version, complied_version)
+
 
 ############################## CHANNEL CLASS TESTS #############################
 


### PR DESCRIPTION
Overview of changes:
- Added a function to get the SDL mixer version information
- Added related tests
- Updated related documentation

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.9) at c8c9e8236cb8ad4178594badb1f29e95ff0c0708