### PR TITLE
Fix some LGTM alerts in the examples code

### DIFF
--- a/examples/headless_no_windows_needed.py
+++ b/examples/headless_no_windows_needed.py
@@ -20,13 +20,10 @@ os.environ["SDL_VIDEODRIVER"] = "dummy"
 
 import pygame.transform
 
-
-if 1:
-    #some platforms need to init the display for some parts of pygame.
-    import pygame.display
-    pygame.display.init()
-    screen = pygame.display.set_mode((1,1))
-
+# Some platforms need to init the display for some parts of pygame.
+import pygame.display
+pygame.display.init()
+screen = pygame.display.set_mode((1, 1))
 
 
 def scaleit(fin, fout, w, h):

--- a/examples/macosx/aliens_app_example/aliens.py
+++ b/examples/macosx/aliens_app_example/aliens.py
@@ -83,7 +83,7 @@ class Player(pygame.sprite.Sprite):
             self.image = self.images[0]
         elif direction > 0:
             self.image = self.images[1]
-        self.rect.top = self.origtop - (self.rect.left/self.bounce%2)
+        self.rect.top = self.origtop - (self.rect.left//self.bounce%2)
 
     def gunpos(self):
         pos = self.facing*self.gun_offset + self.rect.centerx
@@ -110,7 +110,7 @@ class Alien(pygame.sprite.Sprite):
             self.rect.top = self.rect.bottom + 1
             self.rect = self.rect.clamp(SCREENRECT)
         self.frame = self.frame + 1
-        self.image = self.images[self.frame/self.animcycle%3]
+        self.image = self.images[self.frame//self.animcycle%3]
 
 
 class Explosion(pygame.sprite.Sprite):
@@ -126,7 +126,7 @@ class Explosion(pygame.sprite.Sprite):
 
     def update(self):
         self.life = self.life - 1
-        self.image = self.images[self.life/self.animcycle%2]
+        self.image = self.images[self.life//self.animcycle%2]
         if self.life <= 0: self.kill()
 
 
@@ -242,7 +242,6 @@ def main(winstyle = 0):
     #Create Some Starting Values
     global score
     alienreload = ALIEN_RELOAD
-    kills = 0
     clock = pygame.time.Clock()
 
     #initialize our starting sprites

--- a/examples/midi.py
+++ b/examples/midi.py
@@ -795,12 +795,12 @@ def main(mode='output', device_id=None):
         print_device_info()
     else:
         raise ValueError("Unknown mode option '%s'" % mode)
-                
+
 if __name__ == '__main__':
 
     try:
         device_id = int( sys.argv[-1] )
-    except:
+    except ValueError:
         device_id = None
 
     if "--input" in sys.argv or "-i" in sys.argv:

--- a/examples/overlay.py
+++ b/examples/overlay.py
@@ -14,7 +14,7 @@ def vPlayer( fName ):
     f= open( fName, 'rb' )
     fmt= f.readline().strip()
     res= f.readline().strip()
-    col= f.readline().strip()
+    unused_col= f.readline().strip()
     if fmt!= "P5":
         print ('Unknown format( len %d ). Exiting...' % len( fmt ))
         return
@@ -25,7 +25,7 @@ def vPlayer( fName ):
     y= f.read( w*h )
     u= []
     v= []
-    for i in xrange_( 0, h/2 ):
+    for _ in xrange_( 0, h/2 ):
         u.append( f.read( w/2 ))
         v.append( f.read( w/2 ))
     

--- a/examples/scaletest.py
+++ b/examples/scaletest.py
@@ -89,7 +89,7 @@ def SpeedTest(image):
     print("Average transform.smoothscale shrink time: %.4f ms." % (
           duration / 128 * 1000))
 
-    duration = 0
+    duration = 0.0
     for i in range(128):
         expandx = (imgsize[0] * (i + 129)) // 128
         expandy = (imgsize[1] * (i + 129)) // 128
@@ -113,7 +113,7 @@ def SpeedTest(image):
     print("Average transform.scale shrink time: %.4f ms." % (
           duration / 128 * 1000))
 
-    duration = 0
+    duration = 0.0
     for i in range(128):
         expandx = (imgsize[0] * (i + 129)) // 128
         expandy = (imgsize[1] * (i + 129)) // 128


### PR DESCRIPTION
Overview of changes:
- Fixed some issues found by LGTM in the examples code
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)
- Also changed `aliens_app_example/aliens.py` to use floor division (for python 3 compatibility)

Note: Did not fully test `examples/overlay.py` functionality due to issue #1199.

System details:
- os: windows 10 (64bit)
- python: 3.7.2 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 113ee7f03a34300050776cf3d213b62c6aaa86f7

Resolves some of the examples code issues from the LGTM link in #1133.