### PR TITLE
Add mouse.get_visible function

### DIFF
--- a/docs/reST/ref/mouse.rst
+++ b/docs/reST/ref/mouse.rst
@@ -101,6 +101,21 @@ configured.
 
    .. ## pygame.mouse.set_visible ##
 
+.. function:: get_visible
+
+   | :sl:`get the current visibility state of the mouse cursor`
+   | :sg:`get_visible() -> bool`
+
+   Get the current visibility state of the mouse cursor.
+
+   :returns: ``True`` if the mouse cursor is currently visible and ``False`` if
+      the mouse cursor is not visible
+   :rtype: bool
+
+   .. versionadded:: 2.0.0
+
+   .. ## pygame.mouse.get_visible ##
+
 .. function:: get_focused
 
    | :sl:`check if the display is receiving mouse input`

--- a/src_c/doc/mouse_doc.h
+++ b/src_c/doc/mouse_doc.h
@@ -5,6 +5,7 @@
 #define DOC_PYGAMEMOUSEGETREL "get_rel() -> (x, y)\nget the amount of mouse movement"
 #define DOC_PYGAMEMOUSESETPOS "set_pos([x, y]) -> None\nset the mouse cursor position"
 #define DOC_PYGAMEMOUSESETVISIBLE "set_visible(bool) -> bool\nhide or show the mouse cursor"
+#define DOC_PYGAMEMOUSEGETVISIBLE "get_visible() -> bool\nget the current visibility state of the mouse cursor"
 #define DOC_PYGAMEMOUSEGETFOCUSED "get_focused() -> bool\ncheck if the display is receiving mouse input"
 #define DOC_PYGAMEMOUSESETCURSOR "set_cursor(size, hotspot, xormasks, andmasks) -> None\nset the image for the system mouse cursor"
 #define DOC_PYGAMEMOUSEGETCURSOR "get_cursor() -> (size, hotspot, xormasks, andmasks)\nget the image for the system mouse cursor"
@@ -36,6 +37,10 @@ set the mouse cursor position
 pygame.mouse.set_visible
  set_visible(bool) -> bool
 hide or show the mouse cursor
+
+pygame.mouse.get_visible
+ get_visible() -> bool
+get the current visibility state of the mouse cursor
 
 pygame.mouse.get_focused
  get_focused() -> bool

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -166,6 +166,22 @@ mouse_set_visible(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+mouse_get_visible(PyObject *self, PyObject *args)
+{
+    int result;
+
+    VIDEO_INIT_CHECK();
+
+    result = SDL_ShowCursor(SDL_QUERY);
+
+    if (0 > result) {
+        return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+
+    return PyBool_FromLong(result);
+}
+
+static PyObject *
 mouse_get_focused(PyObject *self)
 {
     VIDEO_INIT_CHECK();
@@ -288,6 +304,7 @@ static PyMethodDef _mouse_methods[] = {
      DOC_PYGAMEMOUSEGETPRESSED},
     {"set_visible", mouse_set_visible, METH_VARARGS,
      DOC_PYGAMEMOUSESETVISIBLE},
+    {"get_visible", mouse_get_visible, METH_NOARGS, DOC_PYGAMEMOUSEGETVISIBLE},
     {"get_focused", (PyCFunction)mouse_get_focused, METH_VARARGS,
      DOC_PYGAMEMOUSEGETFOCUSED},
     {"set_cursor", mouse_set_cursor, METH_VARARGS, DOC_PYGAMEMOUSESETCURSOR},

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -1,7 +1,18 @@
 import unittest
 
+import pygame
+
 
 class MouseModuleTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # The display needs to be initialized for mouse functions.
+        pygame.display.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.display.quit()
+
     def todo_test_get_cursor(self):
 
         # __doc__ (as of 2008-08-02) for pygame.mouse.get_cursor:
@@ -143,6 +154,16 @@ class MouseModuleTest(unittest.TestCase):
           #
 
         self.fail()
+
+    def test_get_visible(self):
+        """Ensures get_visible works correctly."""
+        for expected_value in (False, True):
+            pygame.mouse.set_visible(expected_value)
+
+            visible = pygame.mouse.get_visible()
+
+            self.assertEqual(visible, expected_value)
+
 
 ################################################################################
 


### PR DESCRIPTION
Adding a way for users to get the current mouse visibility state.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.9) at ba1be45405bb8402f289661fce271b0270472364