### PR TITLE
Drawing ellipse/circle/arc with width > radius

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -261,9 +261,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       parameter and its width and height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``width > rect.w / 2`` or
-      ``width > rect.h / 2``
-
    .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.arc ##

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -208,8 +208,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       parameter and its width and height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``width > rect.w / 2`` or ``width > rect.h / 2``
-
    .. versionchanged:: 2.0.0 Added support for keyword arguments.
 
    .. ## pygame.draw.ellipse ##

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -169,7 +169,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       values will be truncated) and its width and height will be 0
    :rtype: Rect
 
-   :raises ValueError: if ``radius < 0`` or ``width > radius``
+   :raises ValueError: if ``radius < 0``
 
    .. versionchanged:: 2.0.0 Added support for keyword arguments.
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -547,7 +547,7 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     if (width > rect->w / 2 || width > rect->h / 2) {
-        return RAISE(PyExc_ValueError, "width greater than arc radius");
+        width = MAX(rect->w / 2, rect->h / 2);
     }
 
     if (angle_stop < angle_start) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -617,7 +617,7 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     if (width > rect->w / 2 || width > rect->h / 2) {
-        return RAISE(PyExc_ValueError, "width greater than ellipse radius");
+        width = MAX(rect->w / 2, rect->h / 2);
     }
 
     if (!pgSurface_Lock(surfobj)) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -699,7 +699,7 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (width > radius) {
-        return RAISE(PyExc_ValueError, "width greater than radius");
+        width = radius;
     }
 
     if (!pgSurface_Lock(surfobj)) {

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4714,6 +4714,21 @@ class DrawArcMixin(object):
         self.assertIsInstance(bounds_rect, pygame.Rect)
         self.assertEqual(bounds_rect, pygame.Rect(1, 1, 0, 0))
 
+    def test_arc__args_with_width_gt_radius(self):
+        """Ensures draw arc accepts the args with 
+        width > rect.w // 2 and width > rect.h // 2."""
+        rect = pygame.Rect((0, 0), (4, 4))
+        bounds_rect = self.draw_arc(pygame.Surface((3, 3)),
+            (10, 10, 50, 50), rect, 0, 45, rect.w // 2 + 1)
+    
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+        bounds_rect = self.draw_arc(pygame.Surface((3, 3)),
+            (10, 10, 50, 50), rect, 0, 45, rect.h // 2 + 1)
+    
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+
     def test_arc__kwargs(self):
         """Ensures draw arc accepts the correct kwargs
         with and without a width arg.
@@ -4930,9 +4945,6 @@ class DrawArcMixin(object):
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
-    # This decorator can be removed when the arc portion of issues #975
-    # and #976 are resolved.
-    @unittest.expectedFailure
     def test_arc__valid_width_values(self):
         """Ensures draw arc accepts different width values."""
         arc_color = pygame.Color('yellow')

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -201,6 +201,21 @@ class DrawEllipseMixin(object):
         self.assertIsInstance(bounds_rect, pygame.Rect)
         self.assertEqual(bounds_rect, pygame.Rect(2, 3, 0, 0))
 
+    def test_ellipse__args_with_width_gt_radius(self):
+        """Ensures draw ellipse accepts the args with 
+        width > rect.w / 2 and width > rect.h / 2.
+        """
+        rect = pygame.Rect((0, 0), (4, 4))
+        bounds_rect = self.draw_ellipse(pygame.Surface((3, 3)),
+            (0, 10, 0, 50), rect, rect.w // 2 + 1)
+        
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
+        bounds_rect = self.draw_ellipse(pygame.Surface((3, 3)),
+            (0, 10, 0, 50), rect, rect.h // 2 + 1)
+
+        self.assertIsInstance(bounds_rect, pygame.Rect)
+
     def test_ellipse__kwargs(self):
         """Ensures draw ellipse accepts the correct kwargs
         with and without a width arg.
@@ -352,9 +367,6 @@ class DrawEllipseMixin(object):
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
-    # This decorator can be removed when the ellipse portion of issues #975
-    # and #976 are resolved.
-    @unittest.expectedFailure
     def test_ellipse__valid_width_values(self):
         """Ensures draw ellipse accepts different width values."""
         pos = (1, 1)
@@ -363,7 +375,7 @@ class DrawEllipseMixin(object):
         color = (10, 20, 30, 255)
         kwargs = {'surface' : surface,
                   'color'   : color,
-                  'rect'    : pygame.Rect(pos, (3, 1)),
+                  'rect'    : pygame.Rect(pos, (3, 2)),
                   'width'   : None}
 
         for width in (-1000, -10, -1, 0, 1, 10, 1000):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4214,6 +4214,14 @@ class DrawCircleMixin(object):
         self.assertIsInstance(bounds_rect, pygame.Rect) 
         self.assertEqual(bounds_rect, pygame.Rect(1, 1, 0, 0))
 
+    def test_circle__args_with_width_gt_radius(self):
+        """Ensures draw circle accepts the args with width > radius."""
+        bounds_rect = self.draw_circle(pygame.Surface((2, 2)), (0, 0, 0, 50),
+                                       (1, 1), 2, 3)
+
+        self.assertIsInstance(bounds_rect, pygame.Rect) 
+        self.assertEqual(bounds_rect, pygame.Rect(0, 0, 2, 2))
+
     def test_circle__kwargs(self):
         """Ensures draw circle accepts the correct kwargs
         with and without a width arg.
@@ -4399,9 +4407,6 @@ class DrawCircleMixin(object):
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
-    # This decorator can be removed when the circle portion of issues #975
-    # and #976 are resolved.
-    @unittest.expectedFailure
     def test_circle__valid_width_values(self):
         """Ensures draw circle accepts different width values."""
         center = (2, 2)

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -203,7 +203,7 @@ class DrawEllipseMixin(object):
 
     def test_ellipse__args_with_width_gt_radius(self):
         """Ensures draw ellipse accepts the args with 
-        width > rect.w / 2 and width > rect.h / 2.
+        width > rect.w // 2 and width > rect.h // 2.
         """
         rect = pygame.Rect((0, 0), (4, 4))
         bounds_rect = self.draw_ellipse(pygame.Surface((3, 3)),
@@ -4716,7 +4716,8 @@ class DrawArcMixin(object):
 
     def test_arc__args_with_width_gt_radius(self):
         """Ensures draw arc accepts the args with 
-        width > rect.w // 2 and width > rect.h // 2."""
+        width > rect.w // 2 and width > rect.h // 2.
+        """
         rect = pygame.Rect((0, 0), (4, 4))
         bounds_rect = self.draw_arc(pygame.Surface((3, 3)),
             (10, 10, 50, 50), rect, 0, 45, rect.w // 2 + 1)


### PR DESCRIPTION
Draw functions `draw_circle`, `draw_ellipse` and `draw_arc` accept width > radius without raising `ValueError`. The width value is capped at radius.

This PR is divided in 3 parts:

- [x] Cap width values to radius for pygame.draw.arc (also add relevant tests and update documentation)
- [x] Cap width values to radius for pygame.draw.circle (also add relevant tests and update documentation)
- [x] Cap width values to radius for pygame.draw.ellipse (also add relevant tests and update documentation)

Also removed 3 expectedFailure decorators regarding issues #975 and #976 

Closes #976 