### PR TITLE
Do not import numpy until it is used. Faster pygame import, less memory used.

### DIFF
--- a/src_py/sndarray.py
+++ b/src_py/sndarray.py
@@ -57,9 +57,12 @@ def array (sound):
     pygame.mixer.get_init().
     """
     global numpysnd
-    if numpysnd is None:
+    try:
+        return numpysnd.array (sound)
+    except AttributeError:
         import pygame._numpysndarray as numpysnd
-    return numpysnd.array (sound)
+        return numpysnd.array (sound)
+
 
 def samples (sound):
     """pygame.sndarray.samples(Sound): return array
@@ -71,9 +74,11 @@ def samples (sound):
     always be in the format returned from pygame.mixer.get_init().
     """
     global numpysnd
-    if numpysnd is None:
+    try:
+        return numpysnd.samples (sound)
+    except AttributeError:
         import pygame._numpysndarray as numpysnd
-    return numpysnd.samples (sound)
+        return numpysnd.samples (sound)
 
 def make_sound (array):
     """pygame.sndarray.make_sound(array): return Sound
@@ -85,9 +90,11 @@ def make_sound (array):
     audio format.
     """
     global numpysnd
-    if numpysnd is None:
+    try:
+        return numpysnd.make_sound (array)
+    except AttributeError:
         import pygame._numpysndarray as numpysnd
-    return numpysnd.make_sound (array)
+        return numpysnd.make_sound (array)
 
 def use_arraytype (arraytype):
     """pygame.sndarray.use_arraytype (arraytype): return None

--- a/src_py/sndarray.py
+++ b/src_py/sndarray.py
@@ -44,7 +44,8 @@ Sounds with 16-bit data will be treated as unsigned integers,
 if the sound sample type requests this.
 """
 
-import pygame._numpysndarray as numpysnd
+# import pygame._numpysndarray as numpysnd
+numpysnd = None
 
 def array (sound):
     """pygame.sndarray.array(Sound): return array
@@ -55,6 +56,9 @@ def array (sound):
     array will always be in the format returned from
     pygame.mixer.get_init().
     """
+    global numpysnd
+    if numpysnd is None:
+        import pygame._numpysndarray as numpysnd
     return numpysnd.array (sound)
 
 def samples (sound):
@@ -66,17 +70,23 @@ def samples (sound):
     object. Modifying the array will change the Sound. The array will
     always be in the format returned from pygame.mixer.get_init().
     """
+    global numpysnd
+    if numpysnd is None:
+        import pygame._numpysndarray as numpysnd
     return numpysnd.samples (sound)
 
 def make_sound (array):
     """pygame.sndarray.make_sound(array): return Sound
 
     Convert an array into a Sound object.
-    
+
     Create a new playable Sound object from an array. The mixer module
     must be initialized and the array format must be similar to the mixer
     audio format.
     """
+    global numpysnd
+    if numpysnd is None:
+        import pygame._numpysndarray as numpysnd
     return numpysnd.make_sound (array)
 
 def use_arraytype (arraytype):

--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -61,7 +61,9 @@ and wonder about the values.
 """
 
 # Try to import the necessary modules.
-import pygame._numpysurfarray as numpysf
+# import pygame._numpysurfarray as numpysf
+numpysf = None
+
 
 from pygame.pixelcopy import array_to_surface, make_surface as pc_make_surface
 
@@ -78,6 +80,9 @@ def blit_array (surface, array):
     This function will temporarily lock the Surface as the new values are
     copied.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.blit_array (surface, array)
 
 def array2d (surface):
@@ -93,13 +98,16 @@ def array2d (surface):
     (see the Surface.lock - lock the Surface memory for pixel access
     method).
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.array2d (surface)
 
 def pixels2d (surface):
     """pygame.surfarray.pixels2d (Surface): return array
 
     Reference pixels into a 2d array.
-    
+
     Create a new 2D array that directly references the pixel values in a
     Surface. Any changes to the array will affect the pixels in the
     Surface. This is a fast operation since no data is copied.
@@ -111,6 +119,9 @@ def pixels2d (surface):
     the array (see the Surface.lock - lock the Surface memory for pixel
     access method).
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.pixels2d (surface)
 
 def array3d (surface):
@@ -126,6 +137,9 @@ def array3d (surface):
     (see the Surface.lock - lock the Surface memory for pixel access
     method).
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.array3d (surface)
 
 def pixels3d (surface):
@@ -144,6 +158,9 @@ def pixels3d (surface):
     the array (see the Surface.lock - lock the Surface memory for pixel
     access method).
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.pixels3d (surface)
 
 def array_alpha (surface):
@@ -160,6 +177,9 @@ def array_alpha (surface):
     (see the Surface.lock - lock the Surface memory for pixel access
     method).
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.array_alpha (surface)
 
 def pixels_alpha (surface):
@@ -177,6 +197,9 @@ def pixels_alpha (surface):
     The Surface this array references will remain locked for the
     lifetime of the array.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.pixels_alpha (surface)
 
 def pixels_red (surface):
@@ -193,6 +216,9 @@ def pixels_red (surface):
     The Surface this array references will remain locked for the
     lifetime of the array.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.pixels_red (surface)
 
 def pixels_green (surface):
@@ -209,6 +235,9 @@ def pixels_green (surface):
     The Surface this array references will remain locked for the
     lifetime of the array.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.pixels_green (surface)
 
 def pixels_blue (surface):
