### PR TITLE
Mask.to_surface: Add dest parameter

### DIFF
--- a/docs/reST/ref/mask.rst
+++ b/docs/reST/ref/mask.rst
@@ -572,7 +572,7 @@ to store which parts collide.
 
       | :sl:`Returns a surface with the mask drawn on it`
       | :sg:`to_surface() -> Surface`
-      | :sg:`to_surface(surface=None, setsurface=None, unsetsurface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface`
+      | :sg:`to_surface(surface=None, setsurface=None, unsetsurface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255), dest=(0, 0)) -> Surface`
 
       Draws this mask on the given surface. Set bits (bits set to 1) and unset
       bits (bits set to 0) can be drawn onto a surface.
@@ -603,10 +603,25 @@ to store which parts collide.
          over this parameter
       :type unsetcolor: Color or int or tuple(int, int, int, [int]) or
          list(int, int, int, [int]) or None
+      :param dest: (optional) surface destination of where to position the
+         topleft corner of the mask being drawn (default is ``(0, 0)``), if a
+         Rect is used as the ``dest`` parameter, its ``x`` and ``y`` attributes
+         will be used as the destination, **NOTE1:** rects with a negative width
+         or height value will not be normalized before using their ``x`` and
+         ``y`` values, **NOTE2:** this destination value is only used to
+         position the mask on the surface, it does not offset the ``setsurface``
+         and ``unsetsurface`` from the mask, they are always aligned with the
+         mask (i.e. position ``(0, 0)`` on the mask always corresponds to
+         position ``(0, 0)`` on the ``setsurface`` and ``unsetsurface``)
+      :type dest: Rect or tuple(int, int) or list(int, int) or Vector2(int, int)
 
       :returns: the ``surface`` parameter (or a newly created surface if no
          ``surface`` parameter was provided) with this mask drawn on it
       :rtype: Surface
+
+      :raises ValueError: if the ``setsurface`` parameter or ``unsetsurface``
+         parameter does not have the same format (bytesize/bitsize/alpha) as
+         the ``surface`` parameter
 
       .. note ::
          To skip drawing the set bits, both ``setsurface`` and ``setcolor`` must

--- a/src_c/doc/mask_doc.h
+++ b/src_c/doc/mask_doc.h
@@ -25,7 +25,7 @@
 #define DOC_MASKCONNECTEDCOMPONENT "connected_component() -> Mask\nconnected_component((x, y)) -> Mask\nReturns a mask containing a connected component"
 #define DOC_MASKCONNECTEDCOMPONENTS "connected_components() -> [Mask, ...]\nconnected_components(min=0) -> [Mask, ...]\nReturns a list of masks of connected components"
 #define DOC_MASKGETBOUNDINGRECTS "get_bounding_rects() -> [Rect, ...]\nReturns a list of bounding rects of connected components"
-#define DOC_MASKTOSURFACE "to_surface() -> Surface\nto_surface(surface=None, setsurface=None, unsetsurface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface\nReturns a surface with the mask drawn on it"
+#define DOC_MASKTOSURFACE "to_surface() -> Surface\nto_surface(surface=None, setsurface=None, unsetsurface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255), dest=(0, 0)) -> Surface\nReturns a surface with the mask drawn on it"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -146,7 +146,7 @@ Returns a list of bounding rects of connected components
 
 pygame.mask.Mask.to_surface
  to_surface() -> Surface
- to_surface(surface=None, setsurface=None, unsetsurface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255)) -> Surface
+ to_surface(surface=None, setsurface=None, unsetsurface=None, setcolor=(255, 255, 255, 255), unsetcolor=(0, 0, 0, 255), dest=(0, 0)) -> Surface
 Returns a surface with the mask drawn on it
 
 */


### PR DESCRIPTION
Overview of changes:
- Added support for a `dest` parameter
- Updated Mask documentation
- Added/updated some `to_surface()` tests
- Changed `setcolor`/`unsetcolor` to be passed as pointers to `draw_to_surface()`

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 7a5ed0b864645e7c325d80aa8866e837559c7a1c

Resolves item (and all sub-items) of "support for dest kwarg" of #1070.