### PR TITLE
Add keyword arguments to rect module functions

### DIFF
--- a/src_c/doc/rect_doc.h
+++ b/src_c/doc/rect_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMERECT "Rect(left, top, width, height) -> Rect\nRect((left, top), (width, height)) -> Rect\nRect(object) -> Rect\npygame object for storing rectangular coordinates"
 #define DOC_RECTCOPY "copy() -> Rect\ncopy the rectangle"
-#define DOC_RECTMOVE "move(x, y) -> Rect\nmoves the rectangle"
+#define DOC_RECTMOVE "move(x=0, y=0) -> Rect\nmoves the rectangle"
 #define DOC_RECTMOVEIP "move_ip(x, y) -> None\nmoves the rectangle, in place"
 #define DOC_RECTINFLATE "inflate(x, y) -> Rect\ngrow or shrink the rectangle size"
 #define DOC_RECTINFLATEIP "inflate_ip(x, y) -> None\ngrow or shrink the rectangle size, in place"
@@ -38,7 +38,7 @@ pygame.Rect.copy
 copy the rectangle
 
 pygame.Rect.move
- move(x, y) -> Rect
+ move(x=0, y=0) -> Rect
 moves the rectangle
 
 pygame.Rect.move_ip

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -247,13 +247,18 @@ pg_rect_normalize(pgRectObject *self, PyObject *args)
 }
 
 static PyObject *
-pg_rect_move(pgRectObject *self, PyObject *args)
+pg_rect_move(pgRectObject *self, PyObject *args, PyObject *kwargs)
 {
-    int x, y;
+    int x = 0;
+    int y = 0;
+    static char *keywords[] = {"x", "y", NULL};
 
-    if (!pg_TwoIntsFromObj(args, &x, &y)) {
-        return RAISE(PyExc_TypeError, "argument must contain two numbers");
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ii", keywords,
+                                     &x, &y)) {
+        return NULL; /* Exception already set. */
     }
+
+
 
     return _pg_rect_subtype_new4(Py_TYPE(self), self->r.x + x, self->r.y + y,
                                  self->r.w, self->r.h);
@@ -829,7 +834,8 @@ static struct PyMethodDef pg_rect_methods[] = {
     {"clamp_ip", (PyCFunction)pg_rect_clamp_ip, METH_VARARGS, DOC_RECTCLAMPIP},
     {"copy", (PyCFunction)pg_rect_copy, METH_NOARGS, DOC_RECTCOPY},
     {"fit", (PyCFunction)pg_rect_fit, METH_VARARGS, DOC_RECTFIT},
-    {"move", (PyCFunction)pg_rect_move, METH_VARARGS, DOC_RECTMOVE},
+    {"move", (PyCFunction)pg_rect_move, METH_VARARGS | METH_KEYWORDS, 
+     DOC_RECTMOVE},
     {"inflate", (PyCFunction)pg_rect_inflate, METH_VARARGS, DOC_RECTINFLATE},
     {"union", (PyCFunction)pg_rect_union, METH_VARARGS, DOC_RECTUNION},
     {"unionall", (PyCFunction)pg_rect_unionall, METH_VARARGS,

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -433,6 +433,26 @@ class RectTypeTest(unittest.TestCase):
         expected_r2 = Rect(r.left + move_x, r.top + move_y, r.width, r.height)
         self.assertEqual(expected_r2, r2)
 
+    def test_move__kwargs(self):
+        """Ensures move accepts kwargs."""
+        r = Rect(1, 2, 3, 4)
+        
+        self.assertEqual(r.move(x=1, y=2), Rect(2, 4, 3, 4))
+
+    def test_move__kwargs_missing(self):
+        """Ensures move accepts missing optional kwargs."""
+        r = Rect(1, 2, 3, 4)
+        
+        self.assertEqual(r.move(x=1), Rect(2, 2, 3, 4))
+        self.assertEqual(r.move(y=1), Rect(1, 3, 3, 4))
+
+    def test_move__kwargs_order_independent(self):
+        """Ensures move kwargs are not order dependent."""
+        r1 = Rect(1, 2, 3, 4)
+        r2 = Rect(1, 2, 3, 4)
+        
+        self.assertEqual(r1.move(x=0, y=1), r2.move(y=1, x=0))
+
     def test_move_ip(self):
         r = Rect(1, 2, 3, 4)
         r2 = Rect(r)


### PR DESCRIPTION
Hey, I started some preliminary work on adding support to kwargs on Rect methods, but I need some insights from you, guys.

For example. what should be the signatures for:

- move
- move_ip
- inflate
- inflate_ip

Those methods expect both `x`  and `y` as args. I think that if we are going to add kwargs to them, they should have a default value, e.g:

```
Rect.move(x=0, y=0)

# so this will be valid
rect.move(x=1)
 
# or even
rect.move() 
```

I added some code on that, please let me know what you guys think :)

Edit: builds are all failing, I added this code just to discuss.