### PR TITLE
Fix bundle_docs.py issues

### DIFF
--- a/buildconfig/bundle_docs.py
+++ b/buildconfig/bundle_docs.py
@@ -49,7 +49,7 @@ def main():
         version = '-%s' % match.group(1)
 
     bundle_name = 'pygame%s-docs-and-examples.tar.gz' % version
-    print("Creating bundle".format(bundle_name))
+    print("Creating bundle {}".format(bundle_name))
 
     with tarfile.open(bundle_name, 'w:gz') as bundle:
         root = os.path.abspath('.')

--- a/buildconfig/bundle_docs.py
+++ b/buildconfig/bundle_docs.py
@@ -1,54 +1,68 @@
 #! /usr/bin/env python
 
-"""Tar-zip the Pygame documents and examples
+"""Tar-zip the pygame documents and examples.
 
-Run this script from the Pygame source root directory.
+Run this script from the pygame source root directory.
 """
 
 import os
 import tarfile
 import re
 
+
 def add_files(bundle, root, alias, file_names):
+    """Add files to the bundle."""
     for file_name in file_names:
         file_alias = os.path.join(alias, file_name)
-        print " ", file_name, "-->", file_alias
+        print("  {} --> {}".format(file_name, file_alias))
         bundle.add(os.path.join(root, file_name), file_alias)
 
+
 def add_directory(bundle, root, alias):
+    """Recursively add a directory, subdirectories, and files to the bundle."""
     reject_dirs = re.compile(r'(.svn)$')
+
     # Since it is the file extension that is of interest the reversed
     # file name is checked.
     reject_files_reversed = re.compile(r'((~.*)|(cyp\..*))')
+
     for sub_root, directories, files in os.walk(root):
-        directories[:] = [d for d in directories if reject_dirs.match(d) is None]
-        files[:] = [f for f in files if reject_files_reversed.match(f[-1::-1]) is None]
+        directories[:] = [
+            d for d in directories if reject_dirs.match(d) is None]
+        files[:] = [
+            f for f in files if reject_files_reversed.match(f[-1::-1]) is None]
+
         sub_alias = os.path.join(alias, sub_root[len(root)+1:])
         add_files(bundle, sub_root, sub_alias, files)
 
+
 def main():
-    setup = open('setup.py', 'r')
-    try:
-        match = re.search(r'"version":[ \t]+"([0-9]+\.[0-9]+)\.[^"]+"', setup.read())
-    finally:
-        setup.close()
+    """Create a tar-zip file containing the pygame documents and examples."""
+    with open('setup.py', 'r') as setup:
+        match = re.search(r'"version":[ \t]+"([0-9]+\.[0-9]+)\.[^"]+"',
+                          setup.read())
+
     if match is None:
-        print "*** Unable to find Pygame version in setup.py"
+        print("*** Unable to find the pygame version data in setup.py")
         version = ''
     else:
         version = '-%s' % match.group(1)
+
     bundle_name = 'pygame%s-docs-and-examples.tar.gz' % version
-    print "Creating bundle", bundle_name
-    bundle = tarfile.open(bundle_name, 'w:gz')
-    try:
+    print("Creating bundle".format(bundle_name))
+
+    with tarfile.open(bundle_name, 'w:gz') as bundle:
         root = os.path.abspath('.')
         alias = 'pygame'
-        add_files(bundle, root, alias, ['LGPL', 'readme.html', 'install.html'])
-        add_directory(bundle, os.path.join(root, 'docs'), os.path.join(alias, 'docs'))
-        add_directory(bundle, os.path.join(root, 'examples'), os.path.join(alias, 'examples'))
-        print "\nFinished", bundle_name
-    finally:
-        bundle.close()
+
+        add_files(bundle, root, alias, ['README.rst'])
+        add_directory(bundle, os.path.join(root, 'docs'),
+                      os.path.join(alias, 'docs'))
+        add_directory(bundle, os.path.join(root, 'examples'),
+                      os.path.join(alias, 'examples'))
+
+    print("\nFinished {}".format(bundle_name))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Overview of changes:
- Changed the `try`-`finally` blocks to `with` statements to fix LGTM issues
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)
- Changed `print` statements to be python 3 compatible
- Fixed the list of root files to be included in the bundle
- Other minor changes: docstrings/formatting/wording

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 113ee7f03a34300050776cf3d213b62c6aaa86f7

Resolves the bundle_docs.py issues from the LGTM link in #1133.