### PR TITLE
Fix SDL_WINDOWEVENT event identified as 'Unknown'

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -364,6 +364,8 @@ _pg_name_from_eventtype(int type)
         case SDL_NOEVENT:
             return "NoEvent";
 #if IS_SDLv2
+        case SDL_WINDOWEVENT:
+            return "WindowEvent";
         case SDL_FINGERMOTION:
             return "FingerMotion";
         case SDL_FINGERDOWN:

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -61,12 +61,6 @@ if pygame.get_sdl_version()[0] >= 2:
         ('FingerUp', pygame.FINGERUP),
         ('MultiGesture', pygame.MULTIGESTURE),
 
-        # These can be corrected when issue #1221 is resolved.
-        # Should be: 'AudioDeviceAdded'
-        ('Unknown', pygame.AUDIODEVICEADDED),
-        # Should be: 'AudioDeviceRemoved'
-        ('Unknown', pygame.AUDIODEVICEREMOVED),
-
         ('MouseWheel', pygame.MOUSEWHEEL),
         ('TextInput', pygame.TEXTINPUT),
         ('TextEditing', pygame.TEXTEDITING),
@@ -81,6 +75,16 @@ if pygame.get_sdl_version()[0] >= 2:
 
         ('DropFile', pygame.DROPFILE),
     )
+
+    # Add in any SDL 2.0.4 specific events.
+    if pygame.get_sdl_version() >= (2, 0, 4):
+        NAMES_AND_EVENTS += (
+            # These can be corrected when issue #1221 is resolved.
+            # Should be: 'AudioDeviceAdded'
+            ('Unknown', pygame.AUDIODEVICEADDED),
+            # Should be: 'AudioDeviceRemoved'
+            ('Unknown', pygame.AUDIODEVICEREMOVED),
+        )
 
     # Add in any SDL 2.0.5 specific events.
     if pygame.get_sdl_version() >= (2, 0, 5):

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -28,7 +28,7 @@ events = (
 )
 
 
