### PR TITLE
Fix drop event name issue

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -382,14 +382,14 @@ _pg_name_from_eventtype(int type)
             return "TextEditing";
         case SDL_DROPFILE:
             return "DropFile";
-#ifdef SDL_DROPTEXT
+#if SDL_VERSION_ATLEAST(2, 0, 5)
         case SDL_DROPTEXT:
             return "DropText";
         case SDL_DROPBEGIN:
             return "DropBegin";
         case SDL_DROPCOMPLETE:
             return "DropComplete";
-#endif
+#endif /* SDL_VERSION_ATLEAST(2, 0, 5) */
         case SDL_CONTROLLERAXISMOTION:
             return "ControllerAxisMotion";
         case SDL_CONTROLLERBUTTONDOWN:
@@ -671,7 +671,7 @@ dict_from_event(SDL_Event *event)
             SDL_free(event->drop.file);
             break;
 
-#ifdef SDL_DROPTEXT
+#if SDL_VERSION_ATLEAST(2, 0, 5)
         case SDL_DROPTEXT:
             _pg_insobj(dict, "text", Text_FromUTF8(event->drop.file));
             SDL_free(event->drop.file);
@@ -679,7 +679,7 @@ dict_from_event(SDL_Event *event)
         case SDL_DROPBEGIN:
         case SDL_DROPCOMPLETE:
             break;
-#endif
+#endif /* SDL_VERSION_ATLEAST(2, 0, 5) */
 
         case SDL_CONTROLLERAXISMOTION:
             /* https://wiki.libsdl.org/SDL_ControllerAxisEvent */

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -89,7 +89,6 @@ if pygame.get_sdl_version()[0] >= 2:
     # Add in any SDL 2.0.5 specific events.
     if pygame.get_sdl_version() >= (2, 0, 5):
         NAMES_AND_EVENTS += (
-            # These can be corrected when issue #1223 is resolved.
             ('DropText', pygame.DROPTEXT),
             ('DropBegin', pygame.DROPBEGIN),
             ('DropComplete', pygame.DROPCOMPLETE),

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -90,9 +90,9 @@ if pygame.get_sdl_version()[0] >= 2:
     if pygame.get_sdl_version() >= (2, 0, 5):
         NAMES_AND_EVENTS += (
             # These can be corrected when issue #1223 is resolved.
-            ('Unknown', pygame.DROPTEXT), # Should be: 'DropText'
-            ('Unknown', pygame.DROPBEGIN), # Should be: 'DropBegin'
-            ('Unknown', pygame.DROPCOMPLETE), # Should be: 'DropComplete'
+            ('DropText', pygame.DROPTEXT),
+            ('DropBegin', pygame.DROPBEGIN),
+            ('DropComplete', pygame.DROPCOMPLETE),
         )
 
 


### PR DESCRIPTION
Resolves #1223. These constants are defined since 2.0.5. Macro check does not work as they are enums