### PR TITLE
Fix Rect.collidedict/collidedictall issues

### DIFF
--- a/docs/reST/ref/rect.rst
+++ b/docs/reST/ref/rect.rst
@@ -272,12 +272,19 @@
 
       | :sl:`test if one rectangle in a dictionary intersects`
       | :sg:`collidedict(dict) -> (key, value)`
+      | :sg:`collidedict(dict) -> None`
+      | :sg:`collidedict(dict, use_values=0) -> (key, value)`
+      | :sg:`collidedict(dict, use_values=0) -> None`
 
-      Returns the key and value of the first dictionary value that collides
-      with the Rect. If no collisions are found, None is returned.
+      Returns the first key and value pair that intersects with the calling
+      Rect object. If no collisions are found, ``None`` is returned. If
+      ``use_values`` is 0 (default) then the dict's keys will be used in the
+      collision detection, otherwise the dict's values will be used.
 
-      Rect objects are not hashable and cannot be used as keys in a dictionary,
-      only as values.
+      .. note ::
+         Rect objects cannot be used as keys in a dictionary (they are not
+         hashable), so they must be converted to a tuple/list.
+         e.g. ``rect.collidedict({tuple(key_rect) : value})``
 
       .. ## Rect.collidedict ##
 
@@ -285,12 +292,17 @@
 
       | :sl:`test if all rectangles in a dictionary intersect`
       | :sg:`collidedictall(dict) -> [(key, value), ...]`
+      | :sg:`collidedictall(dict, use_values=0) -> [(key, value), ...]`
 
       Returns a list of all the key and value pairs that intersect with the
-      Rect. If no collisions are found an empty list is returned.
+      calling Rect object. If no collisions are found an empty list is returned.
+      If ``use_values`` is 0 (default) then the dict's keys will be used in the
+      collision detection, otherwise the dict's values will be used.
 
-      Rect objects are not hashable and cannot be used as keys in a dictionary,
-      only as values.
+      .. note ::
+         Rect objects cannot be used as keys in a dictionary (they are not
+         hashable), so they must be converted to a tuple/list.
+         e.g. ``rect.collidedictall({tuple(key_rect) : value})``
 
       .. ## Rect.collidedictall ##
 

--- a/src_c/doc/rect_doc.h
+++ b/src_c/doc/rect_doc.h
@@ -19,8 +19,8 @@
 #define DOC_RECTCOLLIDERECT "colliderect(Rect) -> bool\ntest if two rectangles overlap"
 #define DOC_RECTCOLLIDELIST "collidelist(list) -> index\ntest if one rectangle in a list intersects"
 #define DOC_RECTCOLLIDELISTALL "collidelistall(list) -> indices\ntest if all rectangles in a list intersect"
-#define DOC_RECTCOLLIDEDICT "collidedict(dict) -> (key, value)\ntest if one rectangle in a dictionary intersects"
-#define DOC_RECTCOLLIDEDICTALL "collidedictall(dict) -> [(key, value), ...]\ntest if all rectangles in a dictionary intersect"
+#define DOC_RECTCOLLIDEDICT "collidedict(dict) -> (key, value)\ncollidedict(dict) -> None\ncollidedict(dict, use_values=0) -> (key, value)\ncollidedict(dict, use_values=0) -> None\ntest if one rectangle in a dictionary intersects"
+#define DOC_RECTCOLLIDEDICTALL "collidedictall(dict) -> [(key, value), ...]\ncollidedictall(dict, use_values=0) -> [(key, value), ...]\ntest if all rectangles in a dictionary intersect"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -112,10 +112,14 @@ test if all rectangles in a list intersect
 
 pygame.Rect.collidedict
  collidedict(dict) -> (key, value)
+ collidedict(dict) -> None
+ collidedict(dict, use_values=0) -> (key, value)
+ collidedict(dict, use_values=0) -> None
 test if one rectangle in a dictionary intersects
 
 pygame.Rect.collidedictall
  collidedictall(dict) -> [(key, value), ...]
+ collidedictall(dict, use_values=0) -> [(key, value), ...]
 test if all rectangles in a dictionary intersect
 
 */

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -558,31 +558,28 @@ pg_rect_collidedict(pgRectObject *self, PyObject *args)
 {
     GAME_Rect *argrect, temp;
     Py_ssize_t loop = 0;
-    Py_ssize_t values = 0;
+    Py_ssize_t values = 0; /* Defaults to expecting keys as rects. */
     PyObject *dict, *key, *val;
     PyObject *ret = NULL;
 
     if (!PyArg_ParseTuple(args, "O|i", &dict, &values)) {
         return NULL;
     }
+
     if (!PyDict_Check(dict)) {
-        return RAISE(PyExc_TypeError,
-                     "Argument must be a dict with rectstyle keys.");
+        return RAISE(PyExc_TypeError, "first argument must be a dict");
     }
 
     while (PyDict_Next(dict, &loop, &key, &val)) {
         if (values) {
             if (!(argrect = pgRect_FromObject(val, &temp))) {
-                RAISE(PyExc_TypeError,
-                      "Argument must be a dict with rectstyle values.");
-                break;
+                return RAISE(PyExc_TypeError,
+                             "dict must have rectstyle values");
             }
         }
         else {
             if (!(argrect = pgRect_FromObject(key, &temp))) {
-                RAISE(PyExc_TypeError,
-                      "Argument must be a dict with rectstyle keys.");
-                break;
+                return RAISE(PyExc_TypeError, "dict must have rectstyle keys");
             }
         }
 
@@ -603,18 +600,16 @@ pg_rect_collidedictall(pgRectObject *self, PyObject *args)
 {
     GAME_Rect *argrect, temp;
     Py_ssize_t loop = 0;
-    /* should we use values or keys? */
-    Py_ssize_t values = 0;
-
+    Py_ssize_t values = 0; /* Defaults to expecting keys as rects. */
     PyObject *dict, *key, *val;
     PyObject *ret = NULL;
 
     if (!PyArg_ParseTuple(args, "O|i", &dict, &values)) {
         return NULL;
     }
+
     if (!PyDict_Check(dict)) {
-        return RAISE(PyExc_TypeError,
-                     "Argument must be a dict with rectstyle keys.");
+        return RAISE(PyExc_TypeError, "first argument must be a dict");
     }
 
     ret = PyList_New(0);
@@ -626,14 +621,13 @@ pg_rect_collidedictall(pgRectObject *self, PyObject *args)
             if (!(argrect = pgRect_FromObject(val, &temp))) {
                 Py_DECREF(ret);
                 return RAISE(PyExc_TypeError,
-                             "Argument must be a dict with rectstyle values.");
+                             "dict must have rectstyle values");
             }
         }
         else {
             if (!(argrect = pgRect_FromObject(key, &temp))) {
                 Py_DECREF(ret);
-                return RAISE(PyExc_TypeError,
-                             "Argument must be a dict with rectstyle keys.");
+                return RAISE(PyExc_TypeError, "dict must have rectstyle keys");
             }
         }
 


### PR DESCRIPTION
Overview of changes:
- Updated docs to include information on the `use_values` parameter
- Reworded some of the exceptions to make them clearer
- Fixed the `collidedict` issue of not returning a `NULL` when collision items are not rects
- Added/changed related tests

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.9) at 213c343600c549a5988843053fd039488695a025

Resolves #1174.
Resolves the `colliderect` item of #1203.