-names_and_events = (
+NAMES_AND_EVENTS = (
     ('NoEvent', pygame.NOEVENT),
     ('ActiveEvent', pygame.ACTIVEEVENT),
     ('KeyDown', pygame.KEYDOWN),
@@ -55,41 +55,41 @@ names_and_events = (
 
 # Add in any SDL 2 specific events.
 if pygame.get_sdl_version()[0] >= 2:
-        names_and_events += (
-            ('FingerMotion', pygame.FINGERMOTION),
-            ('FingerDown', pygame.FINGERDOWN),
-            ('FingerUp', pygame.FINGERUP),
-            ('MultiGesture', pygame.MULTIGESTURE),
+    NAMES_AND_EVENTS += (
+        ('FingerMotion', pygame.FINGERMOTION),
+        ('FingerDown', pygame.FINGERDOWN),
+        ('FingerUp', pygame.FINGERUP),
+        ('MultiGesture', pygame.MULTIGESTURE),
 
-            # These can be corrected when issue #1221 is resolved.
-            # Should be: 'AudioDeviceAdded'
-            ('Unknown', pygame.AUDIODEVICEADDED),
-            # Should be: 'AudioDeviceRemoved'
-            ('Unknown', pygame.AUDIODEVICEREMOVED),
+        # These can be corrected when issue #1221 is resolved.
+        # Should be: 'AudioDeviceAdded'
+        ('Unknown', pygame.AUDIODEVICEADDED),
+        # Should be: 'AudioDeviceRemoved'
+        ('Unknown', pygame.AUDIODEVICEREMOVED),
 
-            ('MouseWheel', pygame.MOUSEWHEEL),
-            ('TextInput', pygame.TEXTINPUT),
-            ('TextEditing', pygame.TEXTEDITING),
-            ('WindowEvent', pygame.WINDOWEVENT),
+        ('MouseWheel', pygame.MOUSEWHEEL),
+        ('TextInput', pygame.TEXTINPUT),
+        ('TextEditing', pygame.TEXTEDITING),
+        ('WindowEvent', pygame.WINDOWEVENT),
 
-            ('ControllerAxisMotion', pygame.CONTROLLERAXISMOTION),
-            ('ControllerButtonDown', pygame.CONTROLLERBUTTONDOWN),
-            ('ControllerButtonUp', pygame.CONTROLLERBUTTONUP),
-            ('ControllerDeviceAdded', pygame.CONTROLLERDEVICEADDED),
-            ('ControllerDeviceRemoved', pygame.CONTROLLERDEVICEREMOVED),
-            ('ControllerDeviceMapped', pygame.CONTROLLERDEVICEREMAPPED),
+        ('ControllerAxisMotion', pygame.CONTROLLERAXISMOTION),
+        ('ControllerButtonDown', pygame.CONTROLLERBUTTONDOWN),
+        ('ControllerButtonUp', pygame.CONTROLLERBUTTONUP),
+        ('ControllerDeviceAdded', pygame.CONTROLLERDEVICEADDED),
+        ('ControllerDeviceRemoved', pygame.CONTROLLERDEVICEREMOVED),
+        ('ControllerDeviceMapped', pygame.CONTROLLERDEVICEREMAPPED),
 
-            ('DropFile', pygame.DROPFILE),
+        ('DropFile', pygame.DROPFILE),
+    )
+
+    # Add in any SDL 2.0.5 specific events.
+    if pygame.get_sdl_version() >= (2, 0, 5):
+        NAMES_AND_EVENTS += (
+            # These can be corrected when issue #1223 is resolved.
+            ('Unknown', pygame.DROPTEXT), # Should be: 'DropText'
+            ('Unknown', pygame.DROPBEGIN), # Should be: 'DropBegin'
+            ('Unknown', pygame.DROPCOMPLETE), # Should be: 'DropComplete'
         )
-
-        # Add in any SDL 2.0.5 specific events.
-        if pygame.get_sdl_version() >= (2, 0, 5):
-            names_and_events += (
-                # These can be corrected when issue #1223 is resolved.
-                ('Unknown', pygame.DROPTEXT), # Should be: 'DropText'
-                ('Unknown', pygame.DROPBEGIN), # Should be: 'DropBegin'
-                ('Unknown', pygame.DROPCOMPLETE), # Should be: 'DropComplete'
-            )
 
 
 class EventTypeTest(unittest.TestCase):
@@ -277,7 +277,7 @@ class EventModuleTest(unittest.TestCase):
 
     def test_event_name(self):
         """Ensure event_name() returns the correct event name."""
-        for expected_name, event in names_and_events:
+        for expected_name, event in NAMES_AND_EVENTS:
             self.assertEqual(pygame.event.event_name(event), expected_name,
                              '0x{:X}'.format(event))
 

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -28,6 +28,70 @@ events = (
 )
 
 
+names_and_events = (
+    ('NoEvent', pygame.NOEVENT),
+    ('ActiveEvent', pygame.ACTIVEEVENT),
+    ('KeyDown', pygame.KEYDOWN),
+    ('KeyUp', pygame.KEYUP),
+    ('MouseMotion', pygame.MOUSEMOTION),
+    ('MouseButtonDown', pygame.MOUSEBUTTONDOWN),
+    ('MouseButtonUp', pygame.MOUSEBUTTONUP),
+    ('JoyAxisMotion', pygame.JOYAXISMOTION),
+    ('JoyBallMotion', pygame.JOYBALLMOTION),
+    ('JoyHatMotion', pygame.JOYHATMOTION),
+    ('JoyButtonDown', pygame.JOYBUTTONDOWN),
+    ('JoyButtonUp', pygame.JOYBUTTONUP),
+    ('VideoResize', pygame.VIDEORESIZE),
+    ('VideoExpose', pygame.VIDEOEXPOSE),
+    ('Quit', pygame.QUIT),
+    ('SysWMEvent', pygame.SYSWMEVENT),
+
+    ('UserEvent', pygame.USEREVENT),
+    ('UserEvent', pygame.USEREVENT + 1),
+    ('UserEvent', pygame.NUMEVENTS - 1),
+
+    ('Unknown', 0xFFFF),
+)
+
+# Add in any SDL 2 specific events.
+if pygame.get_sdl_version()[0] >= 2:
+        names_and_events += (
+            ('FingerMotion', pygame.FINGERMOTION),
+            ('FingerDown', pygame.FINGERDOWN),
+            ('FingerUp', pygame.FINGERUP),
+            ('MultiGesture', pygame.MULTIGESTURE),
+
+            # These can be corrected when issue #1221 is resolved.
+            # Should be: 'AudioDeviceAdded'
+            ('Unknown', pygame.AUDIODEVICEADDED),
+            # Should be: 'AudioDeviceRemoved'
+            ('Unknown', pygame.AUDIODEVICEREMOVED),
+
+            ('MouseWheel', pygame.MOUSEWHEEL),
+            ('TextInput', pygame.TEXTINPUT),
+            ('TextEditing', pygame.TEXTEDITING),
+            ('WindowEvent', pygame.WINDOWEVENT),
+
+            ('ControllerAxisMotion', pygame.CONTROLLERAXISMOTION),
+            ('ControllerButtonDown', pygame.CONTROLLERBUTTONDOWN),
+            ('ControllerButtonUp', pygame.CONTROLLERBUTTONUP),
+            ('ControllerDeviceAdded', pygame.CONTROLLERDEVICEADDED),
+            ('ControllerDeviceRemoved', pygame.CONTROLLERDEVICEREMOVED),
+            ('ControllerDeviceMapped', pygame.CONTROLLERDEVICEREMAPPED),
+
+            ('DropFile', pygame.DROPFILE),
+        )
+
+        # Add in any SDL 2.0.5 specific events.
+        if pygame.get_sdl_version() >= (2, 0, 5):
+            names_and_events += (
+                # These can be corrected when issue #1223 is resolved.
+                ('Unknown', pygame.DROPTEXT), # Should be: 'DropText'
+                ('Unknown', pygame.DROPBEGIN), # Should be: 'DropBegin'
+                ('Unknown', pygame.DROPCOMPLETE), # Should be: 'DropComplete'
+            )
+
+
 class EventTypeTest(unittest.TestCase):
     def test_Event(self):
         """Ensure an Event object can be created."""
@@ -213,9 +277,9 @@ class EventModuleTest(unittest.TestCase):
 
     def test_event_name(self):
         """Ensure event_name() returns the correct event name."""
-        self.assertEqual(pygame.event.event_name(pygame.KEYDOWN), "KeyDown")
-        self.assertEqual(pygame.event.event_name(pygame.USEREVENT),
-                         "UserEvent")
+        for expected_name, event in names_and_events:
+            self.assertEqual(pygame.event.event_name(event), expected_name,
+                             '0x{:X}'.format(event))
 
     def test_wait(self):
         """Ensure wait() waits for an event on the queue."""


### PR DESCRIPTION
Overview of changes:
- Fixed the `SDL_WINDOWEVENT` event name to be 'WindowEvent'
- Changed `test_event_name()` to test all the different event names

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 7a5ed0b864645e7c325d80aa8866e837559c7a1c

Resolves #1222.