@@ -225,6 +254,9 @@ def pixels_blue (surface):
     The Surface this array references will remain locked for the
     lifetime of the array.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.pixels_blue (surface)
 
 def array_colorkey (surface):
@@ -242,6 +274,9 @@ def array_colorkey (surface):
     This function will temporarily lock the Surface as pixels are
     copied.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.array_colorkey (surface)
 
 def make_surface(array):
@@ -252,6 +287,9 @@ def make_surface(array):
     Create a new Surface that best resembles the data and format on the
     array. The array can be 2D or 3D with any sized integer values.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.make_surface (array)
 
 def map_array (surface, array):
@@ -263,6 +301,9 @@ def map_array (surface, array):
     format to control the conversion. Palette surface formats are not
     supported.
     """
+    global numpysf
+    if numpysf is None:
+        import pygame._numpysurfarray as numpysf
     return numpysf.map_array (surface, array)
 
 def use_arraytype (arraytype):

--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -81,9 +81,12 @@ def blit_array (surface, array):
     copied.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.blit_array (surface, array)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.blit_array (surface, array)
+        return numpysf.blit_array (surface, array)
+
 
 def array2d (surface):
     """pygame.surfarray.array2d (Surface): return array
@@ -99,9 +102,12 @@ def array2d (surface):
     method).
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.array2d (surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.array2d (surface)
+        return numpysf.array2d (surface)
+
 
 def pixels2d (surface):
     """pygame.surfarray.pixels2d (Surface): return array
@@ -120,9 +126,12 @@ def pixels2d (surface):
     access method).
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.pixels2d(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.pixels2d (surface)
+        return numpysf.pixels2d(surface)
+
 
 def array3d (surface):
     """pygame.surfarray.array3d (Surface): return array
@@ -138,9 +147,12 @@ def array3d (surface):
     method).
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.array3d(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.array3d (surface)
+        return numpysf.array3d(surface)
+
 
 def pixels3d (surface):
     """pygame.surfarray.pixels3d (Surface): return array
@@ -159,9 +171,12 @@ def pixels3d (surface):
     access method).
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.pixels3d(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.pixels3d (surface)
+        return numpysf.pixels3d(surface)
+
 
 def array_alpha (surface):
     """pygame.surfarray.array_alpha (Surface): return array
@@ -178,9 +193,12 @@ def array_alpha (surface):
     method).
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.array_alpha(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.array_alpha (surface)
+        return numpysf.array_alpha(surface)
+
 
 def pixels_alpha (surface):
     """pygame.surfarray.pixels_alpha (Surface): return array
@@ -198,9 +216,12 @@ def pixels_alpha (surface):
     lifetime of the array.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.pixels_alpha(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.pixels_alpha (surface)
+        return numpysf.pixels_alpha(surface)
+
 
 def pixels_red (surface):
     """pygame.surfarray.pixels_red (Surface): return array
@@ -217,9 +238,12 @@ def pixels_red (surface):
     lifetime of the array.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.pixels_red(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.pixels_red (surface)
+        return numpysf.pixels_red(surface)
+
 
 def pixels_green (surface):
     """pygame.surfarray.pixels_green (Surface): return array
@@ -236,9 +260,12 @@ def pixels_green (surface):
     lifetime of the array.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.pixels_green(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.pixels_green (surface)
+        return numpysf.pixels_green(surface)
+
 
 def pixels_blue (surface):
     """pygame.surfarray.pixels_blue (Surface): return array
@@ -255,9 +282,12 @@ def pixels_blue (surface):
     lifetime of the array.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.pixels_blue(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.pixels_blue (surface)
+        return numpysf.pixels_blue(surface)
+
 
 def array_colorkey (surface):
     """pygame.surfarray.array_colorkey (Surface): return array
@@ -275,9 +305,12 @@ def array_colorkey (surface):
     copied.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.array_colorkey(surface)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.array_colorkey (surface)
+        return numpysf.array_colorkey(surface)
+
 
 def make_surface(array):
     """pygame.surfarray.make_surface (array): return Surface
@@ -288,9 +321,12 @@ def make_surface(array):
     array. The array can be 2D or 3D with any sized integer values.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.make_surface(array)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.make_surface (array)
+        return numpysf.make_surface(array)
+
 
 def map_array (surface, array):
     """pygame.surfarray.map_array (Surface, array3d): return array2d
@@ -302,9 +338,12 @@ def map_array (surface, array):
     supported.
     """
     global numpysf
-    if numpysf is None:
+    try:
+        return numpysf.map_array(surface, array)
+    except AttributeError:
         import pygame._numpysurfarray as numpysf
-    return numpysf.map_array (surface, array)
+        return numpysf.map_array(surface, array)
+
 
 def use_arraytype (arraytype):
     """pygame.surfarray.use_arraytype (arraytype): return None


### PR DESCRIPTION
pygame would import numpy if it was installed, even though most pygame apps do not use it.

```python
>>> 'numpy' in sys.modules
False
>>> import pygame
>>> 'numpy' in sys.modules
True
```
So now we do a lazy import. This adds 6ns to each function call in the surfarray and sndarray modules however. With python 3 this function call overhead should be able to be removed entirely with a smarter lazyload system.

Before this PR:
```bash
$ time python3 -c "import pygame"
real    0m0.172s
user    0m0.341s
sys    0m0.094s
```
After this PR:
```bash
$ time python3 -c "import pygame"
real    0m0.079s
user    0m0.055s
sys    0m0.018s
```


Thanks to @robertpfeiffer for finding this one.
