### PR TITLE
Fix missing exception type (TypeError) when assigning rect.width to an invalid param

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1251,6 +1251,7 @@ pg_rect_setwidth(pgRectObject *self, PyObject *value, void *closure)
     int val1;
 
     if (!pg_IntFromObj(value, &val1)) {
+        RAISE(PyExc_TypeError, "invalid rect assignment");
         return -1;
     }
     self->r.w = val1;


### PR DESCRIPTION
Fixes a missing `TypeError` exception when assigning an invalid width param to a rect.

```
>>> import pygame
pygame 2.0.0.dev3 (SDL 2.0.9, python 3.7.3)
Hello from the pygame community. https://www.pygame.org/contribute.html
>>> r = pygame.Rect(0, 0, 0, 0)
>>> r.width = "a"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: invalid rect assignment
```

Closes #1205 