### PR TITLE
Fix test error on Python 3.8.0b3

### DIFF
--- a/test/math_test.py
+++ b/test/math_test.py
@@ -2,7 +2,6 @@
 import sys
 import unittest
 import math
-from time import clock
 import platform
 
 import pygame.math


### PR DESCRIPTION
Fix `ImportError: cannot import name 'clock' from 'time' (unknown location)`