### PR TITLE
WIP, quickfix for blit segfault

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -4026,7 +4026,8 @@ pgSurface_Blit(PyObject *dstobj, PyObject *srcobj, SDL_Rect *dstrect,
 #endif /* IS_SDLv2 */
     else {
         /* Py_BEGIN_ALLOW_THREADS */
-        result = SDL_BlitSurface(src, srcrect, dst, dstrect);
+        pygame_Blit(src, srcrect, dst, dstrect, 0);
+        //result = SDL_BlitSurface(src, srcrect, dst, dstrect);
         /* Py_END_ALLOW_THREADS */
     }
 


### PR DESCRIPTION
I don't know why this works. I don't know if there's a bug in SDL2.
It's not a mustock issue, or a refcount issue, as I initially suspected.
If you add a couple of printfs to surface.c

```python3
    else {
        /* Py_BEGIN_ALLOW_THREADS */
        printf("src->pixels BEFORE: 0x%x\n", src->pixels);
        printf("SDL_BlitSurface()\n");
        result = SDL_BlitSurface(src, srcrect, dst, dstrect);
        printf("src->pixels AFTER: 0x%x\n", src->pixels);
        /* Py_END_ALLOW_THREADS */
    }
```
the code from #1200 prints something like this:

```
src->pixels BEFORE: 0x175b3a0
SDL_BlitSurface()
src->pixels AFTER: 0x0
```
So I replaced SDL_BlitSurface with pygame_Blit in that line, and the bug was gone.