### PR TITLE
WIP: Test on old timey linux for old timey SDL2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   include:
     - os: linux
       sudo: required
-      dist: xenial
+      dist: precise
       python: 2.7
     - os: linux
       sudo: required


### PR DESCRIPTION
pygame should be able to work with older raspberian and older Debian.
We need a CI bot to test this for us, so one of the travis builders has been switched.

Related: https://github.com/pygame/pygame/pull/1225

