### PR TITLE
Make convert_alpha set SRCALPHA with SDL2

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1933,6 +1933,7 @@ surf_convert_alpha(PyObject *self, PyObject *args)
      * support for alpha
      */
     newsurf = pg_DisplayFormatAlpha(surf);
+    SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_BLEND);
     final = surf_subtype_new(Py_TYPE(self), newsurf, 1);
 #else /* IS_SDLv1 */
     pgSurface_Prep(self);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1806,6 +1806,7 @@ surf_convert(PyObject *self, PyObject *args)
             newsurf = SDL_ConvertSurface(surf, &format, flags);
 #else /* IS_SDLv2 */
             newsurf = SDL_ConvertSurface(surf, &format, 0);
+            SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
 #endif /* IS_SDLv2 */
 
         }
@@ -1817,6 +1818,8 @@ surf_convert(PyObject *self, PyObject *args)
 #else  /* IS_SDLv2 */
     else {
         newsurf = pg_DisplayFormat(surf);
+        SDL_SetSurfaceBlendMode(newsurf, SDL_BLENDMODE_NONE);
+
     }
 
     if (has_colorkey) {

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -720,6 +720,21 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         finally:
             pygame.display.quit()
 
+    def test_convert_alpha_SRCALPHA(self):
+        """ Ensure that the surface returned by surf.convert_alpha()
+            has alpha blending enabled"""
+        pygame.display.init()
+        try:
+            pygame.display.set_mode((640,480))
+
+            s1=pygame.Surface((100,100), 0 ,32)
+            #s2=pygame.Surface((100,100), pygame.SRCALPHA, 32)
+            s1_alpha=s1.convert_alpha()
+            self.assertEqual(s1_alpha.get_flags() & SRCALPHA, SRCALPHA)
+            self.assertEqual(s1_alpha.get_alpha(), 255)
+        finally:
+            pygame.display.quit()
+
     def todo_test_convert(self):
 
         # __doc__ (as of 2008-08-02) for pygame.surface.Surface.convert:


### PR DESCRIPTION
Make convert_alpha set SRCALPHA with SDL2. This is the expected behaviour and makes the SDL2 version consistent with pygame 1.9.4.