### PR TITLE
add editorconfig, make docscomments greppable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root=true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# The settings for C (*.c and *.h) files are mirrored in src_c/.clang-format.
+# Keep them in sync.
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+tab_width = 4
+trim_trailing_whitespace = true
+max_line_length = 79
+
+[*.{py,pyx}]
+indent_style = space
+indent_size = 4
+charset = utf-8
+file_type_emacs = python

--- a/docs/ref/docscomments.json
+++ b/docs/ref/docscomments.json
@@ -1,1 +1,5273 @@
-[{"content": "How To Get ALL The Mouse Clicks.\n\nTook me hours to figure this out. Also note that button 1 and 3 pressed at the same time shows up as button 2, at least on my ubuntu computer.\n\ne=pygame.event.wait()\nif e.type == MOUSEBUTTONDOWN and e.button == 4 : do something mousey", "user_title": "Douglas Smith", "datetimeon": "2005-11-11T14:05:52", "link": "pygame.mouse.get_pressed", "id": 3}, {"content": "If you're trying to create a surface with per-pixel alphas, and\n\n  my_surface = pygame.Surface((w, h), SRCALPHA)\n\ncreates a regular surface instead, try\n\n  my_surface = pygame.Surface((w, h)).convert_alpha()", "user_title": "Marius Gedminas", "datetimeon": "2006-01-05T16:07:06", "link": "pygame.Surface", "id": 39}, {"content": "Interestingly, pygame.font.get_default_font() returns a font name ('freesansbold.ttf') which is not among the 189 listed by pygame.font.get_fonts().", "user_title": "Dave Burton", "datetimeon": "2011-01-03T08:47:41", "link": "pygame.font.get_fonts", "id": 3698}, {"content": "The font name is not a list!  It is a single string.\n\nThe string can contain multiple font names with commas between them,\nbut if you pass a Python list (or tuple) you'll get an error.", "user_title": "Dave Burton", "datetimeon": "2011-01-03T09:13:14", "link": "pygame.font.SysFont", "id": 3699}, {"content": "Re: \"During its lifetime, the PixelArray locks the surface, thus you explicitly have to delete it once its not used anymore and the surface should perform operations in the same scope.\"\n\n1. Grammer: s/its/it's/\n\n2. s/you explicitly have to delete/you have to explicitly delete/\n\n3. I assume that to explicitly delete it you can either use \"del pxarray\"\nor else simply exit the function to which pxarray is local.  Is that correct?\n\n4. What does \"and the surface should perform operations in the same scope\" mean?\nIs it saying something about the surface returned by px.make_surface(), i.e.,\nthat it should be a local variable in the same function  to which pxarray is local?\nOr is it saying something about the surface that is passed to pygame.PixelArray()\nto create the pxarray object, and if so WHAT is it saying?", "user_title": "Dave Burton", "datetimeon": "2011-01-07T03:08:20", "link": "pygame.PixelArray", "id": 3703}, {"content": "On my Windows Vista machine running Python 3.1.2 and pygame 1.9.1, pgame.font.get_fonts() returns a list of 189 fonts.  All the font names are lower case, and there are no special characters (like hyphens) in the names.  The expected 'timesnewroman', 'arial', 'arialblack', 'couriernew', 'veranda', 'microsoftsansserif', 'symbol' and 'wingdings' are there (but not 'times' or 'roman' or 'helvetica'), but also many obscure fonts that I've never heard of.", "user_title": "Dave Burton", "datetimeon": "2011-01-03T08:43:54", "link": "pygame.font.get_fonts", "id": 3697}, {"content": "Pretty cool demo Mr. Anony", "user_title": "Robert Leachman", "datetimeon": "2010-12-10T22:09:50", "link": "pygame.key.get_pressed", "id": 3683}, {"content": "If you want to see a list of attributes, do a help(pygame) and it'll show you", "user_title": "Alex Polosky", "datetimeon": "2010-12-15T23:46:38", "link": "pygame.locals", "id": 3686}, {"content": "Works fine for me on OS X 10.6.5, though yes it does need to brought up to Quartz", "user_title": "Robert Leachman", "datetimeon": "2010-12-04T21:54:48", "link": "pygame.display.init", "id": 3675}, {"content": "See tutorials.  \nAfter each line \n     pygame.image.load(\"&lt;&gt;\")\nMake it\n     pygame.image.load(\"&lt;&gt;\").convert()\nNo matter what, this will increase your speed by 600%!\nThanks to whoever put in that tutorial!\n     -P.Z.", "user_title": "Ian Mallett", "datetimeon": "2007-03-05T00:13:41", "link": "pygame.draw", "id": 403}, {"content": "see:\nhttp://www.pygame.org/docs/tut/newbieguide.html\n#4", "user_title": "Ian Mallett", "datetimeon": "2007-03-17T13:13:59", "link": "pygame.draw", "id": 439}, {"content": "Dear readers, here is a working example of MPEG playing.\n-tgfcoder\n\n\nimport pygame, time\n\npygame.init()\n\ncine = pygame.movie.Movie('a-movie.mpg')\nsz=cine.get_size()\npygame.display.set_mode(sz)\nscreen = pygame.display.get_surface()\ncine.set_display(screen)\ncine.play()\nwhile True:\n time.sleep(1)", "user_title": "Jordan Trudgett", "datetimeon": "2008-01-01T09:40:25", "link": "pygame.movie", "id": 1349}, {"content": "Oh, please replace pygame.init() with pygame.display.init()\nBecause we don't want the mixer to be initialised.", "user_title": "Jordan Trudgett", "datetimeon": "2008-01-01T09:46:24", "link": "pygame.movie", "id": 1350}, {"content": "Well, actually it's not even that (x,y) needs to be in the referential of the Rect, because if it was true, then (0,0) would return 1, and it doesn't. It is really a bug.", "user_title": "Guillaume Rava", "datetimeon": "2007-04-20T18:04:08", "link": "Rect.collidepoint", "id": 503}, {"content": "# Ellipse example:\n# When border=0 ellipse is filled\n#                  (screen, (rgb colour) (Xpos,Ypos,width,height),border width)\npygame.draw.ellipse(screen, (0, 127, 0), (300, 150, 80, 40), 0)", "user_title": "Miroslav Cika", "datetimeon": "2008-01-10T10:08:04", "link": "pygame.draw.ellipse", "id": 1392}, {"content": "# Circle example:\n# When border=0 circle is filled\n#                 (screen, (rgb colour), (Xpos,Ypos),Diameter,border width)\npygame.draw.circle(screen, (0, 127, 255), (300, 140), 50, 4)", "user_title": "Miroslav Cika", "datetimeon": "2008-01-10T10:20:38", "link": "pygame.draw.circle", "id": 1393}, {"content": "thank you Trudget for the working code", "user_title": "vishwanath", "datetimeon": "2008-01-13T13:38:10", "link": "pygame.movie", "id": 1407}, {"content": "\"\"\"It seems that this method does not detect point collisions that fall anywhere \nalong the right wall or bottom wall of the rect used. The following program\ncreates a rect with a width and height of 4, and a topleft corner at [0,0]. \nThe program then moves along each row of the rect area from left to right and\ntop to bottom by 1 unit, creating a new point and checking to see if the point\ncollides with the rect. If the point collides, a 1 is printed, and if the\npoint doesn't collide, a 0 is printed.\"\"\"\n\n# import\nimport pygame\n\n# main\ny = 4\nr = pygame.Rect(0,0,y,y)\np = [0,0]\npList = []\nwhile p != [0,y+1]:\n\tfor n in range(0,y+1):\n\t\tp[0] = n\n\t\tif r.collidepoint(p):\n\t\t\tpList.append(1)\n\t\telse:\n\t\t\tpList.append(0)\n\n\tprint '%d %d %d %d %d' % (pList[0],pList[1],pList[2],pList[3],pList[4])\n\t\n\tpList = []\n\tp[0] = 0\n\tp[1] += 1\n\n# wait for user to manually exit program\ninput('press enter to exit')\n\n\"\"\"Here is the output:\"\"\"\n1 1 1 1 0\n1 1 1 1 0\n1 1 1 1 0\n1 1 1 1 0\n0 0 0 0 0\npress enter to exit\n\n\"\"\"Even if you were to directly reference the topright, bottomleft, or bottomright\npoint of the rect as the argument to the collidepoint function, the rect still \nwould not detect a collision. The rect does, however, detect collision with its\ntopleft point:\"\"\"\n\n&gt;&gt;&gt;r.collidepoint(r.bottomleft)\n0\n&gt;&gt;&gt;r.collidepoint(r.topright)\n0\n&gt;&gt;&gt;r.collidepoint(r.bottomright)\n0\n&gt;&gt;&gt;r.collidepoint(r.topleft)\n1", "user_title": "Tim Winter", "datetimeon": "2008-01-16T15:33:48", "link": "Rect.collidepoint", "id": 1420}, {"content": "To use the scrollwheel:\nfor event in pygame.event.get():\n  if event.type == MOUSEBUTTONDOWN:\n    if event.button == 4:\n      #Zoom Out\n    elif event.button == 5:\n      #Zoom In", "user_title": "Ian Mallett", "datetimeon": "2008-01-25T15:59:11", "link": "pygame.mouse", "id": 1442}, {"content": "Use the following class to generate a bezier curve that can be drawn with aalines:\n\n## Class begins here\nclass Bezier:\n\n\tclass SmoothnessError(Exception): pass\n\tclass CurveError(Exception): pass\n\n\tdef __init__(self):\n\t\t\"\"\"\n\t\tA Python class for generating bezier curves\n\t\t\n\t\tAn implementation of an algorithm presented by Nils Pipenbrinck\n\t\thttp://www.cubic.org/docs/bezier.htm\n\t\t\"\"\"\n\t\n\tdef __lerp(self, ptA, ptB, t):\n\t\t\"\"\"\n\t\tReturns the linear interp between two points as a list\n\t\tptA and ptB are a list of xy coords, t is the point on the curve\n\t\t\"\"\"\n\t\tdest = []\n\t\tdest.append(ptA[0]+float(ptB[0]-ptA[0])*t)\n\t\tdest.append(ptA[1]+float(ptB[1]-ptA[1])*t)\n\t\treturn dest\n\t\n\tdef bezierPt(self, ctrlPts, t):\n\t\t\"\"\"A recursive function for finding point t along a bezier curve\"\"\"\n\t\tif len(ctrlPts) == 1:\n\t\t\t#print \"Len is 1\", ctrlPts\n\t\t\treturn ctrlPts[0]\n\t\tlerpList = []\n\t\tfor i in xrange(len(ctrlPts)-1):\n\t\t\tptA = [ctrlPts[i][0],ctrlPts[i][1]]\n\t\t\tptB = [ctrlPts[i+1][0],ctrlPts[i+1][1]]\n\t\t\tlerpList.append(self.__lerp(ptA,ptB,t))\n\t\t#print len(lerpList)\n\t\treturn self.bezierPt(lerpList, t)\n\t\n\tdef makeBezier(self, ctrlPts, smoothness):\n\t\t\"\"\"\n\t\tReturns a list of points on a bezier curve\n\t\t\n\t\tctrlPts is a list of 2d Points that define the curve, in most cases these\n\t\tconsist of control point locations and their handles, except in a 3 point\n\t\tcurve where it's just defined by the three control points.\n\t\t\n\t\tsmoothness is the number of points on the curve that should be generated.\n\t\tThis should always be more than two points or generating the bezier curve is\n\t\tpointless and the script dies in a fire (or throws an exception)\n\t\t\"\"\"\n\t\t\n\t\tif len(ctrlPts) &lt; 2:\n\t\t\traise self.CurverError(\"Curve list must contain more than one point\")\n\t\tif smoothness &lt; 3:\n\t\t\traise self.SmoothnessError(\"Smoothness must be more than two\")\n\t\titeration = smoothness\n\t\tbezierList = []\n\t\tsubtract=1.0/smoothness\n\t\tfor i in xrange(0,iteration):\n\t\t\tt = 1.0-(subtract*i)\n\t\t\tif t &lt; subtract:\n\t\t\t\tt = 0\n\t\t\tbPt = self.bezierPt(ctrlPts,t)\n\t\t\t#print bPt\n\t\t\tbezierList.append(bPt)\n\t\treturn bezierLis\n## Class ends\n\n###################\n# An example of how to use the class with pygame\n\n\n## Pygame Example\nimport math, pygame\nfrom pygame.locals import *\nimport bezier\n\ndef main():\n    pygame.init()\n    screen = pygame.display.set_mode((640,480))\n    clock = pygame.time.Clock()\n    \n    b = bezier.Bezier()\n    \"\"\"\n\tA bezier curve definition, a list of 2d poins, simple innit\n\tIt's basically control points with control handle locations before or\n\tafter the control point.\n\t\n    Read http://www.cubic.org/docs/bezier.htm for more info\n    \"\"\"\n    bezierPts = [[40,100],[80,20],[150,180],[260,100]]\n    bLine = b.makeBezier(bezierPts, 10)\n    screen.fill((255,255,255))\n    pygame.draw.aalines(screen, (1,1,1), False, bLine, 1)\n    pygame.display.flip()\n    bounce = False\n    \n    while True:\n        clock.tick(60)\n        pygame.event.pump()\n        event = pygame.event.poll()\n        if event.type == QUIT:\n            return\n        if event.type == KEYDOWN:\n            if event.key == K_ESCAPE:\n                return\n        setTo = pygame.time.get_ticks()/20\n        bezierPts[1][1] = setTo\n        bLine = b.makeBezier(bezierPts,20)\n        screen.fill((255,255,255))\n        pygame.draw.aalines(screen, (1,1,1), False, bLine, 1)\n        pygame.display.flip()\n\nif __name__ == \"__main__\":\n    m = main()\n## End example", "user_title": "Jeiel Aranal", "datetimeon": "2008-02-06T10:50:10", "link": "pygame.draw.aalines", "id": 1502}, {"content": "Play can return None. So be sure to check the channel before using it. Something like this...\n\n        channel = self.bounce_sound.play()\n        if channel is not None:\n            channel.set_volume(1.0 - stereo, stereo)", "user_title": "Will McGugan", "datetimeon": "2007-06-14T12:13:28", "link": "Sound.play", "id": 635}, {"content": "Should have an optional option \nfor sound playback speed...", "user_title": "Ian Mallett", "datetimeon": "2007-06-30T19:41:18", "link": "Sound.play", "id": 676}, {"content": "When antialias is enabled, rendering it on a black background makes it look bold.", "user_title": "Ian Mallett", "datetimeon": "2007-07-03T01:18:12", "link": "Font.render", "id": 689}, {"content": "Should have an Anti-alias option...", "user_title": "Ian Mallett", "datetimeon": "2008-02-25T23:09:09", "link": "pygame.draw.circle", "id": 1646}, {"content": "mods = pygame.key.get_mods()\nif mods &amp; KMOD_LSHIFT: #use whatever KMOD_ constant you want;)\n       print \"left shift pressed\"", "user_title": "Isaiah Heyer", "datetimeon": "2008-03-29T16:22:04", "link": "pygame.key.get_mods", "id": 1716}, {"content": "I would like to have a method of telling which side of a rect a point collides.  \nIn other words, which side is the point closest to?", "user_title": "Ian Mallett", "datetimeon": "2008-03-29T23:08:21", "link": "Rect.collidepoint", "id": 1718}, {"content": "Right.  Unfortunately, That's the way it is.  A width or height of 0 should also\nbe allowed, for rectangles of changing sizes (think progressbar at 0%)", "user_title": "Ian Mallett", "datetimeon": "2007-08-01T17:48:16", "link": "pygame.draw.rect", "id": 785}, {"content": "Instead of drawing a circle with zero radius, you can use the method set_at on the surface to set the color of a single pixel: http://www.pygame.org/docs/ref/surface.html#Surface.set_at", "user_title": "Victor Blomqvist", "datetimeon": "2007-09-23T08:07:45", "link": "pygame.draw.circle", "id": 873}, {"content": "'dummy' driver is missing ;-)", "user_title": "DR0ID", "datetimeon": "2007-09-23T12:08:05", "link": "pygame.display.init", "id": 875}, {"content": "please able my display mode with opengl acceleration", "user_title": "aaron pedralvez", "datetimeon": "2007-09-27T02:05:16", "link": "pygame.display.init", "id": 882}, {"content": "In the event MOUSEBUTTONDOWN, if you're using a mouse with a rotating wheel,\nevent.button returns 4 when it is rotated forward (counterclockwise) and 5 when\nit is rotating backward (clockwise). I used a print statement to discover this.", "user_title": "Andy Hanson", "datetimeon": "2007-10-02T20:43:15", "link": "pygame.event", "id": 900}, {"content": "In the event MOUSEBUTTONDOWN, if you're using a mouse with a rotating wheel,\nevent.button returns 4 when it is rotated forward (counterclockwise) and 5 when\nit is rotating backward (clockwise). I used a print statement to discover this.", "user_title": "Andy Hanson", "datetimeon": "2007-10-02T20:43:21", "link": "pygame.event", "id": 901}, {"content": "You can request fullscreen, but there doesn't seem to be a way to\ndetermine whether it's on. Meaning, there ought to be a 'get_mode()'.", "user_title": "Andy Sommerville", "datetimeon": "2007-12-04T14:43:28", "link": "pygame.display.set_mode", "id": 1206}, {"content": "http://www.pygame.org/docs/ref/sndarray.html#pygame.sndarray.make_sound\ncan be used to synthesize a sound object from sound samples.", "user_title": "Ian Mallett", "datetimeon": "2008-05-26T20:16:58", "link": "pygame.mixer.Sound", "id": 1953}, {"content": "The movie module in Pygame 1.8 works on Windows.\nThe statement that it doesn't work is out-of-date.", "user_title": "Jason M. Marshall", "datetimeon": "2008-05-21T14:15:44", "link": "pygame.movie", "id": 1917}, {"content": "return bezierLis -&gt; return bezierList (line 65)", "user_title": "Jordan Trudgett", "datetimeon": "2008-06-18T02:46:43", "link": "pygame.draw.aalines", "id": 2060}, {"content": "pygame.mixer.get_num_channels(): return count", "user_title": "Jordan Trudgett", "datetimeon": "2008-07-10T13:15:18", "link": "pygame.mixer.get_num_channels", "id": 2150}, {"content": "Calling Surface.lock() before many calls to Surface.set_at() and Surface.unlock() after is a great and easy optimization.", "user_title": "Ian Mallett", "datetimeon": "2008-07-11T23:25:11", "link": "Surface.set_at", "id": 2156}, {"content": "Just set the delay to something really big.", "user_title": "Ian Mallett", "datetimeon": "2008-08-19T06:01:04", "link": "pygame.key.set_repeat", "id": 2265}, {"content": "Is this thread-safe? Can I safely post messages from a different thread\nfrom the one that's processing events and rendering?", "user_title": "Weeble", "datetimeon": "2008-11-28T19:09:39", "link": "pygame.event.post", "id": 2339}, {"content": "''' Change alpha for surfaces with per-pixel alpha; only for small surfaces '''\ndef change_alpha(surface,alpha=0.5):\n\tsize = surface.get_size()\n\ttry:\n\t\tfor y in xrange(size[1]):\n\t\t\tfor x in xrange(size[0]):\n\t\t\t\tr,g,b,a = surface.get_at((x,y))\n\t\t\t\tsurface.set_at((x,y),(r,g,b,int(a*alpha)))\n\texcept:\n\t\treturn surface\n\treturn surface", "user_title": "Josef Vanzura", "datetimeon": "2010-11-19T09:47:18", "link": "Surface.set_alpha", "id": 3245}, {"content": "You can also do it with surfarray (faster).", "user_title": "Josef Vanzura", "datetimeon": "2010-11-19T09:49:02", "link": "Surface.set_alpha", "id": 3246}, {"content": "Sorry. I didn't read the previous comment, which is a better way.", "user_title": "Josef Vanzura", "datetimeon": "2010-11-19T09:56:18", "link": "Surface.set_alpha", "id": 3247}, {"content": "present in pygame 1.9.1 but not in pygame 1.8.1, which is currently the last binary release on Linux.", "user_title": "Shanti Pothapragada", "datetimeon": "2010-11-22T17:04:34", "link": "Rect.copy", "id": 3249}, {"content": "Also includes the attributes: x, y.", "user_title": "Sam Bull", "datetimeon": "2010-10-26T07:40:18", "link": "pygame.Rect", "id": 3225}, {"content": "Works like a charm. Thanks whoever you are.", "user_title": "Bartosz Debski", "datetimeon": "2010-09-29T19:26:57", "link": "Surface.fill", "id": 3211}, {"content": "The code snippet works perfectly; thanks!\nI think the documentation is sorely in need of an update.\nWishlist: other video formats, like .avi?", "user_title": "Ian Mallett", "datetimeon": "2009-01-01T16:05:17", "link": "pygame.movie", "id": 2360}, {"content": "An example to use this:\nscreen = pygame.display.set_mode(SCREENRECT.size) # SCREENRECT is a rect variable...\n            # ...with screen dimension\n\ndoggie = pygame.sprite.RenderUpdates() #We create the group\nDog.containers = doggie \n# class Dog: Needs 'pygame.sprite.Sprite.__init__(self,self.containers)'\n# inside def __init__(self, ...):\n\ndog1 = Dog(...) #Class Dog\ndog2 = Dog(...)\n...\ndogN = Dog(...)\n\n... #Some move actions and things\n\n#Now, time to re-paint them all\ndoggie.clear(screen, Background)\nchanges = doggie.draw(screen)\npygame.display.update(changes)\n#Now we have all dogs updated in screen\n\n#---------\nEasy, quick and effortless", "user_title": "Patata", "datetimeon": "2009-01-07T12:38:26", "link": "pygame.sprite.RenderUpdates", "id": 2366}, {"content": "# A better loading script:\n\nimport os, pygame\n\ndef load_image(file_name, colorkey=False, image_directory='images'):\n    'Loads an image, file_name, from image_directory, for use in pygame'\n    file = os.path.join(image_directory, file_name)\n    _image = pygame.image.load(file)\n    if colorkey:\n        if colorkey == -1: \n        # If the color key is -1, set it to color of upper left corner\n            colorkey = _image.get_at((0, 0))\n        _image.set_colorkey(colorkey)\n        _image = _image.convert()\n    else: # If there is no colorkey, preserve the image's alpha per pixel.\n        _image = _image.convert_alpha()\n    return _image", "user_title": "Nekody Lenkner", "datetimeon": "2009-03-20T21:58:08", "link": "pygame.image.load", "id": 2399}, {"content": "what does it mean by font name? can it be a path to a font?", "user_title": "Mad Cloud Games", "datetimeon": "2010-07-02T01:21:30", "link": "pygame.font.SysFont", "id": 3151}, {"content": "You can use multiple screens, but you'll need to make a separate process for each.", "user_title": "Ian Mallett", "datetimeon": "2009-08-01T23:26:07", "link": "pygame.display.set_mode", "id": 2900}, {"content": "VIDEORESIZE      size, w, h\nsize == (w, h) # same data, different access", "user_title": "DR0ID", "datetimeon": "2009-04-04T12:27:05", "link": "pygame.event", "id": 2411}, {"content": "je ne sais pas pourquoi, mais; si vous utiliser une surface pour effacer le display au lieu d'utiliser un 'fill',\nil sera beaucoup plus rapide de blitter une copie du display :\n\ndisplay = pygame.display.set_mode((500,500))\nbackground = pygame.image.load('blablabla...')\ndisplay.blit(background,(0,0))\nbackground = display.copy()  ----&gt; utiliser cette copie pour multi-blitter plus rapidement une image de fond.", "user_title": "josmiley", "datetimeon": "2009-08-03T01:50:34", "link": "Surface.copy", "id": 2902}, {"content": "This doesn't say anything about the type attribute.\nYou can compare it to MOUSEBUTTONUP, KEYDOWN, etc to find out what the events\ntype is.", "user_title": "Daniel Westbrook", "datetimeon": "2009-07-29T00:20:38", "link": "pygame.event.Event", "id": 2896}, {"content": "is it a Rect object???", "user_title": "Alex", "datetimeon": "2010-05-04T17:47:38", "link": "pygame.display.update", "id": 3117}, {"content": "TIP:\nIf sound has noise/noisy is choppy or has static, the solution:\n\npygame.mixer.quit() #Make sure you all this before .init()\npygame.mixer.init()", "user_title": "Chris Goldie", "datetimeon": "2009-08-11T05:44:03", "link": "Sound.play", "id": 2911}, {"content": "The convert_alpha function prepares a surface for usage with per-pixel alphas.  That is, for example, if you have a PNG or TGA image with an alpha channel controlling opacity of individual pixels, you would want to use this function on your surface after loading the image to speed up the blitting process.", "user_title": "Brad Smithee", "datetimeon": "2010-04-29T02:55:18", "link": "Surface.convert_alpha", "id": 3113}, {"content": "This will be extremely useful!", "user_title": "Ian Mallett", "datetimeon": "2009-08-15T19:21:45", "link": "pygame.transform.average_surfaces", "id": 2917}, {"content": "Some basic sample code for (approximately) constraining a bunch of text to a given width:\n\nwordsToWrite = toWrite.rstrip().split(\" \") #Get rid of the newline char and split on spaces\ncurrLine = \"\"\nnumLines = 0\nmaxWidthFound = 0\nfor word in wordsToWrite:\n    currLine = currLine + \" \" + word #Add the next word to the line\n\n    if ((textFont.size(currLine))[0] &gt; maxAllowedWidth): #Check if the width of the line exceeds the set limit\n\n        if (textFont.size(currLine))[0] &gt; maxWidthFound: #Get the maximum line width found\n            maxWidthFound = (textFont.size(currLine))[0]\n\n        lines.append (textFont.render(currLine, 1, color, bgcolor)) #Add the rendered line to a list\n        currLine = \"\"\n        numLines = numLines + 1\n\nif currLine != \"\": #Once we exit the loop, we will probably still have a line to be rendered\n    lines.append (textFont.render(currLine, 1, color, bgcolor))\n    currLine = \"\"\n    numLines = numLines + 1\n\nself.image = pygame.Surface((maxWidthFound + 20, numLines * textFont.get_height() + 20)) #Create a surface of the appropriate size\n\nfor lineNum in range(numLines): \n    self.image.blit(lines[lineNum], (10,lineNum * textFont.get_height() + 10))", "user_title": "Aditya Keswani", "datetimeon": "2009-07-20T07:29:06", "link": "Font.render", "id": 2887}, {"content": "For all of these drawing functions, the coordinates are relative to the surface\nyou are drawing to. i.e. if you are drawing to a surface somewhere in the middle of\nthe screen, and you draw a circle at (0,0), its center will be the top-left corner\nof the surface being drawn to, not the top-left corner of the screen", "user_title": "Aditya Keswani", "datetimeon": "2009-07-20T07:23:36", "link": "pygame.draw", "id": 2886}, {"content": "The messages here:\nhttp://www.mail-archive.com/pygame-users@seul.org/msg10616.html\n\nimply that GL_SWAP_CONTROL can also be passed to gl_set_attribute to control whether\ndisplay swaps honor vsync.", "user_title": "Jonathan Hartley", "datetimeon": "2010-03-25T15:42:06", "link": "pygame.display.gl_set_attribute", "id": 3087}, {"content": "Pygame THECOLORS as HTML\nhttps://sites.google.com/site/meticulosslacker/pygame-thecolors", "user_title": "Meticulos Slacker", "datetimeon": "2010-03-18T03:10:26", "link": "pygame.Color", "id": 3078}, {"content": "Should be \"buffer\", not \"buffersize\"", "user_title": "Ian Mallett", "datetimeon": "2010-03-19T00:36:48", "link": "pygame.mixer.pre_init", "id": 3079}, {"content": "Put this first:\nfor e in pygame.event.get()", "user_title": "Ian Mallett", "datetimeon": "2010-03-20T19:51:20", "link": "pygame.key.set_repeat", "id": 3080}, {"content": "mod is the bitfield of KMOD_* constants:\npygame.KMOD_NONE\t0\npygame.KMOD_LSHIFT\t1\npygame.KMOD_RSHIFT\t2\npygame.KMOD_SHIFT\t3\npygame.KMOD_LCTRL\t64\npygame.KMOD_RCTRL\t128\npygame.KMOD_CTRL\t192\npygame.KMOD_LALT\t256\npygame.KMOD_RALT\t512\npygame.KMOD_ALT\t\t768\npygame.KMOD_LMETA\t1024\npygame.KMOD_RMETA\t2048\npygame.KMOD_META\t3072\npygame.KMOD_NUM\t\t4096\npygame.KMOD_CAPS\t8192\npygame.KMOD_MODE\t16384", "user_title": "Vladar", "datetimeon": "2010-03-23T06:16:44", "link": "pygame.event", "id": 3081}, {"content": "If you try to use fadeout, the queued sound will begin, as opposed to stop and pause.", "user_title": "Andy Hanson", "datetimeon": "2009-07-12T22:43:31", "link": "Channel.queue", "id": 2875}, {"content": "I ran into that problem -- the solution is to initialize pygame first :)\n\nimport pygame\npygame.init()\nprint pygame.key.name(pygame.K_UP)", "user_title": "Jared", "datetimeon": "2009-08-29T04:11:27", "link": "pygame.key.name", "id": 2928}, {"content": "It appears that when the delay is set to zero, \nkey.set_repeat is returned to the default, disabled state.\nTo set it to a minimum, essentially no delay, just set it to 1.\n\npygame.key.set_repeat(0,50) #Doesn't work.\npygame.key.set_repeat(1,50) #Works with essentially no delay.", "user_title": "David Khono Hackland", "datetimeon": "2010-03-02T22:20:03", "link": "pygame.key.set_repeat", "id": 3065}, {"content": "It appears that when the delay is set to zero, \nkey.set_repeat is returned to the default, disabled state.\nTo set it to a minimum, essentially no delay, just set it to 1.\n\npygame.key.set_repeat(0,50) #Doesn't work.\npygame.key.set_repeat(1,50) #Works with essentially no delay.", "user_title": "David Khono Hackland", "datetimeon": "2010-03-02T22:19:26", "link": "pygame.key.set_repeat", "id": 3064}, {"content": "Does it matter if you tick at the start or at the end?", "user_title": "Mitchell K", "datetimeon": "2009-09-12T21:09:15", "link": "Clock.tick", "id": 2944}, {"content": "The example's .flip(..) below won't work - maybe I should have checked it before posting...\nHere is a better Version, it should work now.\n\nfrom pygame import Rect, Surface\nclass Sprites():\n    def __init__(self, spritesheet, size):\n        self.sheet = spritesheet\n        self.sheet.convert_alpha()\n        self.size = size\n        \n        self.sprites = []\n        for x in xrange(spritesheet.get_width() / size[0]):\n            list = []\n            for y in xrange(spritesheet.get_height() / size[1]):\n                list.append(spritesheet.subsurface(Rect((x*size[0], y*size[1]) , size)))\n            self.sprites.append(list)\n    def flip(self, xbool, ybool):\n        new = Surface(self.sheet.get_size())\n        new.fill((0, 0, 0, 0))\n        for row in self.sprites:\n            for sprite in row:\n                new.blit(flip(sprite, xbool, ybool), sprite.get_offset())\n        self.sheet.fill((0, 0, 0, 0))\n        self.sheet.blit(new, (0, 0))\n    def __getitem__(self, x=None, y=None):\n        # not very tested, .flip(y=7) won't work\n        # the if conditions should allow you to access a sheet with one row/col more easily .flip(5, 0) == .flip(5)\n        if x is not None:\n            if y is None:\n                if len(self.sprites) &gt; x:\n                    y = 0\n                else:\n                    y = x\n                    x = 0\n        elif y is None:\n            raise IndexError\n                \n        return self.sprites[x][y]\n\n@any Developer/Moderator - it would be nice if my wrong post, \"The example below won't work\" and this Notice would be removed.", "user_title": "Rolf Sievers", "datetimeon": "2009-11-06T11:31:59", "link": "Surface.subsurface", "id": 2998}, {"content": "Here is a simple Sprite-sheet Class I wrote for an application, maybe someone can use it.\n\nfrom pygame import Rect\nclass Sprites():\n    def __init__(self, spritesheet, size):\n        self.sheet = spritesheet\n        self.sheet.convert_alpha()\n        self.size = size\n        \n        self.sprites = []\n        for x in xrange(spritesheet.get_width() / size[0]):\n            list = []\n            for y in xrange(spritesheet.get_height() / size[1]):\n                list.append(spritesheet.subsurface(Rect((x*size[0], y*size[1]) , size)))\n            self.sprites.append(list)\n            print list\n        print self.sprites\n    def flip(self, xbool, ybool):\n        self.sheet.fill((0, 0, 0, 0))\n        for row in self.sprites:\n            for sprite in row:\n                sprite.blit(flip(sprite, xbool, ybool), (0, 0))\n    def __getitem__(self, x=None, y=None):\n        if x is not None:\n            if y is None:\n                if len(self.sprites) &gt; x:\n                    y = 0\n                else:\n                    y = x\n                    x = 0\n        elif y is None:\n            raise IndexError\n                \n        return self.sprites[x][y]", "user_title": "Rolf Sievers", "datetimeon": "2009-11-06T11:14:23", "link": "Surface.subsurface", "id": 2997}, {"content": "Is there anyway to get the rect of a polygon without having to create a surface greater than or equal to the polygon, and then gather the rect from the polygon?", "user_title": "Luke Endres", "datetimeon": "2009-08-08T21:50:46", "link": "pygame.draw.polygon", "id": 2907}, {"content": "This is twice the work because the image is rotated and then resized (subrect\nis copied) but it doesn't hurt my math-addled brain.\n\ndef rot_center(image, angle):\n    \"\"\"rotate an image while keeping its center and size\"\"\"\n    orig_rect = image.get_rect()\n    rot_image = pygame.transform.rotate(image, angle)\n    rot_rect = orig_rect.copy()\n    rot_rect.center = rot_image.get_rect().center\n    rot_image = rot_image.subsurface(rot_rect).copy()\n    return rot_image", "user_title": "Gummbum", "datetimeon": "2010-01-17T01:17:23", "link": "pygame.transform.rotate", "id": 3034}, {"content": "Use pygame.transform.rotate(Surface, angle)", "user_title": "Francesco Pasa", "datetimeon": "2010-01-17T09:30:05", "link": "pygame.Surface", "id": 3035}, {"content": "Does the returned Boolean value indicate success/failure at toggling fullscreen mode,\nor current status of the display (e.g., fullscreen = True, windowed = False)?", "user_title": "Chris L", "datetimeon": "2010-01-27T16:33:12", "link": "pygame.display.toggle_fullscreen", "id": 3041}, {"content": "set_blocked() clear queue from ALL events", "user_title": "ploutos", "datetimeon": "2009-10-23T11:07:21", "link": "pygame.event.set_blocked", "id": 2980}, {"content": "If they play in a CD player, they were burned properly.", "user_title": "Jeffrey Aylesworth", "datetimeon": "2009-10-21T19:51:47", "link": "pygame.cdrom", "id": 2975}, {"content": "This is very important for mac because it shows the icon in the dock.. when I use this, it flashes the snake image for a second before changing, and it also gets smaller then the application icon which is the same (using py2app).", "user_title": "Mitchell K", "datetimeon": "2009-09-24T16:05:59", "link": "pygame.display.set_icon", "id": 2959}, {"content": "\"\"\"\n\t # This is a get_ticks() function simple example\n\t # This script should return 10 as a result\n\"\"\"\n# Standard library imports\nimport time\n# Related third party imports\nimport pygame\n#Pygame start function\n\npygame.init()\n# Create the clock\nclock = pygame.time.Clock()\n# A simple loop of 10 stages\nfor i in range(10):\n\t# Update the clock\n\tclock.tick(1)\n# Print the seconds\nprint int(round(pygame.time.get_ticks()/1000))", "user_title": "Sergio Milardovich", "datetimeon": "2010-06-08T15:33:04", "link": "pygame.time.get_ticks", "id": 3138}, {"content": "Note that pygame.scrap seems to be unimplemented in pygame-1.9.1.win32-py3.1.msi\n\nDefine testscrap.py, like this:\n\nimport pygame\npygame.init()\npygame.scrap.init()\n\n\nRun it, like this:\n\nC:\\Users\\Dave\\Documents\\Python&gt;testscrap.py\nC:\\Users\\Dave\\Documents\\Python\\testscrap.py:3: RuntimeWarning: use scrap: No module named scrap\n(ImportError: No module named scrap)\n  pygame.scrap.init()\nTraceback (most recent call last):\n  File \"C:\\Users\\Dave\\Documents\\Python\\testscrap.py\", line 3, in \n    pygame.scrap.init()\n  File \"C:\\Python31\\lib\\site-packages\\pygame\\__init__.py\", line 70, in __getattr__\n    raise NotImplementedError(MissingPygameModule)\nNotImplementedError: scrap module not available\n(ImportError: No module named scrap)", "user_title": "Dave Burton", "datetimeon": "2011-01-16T00:15:21", "link": "pygame.scrap", "id": 3731}, {"content": "BTW, the same error occurs if you have initialized a display surface, too:\n\nimport pygame\npygame.init()\nscreen=pygame.display.set_mode((640,360),0,32)\npygame.scrap.init()", "user_title": "Dave Burton", "datetimeon": "2011-01-16T00:18:19", "link": "pygame.scrap", "id": 3732}, {"content": "Hey, July 7 2009 Anonymous, that's a nice demo!\n\nFor Python 3 compatibility, just change the last line to:\n\n  pygame.time.delay(1000//50)", "user_title": "Dave Burton", "datetimeon": "2011-01-24T10:00:06", "link": "Surface.subsurface", "id": 3746}, {"content": "Note that the order of the tuple members in virtual attributes like .topleft\nis always (x,y) [or (left,top) or (width,height)] even if the name of the\nvirtual attribute seems to suggest the opposite order.  E.g.,\nrect1.topleft == (rect1.left,rect1.top)", "user_title": "Dave Burton", "datetimeon": "2011-01-25T01:19:14", "link": "pygame.Rect", "id": 3747}, {"content": "There's no 'code' member for type USEREVENT, unless you create one yourself\nwhen you create the event.", "user_title": "Dave Burton", "datetimeon": "2011-01-25T21:33:33", "link": "pygame.event", "id": 3750}, {"content": "July 15 2010 Anonymous, here's your example of a resizeable pygame window.\n\nI don't know what you mean by \"window itself as well as the display.\"\nIf you want to resize something WITHIN the pygame window, just blit something\ndifferent onto it.\n\nDave\n\n\nimport sys, os, pygame\npygame.init()\n\nclock = pygame.time.Clock()\n\nscrsize = width,height = 600,400\nblack = 0,0,0\nbgcolor = (240,240,220)  # light grey\n\n# to get the true full-screen size, do this BEFORE pygame.display.set_mode:\nfullscreen_sz = pygame.display.Info().current_w, pygame.display.Info().current_h\nprint( 'screen size =', fullscreen_sz )\n\n\n# ---------- This works under Windows Vista, no promises elsewhere! ----------\n# initially center the pygame window by setting %SDL_VIDEO_WINDOW_POS%\nwin_pos_left = 1 + ((fullscreen_sz[0] - width) // 2)\nwin_pos_top = 1 + ((fullscreen_sz[1] - height) // 2)\nos.environ['SDL_VIDEO_WINDOW_POS'] = '{0},{1}'.format(win_pos_left, win_pos_top)\n# ----------------------------------------------------------------------------\n\nscreen = pygame.display.set_mode(scrsize, pygame.RESIZABLE)\n\n# ----------------------------------------------------------------------------\nos.environ['SDL_VIDEO_WINDOW_POS'] = ''\n# if you don't clear the environment variable, the window will reposition\n# every time pygame.display.set_mode() gets called due to a VIDEORESIZE event.\n# ----------------------------------------------------------------------------\n\narial = pygame.font.SysFont( 'arial,microsoftsansserif,courier', 14 )\ntxt2display = arial.render( \"This window is resizeable\", True, black )\ntxt2display_w = txt2display.get_size()[0]\n\nwhile True:\n    changed = False\n    for event in pygame.event.get():\n        if event.type == pygame.QUIT:\n            pygame.quit()\n            sys.exit(0)\n        elif event.type == pygame.VIDEORESIZE:\n            scrsize = event.size  # or event.w, event.h\n            screen = pygame.display.set_mode(scrsize,RESIZABLE)\n            changed = True\n\n    screen.fill( bgcolor )\n    screen.blit( txt2display, ((scrsize[0]+1-txt2display_w)//2,1) )  # at top-center of screen\n    pygame.display.update()\n    if not changed:\n        clock.tick(60) # limit to 60 fps", "user_title": "Dave Burton", "datetimeon": "2011-01-25T23:10:35", "link": "pygame.display.init", "id": 3751}, {"content": "Oops!  Tiny correction... the 8th-to-last line should be\n\n            screen = pygame.display.set_mode(scrsize,pygame.RESIZABLE)\n\n(Or else you can \"from pygame.locals import *\")", "user_title": "Dave Burton", "datetimeon": "2011-01-25T23:16:00", "link": "pygame.display.init", "id": 3752}, {"content": "from pygame.locals import *\n\n_evnames = {}                                 # from SDL-1.2.14\\include\\SDL_events.h\n_evnames[NOEVENT]         = 'NOEVENT'          #  0  SDL_NOEVENT\n_evnames[ACTIVEEVENT]     = 'ACTIVEEVENT'      #  1  SDL_ACTIVEEVENT\n_evnames[KEYDOWN]         = 'KEYDOWN'          #  2  SDL_KEYDOWN\n_evnames[KEYUP]           = 'KEYUP'            #  3  SDL_KEYUP\n_evnames[MOUSEMOTION]     = 'MOUSEMOTION'      #  4  SDL_MOUSEMOTION\n_evnames[MOUSEBUTTONDOWN] = 'MOUSEBUTTONDOWN'  #  5  SDL_MOUSEBUTTONDOWN\n_evnames[MOUSEBUTTONUP]   = 'MOUSEBUTTONUP'    #  6  SDL_MOUSEBUTTONUP\n_evnames[JOYAXISMOTION]   = 'JOYAXISMOTION'    #  7  SDL_JOYAXISMOTION\n_evnames[JOYBALLMOTION]   = 'JOYBALLMOTION'    #  8  SDL_JOYBALLMOTION\n_evnames[JOYHATMOTION]    = 'JOYHATMOTION'     #  9  SDL_JOYHATMOTION\n_evnames[JOYBUTTONDOWN]   = 'JOYBUTTONDOWN'    # 10  SDL_JOYBUTTONDOWN\n_evnames[JOYBUTTONUP]     = 'JOYBUTTONUP'      # 11  SDL_JOYBUTTONUP\n_evnames[QUIT]            = 'QUIT'             # 12  SDL_QUIT\n_evnames[SYSWMEVENT]      = 'SYSWMEVENT'       # 13  SDL_SYSWMEVENT\n                                               # 14  SDL_EVENT_RESERVEDA\n                                               # 15  SDL_EVENT_RESERVEDB\n_evnames[VIDEORESIZE]     = 'VIDEORESIZE'      # 16  SDL_VIDEORESIZE\n_evnames[VIDEOEXPOSE]     = 'VIDEOEXPOSE'      # 17  SDL_VIDEOEXPOSE\n                                               # 18  SDL_EVENT_RESERVED2\n                                               # 19  SDL_EVENT_RESERVED3\n                                               # 20  SDL_EVENT_RESERVED4\n                                               # 21  SDL_EVENT_RESERVED5\n                                               # 22  SDL_EVENT_RESERVED6\n                                               # 23  SDL_EVENT_RESERVED7\n_evnames[USEREVENT]       = 'USEREVENT'        # 24  SDL_USEREVENT\n_evnames[NUMEVENTS]       = 'NUMEVENTS'        # 32  SDL_NUMEVENTS\n\n\ndef event_name(evtype):\n    '''return a displayable name for a pygame/SDL event type number'''\n    try:\n        result = _evnames[evtype]\n    except:\n        if evtype in range(USEREVENT,NUMEVENTS):\n            result = 'USEREVENT+' + repr(evtype-USEREVENT)\n        elif evtype &gt;= NUMEVENTS:\n            result = 'ILLEGAL_EVENT_' + repr(evtype)\n        elif evtype == 14:\n            result = 'EVENT_RESERVEDA'\n        elif evtype == 15:\n            result = 'EVENT_RESERVEDB'\n        else:\n            result = 'EVENT_RESERVED' + repr(evtype-16)\n    return result\n\n\nfor i in range(0,33):\n    print(repr(i) + ' = ' + event_name(i))\n\n\n# It's all gonna change in SDL 1.3:\n#\n#   SDL_FIRSTEVENT        = 0      # Unused\n#\n#   SDL_QUIT              = 0x100  # User-requested quit\n#\n#   SDL_WINDOWEVENT       = 0x200  # Window state change\n#   SDL_SYSWMEVENT        = 0x201  # System specific event\n#\n#   # Keyboard events\n#   SDL_KEYDOWN           = 0x300  # Key pressed\n#   SDL_KEYUP             = 0x301  # Key released\n#   SDL_TEXTEDITING       = 0x302  # Keyboard text editing (composition)\n#   SDL_TEXTINPUT         = 0x303  # Keyboard text input\n#\n#   # Mouse events\n#   SDL_MOUSEMOTION       = 0x400  # Mouse moved\n#   SDL_MOUSEBUTTONDOWN   = 0x401  # Mouse button pressed\n#   SDL_MOUSEBUTTONUP     = 0x402  # Mouse button released\n#   SDL_MOUSEWHEEL        = 0x403  # Mouse wheel motion\n#\n#   # Tablet or multiple mice input device events\n#   SDL_INPUTMOTION       = 0x500  # Input moved\n#   SDL_INPUTBUTTONDOWN   = 0x501  # Input button pressed\n#   SDL_INPUTBUTTONUP     = 0x502  # Input button released\n#   SDL_INPUTWHEEL        = 0x503  # Input wheel motion\n#   SDL_INPUTPROXIMITYIN  = 0x504  # Input pen entered proximity\n#   SDL_INPUTPROXIMITYOUT = 0x505  # Input pen left proximity\n#\n#   # Joystick events\n#   SDL_JOYAXISMOTION     = 0x600  # Joystick axis motion\n#   SDL_JOYBALLMOTION     = 0x601  # Joystick trackball motion\n#   SDL_JOYHATMOTION      = 0x602  # Joystick hat position change\n#   SDL_JOYBUTTONDOWN     = 0x603  # Joystick button pressed\n#   SDL_JOYBUTTONUP       = 0x604  # Joystick button released\n#\n#   # Touch events\n#   SDL_FINGERDOWN        = 0x700\n#   SDL_FINGERUP          = 0x701\n#   SDL_FINGERMOTION      = 0x702\n#   SDL_TOUCHBUTTONDOWN   = 0x703\n#   SDL_TOUCHBUTTONUP     = 0x704\n#\n#   # Gesture events\n#   SDL_DOLLARGESTURE     = 0x800\n#   SDL_DOLLARRECORD      = 0x801\n#   SDL_MULTIGESTURE      = 0x802\n#\n#   # Clipboard events\n#   SDL_CLIPBOARDUPDATE   = 0x900  # The clipboard changed\n#\n#   # Obsolete events\n#   SDL_EVENT_COMPAT1     =0x7000  # SDL 1.2 events for compatibility\n#   SDL_EVENT_COMPAT2     =0x7001\n#   SDL_EVENT_COMPAT3     =0x7002\n#\n#   # SDL_USEREVENT thru SDL_LASTEVENT are for your use\n#   SDL_USEREVENT         =0x8000\n#   SDL_LASTEVENT         =0xFFFF", "user_title": "Dave Burton", "datetimeon": "2011-01-27T04:08:06", "link": "pygame.event.Event", "id": 3753}, {"content": "This function seems to me little bit buggy, so I wrote my own:\n\na and b are surfarrays of some surfaces that you want to compare\n\n    def comparray(self,a,b):\n        c = abs(a.__sub__(b))\n        c = c.__ge__(self.tolerance)*255\n        surface = pygame.surfarray.make_surface(c)\n        return surface", "user_title": "Kaan Ak\u00c3\u009fit", "datetimeon": "2011-01-27T18:49:33", "link": "PixelArray.compare", "id": 3756}, {"content": "There's an error in this documentation w/r/t the final (width) argument:\n\n    pygame.draw.rect(self.image, color, self.image.get_rect(), width=1)\nTypeError: rect() takes no keyword arguments\n\nLeave off the \"width=\" to make it work:\n\n    pygame.draw.rect(self.image, color, self.image.get_rect(), 1)\n\nThis is with either pygame-1.9.1.win32-py2.6.msi or pygame-1.9.1.win32-py3.1.msi", "user_title": "Dave Burton", "datetimeon": "2011-01-28T03:12:31", "link": "pygame.draw.rect", "id": 3757}, {"content": "There's an error in this documentation w/r/t the final (width) argument:\n\n    pygame.draw.line(self.image, (0,0,0), (x,y), (x,y+h), width=2)\nTypeError: line() takes no keyword arguments\n\nLeave off the \"width=\" to make it work:\n\n    pygame.draw.line(self.image, (0,0,0), (x,y), (x,y+h), 2)\n\nThis is with either pygame-1.9.1.win32-py2.6.msi or pygame-1.9.1.win32-py3.1.msi", "user_title": "Dave Burton", "datetimeon": "2011-01-28T04:54:01", "link": "pygame.draw.line", "id": 3759}, {"content": "Rect.center rounds UP:\n\nr0x0 = pygame.Rect(0,0,0,0)  # a 0x0 rect\nprint('center of 0x0 rect is ' + repr(r0x0.center))  # result is (0,0) = not in the rect!\nr1x1 = pygame.Rect(0,0,1,1)  # a 1x1 rect\nprint('center of 1x1 rect is ' + repr(r1x1.center))  # result is (0,0) = correct\nr2x2 = pygame.Rect(0,0,2,2)  # a 2x2 rect\nprint('center of 2x2 rect is ' + repr(r2x2.center))  # result is (1,1) = rounded up!\nr3x3 = pygame.Rect(0,0,3,3)  # a 3x3 rect\nprint('center of 3x3 rect is ' + repr(r3x3.center))  # result is (1,1) = exact\nr4x4 = pygame.Rect(0,0,4,4)  # a 4x4 rect\nprint('center of 4x4 rect is ' + repr(r4x4.center))  # result is (2,2) = rounded up!\nr5x5 = pygame.Rect(0,0,5,5)  # a 5x5 rect\nprint('center of 5x5 rect is ' + repr(r5x5.center))  # result is (2,2) = exact\nr6x6 = pygame.Rect(0,0,6,6)  # a 6x6 rect\nprint('center of 6x6 rect is ' + repr(r6x6.center))  # result is (3,3) = rounded up!\nr7x7 = pygame.Rect(0,0,7,7)  # a 7x7 rect\nprint('center of 7x7 rect is ' + repr(r7x7.center))  # result is (3,3) = exact", "user_title": "Dave Burton", "datetimeon": "2011-01-29T20:46:36", "link": "Rect.collidepoint", "id": 3761}, {"content": "(Oops, I added that comment in the wrong place.)", "user_title": "Dave Burton", "datetimeon": "2011-01-29T20:47:58", "link": "Rect.collidepoint", "id": 3762}, {"content": "Rect.center rounds UP:\n\nr0x0 = pygame.Rect(0,0,0,0)  # a 0x0 rect\nprint('center of 0x0 rect is ' + repr(r0x0.center))  # result is (0,0) = not in the rect!\nr1x1 = pygame.Rect(0,0,1,1)  # a 1x1 rect\nprint('center of 1x1 rect is ' + repr(r1x1.center))  # result is (0,0) = correct\nr2x2 = pygame.Rect(0,0,2,2)  # a 2x2 rect\nprint('center of 2x2 rect is ' + repr(r2x2.center))  # result is (1,1) = rounded up!\nr3x3 = pygame.Rect(0,0,3,3)  # a 3x3 rect\nprint('center of 3x3 rect is ' + repr(r3x3.center))  # result is (1,1) = exact\nr4x4 = pygame.Rect(0,0,4,4)  # a 4x4 rect\nprint('center of 4x4 rect is ' + repr(r4x4.center))  # result is (2,2) = rounded up!\nr5x5 = pygame.Rect(0,0,5,5)  # a 5x5 rect\nprint('center of 5x5 rect is ' + repr(r5x5.center))  # result is (2,2) = exact\nr6x6 = pygame.Rect(0,0,6,6)  # a 6x6 rect\nprint('center of 6x6 rect is ' + repr(r6x6.center))  # result is (3,3) = rounded up!\nr7x7 = pygame.Rect(0,0,7,7)  # a 7x7 rect\nprint('center of 7x7 rect is ' + repr(r7x7.center))  # result is (3,3) = exact", "user_title": "Dave Burton", "datetimeon": "2011-01-29T20:48:50", "link": "pygame.Rect", "id": 3763}, {"content": "This documentation is incorrect.  A point along the right or bottom edge IS\nwithin the Rect, and points at coordinates on the bottom or right edge DO\ncollide with the Rect.\n\nHere's proof:\n\nr = Rect(0,0, 4,4)  # a 4x4 rectangle\nprint('0,0: ' + repr(r.collidepoint(0,0)))\nprint('1,1: ' + repr(r.collidepoint(1,1)))\nprint('2,2: ' + repr(r.collidepoint(2,2)))\nprint('3,3: ' + repr(r.collidepoint(3,3)))\nprint('4,4: ' + repr(r.collidepoint(4,4)))\n\nWith pygame 1.9.1 under both Python 3.1 and 2.6, it prints:\n\n0,0: 1\n1,1: 1\n2,2: 1\n3,3: 1\n4,4: 0\n\nNote that the bottom-right pixel within the 4x4 rect is at (3,3) and\ncollidepoint((3,3)) does return 1 (meaning true).\n\nA second (minor) documentation error is that it actually returns an integer\n1 or 0 instead of boolean True or False.", "user_title": "Dave Burton", "datetimeon": "2011-01-29T22:35:18", "link": "Rect.collidepoint", "id": 3764}, {"content": "This class is a bit odd.  Event objects have no event.__dict__ attribute,\nand the dir(event) function doesn't work.  However, repr(event) returns a\nnice, thorough description of an event object and its attributes, and the\nevent.dict attribute lists all the important attributes except .type and\n.dict itself.", "user_title": "Dave Burton", "datetimeon": "2011-02-07T04:48:40", "link": "pygame.event", "id": 3774}, {"content": "With a Microsoft IntelliMouse p/n X05-77975, under Windows Vista,\nwith either Python 2.6 or 3.1, the button numbers are:\n1 = left button\n2 = center button/wheel press\n3 = right button\n4 = wheel roll forward/up\n5 = wheel roll backward/down\n6 = left side extra button\n7 = right side extra button", "user_title": "Dave Burton", "datetimeon": "2011-02-23T21:04:46", "link": "pygame.event", "id": 3794}, {"content": "There's a cursor missing!  sizer_xy_strings defines an upper-left-to-lower-right\nresizer cursor, suitable for dragging the upper-left or lower-right corner.\nBut there's no sizer_yx_strings to make the upper-right-to-lower-left cursor.\nHere's how I made one:\n\nsizer_yx_strings = [ x[12::-1]+x[13:] for x in pygame.cursors.sizer_xy_strings ]", "user_title": "Dave Burton", "datetimeon": "2011-02-24T02:08:27", "link": "pygame.cursors", "id": 3795}, {"content": "Or, equivalently:\n\nsizer_yx_strings = (               #sized 24x16\n \"     XXXXXXXX           \",\n \"      X.....X           \",\n \"       X....X           \",\n \"        X...X           \",\n \"       X.X..X           \",\n \"      X.X X.X           \",\n \"X    X.X   XX           \",\n \"XX  X.X     X           \",\n \"X.XX.X                  \",\n \"X...X                   \",\n \"X...X                   \",\n \"X....X                  \",\n \"X.....X                 \",\n \"XXXXXXXX                \",\n \"                        \",\n \"                        \",\n)", "user_title": "Dave Burton", "datetimeon": "2011-02-24T02:13:59", "link": "pygame.cursors", "id": 3796}, {"content": "The Sound function now accepts 'buffer', 'file', and 'array' keyword arguments\nto remove any ambiguity in how to treat an argument. The 'array' keyword is new,\nand tells Sound to look check the argument for an array struct interface or\nthe new buffer protocol if supported. This allows Sound to function like\nsndarray.make_sound.\n\nSound also exposes an array struct interface and the new buffer protocol.", "user_title": "Lenard Lindstrom", "datetimeon": "2011-03-01T13:26:33", "link": "pygame.mixer.Sound", "id": 3799}, {"content": "I'm not sure which version of Pygame is being used here, 1.9? At the time it was\nreleased NumPy was unavailable for Python 3.1. Python 1.9.2 alpha from SVN\ncertainly does support NumPy for Python 3.1, and 3.2.", "user_title": "Lenard Lindstrom", "datetimeon": "2011-03-01T13:35:12", "link": "pygame.surfarray", "id": 3800}, {"content": "That should be \"which version of Pygame is being used here, 1.9.1?\"", "user_title": "Lenard Lindstrom", "datetimeon": "2011-03-01T13:37:12", "link": "pygame.surfarray", "id": 3801}, {"content": "New to Pygame 1.9.2 for NumPy: pixels_red, pixels_green, and pixels_blue.", "user_title": "Lenard Lindstrom", "datetimeon": "2011-03-01T13:38:40", "link": "pygame.surfarray.pixels_alpha", "id": 3802}, {"content": "For the KEYDOWN and KEYUP event \"scancode\" is also a member and can be used \nfor the unknown keys", "user_title": "Daniel Kaminsky", "datetimeon": "2011-03-23T05:51:58", "link": "pygame.event", "id": 3872}, {"content": "The wheel generates pygame.MOUSEBUTTONUP events too, not just pygame.MOUSEBUTTONDOWN event.", "user_title": "Dan Ross", "datetimeon": "2011-04-02T23:30:45", "link": "pygame.mouse", "id": 3884}, {"content": "Forget what the functions do, check out Mr. Brown's naming style. Its pure genius!\n1) angle_times_WOW_pi_divided_by_180\n2) HE_HE_strange_popper_z\n3) buffy_the_fat2\n4) they_did_touch\n5) while Grr &lt; LIN_collide_max:\n6) Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol\n7) write_to_file_WEEE_STRANGE()\n8) freaky_rect_switcharoo_2D()", "user_title": "Mad Cloud Games", "datetimeon": "2011-04-03T18:28:23", "link": "pygame.draw.circle", "id": 3885}, {"content": "If you like to receive the inner rectangle, the blit is a much better setup. \nThe following comparing examples show how-to cut a (centered) 150x150 frame out of a 250x250 image:\norig_surf = pygame.Surface((250,250),flags=pygame.SRCALPHA)\npygame.draw.circle(orig_surf,(255,0,0),(50,50),25)\npygame.draw.circle(orig_surf,(0,255,0),(50,200),25)\npygame.draw.circle(orig_surf,(0,0,255),(200,50),25)\npygame.draw.circle(orig_surf,(0,255,255),(200,200),25)\n\ncrop_surf = pygame.transform.chop(pygame.transform.chop(orig_surf,(0,0,50,50)),(150,150,250,250))\npygame.image.save(crop_surf, 'test-crop.png')\n\n\ncrop_surf =  pygame.Surface((150,150),flags=pygame.SRCALPHA)\ncrop_surf.blit(orig_surf, (0,0),(50,50,200,200))\npygame.image.save(crop_surf, 'test-blit.png')", "user_title": "Rick van der Zwet", "datetimeon": "2011-05-05T04:36:44", "link": "pygame.transform.chop", "id": 4045}, {"content": "It all seemed simple and working properly, then I noticed... \"The area covered by a Rect does not include the right- and bottom-most edge of pixels. If one Rect's bottom border is another Rect's top border (i.e., rect1.bottom=rect2.top), the two meet exactly on the screen but do not overlap, and rect1.colliderect(rect2) returns false.\"\n\n*mutter* good to know.", "user_title": "Anonymous", "datetimeon": "2011-01-10T19:28:58", "link": "Rect.colliderect", "id": 3725}, {"content": "Note that when the user resizes the game window, pygame does not automatically update its internal screen surface. You must call set_mode() every time VIDEORESIZE is sent. This really should be more clear in the documentation.", "user_title": "Anonymous", "datetimeon": "2011-01-11T15:55:57", "link": "pygame.display", "id": 3726}, {"content": "Is it possible to set this mode transparent?\nI mean without changing the transparency with set_alpha or ... but from the beginning.", "user_title": "Anonymous", "datetimeon": "2011-01-13T08:28:22", "link": "pygame.display.set_mode", "id": 3727}, {"content": "Draw a normal thick line, then draw two aa lines either side. Not exactly what you want but it will work.", "user_title": "Anonymous", "datetimeon": "2011-01-13T15:22:43", "link": "pygame.draw.aaline", "id": 3728}, {"content": "This code fixes the bad rect given by the line function.\n\ntemprect=(pygame.draw.line(screen,color,firstpos,newpos,thick))\ntemprect.inflate_ip(thick*2, thick*2)\ndirty.append(temprect)", "user_title": "Anonymous", "datetimeon": "2005-11-22T22:22:44", "link": "pygame.draw.line", "id": 8}, {"content": "if your rect contains a negative width or height you need to rect.normalize() your rect before passing it to this function", "user_title": "Anonymous", "datetimeon": "2005-11-27T22:45:10", "link": "pygame.draw.ellipse", "id": 13}, {"content": "Rotates image about its center.", "user_title": "Anonymous", "datetimeon": "2005-11-28T19:22:44", "link": "pygame.transform.rotate", "id": 14}, {"content": "Make sure you blit according to the center of the newly formed surface, and not what the center of the orginal image is.", "user_title": "Anonymous", "datetimeon": "2005-11-28T19:24:48", "link": "pygame.transform.rotate", "id": 15}, {"content": "This probably goes without saying, but always rotate the orginal image, not a rotated copy.", "user_title": "Anonymous", "datetimeon": "2005-11-28T19:26:45", "link": "pygame.transform.rotate", "id": 16}, {"content": "Before calling pygame.key.get_pressed(), one should call pygame.event.pump() to get the lates state of the keyboard.\n\nThis is so because the get_pressed() function wraps the SDL_GetKeyState() function and in the SDL_GetKeyState() documentation it is written that one should use SDL_PumpEvents() to update the state array and pygame.event.pump() just happens to be a wrapper for SDL_PumpEvents() :-)", "user_title": "Anonymous", "datetimeon": "2005-12-01T10:30:49", "link": "pygame.key.get_pressed", "id": 18}, {"content": "When I tryed to use this, he couldn't find the key K_t I wanted\n untill I used:\n\nfrom pygame.locals import *\n\nSo be sure to use it - Shefy", "user_title": "Anonymous", "datetimeon": "2005-12-07T04:09:33", "link": "pygame.key.get_pressed", "id": 19}, {"content": "if you pass in None as the background argument, you get the error\n\"TypeError: Invalid background RGBA argument\"", "user_title": "Anonymous", "datetimeon": "2005-12-10T19:21:13", "link": "Font.render", "id": 22}, {"content": "pygame.event.pump()\n  m = pygame.key.get_mods()\n  if m &amp; KMOD_SHIFT:\n    print 'shift pressed'", "user_title": "Anonymous", "datetimeon": "2005-12-25T19:36:47", "link": "pygame.key.get_pressed", "id": 32}, {"content": "Rotated objects tend to move around because bounding rectangle changes size.\nStore the center in a temporary variable, then rotate the original image, and finally reset the center before you blit or update\nThis code comes from a sprite class:\n\n  def turn(self, amount):\n    \"turn some amount\"\n    oldCenter = self.rect.center\n    self.dir += amount\n    self.image = pygame.transform.rotate(self.baseImage, self.dir)\n    self.rect = self.image.get_rect()\n    self.rect.center = oldCenter", "user_title": "Anonymous", "datetimeon": "2006-01-03T09:48:09", "link": "pygame.transform.rotate", "id": 36}, {"content": "This effect (1 + 3 = 2) is caused by your X.org/XServer mouse configuration section, which allows to emulate the middle button by clicking both the left and right mouse button at the same time.", "user_title": "Anonymous", "datetimeon": "2006-01-04T09:16:25", "link": "pygame.mouse.get_pressed", "id": 37}, {"content": "This does not result in 'truly' transparent text, as the area between the letters is filled in with the background color. For truly transparent text with an invisible background behind the letters, use Numeric:\n\ndef RenderTransparent(font, text, antialias=1, color=(255, 0, 0, 0)):\n    'Render text with transparency underneath the letters'\n    'Requires Numeric'\n\n    # Create a colored block big enough to hold the text\n    w, h = font.size(text)\n    surface = pygame.Surface((w, h), pygame.SRCALPHA)\n    surface.fill(color)\n    \n    # Create an alpha channel that contains the shapes of the letters\n    alpha = pygame.Surface((w, h), pygame.SRCALPHA)\n    WHITE = (255, 255, 255, 0)\n    BLACK = (0, 0, 0, 0)\n    a = font.render(text, antialias, WHITE, BLACK)\n    alpha.blit(a, (0, 0))\n        \n    # Combine the alpha channel with the colored block\n    pic = surface.convert_alpha()\n    mask = alpha.convert(32)\n    mskarray = pygame.surfarray.pixels3d(mask)\n    pygame.surfarray.pixels_alpha(pic)[:, :] = mskarray[:, :, 0]\n\n    # Return the 'truly' transparent text.\n    return pic", "user_title": "Anonymous", "datetimeon": "2006-01-17T14:45:02", "link": "Font.render", "id": 41}, {"content": "LOL", "user_title": "Anonymous", "datetimeon": "2011-01-03T19:03:40", "link": "PixelArray.replace", "id": 3700}, {"content": "FUCKING SPAMMER MOTHER FUCKERS WHO OWNS THIS SHIT THEY SHOULD BURN IN HELLL", "user_title": "Anonymous", "datetimeon": "2011-01-03T19:05:09", "link": "pygame.locals", "id": 3701}, {"content": "On my Windows Vista machine running Python 3.1.2 and pygame 1.9.1,\nthe 'black=' and 'white=' parameters are swapped.\n\nSo, to make the example work (with a black arrow outline\naround a white center), you have to do this:\n\nthickarrow_strings = (            #sized 24x24\n      \"XX                      \",\n      \"XXX                     \",\n      \"XXXX                    \",\n      \"XX.XX                   \",\n      \"XX..XX                  \",\n      \"XX...XX                 \",\n      \"XX....XX                \",\n      \"XX.....XX               \",\n      \"XX......XX              \",\n      \"XX.......XX             \",\n      \"XX........XX            \",\n      \"XX........XXX           \",\n      \"XX......XXXXX           \",\n      \"XX.XXX..XX              \",\n      \"XXXX XX..XX             \",\n      \"XX   XX..XX             \",\n      \"     XX..XX             \",\n      \"      XX..XX            \",\n      \"      XX..XX            \",\n      \"       XXXX             \",\n      \"       XX               \",\n      \"                        \",\n      \"                        \",\n      \"                        \")\n\ndatatuple, masktuple = pygame.cursor.compile( thickarrow_strings,\n                                  black='.', white='X', xor='o' )\npygame.mouse.set_cursor( (24,24), (0,0), datatuple, masktuple )", "user_title": "Anonymous", "datetimeon": "2011-01-04T09:45:11", "link": "pygame.cursors.compile", "id": 3702}, {"content": "I'm using this generator to get a channel id for each sprite:\n\ndef free_sound_channel():\n    \"\"\"Get next available sound channel\n    Usage:\n    free_channels=free_sound_channel()\n    id=free_channels.next()\n    \"\"\"\n    id=0\n    while id&lt;pygame.mixer.get_num_channels():\n        yield id\n        id+=1\n    return    # or: raise StopIteration()", "user_title": "Anonymous", "datetimeon": "2006-01-29T16:18:15", "link": "pygame.mixer.Channel", "id": 49}, {"content": "COLORKEY and ALPHA should have 'SRC' prefixed to them. Here is a more-complete list of flags revelvant to surface.get_flags():\n,\"SRCCOLORKEY\"\n,\"RLEACCEL\"\n,\"RLEACCELOK\"\n,\"PREALLOC\"\n,\"HWACCEL\"\n,\"SRCALPHA\"\n,\"UYVY_OVERLAY\"\n,\"YV12_OVERLAY\"\n,\"YVYU_OVERLAY\"\n,\"YUY2_OVERLAY\"\n,\"HWPALETTE\"\nSWSURFACE - not really usable as a surface flag, equates to 0 and is always default\nANYFORMAT - used to create surfaces, pygame defaults to this flag if you don't specifya bit depth\nHWACCEL - surface is hardware accelerated, readonly\nSRCCOLORKEY- surface has a colorkey for blits, readonly\nSRCALPHA - surface has alpha enabled, readonly\nRLEACCELOK - surface is rle accelerated, but hasn't been compiled yet, readonly\nPREALLOC - not even sure?\nHope this helps....", "user_title": "Anonymous", "datetimeon": "2006-02-07T21:37:24", "link": "Surface.get_flags", "id": 52}, {"content": "I wish all the possible flags were documented here...", "user_title": "Anonymous", "datetimeon": "2006-02-07T22:02:57", "link": "pygame.Surface", "id": 53}, {"content": "I don't know what is wrong with you two. I tested the following and it worked as expected. Perhaps it is because I tested it on windows, if you tested it somewhere else (of course that's not the likely cause but I really can't see what else is wrong).\n\nIt is true that passing None for the final argument causes \"Invalid RGBA argument\". This is a bug in the documentation, not the code. The proper way to get transparency is to simply omit the last argument.\n\n$python\n&gt;&gt;&gt;import pygame\n&gt;&gt;&gt;pygame.init()\n&gt;&gt;&gt;screen = pygame.display.set_mode((300,300))\n&gt;&gt;&gt;screen.fill((255,0,0))\n&gt;&gt;&gt;pygame.display.flip()\n\n&gt;&gt;&gt;font = pygame.font.SysFont(\"Times New Roman\",30)\n&gt;&gt;&gt;s = font.render(\"Eggs are good for you, but not on the eiffel tower\",True,(0,255,255))\n&gt;&gt;&gt;s.get_flags() #-&gt; 65536 [SRCALPHA].. good, implies the image has per-pixel transparency\n&gt;&gt;&gt;[s.get_at((i,j)) for i in range(20) for j in range(20)]\n[....          #here we see that indeed each\n(0,255,255,68) #pixel is a full RGBA pixel with 4\n....]          #components.\n&gt;&gt;&gt;screen.blit(s, (0,0))\n&gt;&gt;&gt;pygame.display.flip()\n&gt;&gt;&gt;pygame.event.pump() #in order to bring the window back to life...\n\nAnd the result is turquoise text with red in the background, clearly showing transparency. Phew, you had me worried there, thinking I couldn't do transparency with this... until I looked closer. These docs are shiny but can be very hard to read sometimes.", "user_title": "Anonymous", "datetimeon": "2006-02-08T02:29:13", "link": "Font.render", "id": 54}, {"content": "Here's another solution for creating surfaces with per-pixel-alpha:\n\nimage = pygame.Surface((width,height),pygame.SRCALPHA,32);\n\nAdding the depth argument '32' seems to make this work every time.", "user_title": "Anonymous", "datetimeon": "2006-02-21T15:49:19", "link": "pygame.Surface", "id": 58}, {"content": "In the documentery it says \"The antialias argument is a boolean, if true the \ncharacters will have smooth edges.\". If you pass a string as the antialias \nargument it raises an exception saying \"TypeError: an integer is required\". This\nis very confusing. It should raise \"TypeError: a boolean is required\". \nIf antialias is enabled it will greatly drop the framerate (from 100 to 33 on my\nmachine). Font.render should be called only for as many times as you need fonts.\nDo not call this function every gameloop for it will greatly drop the framerate.\n(this cost me about 2 houres of debugging to find out.)\nIf any admins read this: Please change the script so that long lines will be seperated to shorter lines. Those 500+ words lines are uncomfortable to read with all that scrolling. mfg nwp.", "user_title": "Anonymous", "datetimeon": "2006-03-05T13:28:14", "link": "Font.render", "id": 61}, {"content": "you may want to initalise the \ndifferent modules seperately\nto speed up your program. Of \ncourse, then you would need \nto know which modules you have\ninitalised and which ones you\nhave not.", "user_title": "Anonymous", "datetimeon": "2006-03-08T22:55:41", "link": "pygame.init", "id": 64}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-30T07:59:42", "link": "Hope to find some more useful information on your site!  It is really great!", "id": 196}, {"content": "format of music files\non cds are (usualy) in\nCD Digital Audio, except\nsometimes a program will\nmake a cd useing a \ndifferent format, so \npygame.cdrom.CD(n).play()\nwill maby not play it.", "user_title": "Anonymous", "datetimeon": "2006-03-08T23:02:35", "link": "pygame.cdrom", "id": 67}, {"content": "import pygame\nfrom pygame.locals import *\n\npygame.init()\npygame.display.set_mode((300,200))\npygame.display.set_caption('Mouse Input Demonstration')\nrunning = True\nwhile running:\n    for event in pygame.event.get():\n        if event.type == QUIT:\n            running = False\n        if event.type == KEYDOWN and event.key == K_ESCAPE:\n            running = False\n        if event.type == MOUSEBUTTONDOWN:\n            print event.button\n\npygame.display.quit()", "user_title": "Anonymous", "datetimeon": "2006-04-02T00:38:08", "link": "pygame.mouse.get_pressed", "id": 82}, {"content": "# An Example from perldude69@gmail.com  www.wachadoo.com/forum/\n# CONSTANTS\nSCREEN_WIDTH  = 800\nSCREEN_HEIGHT = 600\n#Initialise Game\npygame.init()\nscreen = pygame.display.set_mode( (SCREEN_WIDTH,SCREEN_HEIGHT))\npygame.display.set_caption('Space Invaders')\nbackground = pygame.image.load('./pics/background1.jpg').convert()\nbackground = pygame.transform.scale(background,( SCREEN_WIDTH, SCREEN_HEIGHT))\nscreen.blit(background, (0,0)) \npygame.display.flip() \ndone = False\nwhile not done:\n\tfor e in pygame.event.get():\n\t\tif e.type == KEYDOWN:\n\t\t\tdone = True\nif __name__ == \"__main__\":\n    main()", "user_title": "Anonymous", "datetimeon": "2006-04-07T18:04:11", "link": "pygame.transform.scale", "id": 84}, {"content": "Don't specify flags unless you absolutely *must* (that is, don't specify HWSURFACE, depth=32 just because you think it's a good idea). This will reduce the portability of your game.", "user_title": "Anonymous", "datetimeon": "2006-06-13T21:27:25", "link": "pygame.display.set_mode", "id": 98}, {"content": "Could someone please post the integer values corresponding to the various shift/ctl/alt keys?  Or provide a link.\nthank you!", "user_title": "Anonymous", "datetimeon": "2006-12-18T16:29:25", "link": "pygame.key.get_mods", "id": 183}, {"content": "numpy is fine in Python 3.1.2.  However, pygame.surfarray doesn't work\nat all in pygame-1.9.1.win32-py3.1.msi with python-3.1.2.msi and\nnumpy-1.5.1-win32-superpack-python3.1.exe under Windows Vista.\n\nTo see the problem, just run the test that comes with it; 4 of 14 tests fail:\n\nC:\\&gt;cd \\python31\\lib\\site-packages\\pygame\\tests\n\nC:\\Python31\\Lib\\site-packages\\pygame\\tests&gt;\\python31\\python surfarray_test.py\nEE.EE.........\n======================================================================\nERROR: test_array2d (__main__.SurfarrayModuleTest)\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"surfarray_test.py\", line 147, in test_array2d\n    arr = pygame.surfarray.array2d(surf)\n  File \"C:\\python31\\lib\\site-packages\\pygame\\surfarray.py\", line 104, in array2d\n    return numpysf.array2d (surface)\n  File \"C:\\python31\\lib\\site-packages\\pygame\\_numpysurfarray.py\", line 77, in array2d\n    data = ''.join (pattern.findall (data))\nTypeError: can't use a string pattern on a bytes-like object\n[...snip...]", "user_title": "Anonymous", "datetimeon": "2011-01-07T03:47:28", "link": "pygame.surfarray", "id": 3704}, {"content": "no fill?", "user_title": "Anonymous", "datetimeon": "2006-11-19T14:38:36", "link": "pygame.draw.arc", "id": 163}, {"content": "works perfectly fine for me... question: what's the name of the overloaded operator that does the pxarray[x,y] subscripting?", "user_title": "Anonymous", "datetimeon": "2010-12-23T18:28:10", "link": "pygame.PixelArray", "id": 3689}, {"content": "pygame.cursors.ball is also a cool one.", "user_title": "Anonymous", "datetimeon": "2010-12-28T16:21:48", "link": "pygame.cursors", "id": 3690}, {"content": "Its a success/failure scenario. It returns True (1) if it went well.", "user_title": "Anonymous", "datetimeon": "2010-12-30T05:47:55", "link": "pygame.display.toggle_fullscreen", "id": 3691}, {"content": "These appear to be in degrees rather than radians (different than how draw.arc()'s are specified) which is kind of inconsistent.  Are these documented better elsewhere?", "user_title": "Anonymous", "datetimeon": "2011-01-01T15:04:01", "link": "pygame.gfxdraw.pie", "id": 3694}, {"content": "You need to put\nimport pygame\nat the top of your program, anonymous.", "user_title": "Anonymous", "datetimeon": "2011-01-02T07:03:47", "link": "pygame.display", "id": 3695}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-28T17:27:45", "link": "Looking for information and found it at this great site...", "id": 188}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-29T02:41:08", "link": "I love the whiiite suits! Great show!", "id": 189}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-29T10:09:22", "link": "Thank you for your site. I have found here much useful information...", "id": 190}, {"content": "I had this weird thing where blue/red was inversed, but not the other colours, when I was mapping some pixels from one image to a blank surface.\nIt was caused by copying the color integer directly to one pixel to the other, so the trick is to always surface.unmap_rgb(pixel) before setting the color to a new pixel", "user_title": "Anonymous", "datetimeon": "2010-12-13T21:22:42", "link": "pygame.PixelArray", "id": 3685}, {"content": ".", "user_title": "Anonymous", "datetimeon": "2010-12-17T14:01:47", "link": "Movie.play", "id": 3687}, {"content": "import pygame, sys\nfrom pygame.version import ver\nprint (\"pygame \", ver)\nstartstate = pygame.init()\nprint (\"{pygame.init()}\", startstate)\nscreen = pygame.display.set_mode([640, 480])\nprint (\"{pygame.display.set_mode([640, 480]}\", screen)\nwhile True:\n    for event in pygame.event.get():\n        if not event:\n            print (\"Event processing error: cannot find event.\")\n        elif event.type == pygame.QUIT or event.type == pygame.K_ESCAPE:\n            print (\"{for event in pygame.event.get():} : \", event)\n            sys.exit()\nsys.exit() command does not run when I press escape, all it does is the same as if not event.", "user_title": "Anonymous", "datetimeon": "2010-12-18T17:09:49", "link": "pygame.key", "id": 3688}, {"content": "It the range for H should only be [0, 360); at exactly 360 the expression throws an OverflowError. The other ranges are not affected as such.", "user_title": "Anonymous", "datetimeon": "2010-12-08T17:55:35", "link": "Color.hsva", "id": 3677}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-30T22:35:22", "link": "Very cool design! Useful information. Go on!", "id": 202}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-31T05:52:59", "link": "Very interesting! site. A must bookmark! I wait for continuation", "id": 203}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-31T13:03:40", "link": "Very interesting! site. A must bookmark! I wait for continuation", "id": 204}, {"content": "", "user_title": "Anonymous", "datetimeon": "2006-12-31T19:55:09", "link": "Just wanted to say you have some happyY looking walkers. All natural!", "id": 205}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-01T16:59:55", "link": "You have an outstanding good and well structured site. I enjoyed browsing through it.", "id": 208}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-02T00:19:19", "link": "I love the whiiite suits! Great show!", "id": 211}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-02T15:12:24", "link": "Hope to find some more useful information on your site!  It is really great!", "id": 212}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-02T22:17:19", "link": "Just wanted to say you have some happyY looking walkers. All natural!", "id": 213}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-03T05:35:22", "link": "You have a great site. All in your web is very useful. Please keep on working.", "id": 214}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-03T12:53:55", "link": "Pretty nice site, wants to see much more on it! :)", "id": 215}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-03T20:02:38", "link": "You have an outstanding good and well structured site. I enjoyed browsing through it.", "id": 216}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-04T18:10:07", "link": "This site is asomeee, well done, thanks for all!", "id": 218}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-01-05T01:15:13", "link": "Very nice site. Keep up the great work.", "id": 219}, {"content": "Left:\nctrl 4160 \nshift 4097 \nalt 4352 \n\nRight:\nctrl 4224\nshift 4098\nalt 4608\n\nLeft:\nc+s 4161\nc+a 4416\na+s 4353\n\nRight:\nc+s 4226\nc+a 4736\na+s 4610\n\nDone by hand ;)\n\n-Jabapyth", "user_title": "Anonymous", "datetimeon": "2007-01-29T17:22:04", "link": "pygame.key.get_mods", "id": 316}, {"content": "Depending on your keyboard there may be limitations of how many simultaneous keypresses can be detected by this command. Some combinations will work on one keyboard and not on another.", "user_title": "Anonymous", "datetimeon": "2007-02-08T19:53:05", "link": "pygame.key.get_pressed", "id": 335}, {"content": "Just use the same line width as your radius.\nThis of course dosn't solve your problem if you want a border on your arc, but then you can just paint twice.", "user_title": "Anonymous", "datetimeon": "2007-02-26T18:27:17", "link": "pygame.draw.arc", "id": 374}, {"content": "It looks like width is not a keyword argument, but a required/positional/whatever one instead.\n\n&gt;&gt;&gt; pygame.draw.line(surf, color, (x1, y1), (x2, y2), width=width)\nTraceback (most recent call last):\n  File \"\", line 1, in ?\nTypeError: line() takes no keyword arguments\n&gt;&gt;&gt; pygame.draw.line(surf, color, (x1, y1), (x2, y2))\n\n&gt;&gt;&gt; pygame.draw.line(surf, color, (x1, y1), (x2, y2), 1)", "user_title": "Anonymous", "datetimeon": "2007-03-01T11:28:42", "link": "pygame.draw.line", "id": 386}, {"content": "first number = top left rectangle x coordinate\nsecond number = top left rectangle y coordinate\nthird number = width of rectangle\nfourth number = length of rectangle", "user_title": "Anonymous", "datetimeon": "2007-03-03T16:39:29", "link": "pygame.draw.rect", "id": 400}, {"content": "If you want to make a deep copy of a Rect object (without importing the copy module)\nthen you can do so by calling move with the arguments (0,0).", "user_title": "Anonymous", "datetimeon": "2008-01-04T00:22:04", "link": "Rect.move", "id": 1359}, {"content": "the forth numer is the height of the rect", "user_title": "Anonymous", "datetimeon": "2007-03-11T20:32:13", "link": "pygame.draw.rect", "id": 434}, {"content": "The documentation is incorrect. pygame.mixer.music(5) will indeed play the music five times, not six. Perhaps the function used to behave differently, but I can find nothing in the documentation for either pygame or SDL_mixer that suggests so.", "user_title": "Anonymous", "datetimeon": "2007-03-19T15:33:19", "link": "pygame.mixer.music.play", "id": 440}, {"content": "I meant to say pygame.mixer.music.play(5), of course. I left out the \"play\" part.", "user_title": "Anonymous", "datetimeon": "2007-03-19T15:34:19", "link": "pygame.mixer.music.play", "id": 441}, {"content": "Properties in the object returned by get_rect():\n\nbottom\nbottomleft\nbottomright\ncenter\ncenterx\ncentery\nclamp\nclamp_ip\nclip\ncollidedict\ncollidedictall\ncollidelist\ncollidelistall\ncollidepoint\ncolliderect\ncontains\nfit\nh\nheight\ninflate\ninflate_ip\nleft\nmidbottom\nmidleft\nmidright\nmidtop\nmove\nmove_ip\nnormalize\nright\nsize\ntop\ntopleft\ntopright\nunion\nunion_ip\nunionall\nunionall_ip\nw\nwidth\nx\ny", "user_title": "Anonymous", "datetimeon": "2007-03-23T00:10:38", "link": "Surface.get_rect", "id": 446}, {"content": "i've noticed the loop functionality to be iffy for certain wave files (an audible gap between each loop). from what i can tell, it looks like this happens with stereo wave files, but i'm not completely sure. the mono waves i try to loop play as expected", "user_title": "Anonymous", "datetimeon": "2008-01-04T23:39:18", "link": "pygame.mixer.music.fadeout", "id": 1365}, {"content": "i've noticed the loop functionality to be iffy for certain wave files (an audible gap between each loop). from what i can tell, it looks like this happens with stereo wave files, but i'm not completely sure. the mono waves i try to loop play as expected (i accidentally added this comment to fadeout(), sorry)", "user_title": "Anonymous", "datetimeon": "2008-01-04T23:39:59", "link": "pygame.mixer.music.play", "id": 1366}, {"content": "what about osx? is macosx working?", "user_title": "Anonymous", "datetimeon": "2007-03-25T15:39:01", "link": "pygame.display.init", "id": 448}, {"content": "omg, you should really use the KMOD_ constants here", "user_title": "Anonymous", "datetimeon": "2007-03-28T15:20:15", "link": "pygame.key.get_mods", "id": 451}, {"content": "In 1.7.1, the behaviour when None is passed in is NOT reversed. pygame.event.set_allowed(None) will BLOCK all events.", "user_title": "Anonymous", "datetimeon": "2007-04-01T20:22:29", "link": "pygame.event.set_allowed", "id": 457}, {"content": "just do:\nimg = pygame.image.load(\"&lt;&gt;\").convert()\n\n-harry666t", "user_title": "Anonymous", "datetimeon": "2007-04-03T12:22:16", "link": "pygame.draw", "id": 463}, {"content": "BTW, Those values gotten below are if num-lock is on\nKMOD_NUM == 4096\nKMOD_LSHIFT == 1\nKMOD_RSHIFT == 2\nKMOD_NUM | KMOD_LSHIFT == 4097\nThe simpler way is to use the bitwise AND (&amp;)\n\nkeymods &amp; KMOD_LSHIFT \n\nreturns true (actually 1 in this case) if left shift is pressed, no matter what else is pressed or if num lock is on, or if the planets are aligned correctly.", "user_title": "Anonymous", "datetimeon": "2007-04-03T19:15:04", "link": "pygame.key.get_mods", "id": 466}, {"content": "What is the definition of the key and mod members of KEYDOWN?", "user_title": "Anonymous", "datetimeon": "2007-04-07T05:35:39", "link": "pygame.event", "id": 475}, {"content": "who do i get a reference to a reserved channel? its not channel 0 nor num_channels-1", "user_title": "Anonymous", "datetimeon": "2007-04-07T11:19:42", "link": "pygame.mixer.set_reserved", "id": 476}, {"content": "\"does not work with current release\". Which release is that? Is the information valid?", "user_title": "Anonymous", "datetimeon": "2007-04-18T13:12:55", "link": "pygame.movie", "id": 497}, {"content": "FLAC support would be cool", "user_title": "Anonymous", "datetimeon": "2007-11-19T06:00:08", "link": "pygame.mixer.Sound", "id": 1142}, {"content": "fadeout does not block in linux either", "user_title": "Anonymous", "datetimeon": "2008-01-01T21:41:36", "link": "pygame.mixer.music.fadeout", "id": 1351}, {"content": "Watch out for this one, it has a major twist:\n(x,y) are coordinates in the referential of the rectangle.\nFor instance:\n&gt;&gt;&gt; import pygame\n&gt;&gt;&gt; r = pygame.Rect(32,32,132,132)\n&gt;&gt;&gt; r.collidepoint(140,140)\n1", "user_title": "Anonymous", "datetimeon": "2007-04-20T17:57:54", "link": "Rect.collidepoint", "id": 502}, {"content": "Music will be resampled in some cases, not in others. When playing a 44.1kHz MP3, the default 22050 frequency works, but a 48kHz mp3 plays in less than half speed - 48000 or 24000 works then.\nTo handle this behaviour, you have to know the sample rate of your music files before playing them, and can't switch smoothly. Big bummer.", "user_title": "Anonymous", "datetimeon": "2008-01-13T07:45:26", "link": "pygame.mixer.music.play", "id": 1406}, {"content": "# This should draw a square with a hight of 20 pixels on a Surface:\nheight = 20\npygame.draw.rect(Surface, (255, 255, 255), (0, 0, height, height))", "user_title": "Anonymous", "datetimeon": "2007-12-06T15:43:11", "link": "pygame.draw.rect", "id": 1220}, {"content": "Anonymous[0], that's nonsense. The x,y coords are absolute coordinates. To illustrate:\n\n&gt;&gt;&gt; r = pygame.rect.Rect(32, 32, 132, 132)\n&gt;&gt;&gt; r.collidepoint(1,1)\n0\n&gt;&gt;&gt; r.collidepoint(32,32)\n1", "user_title": "Anonymous", "datetimeon": "2007-11-23T19:43:53", "link": "Rect.collidepoint", "id": 1153}, {"content": "A little black cross. Mouse cursor is 8*8 Pixel, hotspot is at (4, 4). \nthe cross is (Read Binary):\n00011000 =&gt; 24 \n00011000\n00011000\n11100111 =&gt; 231\n11100111\n00011000\n00011000\nand has no AND-Mask. \n\npygame.mouse.set_cursor((8, 8), (4, 4), (24, 24, 24, 231, 231, 24, 24, 24), (0, 0, 0, 0, 0, 0, 0, 0))", "user_title": "Anonymous", "datetimeon": "2007-11-26T11:20:04", "link": "pygame.mouse.set_cursor", "id": 1157}, {"content": "excellent comments!\njorgen", "user_title": "Anonymous", "datetimeon": "2007-11-26T19:56:49", "link": "Surface.fill", "id": 1158}, {"content": "True.  set_allowed(None) blocks all event types.\n\n- Another (initially skeptical) pygame user.", "user_title": "Anonymous", "datetimeon": "2007-11-26T22:35:30", "link": "pygame.event.set_blocked", "id": 1159}, {"content": "The first channels are reserved.\nFor example: pygame.mixer.Channel(0)", "user_title": "Anonymous", "datetimeon": "2007-11-27T12:11:21", "link": "pygame.mixer.set_reserved", "id": 1160}, {"content": "I have found that just watching for joystick events may not provide enough \ngranularity for fast-paced arcade games that require 100 millisecond changes.\nInstead of events, consider polling the status of the axes in the main game loop\n(or whatever your local equivalent is)", "user_title": "Anonymous", "datetimeon": "2007-12-08T11:08:32", "link": "pygame.joystick", "id": 1230}, {"content": "Actually, on my system [Ubunty Gutsy] it returned a list of None:\n&gt;&gt;&gt; import pygame\n&gt;&gt;&gt; pygame.font.get_fonts()\n[None]", "user_title": "Anonymous", "datetimeon": "2007-12-12T08:11:00", "link": "pygame.font.get_fonts", "id": 1242}, {"content": "How do you draw squares in pygame??", "user_title": "Anonymous", "datetimeon": "2007-11-29T13:19:20", "link": "pygame.draw.rect", "id": 1171}, {"content": "\"... will only effect the smaller area\" is probably meant to read \"... will only affect the smaller area\"", "user_title": "Anonymous", "datetimeon": "2007-12-20T07:32:23", "link": "pygame.Surface", "id": 1290}, {"content": "# Matthew N. Brown copyright 2007\n\n# Here is an example program in wich\n# balls hit walls and other balls:\n#\n# This program draws circles using:   pygame.draw.circle\n#\n# You can copy this program on to\n# your own computer and run it.\n#\n\nimport os, sys\n\n ## INIT STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef HE_HE_init():\n    global screen, big_black_rect, APPLICATION_w_size, APPLICATION_z_size\n    global WOW_pi_divided_by_180, WOW_180_divided_by_pi\n    pygame.init()\n    random.seed()\n    APPLICATION_w_size = 700\n    APPLICATION_z_size = 500\n    ##### To close window while in fullscreen, press Esc while holding shift. #######\n    screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size))\n    #screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), FULLSCREEN)\n    pygame.display.set_caption(\"They bwounce off bwalls? Matthew N. Brown copyright 2007\")\n    pygame.mouse.set_visible(1)\n    big_black_rect = pygame.Surface(screen.get_size())\n    big_black_rect = big_black_rect.convert()\n    big_black_rect.fill((0, 0, 0))\n    screen.blit(big_black_rect, (0, 0))\n    #fonty = pygame.font.Font(None, 36)\n    fonty = pygame.font.SysFont(\"Times New Roman\", 25)\n    fonty.set_bold(0)\n    IMAGEE = fonty.render('Loading . . .', 1, (0, 250, 10))\n    screen.blit(IMAGEE, (100, 200)); del IMAGEE\n    pygame.display.flip()\n    pygame.mixer.init(22050, -16, True, 1024)\n    WOW_pi_divided_by_180 = math.pi / 180.0\n    WOW_180_divided_by_pi = 180.0 / math.pi\n    set_up_key_variables()\n    Lets_ROLL()\n ## INIT STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n\n ## SAVE LEVEL?!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef write_to_file_WEEE_STRANGE(file_namey, data):\n    noq = '\\n'\n    filey = open(file_namey, 'w')\n    for d in data:\n     filey.write(   str(d) + noq)\n ## SAVE LEVEL?!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n\n ## SMALL FUNCTIONS STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n     ### some functions: ###\ndef distance_2D (w1, z1, w2, z2):\n    return math.sqrt(math.pow(float(w1) - float(w2), 2) + math.pow(float(z1) - float(z2), 2))\ndef rect_touching_rect(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n    w2 -= w1\n    z2 -= z1\n    ww1 = -wol2\n    zz1 = -zol2\n    return (w2 &gt; ww1 and w2 &lt; wol1 and z2 &gt; zz1 and z2 &lt; zol1)\ndef rect_touching_rect2(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n    w2 -= w1\n    z2 -= z1\n    ww1 = -wol2\n    zz1 = -zol2\n    return (w2 &gt;= ww1 and w2 &lt;= wol1 and z2 &gt;= zz1 and z2 &lt;= zol1)\ndef positive(n):\n    if n &lt; 0: n = -n; return n\ndef int_randy(range, add):\n    return int((random.random() * range) + add)\ndef randy(range, add):\n    return (random.random() * range) + add\ndef freaky_rect_switcharoo_2D(pw, pz, pwol, pzol, buffy_the_fat):\n    buffy_the_fat2 = buffy_the_fat * 2\n    if pwol &gt; 0:\n     gw = pw; gwol = pwol\n    else:\n     gw = pwol + pw; gwol = pw - gw\n    if pzol &gt; 0:\n     gz = pz; gzol = pzol\n    else:\n     gz = pzol + pz; gzol = pz - gz\n    return [gw - buffy_the_fat, gz - buffy_the_fat, gwol + buffy_the_fat2, gzol + buffy_the_fat2]\ndef points_rotated_by_angle_2D(points_wz, axis_w, axis_z, angle):\n    rotated_points_wz = []\n    angle = -angle -90\n    angle_times_WOW_pi_divided_by_180 = angle * WOW_pi_divided_by_180\n    c1 = math.cos(angle_times_WOW_pi_divided_by_180)\n    s1 = math.sin(angle_times_WOW_pi_divided_by_180)\n    for pointy in points_wz:\n     xt = pointy[0] - axis_w\n     yt = pointy[1] - axis_z\n     rotated_points_wz += [(-xt * s1) + (yt * c1) + axis_w, (-xt * c1) - (yt * s1) + axis_z]\n    return rotated_points_wz\ndef point_rotated_by_angle_2D(point_w, point_z, axis_w, axis_z, angle):\n    angle = -angle -90\n    angle_times_WOW_pi_divided_by_180 = angle * WOW_pi_divided_by_180\n    c1 = math.cos(angle_times_WOW_pi_divided_by_180)\n    s1 = math.sin(angle_times_WOW_pi_divided_by_180)\n    xt = point_w - axis_w\n    yt = point_z - axis_z\n    return (-xt * s1) + (yt * c1) + axis_w, (-xt * c1) - (yt * s1) + axis_z\ndef arc_tangent_2D(point_w, point_z):\n    return math.atan2(point_w, point_z) * WOW_180_divided_by_pi + 180\ndef arc_tangent_2D_2(point_w, point_z):\n    return -math.atan2(point_w, point_z) * WOW_180_divided_by_pi + 180\ndef ball_to_ball_wzkol_bounce(V1, m1, V2, m2, ball1_is_to_the_left):\n    if (ball1_is_to_the_left and V1 &gt;= V2) or (not ball1_is_to_the_left and V1 &lt;= V2):\n     Rv1 = V1 - V2\n     Rv2 = 0 #V2 - V2\n     NewV1 = ((m1 - m2) / float(m1 + m2)) * float(Rv1) + V2\n     NewV2 = (( 2 * m1) / float(m1 + m2)) * float(Rv1) + V2\n     return NewV1, NewV2\n    else:\n     return V1, V2\ndef Find_where_ball_stops_on_line_w(ball_w, ball_z, ball_wol, ball_zol, ball_rad, line_w, line_rad):\n    did_collide = False\n    totally = ball_rad + line_rad\n    b1 = line_w + totally\n    b2 = line_w - totally\n    New_ball_w = ball_w + ball_wol\n    New_ball_z = ball_z + ball_zol\n    if   ball_w &gt;= b1 and ball_wol &lt; 0 and New_ball_w &lt; b1: New_ball_w = b1; did_collide = True\n    elif ball_w &lt;= b2 and ball_wol &gt; 0 and New_ball_w &gt; b2: New_ball_w = b2; did_collide = True\n    else:\n     if ball_w &gt; b2 and ball_w &lt; b1:\n      if   ball_w &gt; line_w and ball_wol &lt; 0:\n       New_ball_w = ball_w; New_ball_z = ball_z\n       did_collide = True\n      elif ball_w &lt; line_w and ball_wol &gt; 0:\n       New_ball_w = ball_w; New_ball_z = ball_z\n       did_collide = True\n     return New_ball_w, New_ball_z, did_collide\n    New_ball_z = (float(ball_zol) / float(ball_wol) * float(New_ball_w - ball_w)) + float(ball_z)\n    return New_ball_w, New_ball_z, did_collide\ndef find_where_ball_collides_on_a_wall(\n                                       ball_w, ball_z,\n                                       ball_wol, ball_zol,\n                                       ball_rad,\n                                       wall_type,\n                                       wall_w1, wall_z1,\n                                       wall_w2, wall_z2,\n                                       wall_rad):\n    toetoadly = ball_rad + wall_rad\n    did_collide = False\n    New_ball_w = ball_w + ball_wol\n    New_ball_z = ball_z + ball_zol\n    angle_hit_at = None\n    Relate_ball_w = ball_w - wall_w1\n    Relate_ball_z = ball_z - wall_z1\n    Relate_wall_w2 = wall_w2 - wall_w1\n    Relate_wall_z2 = wall_z2 - wall_z1\n    arc_tangeriney = arc_tangent_2D(Relate_wall_w2, Relate_wall_z2)\n    Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_Relate_wall_w2, Rotate_Relate_wall_z2 = points_rotated_by_angle_2D(((Relate_ball_w, Relate_ball_z), (Relate_wall_w2, Relate_wall_z2)), 0, 0, arc_tangeriney)\n    Rotate_ball_wol, Rotate_ball_zol = point_rotated_by_angle_2D(ball_wol, ball_zol, 0, 0, arc_tangeriney)\n    Rotate_Relate_ball_collide_w, Rotate_Relate_ball_collide_z, did_hit_weird_line = Find_where_ball_stops_on_line_w(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, ball_rad, 0, wall_rad)\n    if Rotate_Relate_ball_w &gt; -toetoadly and Rotate_Relate_ball_w &lt; toetoadly:\n     HE_HE_strange_popper_z = Rotate_Relate_ball_z\n    else:\n     HE_HE_strange_popper_z = Rotate_Relate_ball_collide_z\n    Rotate_angle_hit_at = None\n    if   HE_HE_strange_popper_z &lt; Rotate_Relate_wall_z2:\n       if ball_is_going_towards_point(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, 0, Rotate_Relate_wall_z2):\n        p1_touched, p1_collide_w, p1_collide_z, p1_angle_hit_at = find_where_ball_collides_on_another_ball(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, ball_rad, 0, Rotate_Relate_wall_z2, wall_rad)\n        if p1_touched:\n         Rotate_Relate_ball_collide_w = p1_collide_w\n         Rotate_Relate_ball_collide_z = p1_collide_z\n         Rotate_angle_hit_at = p1_angle_hit_at\n         did_collide = True\n    elif HE_HE_strange_popper_z &gt; 0:\n       if ball_is_going_towards_point(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, 0, 0):\n        p2_touched, p2_collide_w, p2_collide_z, p2_angle_hit_at = find_where_ball_collides_on_another_ball(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, ball_rad, 0, 0, wall_rad)\n        if p2_touched:\n         Rotate_Relate_ball_collide_w = p2_collide_w\n         Rotate_Relate_ball_collide_z = p2_collide_z\n         Rotate_angle_hit_at = p2_angle_hit_at\n         did_collide = True\n    else:\n       if did_hit_weird_line:\n        did_collide = True\n        if Rotate_Relate_ball_collide_w &lt; 0: Rotate_angle_hit_at = 90\n        else: Rotate_angle_hit_at = 270\n    if did_collide:\n     arc_tangeriney_2 = -arc_tangeriney\n     angle_hit_at = Rotate_angle_hit_at + arc_tangeriney\n     New_ball_w, New_ball_z = point_rotated_by_angle_2D(Rotate_Relate_ball_collide_w, Rotate_Relate_ball_collide_z, 0, 0, arc_tangeriney_2)\n     New_ball_w += wall_w1\n     New_ball_z += wall_z1\n    return did_collide, New_ball_w, New_ball_z, angle_hit_at  #, is_moving_towards\ndef zol_at_angle(wol, zol, angle):\n    rotated_wol, rotated_zol = point_rotated_by_angle_2D(wol, zol, 0, 0, angle)\n    return rotated_zol\ndef wzol_bounce_at_angle(wol, zol, angle, multi):\n    rotated_wol, rotated_zol = point_rotated_by_angle_2D(wol, zol, 0, 0, angle)\n    if rotated_zol &gt; 0: rotated_zol = -rotated_zol * multi\n    return point_rotated_by_angle_2D(rotated_wol, rotated_zol, 0, 0, -angle)\ndef ball_is_going_towards_point(ball_w, ball_z, ball_wol, ball_zol, point_w, point_z):\n    angley = arc_tangent_2D(ball_w - point_w, ball_z - point_z)\n    rotated_wol, rotated_zol = point_rotated_by_angle_2D(ball_wol, ball_zol, 0, 0, angley)\n    return rotated_zol &gt; 0\ndef find_where_ball_collides_on_another_ball (\n                                               ball1_w, ball1_z,\n                                               ball1_wol, ball1_zol,\n                                               ball1_rad,\n                                               ball2_w, ball2_z,\n                                               ball2_rad\n                                             ):\n    totally = ball1_rad + ball2_rad\n    dis_from_each_other = math.sqrt(math.pow(float(ball1_w) - float(ball2_w), 2) + math.pow(float(ball1_z) - float(ball2_z), 2))\n    if dis_from_each_other &lt; totally:\n     angley = arc_tangent_2D(ball1_w - ball2_w, ball1_z - ball2_z)\n     return True, ball1_w, ball1_z, angley\n    else:\n        they_did_touch = False\n        New_ball1_w = ball1_w + ball1_wol\n        New_ball1_z = ball1_z + ball1_zol\n        angle_hit_at = None\n        Relate_ball1_w = ball1_w - ball2_w\n        Relate_ball1_z = ball1_z - ball2_z\n        Relate_ball2_w = 0\n        Relate_ball2_z = 0\n        arcy_tangeriney = arc_tangent_2D(ball1_wol, ball1_zol)\n        Rotated_Relate_ball1_w, Rotated_Relate_ball1_z, Rotated_ball1_wol, Rotated_ball1_zol = points_rotated_by_angle_2D(((Relate_ball1_w, Relate_ball1_z), (ball1_wol, ball1_zol)), 0, 0, arcy_tangeriney)\n        did_collidey = False\n        if Rotated_Relate_ball1_z &gt; 0 and (Rotated_Relate_ball1_w &gt; -totally and Rotated_Relate_ball1_w &lt; totally):\n         Rotated_Relate_ball1_collide_w = Rotated_Relate_ball1_w # + Rotated_ball1_wol\n         HE_HE = math.pow(Rotated_Relate_ball1_w, 2) - math.pow(totally, 2)\n         if HE_HE &lt; 0: HE_HE = -HE_HE\n         Rotated_Relate_ball1_collide_z = math.sqrt(HE_HE)\n         Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol = Rotated_Relate_ball1_z + Rotated_ball1_zol\n         if Rotated_Relate_ball1_collide_z &lt; Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol:\n          collision_wol = Rotated_ball1_wol\n          collision_zol = Rotated_ball1_zol\n          Rotated_Relate_ball1_collide_z = Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol\n          angley_to_hit = None\n         else:\n          did_collidey = True\n          they_did_touch = True\n          angley_to_hit = arc_tangent_2D(Rotated_Relate_ball1_collide_w, Rotated_Relate_ball1_collide_z)\n        else:\n         angley_to_hit = None\n         collision_wol = Rotated_ball1_wol\n         collision_zol = Rotated_ball1_zol\n         Rotated_Relate_ball1_collide_w = Rotated_Relate_ball1_w + Rotated_ball1_wol\n         Rotated_Relate_ball1_collide_z = Rotated_Relate_ball1_z + Rotated_ball1_zol\n        if did_collidey:\n         arcy_tangeriney_2 = -arcy_tangeriney\n         angle_hit_at = angley_to_hit + arcy_tangeriney\n         New_ball1_w, New_ball1_z = point_rotated_by_angle_2D(Rotated_Relate_ball1_collide_w, Rotated_Relate_ball1_collide_z, 0, 0, arcy_tangeriney_2)\n         New_ball1_w += ball2_w\n         New_ball1_z += ball2_z\n    return they_did_touch, New_ball1_w, New_ball1_z, angle_hit_at  #, New_ball1_wol, New_ball1_zol\n     ### some functions: ###\n\n ## GRAPHICS STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef chilly_font(size):\n    fonti = pygame.font.SysFont(\"Times New Roman\", size)\n    return fonti\ndef chilly_font_Italicy(size):\n    fonti = pygame.font.SysFont(\"Times New Roman\", size)\n    fonti.set_italic(1)\n    return fonti\ndef draw_loading_messagey(stringy): # Draw loading message\n    pygame.mouse.set_visible(1)\n    fonty = chilly_font(26)\n    IMAGEE = fonty.render(stringy, 0, (0, 255, 0), (0, 0, 0))\n    screen.blit(IMAGEE, (200, 250))\n    del IMAGEE\n    pygame.display.flip()\n           ## GRAPHICS STUFF: ##\n#########################################################################################\n\n ## KEYS AND MOUSE STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef set_up_key_variables():\n     global ky_held, ky_first_held, ky_time_last_pressed\n     global mowse_w, mowse_z, mowse_inn\n     global mowse_left_pressed, mowse_right_pressed, mowse_left_held, mowse_right_held\n     mowse_left_held = False\n     mowse_right_held = False\n     mowse_left_pressed = False\n     mowse_right_pressed = False\n     mowse_w = 0\n     mowse_z = 0\n     mowse_inn = 0\n     ky_held = []\n     ky_first_held = []\n     ky_time_last_pressed = []\n     m = -1\n     while m &lt; 500:\n      m += 1\n      ky_held              += [0]\n      ky_first_held        += [0]\n      ky_time_last_pressed += [0]\ndef clear_all_kys():\n    global mowse_left_pressed, mowse_right_pressed, mowse_left_held, mowse_right_held\n    mowse_left_held = False\n    mowse_right_held = False\n    mowse_left_pressed = False\n    mowse_right_pressed = False\n    m = -1\n    while (m &lt; 500):\n     m += 1; ky_held[m] = 0; ky_first_held[m] = 0; ky_time_last_pressed[m] = 0\ndef clear_these_ky_first_held(list_keys_numbers):\n    for k in list_keys_numbers:\n     ky_first_held[k] = 0\ndef clear_first_held_kys():\n    m = -1\n    while (m &lt; 500):\n     m += 1; ky_first_held[m] = 0\ndef old_style_ky(n):\n    return (ky_first_held_CEV(n) or (ky_held[n] and ky_time_last_pressed[n] &lt; time.time() - .3))\ndef ky_first_held_CEV(n):\n    if (ky_first_held[n]):\n     ky_first_held[n] = 0; return 1\n    else:\n     return 0\ndef mowse_in_rect (w, z, wol, zol):\n    return (mowse_w &gt;= w and mowse_z &gt;= z and mowse_w &lt;= w + wol and mowse_z &lt;= z + zol)\ndef mowse_in_circle (w, z, rad):\n    dia = rad * 2\n    if mowse_in_rect(w - rad, z - rad, w + dia, z + dia):\n     return (distance_2D(mowse_w, mowse_z, w, z) &lt; rad)\n    else:\n     return 0\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\ndef check_for_keys():\n        global mowse_w, mowse_z, mowse_inn, mowse_left_pressed, mowse_right_pressed, mowse_left_held, mowse_right_held, APPLICATION_w_size, APPLICATION_z_size\n        global loopy\n        global unicodey\n        mowse_left_pressed = False\n        mowse_right_pressed = False\n        unicodey = ''\n        for e in pygame.event.get():\n          if e.type == QUIT:\n            loopy = 0\n          elif e.type == ACTIVEEVENT:\n            mowse_inn = (e.gain and (e.state == 1 or e.state == 6))\n          elif e.type == KEYDOWN:\n            ky_held[e.key] = 1\n            ky_first_held[e.key] = 1\n            ky_time_last_pressed[e.key] = time.time()\n            unicodey = e.unicode\n          elif e.type == KEYUP:\n            ky_held[e.key] = 0\n          elif e.type == MOUSEMOTION:\n            mowse_w = e.pos[0]\n            mowse_z = e.pos[1]\n            if mowse_w &gt;= 0 and mowse_w &lt;= APPLICATION_w_size and mowse_z &gt;= 0 and mowse_z &lt;= APPLICATION_z_size:\n             mowse_inn = 1\n            else:\n             mowse_inn = 0\n          elif e.type == MOUSEBUTTONUP:\n            if e.button == 1: mowse_left_held = 0\n            if e.button == 3: mowse_right_held = 0\n          elif e.type == MOUSEBUTTONDOWN:\n            mowse_left_pressed  = (e.button == 1)\n            mowse_right_pressed = (e.button == 3)\n            mowse_left_held =  mowse_left_held or e.button == 1\n            mowse_right_held = mowse_right_held or e.button == 3\n          elif e.type == JOYAXISMOTION:\n            pass\n          elif e.type == JOYBALLMOTION:\n            pass\n          elif e.type == JOYHATMOTION:\n            pass\n          elif e.type == JOYBUTTONUP:\n            pass\n          elif e.type == JOYBUTTONDOWN:\n            pass\n          elif e.type == VIDEORESIZE:\n            print e\n            print \"What happened!?\"\n            #global big_black_rect, screen\n            #APPLICATION_w_size = e.size[0]\n            #APPLICATION_z_size = e.size[1]\n            #screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size))#, RESIZABLE)\n            #big_black_rect = pygame.Surface(screen.get_size())\n            #big_black_rect = big_black_rect.convert()\n            #big_black_rect.fill((0, 100, 200))\n          elif e.type == VIDEOEXPOSE:\n            pass\n          elif e.type == USEREVENT:\n            pass\n        if ky_held[27] and (ky_held[303] or ky_held[304]): loopy = 0\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\n ## KEYS AND MOUSE STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n\n\n ## MAIN LOOPY STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef ball_is_going_towards_ball(Bn1, Bn2):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_mass, ball_RECT\n    arc_tangerine = arc_tangent_2D(ball_w[Bn1] - ball_w[Bn2], ball_z[Bn1] - ball_z[Bn2])\n    woly1, zoly1 = point_rotated_by_angle_2D(ball_wol[Bn1], ball_zol[Bn1], 0, 0, arc_tangerine)\n    return zoly1 &gt; 0\ndef ball_is_relatively_going_towards_ball(Bn1, Bn2):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_mass, ball_RECT\n    arc_tangerine = arc_tangent_2D(ball_w[Bn1] - ball_w[Bn2], ball_z[Bn1] - ball_z[Bn2])\n    woly1, zoly1, woly2, zoly2 = points_rotated_by_angle_2D(((ball_wol[Bn1], ball_zol[Bn1]), (ball_wol[Bn2], ball_zol[Bn2])), 0, 0, arc_tangerine)\n    return zoly1 &gt; 0 and zoly1 &gt; zoly2  # zoly2 &lt; zoly1 or zoly2 &gt; zoly1 # zoly1 + zoly2 &gt; 0\n    #return zoly1 &gt; 0 or zoly1 &gt; zoly2\ndef Make_two_balls_hit_at_angle(Bn1, Bn2, angle):\n    global bounce_friction\n    #print angle\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_mass, ball_RECT\n    woly1, zoly1, woly2, zoly2 = points_rotated_by_angle_2D(((ball_wol[Bn1], ball_zol[Bn1]), (ball_wol[Bn2], ball_zol[Bn2])), 0, 0, angle)\n    V1 = zoly1 * bounce_friction\n    V2 = zoly2 * bounce_friction\n    zoly1, zoly2 = ball_to_ball_wzkol_bounce(V1, ball_mass[Bn1], V2, ball_mass[Bn2], True)\n    ball_wol[Bn1], ball_zol[Bn1], ball_wol[Bn2], ball_zol[Bn2] = points_rotated_by_angle_2D(((woly1, zoly1), (woly2, zoly2)), 0, 0, -angle)\n    updatey_ball_quick_rect(Bn1)\n    updatey_ball_quick_rect(Bn2)\ndef updatey_ball_quick_rect(B):\n    dia = ball_rad[B] * 2 + 4\n    ball_squar[B] = [ball_w[B] - ball_rad[B] - 2, ball_z[B] - ball_rad[B] - 2, dia, dia]\n    ball_RECT[B] = freaky_rect_switcharoo_2D(ball_w[B], ball_z[B], ball_wol[B], ball_zol[B], ball_rad[B] + 4)\ndef minus_ball_thing(n):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n    if ball_max &gt;= 0:\n     del ball_w      [n]\n     del ball_z      [n]\n     del ball_wol    [n]\n     del ball_zol    [n]\n     del ball_rad    [n]\n     del ball_color  [n]\n     del ball_squar  [n]\n     del ball_angle  [n]\n     del ball_angleol[n]\n     del ball_mass   [n]\n     del ball_RECT   [n]\n     ball_max -= 1\ndef add_ball_thing(w, z, wol, zol, rad, color, angle, angleol, mass_thing, rect_thing):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_squar, ball_angle, ball_angleol, ball_mass, ball_RECT\n    ball_max += 1\n    ball_w       += [w]\n    ball_z       += [z]\n    ball_wol     += [wol]\n    ball_zol     += [zol]\n    ball_rad     += [rad]\n    ball_color   += [color]\n    ball_angle   += [angle]\n    ball_angleol += [angleol]\n    dia = rad * 2\n    ball_squar += [[w - rad, z - rad, dia, dia]]\n    if mass_thing == True:\n     ball_mass += [4 / 3 * math.pi * rad * rad * rad]\n    else:\n     ball_mass += [mass_thing]\n    if rect_thing == True:\n     ball_RECT += [None]\n     updatey_ball_quick_rect(ball_max)\n     #ball_RECT += [freaky_rect_switcharoo_2D(w, z, wol, zol, rad)]\n    else:\n     ball_RECT += [rect_thing]\ndef minus_wall_thing(WAL):\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    if wall_max &gt;= 0:\n     del wall_type   [WAL]\n     del wall_w1     [WAL]\n     del wall_z1     [WAL]\n     del wall_w2     [WAL]\n     del wall_z2     [WAL]\n     del wall_rad    [WAL]\n     del wall_color  [WAL]\n     del wall_RECT   [WAL]\n     wall_max        -= 1\ndef add_wall_thing(type, w1, z1, w2, z2, rad, color_thing, rect_thing):\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    wall_max    += 1\n    wall_type   += [type]\n    wall_w1     += [w1]\n    wall_z1     += [z1]\n    wall_w2     += [w2]\n    wall_z2     += [z2]\n    wall_rad    += [rad]\n    if color_thing == True:\n     if   type == 1: color_thing = (220, 220, 220)\n     elif type == 2: color_thing = (240, 140, 130)\n     elif type == 3: color_thing = (100, 255, 100)\n     elif type == 4: color_thing = (255, 100, 100)\n     elif type == 5: color_thing = (100, 100, 255)\n    wall_color  += [color_thing]\n    if rect_thing == True:\n     wall_RECT   += [freaky_rect_switcharoo_2D(w1 - 2, z1 - 2, w2 - w1 + 4, z2 - z1 + 4, rad)]\n    else:\n     wall_RECT   += [rect_thing]\ndef reset_stuff():\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    global levely\n    if levely == 1:\n     ball_max     = -1\n     ball_w       = []\n     ball_z       = []\n     ball_wol     = []\n     ball_zol     = []\n     ball_rad     = []\n     ball_color   = []\n     ball_angle   = []\n     ball_angleol = []\n     ball_squar   = []\n     ball_mass    = []\n     ball_RECT    = []\n     #add_ball_thing(350, 300, 0, 0, 18, (230, 230, 250), 0, 0, True, True)\n     #add_ball_thing(150, 400, 0, 0, 40, (220, 210, 255), 0, 0, True, True)\n     #add_ball_thing(300, 150, 0, 0, 62, (110, 106, 255), 0, 0, True, True)\n     add_ball_thing(220, 200, 0, 0, 50, (180, 226, 255), 180, 0, True, True)\n     wall_max    = -1\n     wall_type   = []\n     wall_w1     = []\n     wall_z1     = []\n     wall_w2     = []\n     wall_z2     = []\n     wall_rad    = []\n     wall_color  = []\n     wall_RECT   = []\n     add_wall_thing(1, 160, 250, 300, 270,  1, True, True)\n     add_wall_thing(1, 500, 270, 600, 310,  1, True, True)\n     add_wall_thing(1, 200, 450, 600, 450, 10, True, True)\n     add_wall_thing(1, 300, 350, 400, 370,  5, True, True)\n     add_wall_thing(1, 300, 100, 400, 100, 20, True, True)\n     add_wall_thing(1, 650, 140, 700, 200,  6, True, True)\n     add_wall_thing(1, 650, 140, 600,  40,  6, True, True)\n     add_wall_thing(1, 150, 340, 150, 340, 30, True, True)\n     add_wall_thing(1,  40, 200,  40, 200, 30, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  0, 0, APPLICATION_w_size, 0, 5, True, True)\n     add_wall_thing(1,  0, 0, 0, APPLICATION_z_size, 5, True, True)\n     add_wall_thing(1,  0, APPLICATION_z_size, APPLICATION_w_size, APPLICATION_z_size, 5, True, True)\n     add_wall_thing(1,  APPLICATION_w_size, 0, APPLICATION_w_size, APPLICATION_z_size, 5, True, True)\n    elif levely == 2:\n     ball_max = 1\n     ball_w = [323.62638473709342, 384.72135876760257]\n     ball_z = [298.67896746658624, 109.24043981044279]\n     ball_wol = [-0.27396932987421913, 7.133321987715842]\n     ball_zol = [-0.38420912894762504, 1.6564147490246901]\n     ball_rad = [15, 28]\n     ball_color = [(137, 244, 234), (138, 221, 217)]\n     ball_angle = [51.908780125668613, 294.77431504891717]\n     ball_angleol = [-1.2400074168431123, 17.698615258690229]\n     ball_squar = [[306.62638473709342, 281.67896746658624, 34, 34], [354.72135876760257, 79.240439810442794, 60, 60]]\n     ball_mass = [10602.875205865552, 68964.24193160313]\n     ball_RECT = [[304.35241540721921, 279.2947583376386, 38.273969329874205, 38.384209128947646], [352.72135876760257, 77.240439810442794, 71.133321987715846, 65.656414749024691]]\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [189, 290, 166, 14, 697, 562, 643, 3, 0, 223, 117, 695, 497, 497, 0, 0, 0, 700]\n     wall_z1 = [284, 316, 436, 499, 446, 0, 128, 225, 106, 310, 155, 210, 159, 159, 0, 0, 500, 0]\n     wall_w2 = [222, 446, 697, 157, 377, 681, 679, 49, 383, 287, 5, 448, 376, 546, 700, 0, 700, 700]\n     wall_z2 = [301, 314, 478, 432, 487, 99, 98, 416, 171, 324, 225, 323, 147, 179, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[186, 281, 39, 23], [287, 313, 162, 4], [154, 424, 555, 66], [7, 429, 157, 73], [359, 424, 356, 85], [554, -8, 135, 115], [635, 94, 52, 38], [-29, 193, 110, 255], [-32, 74, 447, 129], [211, 298, 88, 38], [-3, 143, 128, 94], [440, 198, 263, 137], [368, 139, 137, 28], [485, 147, 73, 44], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\n    elif levely == 3:\n     ball_max = 2\n     ball_w = [425.0, 492.31837629165733, 98.512856261065167]\n     ball_z = [126.0, 422.24553778829392, 430.4902396760661]\n     ball_wol = [-12.0, 2.6816237083426699, 6.487143738934833]\n     ball_zol = [-3.0, -1.245537788293916, -21.490239676066096]\n     ball_rad = [15, 28, 21]\n     ball_color = [(137, 244, 234), (138, 221, 217), (136, 235, 236)]\n     ball_angle = [93.833857527468922, 75.681742520058592, 323.2915629772819]\n     ball_angleol = [-0.87655530207419896, 0.30220691772972269, 1.1825329351046094]\n     ball_squar = [[408.0, 109.0, 34, 34], [462.31837629165733, 392.24553778829392, 60, 60], [75.512856261065167, 407.4902396760661, 46, 46]]\n     ball_mass = [10602.875205865552, 68964.24193160313, 29094.28956489508]\n     ball_RECT = [[394.0, 104.0, 50.0, 41.0], [460.31837629165733, 389.0, 66.68162370834267, 65.245537788293916], [73.512856261065167, 384.0, 56.487143738934833, 71.490239676066096]]\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [189, 290, 166, 14, 697, 562, 643, 3, 0, 223, 117, 695, 497, 497, 0, 0, 0, 700]\n     wall_z1 = [284, 316, 436, 499, 446, 0, 128, 225, 106, 310, 155, 210, 159, 159, 0, 0, 500, 0]\n     wall_w2 = [222, 446, 697, 157, 377, 681, 679, 49, 383, 287, 5, 480, 376, 546, 700, 0, 700, 700]\n     wall_z2 = [301, 314, 478, 432, 487, 99, 98, 416, 171, 324, 225, 325, 147, 179, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[186, 281, 39, 23], [287, 313, 162, 4], [154, 424, 555, 66], [7, 429, 157, 73], [359, 424, 356, 85], [554, -8, 135, 115], [635, 94, 52, 38], [-29, 193, 110, 255], [-32, 74, 447, 129], [211, 298, 88, 38], [-3, 143, 128, 94], [472, 198, 231, 139], [368, 139, 137, 28], [485, 147, 73, 44], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\n    elif levely == 4:\n     ball_max = 15\n     ball_w = [60.722554805471077, 452.1573538490178, 80.244575784959252, 38.90004863123329, 526.62934623960155, 561.76077439217966, 51.00641675327735, 476.21179724447387, 74.019911348330012, 104.13986580489509, 77.672785567417591, 97.908669417930454, 492.31309851379422, 107.55531577343871, 25.677250467589708, 408.28461679522843]\n     ball_z = [123.53309256655999, 426.85562864865636, 446.98025958602022, 145.55077237791539, 432.36880616921724, 419.52605372165829, 185.76812996010321, 398.60172712183214, 227.90675893521163, 330.14246403509031, 280.7917430301959, 382.77488932204739, 431.7008452670733, 426.72875393133694, 108.86075181750218, 420.07030113046562]\n     ball_wol = [0.58974898201312453, 0.29357826379544644, -0.7453458908661944, -0.26977452024547638, -0.13077525550683244, 0.35703289164546842, 0.25581836770201244, -0.16968524576896582, -0.96858759109981474, 0.020541831638986374, 0.21623640500730243, 0.16869582232640204, -0.32778500262837312, -1.0423733543425631, 0.078384075232750969, 0.070169924397188832]\n     ball_zol = [2.5202528491916918, -0.067935899483811957, 1.0209651395893582, 1.5519551597452736, 0.37674466231734333, 0.7179102343171756, 1.2098558443319702, -0.21937811619009639, 1.6292902773669935, 0.95366629391114355, 0.99836183708718151, 0.65985328138026611, 0.72997687518744558, -0.33325230167901332, 1.8584237502130836, 1.1180771215980612]\n     ball_rad = [12, 20, 14, 19, 14, 23, 23, 13, 25, 28, 28, 25, 20, 20, 20, 24]\n     ball_color = [(132, 202, 208), (130, 220, 228), (133, 230, 241), (133, 200, 224), (138, 244, 248), (134, 176, 212), (132, 246, 206), (136, 191, 201), (130, 247, 204), (135, 190, 248), (136, 196, 244), (137, 246, 211), (132, 176, 232), (139, 200, 204), (135, 204, 206), (137, 234, 248)]\n     ball_angle = [250.64218161257492, 228.50285566079282, 169.93029421257162, 93.92451866434908, 160.53385135173758, 101.81391124171368, 58.682544988047297, 42.833392250734839, 278.96920717602609, 157.52451729820555, 104.82808146227505, 319.29094377305643, 8.3988066326588289, 61.303383965779759, 262.01723832271352, 187.75853100116501]\n     ball_angleol = [-11.145052526574146, 0.73910476098485844, -1.916370769365741, 7.8109934129380036, 1.2564621818214414, -0.21633250902344123, 0.96094866236460608, 18.696614939999161, -2.7765510174821686, -0.46915418861267033, 1.3615127061730832, 0.55215997018655683, 0.83188571652892485, -2.1096665563746759, 4.3536534603644128, 0.77565328887569629]\n     ball_squar = [[46.722554805471077, 109.53309256655999, 28, 28], [430.1573538490178, 404.85562864865636, 44, 44], [64.244575784959252, 430.98025958602022, 32, 32], [17.90004863123329, 124.55077237791539, 42, 42], [510.62934623960155, 416.36880616921724, 32, 32], [536.76077439217966, 394.52605372165829, 50, 50], [26.00641675327735, 160.76812996010321, 50, 50], [461.21179724447387, 383.60172712183214, 30, 30], [47.019911348330012, 200.90675893521163, 54, 54], [74.139865804895095, 300.14246403509031, 60, 60], [47.672785567417591, 250.7917430301959, 60, 60], [70.908669417930454, 355.77488932204739, 54, 54], [470.31309851379422, 409.7008452670733, 44, 44], [85.555315773438707, 404.72875393133694, 44, 44], [3.6772504675897082, 86.860751817502177, 44, 44], [382.28461679522843, 394.07030113046562, 52, 52]]\n     ball_mass = [5428.6721054031623, 25132.741228718347, 8620.5302414503913, 21548.184010972389, 8620.5302414503913, 38223.757816227015, 38223.757816227015, 6902.0790599367756, 49087.385212340516, 68964.24193160313, 68964.24193160313, 49087.385212340516, 25132.741228718347, 25132.741228718347, 25132.741228718347, 43429.376843225298]\n     tempy = [[24.00641675327735, 158.76812996010321, 54.255818367702012, 55.209855844331969], [459.04211199870491, 381.38234900564203, 34.16968524576896, 34.219378116190114], [44.051323757230193, 198.90675893521163, 58.968587591099819, 59.629290277366991], [72.139865804895095, 298.14246403509031, 64.02054183163898, 64.953666293911141], [45.672785567417591, 248.7917430301959, 64.216236405007308, 64.998361837087188], [68.908669417930454, 353.77488932204739, 58.168695822326399, 58.659853281380265], [467.98531351116583, 407.7008452670733, 48.327785002628389, 48.729976875187447], [82.512942419096149, 402.39550162965793, 49.042373354342558, 48.333252301679011], [1.6772504675897082, 84.860751817502177, 48.078384075232748, 49.858423750213085], [380.28461679522843, 392.07030113046562, 56.070169924397192, 57.118077121598063]]\n     ball_RECT = [[44.722554805471077, 107.53309256655999, 32.589748982013127, 34.520252849191692], [428.1573538490178, 402.78769274917255, 48.293578263795446, 48.067935899483814], [61.499229894093062, 428.98025958602022, 36.74534589086619, 37.020965139589357], [15.630274110987813, 122.55077237791539, 46.269774520245477, 47.551955159745276], [508.49857098409473, 414.36880616921724, 36.130775255506819, 36.376744662317343], [534.76077439217966, 392.52605372165829, 54.357032891645467, 54.717910234317173]] + tempy\n     del tempy\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [189, 196, 166, 14, 697, 562, 643, 0, 326, 51, 18, 695, 497, 497, 0, 0, 0, 700]\n     wall_z1 = [284, 221, 436, 499, 446, 0, 128, 201, 62, 9, 182, 210, 159, 159, 0, 0, 500, 0]\n     wall_w2 = [220, 297, 697, 157, 377, 681, 679, 49, 304, 139, 0, 480, 376, 524, 700, 0, 700, 700]\n     wall_z2 = [244, 218, 478, 432, 487, 99, 98, 416, 161, 315, 126, 325, 147, 176, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[186, 245, 37, 38], [193, 218, 107, 3], [154, 424, 555, 66], [7, 429, 157, 73], [359, 424, 356, 85], [554, -8, 135, 115], [635, 94, 52, 38], [-32, 169, 113, 279], [276, 30, 78, 163], [39, -3, 112, 330], [-8, 118, 34, 72], [472, 198, 231, 139], [368, 139, 137, 28], [485, 147, 51, 41], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\n    elif levely == 5:\n     ball_max = 15\n     ball_w = [563.2380017184845, 135.5091931534665, 435.09697027584525, 132.51126304855137, 158.80356877160969, 486.49890666361813, 28.0454597909272, 469.94449157610796, 253.77058846375945, 33.311743878553251, 651.08671805489632, 467.4560139814393, 420.90145867058521, 248.83956419449743, 98.267666685148598, 670.85536291962285]\n     ball_z = [340.3499477728684, 192.53572614832325, 274.00276170743837, 474.72360924550071, 248.04392629767023, 199.66234253741388, 291.77486188629132, 98.828156873677884, 261.79870802935454, 452.90721309179793, 434.31611085503482, 422.84067516142846, 143.71750465032488, 474.55563009909457, 63.407930077910926, 97.5392796541895]\n     ball_wol = [-0.12736934788998625, -0.34670289908297647, -0.62730956112551528, -0.01316352118701539, -0.36875760413492498, 0.3253705975573648, -0.43186646985168864, 0.029829055857965088, -0.051399766840351885, 0.31143213467472303, 0.91261705660387604, -0.39289683694945782, 0.6973192899270082, -0.026739395385515136, 0.47773812365404217, -0.14449244329674141]\n     ball_zol = [0.2651067487506561, 0.33747092449158278, -0.20330004911815291, 0.11263669365628809, 0.62183969591811039, 0.220324713577495, 0.12382039798193512, -0.062689280803922554, 0.13756798955280808, 0.8702172500111478, -0.031277763984301599, 0.28378328194527458, 0.1666190295210413, 0.056074468995401638, 0.75422143538357722, 0.14790083350095956]\n     ball_rad = [12, 20, 14, 19, 14, 23, 23, 13, 25, 28, 28, 25, 20, 20, 20, 24]\n     ball_color = [(132, 202, 208), (130, 220, 228), (133, 230, 241), (133, 200, 224), (138, 244, 248), (134, 176, 212), (132, 246, 206), (136, 191, 201), (130, 247, 204), (135, 190, 248), (136, 196, 244), (137, 246, 211), (132, 176, 232), (139, 200, 204), (135, 204, 206), (137, 234, 248)]\n     ball_angle = [103.32400188884675, 316.71158855283181, 66.797426175129175, 35.509394217326573, 15.886531654813545, 0.61656478963343941, 195.33151301725019, 152.08747184390086, 199.80989069184068, 131.62120808048311, 339.38767654500623, 158.21789358507957, 322.31233400906359, 97.437869538449633, 179.6312883714439, 134.41162557033078]\n     ball_angleol = [0.54118695268280415, -1.0009948706990461, -0.42583251039327935, -0.049119552546591096, -1.7234897593393199, 0.1278122582140804, -0.33925087348758332, 0.98916269599321738, 0.054177225060088277, 0.93648329222661952, 2.0855948904138386, -1.2792816321392795, 1.9343475351789952, -0.094694117658838645, 1.3328174529019678, 1.0390947956294083]\n     ball_squar = [[549.2380017184845, 326.3499477728684, 28, 28], [113.5091931534665, 170.53572614832325, 44, 44], [419.09697027584525, 258.00276170743837, 32, 32], [111.51126304855137, 453.72360924550071, 42, 42], [142.80356877160969, 232.04392629767023, 32, 32], [461.49890666361813, 174.66234253741388, 50, 50], [3.0454597909272003, 266.77486188629132, 50, 50], [454.94449157610796, 83.828156873677884, 30, 30], [226.77058846375945, 234.79870802935454, 54, 54], [3.3117438785532514, 422.90721309179793, 60, 60], [621.08671805489632, 404.31611085503482, 60, 60], [440.4560139814393, 395.84067516142846, 54, 54], [398.90145867058521, 121.71750465032488, 44, 44], [226.83956419449743, 452.55563009909457, 44, 44], [76.267666685148598, 41.407930077910926, 44, 44], [644.85536291962285, 71.5392796541895, 52, 52]]\n     ball_mass = [5428.6721054031623, 25132.741228718347, 8620.5302414503913, 21548.184010972389, 8620.5302414503913, 38223.757816227015, 38223.757816227015, 6902.0790599367756, 49087.385212340516, 68964.24193160313, 68964.24193160313, 49087.385212340516, 25132.741228718347, 25132.741228718347, 25132.741228718347, 43429.376843225298]\n     tempy = [[140.43481116747478, 230.04392629767023, 36.368757604134913, 36.621839695918112], [459.49890666361813, 172.66234253741388, 54.325370597557367, 54.220324713577497], [0.61359332107551268, 264.77486188629132, 54.431866469851684, 54.123820397981937], [452.94449157610796, 81.765467592873961, 34.029829055857967, 34.062689280803923], [224.7191886969191, 232.79870802935454, 58.051399766840348, 58.137567989552807], [1.3117438785532514, 420.90721309179793, 64.311432134674718, 64.870217250011152], [619.08671805489632, 402.28483309105053, 64.912617056603878, 64.031277763984292], [438.06311714448987, 393.84067516142846, 58.392896836949433, 58.283783281945276], [396.90145867058521, 119.71750465032488, 48.697319289927009, 48.166619029521044], [224.81282479911192, 450.55563009909457, 48.026739395385505, 48.056074468995405], [74.267666685148598, 39.407930077910926, 48.477738123654042, 48.754221435383577], [642.71087047632614, 69.5392796541895, 56.144492443296713, 56.147900833500962]]\n     ball_RECT = [[547.11063237059454, 324.3499477728684, 32.127369347889953, 32.265106748750654], [111.16249025438353, 168.53572614832325, 48.34670289908297, 48.337470924491583], [416.46966071471974, 255.79946165832024, 36.627309561125514, 36.203300049118127], [109.49809952736436, 451.72360924550071, 46.01316352118701, 46.112636693656285]] + tempy\n     del tempy\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [135, 120, 230, 14, 531, 562, 441, 128, 403, 51, 504, 518, 377, 447, 0, 0, 0, 700]\n     wall_z1 = [265, 216, 439, 499, 339, 0, 217, 104, 306, 9, 441, 210, 168, 127, 0, 0, 500, 0]\n     wall_w2 = [227, 288, 697, 157, 456, 665, 476, 432, 61, 139, 633, 547, 435, 537, 700, 0, 700, 700]\n     wall_z2 = [262, 200, 478, 432, 302, 141, 228, 77, 334, 315, 295, 193, 178, 114, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[132, 262, 98, 3], [117, 201, 174, 14], [218, 427, 491, 63], [7, 429, 157, 73], [438, 284, 111, 73], [554, -8, 119, 157], [433, 209, 51, 27], [96, 49, 368, 83], [33, 274, 398, 92], [39, -3, 112, 330], [492, 287, 153, 162], [506, 185, 53, 33], [365, 156, 82, 34], [435, 106, 114, 29], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\ndef draw_walls_on_big_black_rect():\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    global big_black_rect\n    global LIN_selected, CLICKER, CLICKER2\n    if CLICKER:\n     if LIN_selected != -1:\n      nnn = LIN_selected[0]\n      if LIN_selected[1] == 1:\n       wall_w1[nnn] = mowse_w\n       wall_z1[nnn] = mowse_z\n      else:\n       wall_w2[nnn] = mowse_w\n       wall_z2[nnn] = mowse_z\n      w1 = wall_w1[nnn]\n      z1 = wall_z1[nnn]\n      w2 = wall_w2[nnn]\n      z2 = wall_z2[nnn]\n      rad = wall_rad[nnn]\n      wall_RECT[nnn] = freaky_rect_switcharoo_2D(w1 - 2, z1 - 2, w2 - w1 + 4, z2 - z1 + 4, rad)\n    wl = -1\n    while wl &lt; wall_max:\n     wl += 1\n     w1 = wall_w1[wl]\n     z1 = wall_z1[wl]\n     w2 = wall_w2[wl]\n     z2 = wall_z2[wl]\n     rad = wall_rad[wl]\n     collyu = wall_color[wl]\n     pygame.draw.line(big_black_rect, collyu, (w1, z1), (w2, z2), rad * 2)\n     pygame.draw.circle(big_black_rect, collyu, (w1, z1), rad)\n     pygame.draw.circle(big_black_rect, collyu, (w2, z2), rad)\n     #pygame.draw.rect(big_black_rect, (200, 200, 200), wall_RECT[wl], 1)\n     if CLICKER2:\n      if mowse_in_rect(wall_RECT[wl][0], wall_RECT[wl][1], wall_RECT[wl][2], wall_RECT[wl][3]):\n       if   mowse_in_circle(w1, z1, rad+3): selected = -1; LIN_selected = [wl, 1]\n       elif mowse_in_circle(w2, z2, rad+3): selected = -1; LIN_selected = [wl, 2]\ndef Lets_ROLL():\n    global loopy\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    global bounce_friction, air_friction, gravity, rock_and_ROLLY\n    global LIN_selected, CLICKER, CLICKER2\n    global levely\n    levely = 3\n    bounce_friction = 0.8\n    #bounce_friction = 1.0\n    air_friction = 0.999\n    #air_friction = 1.0\n    gravity = 0.5\n    rock_and_ROLLY = math.pi / 8 * 180 #24\n    reset_stuff()\n    fontyyy = chilly_font_Italicy(24)\n    PRESS_SPACE_BAR_TO_MOVE_immy = fontyyy.render('Press SPACE BAR to start motion.', 0, (100, 200, 100))\n    PRESS_SPACE_BAR_TO_STOP_immy = fontyyy.render('Press SPACE BAR to stop motion.', 0, (200, 100, 100))\n    PRESS_ENTER_TO_RESET_immy    = fontyyy.render('Press ENTER to reset.', 0, (150, 150, 150))\n    PRESS_MINUS_TO_MINUS_immy    = fontyyy.render('Press - to delete a ball.', 0, (150, 150, 150))\n    PRESS_ADD_TO_ADD_immy        = fontyyy.render('Press + to add a ball.', 0, (150, 150, 150))\n    LEFT_CLICK_TO_immy           = fontyyy.render('Left click on a \"ghost ball\" to change its speed.', 0, (150, 150, 150))\n    RIGHT_CLICK_TO_immy          = fontyyy.render('Right click on a ball to stop its motion.', 0, (150, 150, 150))\n    PRESS_S_TO_immy              = fontyyy.render('Press S to stop all balls.', 0, (150, 150, 150))\n    PRESS_PAGE_UP_TO_immy        = fontyyy.render('Press Page Up to change the level.', 0, (150, 150, 150))\n    #message_1_immy\n    del fontyyy\n    #calculate_for_sure = True\n    selected = -1\n    LIN_selected = -1\n    move_stuff = True\n    t = time.time() + .01\n    CLICKER = False\n    CLICKER2 = False\n    loopy = 1\n    while loopy:\n          big_black_rect.fill((0, 0, 0))\n          draw_walls_on_big_black_rect()\n          screen.blit(big_black_rect, (0, 0))\n          check_for_keys()\n          CLICKER    = mowse_left_held\n          CLICKER2   = mowse_left_pressed\n          CLICKER_2  = mowse_right_held\n          CLICKER2_2 = mowse_right_pressed\n          if ky_first_held_CEV(32): move_stuff = not move_stuff\n          if ky_first_held_CEV(13): reset_stuff()\n          if ky_first_held_CEV(280):\n           levely += 1\n           if levely &gt; 5: levely = 1\n           reset_stuff()\n          if ky_first_held_CEV(115): # S\n            M = -1\n            while M &lt; ball_max:\n             M += 1\n             ball_wol[M] = 0\n             ball_zol[M] = 0\n             updatey_ball_quick_rect(M)\n          if ky_first_held_CEV(45) or ky_first_held_CEV(269): # -\n           minus_ball_thing(0)\n          if ky_first_held_CEV(61) or ky_first_held_CEV(270): # +\n           add_ball_thing(350 + randy(40, -20), 400 + randy(40, -20), randy(40, -20), randy(40, -20), int_randy(20, 10), (int_randy(10, 130), int_randy(80, 170), int_randy(50, 200)), 0, 0, True, True)\n          if ky_first_held_CEV(49):\n           listy  = ['Level_save']\n           listy += ['ball_max = ' + str(ball_max)]\n           listy += ['ball_w = ' + str(ball_w)]\n           listy += ['ball_z = ' + str(ball_z)]\n           listy += ['ball_wol = ' + str(ball_wol)]\n           listy += ['ball_zol = ' + str(ball_zol)]\n           listy += ['ball_rad = ' + str(ball_rad)]\n           listy += ['ball_color = ' + str(ball_color)]\n           listy += ['ball_angle = ' + str(ball_angle)]\n           listy += ['ball_angleol = ' + str(ball_angleol)]\n           listy += ['ball_squar = ' + str(ball_squar)]\n           listy += ['ball_mass = ' + str(ball_mass)]\n           listy += ['ball_RECT = ' + str(ball_RECT)]\n           listy += ['wall_max = ' + str(wall_max)]\n           listy += ['wall_type = ' + str(wall_type)]\n           listy += ['wall_w1 = ' + str(wall_w1)]\n           listy += ['wall_z1 = ' + str(wall_z1)]\n           listy += ['wall_w2 = ' + str(wall_w2)]\n           listy += ['wall_z2 = ' + str(wall_z2)]\n           listy += ['wall_rad = ' + str(wall_rad)]\n           listy += ['wall_color = ' + str(wall_color)]\n           listy += ['wall_RECT = ' + str(wall_RECT)]\n           ##write_to_file_WEEE_STRANGE(\"Level_Save.dat\", listy)\n           del listy\n          if CLICKER2:\n           allow_selectey_thing = True\n          else:\n           allow_selectey_thing = False\n           if not CLICKER:\n            selected = -1\n            LIN_selected = -1\n          to_be_selected = selected\n          M = -1\n          while M &lt; ball_max:\n           M += 1\n           if move_stuff:\n            move_ball(M)\n           wwol = int(ball_w[M] + ball_wol[M])\n           zzol = int(ball_z[M] + ball_zol[M])\n           pygame.draw.circle(screen, ball_color[M], (int(ball_w[M]), int(ball_z[M])), ball_rad[M])\n           blpw, blpz = point_rotated_by_angle_2D(0, -ball_rad[M], 0, 0, ball_angle[M])\n           pygame.draw.line(screen, (100, 100, 100), (int(ball_w[M] + blpw), int(ball_z[M] + blpz)), (int(ball_w[M]), int(ball_z[M])))\n           if not move_stuff:\n            pygame.draw.circle(screen, (100, 100, 250), (wwol, zzol), ball_rad[M], 1)\n            pygame.draw.circle(screen, (100, 100, 150), (wwol, zzol), int(ball_rad[M] * 1.0), 1)\n            pygame.draw.circle(screen, (150, 150, 200), (wwol, zzol), int(ball_rad[M] * 0.8), 1)\n            pygame.draw.circle(screen, (200, 200, 250), (wwol, zzol), int(ball_rad[M] * 0.5), 1)\n            pygame.draw.line(screen, (100, 160, 250), (int(ball_w[M]), int(ball_z[M])), (wwol, zzol))\n            pygame.draw.rect(screen, (130, 130, 130), ball_RECT[M], 1)\n            pygame.draw.rect(screen, (140, 140, 140), ball_squar[M], 1)\n           if allow_selectey_thing:\n            if mowse_in_rect(ball_RECT[M][0], ball_RECT[M][1], ball_RECT[M][2], ball_RECT[M][3]):\n             if mowse_in_circle(wwol, zzol, ball_rad[M]):\n              to_be_selected = M\n              LIN_selected = -1\n           if CLICKER_2:\n            if mowse_in_rect(ball_squar[M][0], ball_squar[M][1], ball_squar[M][2], ball_squar[M][3]):\n             if mowse_in_circle(ball_w[M], ball_z[M], ball_rad[M]):\n              ball_wol[M] = 0\n              ball_zol[M] = 0\n              ball_angleol[M] = 0\n              updatey_ball_quick_rect(M)\n           if CLICKER:\n            if selected == M:\n             if move_stuff:\n              mowseyy_w = mowse_w\n              mowseyy_z = mowse_z\n              bw1 = ball_rad[M]\n              bz1 = ball_rad[M]\n              bw2 = APPLICATION_w_size - ball_rad[M]\n              bz2 = APPLICATION_z_size - ball_rad[M]\n              if mowseyy_w &lt; bw1: mowseyy_w = bw1\n              if mowseyy_w &gt; bw2: mowseyy_w = bw2\n              if mowseyy_z &lt; bz1: mowseyy_z = bz1\n              if mowseyy_z &gt; bz2: mowseyy_z = bz2\n              ww = mowseyy_w - ball_w[M]\n              zz = mowseyy_z - ball_z[M]\n              #dissy = distance_2D(0, 0, ww, zz)\n              ball_wol[M] = ww # / 2.0 # / dissy\n              ball_zol[M] = zz # / 2.0 # / dissy\n             else:\n              ball_wol[M] = mowse_w - ball_w[M]\n              ball_zol[M] = mowse_z - ball_z[M]\n             updatey_ball_quick_rect(M)\n          selected = to_be_selected\n          if not move_stuff:\n           screen.blit(PRESS_SPACE_BAR_TO_MOVE_immy, (10, 10))\n          else:\n           screen.blit(PRESS_SPACE_BAR_TO_STOP_immy, (10, 10))\n          screen.blit(PRESS_MINUS_TO_MINUS_immy, (10, 30))\n          screen.blit(PRESS_ADD_TO_ADD_immy, (10, 50))\n          screen.blit(PRESS_ENTER_TO_RESET_immy, (10, 70))\n          screen.blit(LEFT_CLICK_TO_immy, (10, 90))\n          screen.blit(RIGHT_CLICK_TO_immy, (10, 110))\n          screen.blit(PRESS_S_TO_immy, (10, 130))\n          screen.blit(PRESS_PAGE_UP_TO_immy, (10, 150))\n          pygame.display.flip()\n          while t &gt; time.time(): pass\n          t = time.time() + .01\n # Try_Again_HE_HE Is weird!! maybe It should be deleted!!\ndef move_ball(M):\n            ball_angle[M] += ball_angleol[M]\n            if   ball_angle[M] &gt; 359: ball_angle[M] -= 360\n            elif ball_angle[M] &lt;   0: ball_angle[M] += 361\n            #movey_bally_speciality(M, ball_wol[M], ball_zol[M], 10)\n            movey_bally_speciality(M, ball_wol[M], ball_zol[M], 10)\n            ball_zol[M] += gravity\n            updatey_ball_quick_rect(M)\ndef movey_bally_speciality(M, wol_special, zol_special, Try_Again_HE_HE):\n            global loopy\n            global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n            global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n            global bounce_friction, air_friction, gravity, rock_and_ROLLY\n            distance_is_supposed_to_be_at = distance_2D(0, 0, wol_special, zol_special)\n            wa = ball_w[M]\n            za = ball_z[M]\n            #will_be_w = wa + ball_wol[M]\n            #will_be_z = za + ball_zol[M]\n            will_be_w = wa + wol_special\n            will_be_z = za + zol_special\n            LIN_collide_max = -1\n            LIN_collide_w    = []\n            LIN_collide_z     = []\n            LIN_collide_ang    = []\n            LIN_collide_dis     = []\n            LL = -1\n            while LL &lt; wall_max:\n              LL += 1\n              if rect_touching_rect2(ball_RECT[M][0], ball_RECT[M][1], ball_RECT[M][2], ball_RECT[M][3], wall_RECT[LL][0], wall_RECT[LL][1], wall_RECT[LL][2], wall_RECT[LL][3]):\n                  #print 'weee'\n                  did_collide, New_ball_w, New_ball_z, angle_hit_at = find_where_ball_collides_on_a_wall(wa, za, wol_special, zol_special, ball_rad[M], wall_type[LL], wall_w1[LL], wall_z1[LL], wall_w2[LL], wall_z2[LL], wall_rad[LL])\n                  if did_collide:\n                   #print 'collide'\n                   #print str(New_ball_w), str(New_ball_z)\n                   LIN_collide_max += 1\n                   LIN_collide_w    += [New_ball_w]\n                   LIN_collide_z     += [New_ball_z]\n                   LIN_collide_ang    += [angle_hit_at]\n                   LIN_collide_dis     += [distance_2D(wa, za, New_ball_w, New_ball_z)]\n            HEH_collide_max = -1\n            HEH_collide_w    = []\n            HEH_collide_z     = []\n            HEH_collide_ang    = []\n            HEH_collide_dis     = []\n            HEH_collide_ball_hit = []\n            M2 = -1\n            while M2 &lt; ball_max:\n             M2 += 1\n             if M2 != M:\n              if rect_touching_rect2(ball_RECT[M][0], ball_RECT[M][1], ball_RECT[M][2], ball_RECT[M][3], ball_squar[M2][0], ball_squar[M2][1], ball_squar[M2][2], ball_squar[M2][3]):\n                  #they_did_touch, New_ball1_w, New_ball1_z, angle_hit_at = find_where_ball_collides_on_another_ball(wa, za, ball_wol[M], ball_zol[M], ball_rad[M], ball_w[M2], ball_z[M2], ball_rad[M2])\n                  they_did_touch, New_ball1_w, New_ball1_z, angle_hit_at = find_where_ball_collides_on_another_ball(wa, za, wol_special, zol_special, ball_rad[M], ball_w[M2], ball_z[M2], ball_rad[M2])\n                  if they_did_touch:\n                   HEH_collide_max += 1\n                   HEH_collide_w    += [New_ball1_w]\n                   HEH_collide_z     += [New_ball1_z]\n                   HEH_collide_ang    += [angle_hit_at]\n                   HEH_collide_dis     += [distance_2D(wa, za, New_ball1_w, New_ball1_z)]\n                   HEH_collide_ball_hit += [M2]\n            current_dis = distance_is_supposed_to_be_at\n            Wall_to_hit_at_angley = None\n            Grr = -1\n            while Grr &lt; LIN_collide_max:\n             Grr += 1\n             #print LIN_collide_dis[Grr], current_dis\n             if LIN_collide_dis[Grr] &lt; current_dis:\n               #print 'weee!'\n               Wall_to_hit_at_angley = LIN_collide_ang[Grr]\n               current_dis = LIN_collide_dis[Grr]\n               will_be_w = LIN_collide_w[Grr]\n               will_be_z = LIN_collide_z[Grr]\n            Ball_to_hit = None\n            Ball_to_hit_at_angley = None\n            Heh = -1\n            while Heh &lt; HEH_collide_max:\n             Heh += 1\n             if HEH_collide_dis[Heh] &lt; current_dis:\n              if ball_is_going_towards_ball(M, HEH_collide_ball_hit[Heh]):\n               if ball_is_relatively_going_towards_ball(M, HEH_collide_ball_hit[Heh]):\n                Ball_to_hit = HEH_collide_ball_hit[Heh]\n                Ball_to_hit_at_angley = HEH_collide_ang[Heh]\n               else:\n                Ball_to_hit = None\n                Ball_to_hit_at_angley = None\n               current_dis = HEH_collide_dis[Heh]\n               will_be_w = HEH_collide_w[Heh]\n               will_be_z = HEH_collide_z[Heh]\n            if Ball_to_hit != None:\n             Make_two_balls_hit_at_angle(M, Ball_to_hit, Ball_to_hit_at_angley)\n            else:\n             #if   bouncey == 1: ball_wol[M] = -ball_wol[M] * bounce_friction\n             #elif bouncey == 2: ball_zol[M] = -ball_zol[M] * bounce_friction\n             if Wall_to_hit_at_angley != None:\n              ball_wol[M], ball_zol[M] = wzol_bounce_at_angle(ball_wol[M], ball_zol[M], Wall_to_hit_at_angley, bounce_friction)\n              ball_angleol[M] = zol_at_angle(ball_wol[M], ball_zol[M], Wall_to_hit_at_angley + 90) / ball_rad[M] * rock_and_ROLLY\n            ball_w[M] = will_be_w\n            ball_z[M] = will_be_z\n            if ball_w[M] &lt; 0 or ball_w[M] &gt; APPLICATION_w_size or ball_z[M] &lt; 0 or ball_z[M] &gt; APPLICATION_z_size:\n             #print str(M) + \"   \", str(wa), str(za)\n             print str(M) + \"   \", str(ball_w[M]), str(ball_z[M]), str(ball_rad[M])\n            ball_wol[M] *= air_friction\n            ball_zol[M] *= air_friction\n            updatey_ball_quick_rect(M)\n            if current_dis &lt; distance_is_supposed_to_be_at:\n             if Try_Again_HE_HE &gt; 0:\n              distance_to_travel_next = distance_is_supposed_to_be_at - current_dis\n              disy_HE_HE = distance_2D(0, 0, ball_wol[M], ball_zol[M])\n              next_wol = ball_wol[M]\n              next_zol = ball_zol[M]\n              movey_bally_speciality(M, next_wol, next_zol, Try_Again_HE_HE - 1)\n\n           ## Woah... Finally! Were near the end of the program! ##\nif __name__ == '__main__':\n  import math\n  import pygame\n  import random\n  import time\n  import gc\n  import copy\n  from   pygame.locals import *\n  if not pygame.font: print 'Warning, fonts disabled?'\n  if not pygame.mixer: print 'Warning, sound disabled?'\n  HE_HE_init()\n           ## THE END! ##", "user_title": "Anonymous", "datetimeon": "2007-12-23T15:46:20", "link": "pygame.draw.circle", "id": 1320}, {"content": "Guillame was confused on the nature of the last two arguments to Rect().\nhe thought that they were absolute coordinates, not width-height.\nThere isn't a bug with collidepoint.\nsee the pygame mailing list archives for the discussion with Guillame where this topic arose.", "user_title": "Anonymous", "datetimeon": "2007-04-25T17:52:17", "link": "Rect.collidepoint", "id": 524}, {"content": "I'm guessing they're key pressed (eg, the A or J keys) and the modifiers (Shift, Ctrl, Alt, Meta, Super, etc). Experiment to find details.", "user_title": "Anonymous", "datetimeon": "2007-04-26T17:03:55", "link": "pygame.event", "id": 528}, {"content": "I, too, get a list with a single item, None. This on Mac OS X 10.4 (Tiger) and Python 2.4.4; \npygame.ver returns '1.8.0pre'", "user_title": "Anonymous", "datetimeon": "2008-01-20T04:04:36", "link": "pygame.font.get_fonts", "id": 1428}, {"content": "The params units are in pixels.\nThe smallest unit for Pygame I think.\nIt doesn't make sense to change this to float.", "user_title": "Anonymous", "datetimeon": "2008-01-21T10:48:00", "link": "Rect.move_ip", "id": 1430}, {"content": "this resource is perfect for games with controls options\nbecause through it you can show the current input without creating a whole database of inputs\ntxt = font.render(pygame.key.name(current_key),True,(0,0,0))\nscreen.blit(txt,(0,0))", "user_title": "Anonymous", "datetimeon": "2008-01-21T20:04:03", "link": "pygame.key.name", "id": 1431}, {"content": "#!/usr/bin/python\nimport pygame\nfrom pygame.locals import *\n\ndef main():\n   pygame.init()\n   pygame.display.set_mode((300,200))\n   pygame.display.set_caption('Testing')\n   running = True\n   while running:\n      for event in pygame.event.get():\n         if event.type == QUIT:\n            running = False\n         if event.type == KEYDOWN and event.key == K_ESCAPE:\n            running = False\n         if event.type == MOUSEBUTTONDOWN:\n            #print event.button\n           print pygame.mouse.get_pos()\n   pygame.display.quit()\n\nif __name__ == '__main__':\n   main()", "user_title": "Anonymous", "datetimeon": "2008-01-23T15:43:49", "link": "pygame.mouse.get_pos", "id": 1436}, {"content": "Once you draw something, how do you delete it??", "user_title": "Anonymous", "datetimeon": "2007-05-04T00:39:15", "link": "pygame.draw.rect", "id": 548}, {"content": "Hi,\n\nI was having a problem when trying to jump from one movie to another.  Even with the fist one stopped the second movie played at half speed with no volume.  A solution was to keep a reference to the old movie, which I assume stops the garbage collector trying to delete it before its finished doing whatever it was doing.  \n\nThis would cause problems:\n\ncurrentMovie.stop()\ncurrentMovie = pygame.movie.Movie(fullname)\ncurrentMovie.play()\n\nAnd this fixes it:\n\ncurrentMovie.stop()\noldMovie = currentMovie\ncurrentMovie = pygame.movie.Movie(fullname)\ncurrentMovie.play()\n\nMaybe need a method for unloading the memory and stopping all its threads.", "user_title": "Anonymous", "datetimeon": "2007-05-09T10:27:03", "link": "pygame.movie", "id": 554}, {"content": "Does anyone know how to make multiple screens? I've tried making a different variable with different dimensions, but it only changes original\n\nsize=400,400\nscreen=display.set_mode(size)\n\nsize1=200,200\nnew_screen=display.set_mode(size1)", "user_title": "Anonymous", "datetimeon": "2008-01-29T10:33:27", "link": "pygame.display.set_mode", "id": 1456}, {"content": "The first two arguments to Surface.blit() seem to be reversed. To draw Surface \"source\" onto Surface \"dest\" the correct call is:\n\n    pygame.Surface.blit(dest, source, position)\n\nor\n\n    dest.blit(source, position)\n\n\nExample:\n\n    screen = pygame.display.set_mode((100,100))\n    screen.fill((255,255,255)) # white background\n    red_block = pygame.Surface((50,50))\n    red_block.fill((255,0,0))\n\n    # draw red block onto white background\n    screen.blit(red_block, (25,25))\n\n    pygame.display.update()", "user_title": "Anonymous", "datetimeon": "2007-05-16T08:51:09", "link": "Surface.blit", "id": 572}, {"content": "Actually, on re-reading the method description, I realize that the \"dest\" argument means the position to where the source Surface should be copied too. So the call synopsis is equivalent to the second case in my comment.\n\nThe naming of the arguments is a bit confusing, IMHO, and also that it is not (visually) clear that the documentation describes the methods of a Surface object instance and makes no mention of the class methods.", "user_title": "Anonymous", "datetimeon": "2007-05-16T09:15:43", "link": "Surface.blit", "id": 573}, {"content": "Only the \"systems with multiple choices\" are listed there.", "user_title": "Anonymous", "datetimeon": "2007-05-20T19:04:19", "link": "pygame.display.init", "id": 578}, {"content": "Yeah the doc could be improved. The wrong comment below should be removed, it's only confusing. I did find another problem, though: It's important to note that when you cut out an area from the source, then the dest argument does _not_ specify where the origin of the source would be on the surface that is blitted on, but instead dest specifies the top left corner of just the area that is actually blitted. This is not quite clear from this doc, I think.", "user_title": "Anonymous", "datetimeon": "2007-05-24T07:20:10", "link": "Surface.blit", "id": 588}, {"content": "Pygame (and SDL) doesn't support multiple windows.", "user_title": "Anonymous", "datetimeon": "2008-02-09T15:29:56", "link": "pygame.display.set_mode", "id": 1525}, {"content": "you can't \"delete\" something you have drawn, you have to draw something over it instead.\nyou can make classes that wrap the different draw function and have both a \"show\" and a \"hide\" function and the hide function has to draw the background over the shape you created in \"hide\", but this can have weird results if shapes overlap and are not correctly redrawn.\ncheers", "user_title": "Anonymous", "datetimeon": "2007-06-02T10:44:48", "link": "pygame.draw.rect", "id": 607}, {"content": "destination.blit(source (distination location),(source location x,y and size x,y)", "user_title": "Anonymous", "datetimeon": "2007-06-05T09:13:28", "link": "pygame.Surface", "id": 609}, {"content": "destination.blit(source (distination location),(source location x,y and size x,y)", "user_title": "Anonymous", "datetimeon": "2007-06-05T09:13:56", "link": "Surface.blit", "id": 610}, {"content": "use events to save and release keystates to use it only for some:\n\nif event.type == pygame.KEYDOWN: if event.key == MYKEY: i = True\nelif event.type == pygame.KEYUP: if event.key == MYKEY: i = False\nif i: do stuff.", "user_title": "Anonymous", "datetimeon": "2008-02-11T16:09:33", "link": "pygame.key.set_repeat", "id": 1541}, {"content": "Is there a way to make the collision box of the line accurate to the line itself?", "user_title": "Anonymous", "datetimeon": "2008-02-12T18:09:15", "link": "pygame.draw.line", "id": 1549}, {"content": "Is there a way to produce small line segments that have accurate collision boxes\nso that one could have two lines that would be parallel to each other with out them colliding?", "user_title": "Anonymous", "datetimeon": "2008-02-12T18:13:18", "link": "pygame.draw", "id": 1550}, {"content": "Yes, actually it would be quite useful for it to be float, if it could store the\ndecimals and increment them as such but not display it until it would take effect...", "user_title": "Anonymous", "datetimeon": "2008-02-12T20:21:41", "link": "Rect.move_ip", "id": 1552}, {"content": "Clearly, more documentation about the event properties should be written.", "user_title": "Anonymous", "datetimeon": "2007-06-10T10:28:36", "link": "pygame.event", "id": 628}, {"content": "MOUSEBUTTONDOWN/UP:\n pos: tuple of x and y coordinates of the click\n button: 1 - left 2 - middle 3 - right button", "user_title": "Anonymous", "datetimeon": "2007-06-10T13:16:50", "link": "pygame.event", "id": 630}, {"content": "MOUSEMOTION\n pos: tuple of x and y coordinates\n rel: tuple of relative x and relative y change from previous position\n buttons: tuple of three values (left,middle,right). 0-not pressed 1-pressed", "user_title": "Anonymous", "datetimeon": "2007-06-10T13:18:03", "link": "pygame.event", "id": 631}, {"content": "While thick arcs do get filled, they also get moire holes - at least on Debian's 1.7.1release-4.1.  For now, I've been using a rather ugly workaround where one draws the arc several times with the start angle offset by 0.01 to cut the moires back.", "user_title": "Anonymous", "datetimeon": "2008-02-16T15:39:17", "link": "pygame.draw.arc", "id": 1580}, {"content": "I have noticed that with my analog joystick square shaped information is returned\nfrom this function.  For example, pressing fully down and right would return 1.0\nfor both axis directions, instead of 0.7071... as one might expect (since analog\njoysticks have a circle shaped socket for the stick to move in.)\n\nTo correct this one might want to use a function similar to the following\njoystick_transform function:\n\ndef length(v):\n\treturn math.sqrt(v[0]*v[0] + v[1]*v[1])\n\n# Transforms the square info of an analog joystick into circular info\ndef joystick_transform(j):\n\t# If joystick is not centered:\n\tif (j[0],j[1]) != (0,0):\n\t\t# Check if x axis is larger than y axis\n\t\tif abs(j[0]) &gt; abs(j[1]):\n\t\t\t# Since x&gt;y we will check for line intersection with wall\n\t\t\t# Get slope (m = y/x) for y = m * x (line equation)\n\t\t\tm = abs(j[1] / j[0])\n\t\t\t# At x=1.0 (intersecting right wall), y would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((1.0, m))\n\t\telse:\n\t\t\t# Since y&gt;=x we will check for line intersection with ceiling\n\t\t\t# Get slope (m = x/y) for x = m * y (line equation)\n\t\t\tm = abs(j[0] / j[1])\n\t\t\t# At y=1.0 (intersecting ceiling), x would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((m,1.0))\n\telse:\n\t\t# Since the joystick is centered, the scaler will be 0\n\t\ts = 0\n\t\t\n\t# Simply scale the joystick axis data by the scaler\n\treturn (j[0] * s, j[1] * s)\n\n-----\n\nHere is a full example illustrating the difference between raw joystick input\nand transformed joystick information:\n\n#!/usr/bin/python\n\n# In this example the function joystick_transform will transform the\n# square shaped joystick axis information into a circular shape.\n# This will make the new joystick axis information easier to use while\n# moving around a character or cursor.\n\n# The RED dot represents the actual joystick information.\n\n# The BLUE dot represents the transformed joystick information.\n\n# The GREEN dot is a cursor that moves by the transformed joystick\n# information in a motion relative to it's previous location.\n\n\nimport pygame\nimport math\n\ndef norm(v):\n\tl = length(v)\n\tif l != 0:\n\t\treturn (v[0] / l, v[1] / l)\n\treturn (0,0)\n\t\ndef length(v):\n\treturn math.sqrt(v[0]*v[0] + v[1]*v[1])\n\n# Transforms the square info of an analog joystick into circular info\ndef joystick_transform(j):\n\t# If joystick is not centered:\n\tif (j[0],j[1]) != (0,0):\n\t\t# Check if x axis is larger than y axis\n\t\tif abs(j[0]) &gt; abs(j[1]):\n\t\t\t# Since x&gt;y we will check for line intersection with wall\n\t\t\t# Get slope (m = y/x) for y = m * x (line equation)\n\t\t\tm = abs(j[1] / j[0])\n\t\t\t# At x=1.0 (intersecting right wall), y would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((1.0, m))\n\t\telse:\n\t\t\t# Since y&gt;=x we will check for line intersection with ceiling\n\t\t\t# Get slope (m = x/y) for x = m * y (line equation)\n\t\t\tm = abs(j[0] / j[1])\n\t\t\t# At y=1.0 (intersecting ceiling), x would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((m,1.0))\n\telse:\n\t\t# Since the joystick is centered, the scaler will be 0\n\t\ts = 0\n\t\t\n\t# Simply scale the joystick axis data by the scaler\n\treturn (j[0] * s, j[1] * s)\n\npygame.init()\npygame.joystick.init()\n\nscreen = pygame.display.set_mode((640,480))\n\njs = pygame.joystick.Joystick(0)\njs.init()\n\npx = 320.0\npy = 240.0\n\nmove_speed = 2.0\n\ndone = False\nwhile not done:\n\tkey = pygame.key.get_pressed()\n\tscreen.fill((255,255,255))\n\t\n\t# Outer box boundry\n\tpygame.draw.rect(screen, (200,200,200), ((10,10),(180,180)), 1)\n\t\n\t# Circle boundry\n\tpygame.draw.circle(screen, (0,0,0), (100,100), 90, 1)\n\t\n\t# Center point\n\tpygame.draw.circle(screen, (200,200,200), (100,100), 2, 1)\n\t\n\tjx = js.get_axis(0)\n\tjy = js.get_axis(1)\n\tn = norm((jx,jy))\n\t\n\t# Line representing normalized joystick information\n\tpygame.draw.line(screen, (200,200,200), (100,100), (100 + int(n[0] * 90.0), 100 + int(n[1] * 90.0)))\n\t\n\t# Raw joystick information\n\tx = 100 + int(jx * 90.0)\n\ty = 100 + int(jy * 90.0)\n\tpygame.draw.circle(screen, (255,0,0), (x, y), 5)\n\t\n\t# Transformed joystick information\n\ttj = joystick_transform((jx,jy))\n\tx = 100 + int(tj[0] * 90.0)\n\ty = 100 + int(tj[1] * 90.0)\n\tpygame.draw.circle(screen, (0,0,255), (x, y), 5)\n\t\n\t# Cursor moved by transformed joystick information\n\tpx = px + tj[0] * move_speed\n\tpy = py + tj[1] * move_speed\n\tpygame.draw.circle(screen, (0, 255, 0), (int(px), int(py)), 5)\n\t\n\tpygame.display.flip()\n\t\n\tfor event in pygame.event.get():\n\t\tif event.type == pygame.QUIT: \n\t\t\tdone = True\n\t\t\t\n\t\tif key[pygame.K_ESCAPE]:\n\t\t\tdone = True", "user_title": "Anonymous", "datetimeon": "2008-02-16T23:25:56", "link": "Joystick.get_axis", "id": 1584}, {"content": "the playback doesnt work, the music stops for a second and then starts again\nHELP ME", "user_title": "Anonymous", "datetimeon": "2010-11-27T14:29:59", "link": "pygame.mixer.music.play", "id": 3415}, {"content": "An example of the Color object is an rgb tuple like (100,0,200).", "user_title": "Anonymous", "datetimeon": "2008-02-27T10:13:22", "link": "Surface.set_at", "id": 1657}, {"content": "It might be convenient to have this particular documentation within the\nhelp(pygame.display.init) documentation, as of this writing it is not.\n\nAdditionally, information pertaining to Mac-OS X is not present; it may also be\nnoteworthy to document the methods by which Pygame renders its surfaces, as OSX,\nlike Windows, has its own various subsystems to draw views(surfaces).", "user_title": "Anonymous", "datetimeon": "2008-03-01T23:13:53", "link": "pygame.display.init", "id": 1680}, {"content": "All the keyboard event.key constants:\n\nLetters:\n    K_a ... K_z\n\nNumbers:\n    K_0  ... K_9\n\nControl:\n    K_TAB\n    K_RETURN\n    K_ESCAPE\n    K_SCROLLOCK\n    K_SYSREQ\n    K_BREAK\n    K_DELETE\n    K_BACKSPACE\n    K_CAPSLOCK\n    K_CLEAR\n    K_NUMLOCK\n\nPunctuation:\n    K_SPACE\n    K_PERIOD\n    K_COMMA\n    K_QUESTION\n    K_AMPERSAND\n    K_ASTERISK\n    K_AT\n    K_CARET\n    K_BACKQUOTE\n    K_DOLLAR\n    K_EQUALS\n    K_EURO\n    K_EXCLAIM\n    K_SLASH,      K_BACKSLASH\n    K_COLON,      K_SEMICOLON\n    K_QUOTE,      K_QUOTEDBL\n    K_MINUS,      K_PLUS\n    K_GREATER,    K_LESS\n\nBrackets:\n    K_RIGHTBRACKET,  K_LEFTBRACKET\n    K_RIGHTPAREN,    K_LEFTPAREN\n\nF-Keys:\n    K_F1 ... K_F15\n\nEdit keys:\n    K_HELP\n    K_HOME\n    K_END\n    K_INSERT\n    K_PRINT\n    K_PAGEUP, K_PAGEDOWN\n    K_FIRST,  K_LAST\n\nKeypad:\n    K_KP0 ... K_KP9\n    K_KP_DIVIDE\n    K_KP_ENTER\n    K_KP_EQUALS\n    K_KP_MINUS\n    K_KP_MULTIPLY\n    K_KP_PERIOD\n    K_KP_PLUS\n\nSHF,CTL,ALT etc:\n    K_LALT,   K_RALT\n    K_LCTRL,  K_RCTRL\n    K_LSUPER, K_RSUPER\n    K_LSHIFT, K_RSHIFT\n    K_RMETA,  K_LMETA\n\nArrows:\n    K_LEFT\n    K_UP\n    K_RIGHT\n    K_DOWN\n\nOther:\n    K_MENU\n    K_MODE\n    K_PAUSE\n    K_POWER\n    K_UNDERSCORE\n    K_HASH\n\n    K_UNKNOWN", "user_title": "Anonymous", "datetimeon": "2008-03-11T11:07:08", "link": "pygame.event.Event", "id": 1682}, {"content": "key is one of the K_* constants in the pygame package level -- it indicates the key pressed. For example, K_UP or K_ESCAPE.\nmod is the modifier. I'm assuming it's either a bitfield or a list. Shouldn't be hard to figure it out.", "user_title": "Anonymous", "datetimeon": "2008-03-16T02:36:10", "link": "pygame.event", "id": 1685}, {"content": "can anyone give me just a small script about how can i play a movie, please?\n\ni used this script but nothing happened. just a window but blank :(\n\nimport pygame\n\n\npygame.init()\n\n\ncine = pygame.movie.Movie('film.mpg')\nsz=cine.get_size()\npygame.display.set_mode(sz)\nwhile 1:\n    cine.play(1)\n\nthe movie loads because i tried to find the length and worked and the movie is at the same location. please HELP!!", "user_title": "Anonymous", "datetimeon": "2007-07-12T09:58:26", "link": "pygame.movie", "id": 716}, {"content": "JOYBUTTONDOWN/JOYBUTTONUP\nbutton -- the ID of the button which fired the event.", "user_title": "Anonymous", "datetimeon": "2007-07-14T15:07:03", "link": "pygame.event", "id": 719}, {"content": "Is there a way to draw an anti aliased line with a thickness?", "user_title": "Anonymous", "datetimeon": "2008-03-28T14:12:55", "link": "pygame.draw.aaline", "id": 1713}, {"content": "I've notice that passing any negative number will cause the music to loop forever, not just -1.", "user_title": "Anonymous", "datetimeon": "2008-03-30T20:55:44", "link": "pygame.mixer.music.play", "id": 1722}, {"content": "It seams that you can't read the axes or button positions if you don't start the event loop.\nThis is a little different from what the docs are saying but actually expected since the joystick \nbroadcasts the position (is this right for all drivers?)", "user_title": "Anonymous", "datetimeon": "2008-04-02T23:40:29", "link": "pygame.joystick.Joystick", "id": 1727}, {"content": "Can I draw just one pixel with this? \nApparantly the smallest rect one can draw is 2 pixels big, I guess?", "user_title": "Anonymous", "datetimeon": "2007-07-16T21:15:36", "link": "pygame.draw.rect", "id": 726}, {"content": "the fade_in parameter seems to be missing. Using 1.7: \nTypeError: function takes at most 2 arguments (3 given)", "user_title": "Anonymous", "datetimeon": "2008-04-04T23:21:49", "link": "Sound.play", "id": 1732}, {"content": "The algorithm used will probably ruin the edges in your images. Makes them kinda blurry.", "user_title": "Anonymous", "datetimeon": "2008-04-05T17:52:43", "link": "pygame.transform.smoothscale", "id": 1734}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-07-18T19:04:17", "link": "Very cool design! Useful information. Go on!", "id": 733}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-07-18T19:04:17", "link": "Pretty nice site, wants to see much more on it! :)", "id": 734}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-07-18T19:04:17", "link": "Thanks for the enjoy to have you on my site ! Good luck.", "id": 735}, {"content": "How about creating a sound from a string of raw samples?  I shouldn't have to construct a fake WAV header just to get Pygame to accept sound data.", "user_title": "Anonymous", "datetimeon": "2008-04-09T23:10:47", "link": "pygame.mixer.Sound", "id": 1742}, {"content": "Here are attributes of the different events (as best I can tell):\n\nACTIVEEVENT:\n\tgain\n\tstate\nKEYDOWN:\n\tunicode\nKEYUP:\n\tkey\n\tmod\nMOUSEMOTION:\n\tpos\n\trel\n\tbuttons\nMOUSEBUTTONDOWN and MOUSEBUTTONUP:\n\tpos\n\tbutton\nJOYAXISMOTION:\n\tjoy\n\taxis\n\tvalue\nJOYBALLMOTION:\n\tjoy\n\tball\n\trel\nJOYHATMOTION:\n\tjoy\n\that\n\tvalue\nJOYBUTTONUP and case JOYBUTTONDOWN:\n\tjoy\n\tbutton\nVIDEORESIZE:\n\tsize\n\tw\n\th\nSYSWMEVENT (WIN32 only):\n\thwnd\n\tmsg\n\twparam\n\tlparam", "user_title": "Anonymous", "datetimeon": "2007-07-19T13:22:47", "link": "pygame.event", "id": 740}, {"content": "&gt; It is true that passing None for the final argument causes \"Invalid RGBA argument\". This is a bug in the documentation, not the code.\nI'd suggest replacing 'None' with 'NULL' in the documentation, then - it also indicates no value, but is not one you can enter in Python (hence there's no confusion).", "user_title": "Anonymous", "datetimeon": "2007-07-19T16:32:03", "link": "Font.render", "id": 741}, {"content": "There seems to be a typo in the sentence \"The blit routines will attempt to use hardware acceleration when possible, otherwise will use highly optimized software blitting methods.\"", "user_title": "Anonymous", "datetimeon": "2007-07-22T04:31:03", "link": "pygame.Surface", "id": 748}, {"content": "hey thanks for the tip ive been searchin in vain for days", "user_title": "Anonymous", "datetimeon": "2007-07-22T10:05:15", "link": "Surface.get_rect", "id": 749}, {"content": "Yes, it's particularly an issue for when a sprite wants to move diagonally in a low resolution.\n\nWhen you're only moving sideways 1 pixel at a time, it's impossible to move diagonally without breaking conservation of momentum.", "user_title": "Anonymous", "datetimeon": "2008-04-23T19:32:47", "link": "Rect.move_ip", "id": 1782}, {"content": "# Mattew N. Brown copyright 2007\n# This is an example program for key input:\n\n   ## IMPORT THEN EXECUTE IMPORTED MODULE ('*.py'): ##\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\n   ## UH!? WHAT IF IT ISN'T EXISTANT!?: ##\nif not pygame.font: print 'Warning, fonts disabled'\nif not pygame.mixer: print 'Warning, sound disabled'\n\n           ## LOAD IMAGE AND SOUND: ##\ndef image_file_data(file_name, colorkey=None):\n   try:\n    image = pygame.image.load(file_name)\n   except pygame.error, message:\n    print 'ERROR: Image did not load:', file_name\n    raise SystemExit, message\n   image = image.convert()\n   if colorkey is not None:\n    if colorkey is -1:\n     colorkey = image.get_at((0,0))\n    image.set_colorkey(colorkey, RLEACCEL)\n   return image, image.get_rect()\ndef sound_file_data(file_name):\n   class NoneSound:\n    def play(self): pass\n   if not pygame.mixer:\n    return NoneSound()\n   try:\n    sound = pygame.mixer.Sound(file_name)\n   except pygame.error, message:\n    print 'ERROR: Sound did not load:', file_name\n    raise SystemExit, message\n   return sound\ndef HEHEHE_font(size):\n    fonti = pygame.font.Font(None, size)\n    fonti.set_bold(0)\n    return fonti\n           ## IMAGE STRETCH AND ROTATE: ##\ndef HEHEHE_stretch_image (IMAGEY, wol, zol):\n    #return pygame.transform.scale(IMAGEY, (wol, zol))\n    return pygame.transform.scale(IMAGEY, (wol + IMAGEY.get_width(), zol + IMAGEY.get_height()))\ndef HEHEHE_rotate_image (IMAGEY, angle):\n    center = (0, 0)\n    rotate = pygame.transform.rotate\n    IMAGEY = rotate(IMAGEY, angle)\n    recty = IMAGEY.get_rect(center=center)\n    return IMAGEY, recty\n           ## DRAW IMAGE: ##\ndef draw_HEHEHE_image (IMAGEE, w, z):\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_image_stretch (IMAGEE, w, z, wol, zol):\n    IMAGEE = HEHEHE_stretch_image(IMAGEE, wol, zol)\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_image_stretch_rotate (IMAGEE, w, z, wol, zol, angle):\n    IMAGEE = HEHEHE_stretch_image(IMAGEE, wol, zol)\n    IMAGEE, recty = HEHEHE_rotate_image(IMAGEE, angle)\n    screen.blit(IMAGEE, (w + recty.x, z + recty.y))\n           ## DRAW TEXT IMAGE: ##\ndef draw_HEHEHE_text (t, special, size, w, z, colory):\n    fonty = HEHEHE_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_text_stretch (t, special, size, w, z, colory, wol, zol):\n    fonty = HEHEHE_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    IMAGEE = HEHEHE_stretch_image(IMAGEE, wol, zol)\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_text_stretch_rotate (t, special, size, w, z, colory, wol, zol, angle):\n    fonty = HEHEHE_font(size)\n    IMAGE = fonty.render(t, special, colory)\n    IMAGE = HEHEHE_stretch_image(IMAGE, wol, zol)\n    IMAGE, recty = HEHEHE_rotate_image(IMAGE, angle)\n    screen.blit(IMAGE, (w + recty.x, z + recty.y))\n     ### AAAH! FREAKY!! ###\nclock = pygame.time.Clock()\nImage_directory = \"PNG/\"\nSound_directory = \"SOUND/\"\n     ### WHAT IN THE WORLD IS THIS!!??: ###\npygame.init()\nAPPLICATION_w_size = 700\nAPPLICATION_z_size = 500\nscreen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n#pygame.display.set_icon(image_file_data(Image_directory + \"ICON.PNG\", 0)[0])\npygame.display.set_caption('Mattew N. Brown copyright 2007')\npygame.mouse.set_visible(1)\n     ### WHAT IN THE WORLD IS THIS!!!!!!!!!!!!??: ###\nbackground = pygame.Surface(screen.get_size())\nbackground = background.convert()\nbackground.fill((0, 0, 0))\n     ### THIS IS DRIVING MY CAR CRAZYs!!!\nscreen.blit(background, (0, 0))\npygame.display.flip()\nrandom.seed()\n\n           ## LOAD ALL IMAGES AND SOUNDS: ##\nimage_MAX = 0\nimage_file_name =                 [];\nimage = []\nimage_rect = []\nwhile (image_MAX &lt;=                        (-1)   ):\n   I = image_MAX\n   Itemp1, Itemp2 = image_file_data(Image_directory + image_file_name[I], 0)\n   image += [Itemp1]\n   image_rect += [Itemp2]\n   image_MAX += 1\nsound_MAX = 0\nsound_file_name =                 [];\nsound = []\nsound_rect = []\nwhile (sound_MAX &lt;=                        (-1)   ):\n   I = sound_MAX\n   Itemp1, Itemp2 = sound_file_data(Sound_directory + sound_file_name[I])\n   sound += [Itemp1]\n   sound_rect += [Itemp2]\n   sound_MAX += 1\n       ## LOAD ONE AND ONLY MUSIC FILE: ##\n#pygame.mixer.music.load(d + 'PCDV0043.WAV')\n\n    # QUIT\t       none\n    # ACTIVEEVENT      gain, state\n    # KEYDOWN\t       unicode, key, mod\n    # KEYUP\t       key, mod\n    # MOUSEMOTION      pos, rel, buttons\n    # MOUSEBUTTONUP    pos, button\n    # MOUSEBUTTONDOWN  pos, button\n    # JOYAXISMOTION    joy, axis, value\n    # JOYBALLMOTION    joy, ball, rel\n    # JOYHATMOTION     joy, hat, value\n    # JOYBUTTONUP      joy, button\n    # JOYBUTTONDOWN    joy, button\n    # VIDEORESIZE      size, w, h\n    # VIDEOEXPOSE      none\n    # USEREVENT        code\n\n\n\n           ## MAIN: ##\nif __name__ == '__main__':\n    EE = ['', '', '', '', '', '', '', '', '', '',\n          '', '', '', '', '']\n    b = (190, 130, 110)\n    COLORY = [b, b, b, b, b, b, b, b, b, b,\n              b, b, b, b, b]\n    angy = 0\n    loopy = 1\n    while (loopy == 1):\n        angy += 1\n        if angy &gt; 360:\n         angy = 1\n        clock.tick(70)\n        screen.blit(background, (0, 0))\n        for e in pygame.event.get():\n         if e.type == QUIT:\n           loopy = 0\n         #elif e.type == KEYDOWN and e.key == K_ESCAPE:\n         # loopy = 0\n         else:\n          nnnnnn = -1\n          if e.type == QUIT: nnnnnn = 0\n          if e.type == ACTIVEEVENT: nnnnnn = 1\n          if e.type == KEYDOWN: nnnnnn = 2\n          if e.type == KEYUP: nnnnnn = 3\n          if e.type == MOUSEMOTION: nnnnnn = 4\n          if e.type == MOUSEBUTTONUP: nnnnnn = 5\n          if e.type == MOUSEBUTTONDOWN: nnnnnn = 6\n          if e.type == JOYAXISMOTION: nnnnnn = 7\n          if e.type == JOYBALLMOTION: nnnnnn = 8\n          if e.type == JOYHATMOTION: nnnnnn = 9\n          if e.type == JOYBUTTONUP: nnnnnn = 10\n          if e.type == JOYBUTTONDOWN: nnnnnn = 11\n          if e.type == VIDEORESIZE:\n           nnnnnn = 12\n           APPLICATION_w_size = e.size[0]\n           APPLICATION_z_size = e.size[1]\n           screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n          if e.type == VIDEOEXPOSE: nnnnnn = 13\n          if e.type == USEREVENT: nnnnnn = 14\n          if nnnnnn != -1:\n           EE[nnnnnn] = str(e); COLORY[nnnnnn] = (190, 200, 255)\n        WOW = 0\n        while (WOW &lt; 14):\n         draw_HEHEHE_text(\"E\" + str(WOW) + \"  =  \" + EE[WOW], 1, 24, 30, 20 + (WOW * 22), COLORY[WOW])\n         if COLORY[WOW] == b:\n          COLORY[WOW] = COLORY[WOW]\n         else:\n          COLORY[WOW] = (200, 240, 200)\n         WOW += 1\n    # QUIT\t       none\n    # ACTIVEEVENT      gain, state\n    # KEYDOWN\t       unicode, key, mod\n    # KEYUP\t       key, mod\n    # MOUSEMOTION      pos, rel, buttons\n    # MOUSEBUTTONUP    pos, button\n    # MOUSEBUTTONDOWN  pos, button\n    # JOYAXISMOTION    joy, axis, value\n    # JOYBALLMOTION    joy, ball, rel\n    # JOYHATMOTION     joy, hat, value\n    # JOYBUTTONUP      joy, button\n    # JOYBUTTONDOWN    joy, button\n    # VIDEORESIZE      size, w, h\n    # VIDEOEXPOSE      none\n    # USEREVENT        code\n        #I = 0\n        #www = 0\n        #while (www &lt; 2):\n        # www += 1\n        # zzz = 0\n        # while (zzz &lt; 10):\n        #  zzz += 1\n        #  #if (I &lt; image_MAX): draw_HEHEHE_image(I, www * 40, zzz * 40)\n        #  if (I &lt; image_MAX): draw_HEHEHE_image_stretch_rotate(I, www * 40, zzz * 40, 40, 40, angy)\n        #  I += 1\n        #draw_HEHEHE_text_stretch(\"BOOM!\", 1, 40, 330, 400, (255, 255, 255), 20, 20)\n        #draw_HEHEHE_text_stretch_rotate(\"BOOM!\", 1, 40, 140, 400, (255, 255, 255), 0, 0, angy)\n        #draw_HEHEHE_text_stretch_rotate(\"WEEEE!\", 1, 30, 450, 470, (255, 255, 255), 0, 0, angy)\n        pygame.display.flip()", "user_title": "Anonymous", "datetimeon": "2007-07-28T12:28:50", "link": "pygame.event", "id": 779}, {"content": "# Matthew N. Brown copyright 2007\n# Here is an example program that\n# draws: polygons, circles, and rectangles:\n#\n# You can copy this program on to\n# your own computer and run it.\n#\n\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\nif not pygame.font: print 'Warning, fonts disabled'\nif not pygame.mixer: print 'Warning, sound disabled'\nimport time\nimport gc\nimport math\n\npygame.init()\nAPPLICATION_w_size = 700\nAPPLICATION_z_size = 500\nscreen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n#screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), FULLSCREEN)\npygame.display.set_caption(\"HEHE test draw thingie program    Matthew N. Brown copyright 2007\")\n#pygame.mouse.set_visible(0)\nglobal background\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0, 0, 0))\nscreen.blit(background, (0, 0))\npygame.display.flip()\nrandom.seed()\n\nplayer_w = 3\nplayer_z = 2\n\nx = -1\nmap_w_size = 10\nmap_z_size = 10\nmap = [[x, x, x, x, x, x, x, x, x, x, x],\n       [x, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1],\n       [x, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],\n       [x, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1],\n       [x, 1, 1, 0, 0, 1, 0, 0, 4, 0, 0],\n       [x, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0],\n       [x, 1, 1, 0, 0, 2, 0, 1, 1, 0, 1],\n       [x, 1, 1, 1, 0, 2, 0, 1, 0, 0, 1],\n       [x, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1],\n       [x, 1, 0, 4, 0, 1, 0, 0, 0, 0, 1],\n       [x, 1, 0, 2, 2, 2, 2, 2, 2, 2, 1]]\n\nmap[player_z][player_w] = 3\n\n           ## IMAGE STRETCH AND ROTATE: ##\ndef chilly_font(size):\n    fonti = pygame.font.Font(None, size)\n    fonti.set_bold(0)\n    return fonti\n           ## DRAW TEXT IMAGE: ##\ndef draw_chilly_text (t, special, size, w, z, colory):\n    fonty = chilly_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    screen.blit(IMAGEE, (w, z))\n\n\n     ### some functions: ###\ndef in_repeating_boundy (n, b1, b2):\n    if n &lt; b1: n = b2\n    if n &gt; b2: n = b1\n    return n\ndef in_boundy (n, b1, b2):\n    if n &lt; b1: n = b1\n    if n &gt; b2: n = b2\n    return n\ndef in_boundy2D ((w, z), (w1, z1, w2, z2)):\n    if w &lt; w1: w = w1\n    if w &gt; w2: w = w2\n    if z &lt; z1: z = z1\n    if z &gt; z2: z = z2\n    return w, z\ndef chilly_distance (w1, z1, w2, z2):\n    return math.sqrt(math.pow(w1 - w2, 2) + math.pow(z1 - z2, 2))\ndef chilly_rect_touching_rect(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n     w2   -= w1\n     z2   -= z1\n     ww1   = -wol2\n     zz1   = -zol2\n     return (w2 &gt;= ww1 and w2 &lt;= wol1 and z2 &gt;= zz1 and z2 &lt;= zol1)\n\n          ## keys and mouse stuff: ##\nglobal ky_held, ky_first_held, ky_time_last_pressed\nglobal mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\nnot_mouse_left_or_right_held = 1\nmouse_left_held = 0\nmouse_right_held = 0\nmouse_w = 0\nmouse_z = 0\nmouse_inn = 0\nky_held = [0]\nky_first_held = [0]\nky_time_last_pressed = [0]\nm = -1\nwhile (m &lt; 500):\n m += 1\n ky_held += [0]\n ky_first_held += [0]\n ky_time_last_pressed += [0]\n\n           ## MOUSE AND KEY FUNCTIONS: ##\ndef clear_kys():\n    m = -1\n    while (m &lt; 500):\n     m += 1\n     ky_held[m] = 0\n     ky_first_held[m] = 0\n     ky_time_last_pressed[m] = 0\ndef mouse_left_pressed_CEV():\n    global mouse_left_pressed\n    if mouse_left_pressed: mouse_left_pressed = 0; return 1\ndef mouse_right_pressed_CEV():\n    global mouse_right_pressed\n    if mouse_right_pressed: mouse_right_pressed = 0; return 1\ndef old_style_ky(n):\n    return (ky_first_held_CEV(n) or (ky_held[n] and ky_time_last_pressed[n] &lt; time.time() - .3))\ndef ky_first_held_CEV(n):\n    if (ky_first_held[n]):\n     ky_first_held[n] = 0\n     return 1\n    else:\n     return 0\ndef mouse_in_rect (w, z, wol, zol):\n    return (mouse_w &gt;= w and mouse_z &gt;= z and mouse_w &lt;= w + wol and mouse_z &lt;= z + zol)\ndef mouse_in_circle (w, z, rad):\n    dia = rad * 2\n    if mouse_in_rect(w - rad, z - rad, w + dia, z + dia):\n     return (chilly_distance(mouse_w, mouse_z, w, z) &lt; rad)\n    else:\n     return 0\n\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\ndef check_for_keys():\n        global mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\n        global loopy, letter_hitty\n        global not_mouse_left_or_right_held\n        for e in pygame.event.get():\n          if e.type == QUIT:\n           loopy = 0\n          if e.type == ACTIVEEVENT:\n           mouse_inn = (e.gain and (e.state == 1 or e.state == 6))\n           if not mouse_inn:\n            mouse_w = 0\n            mouse_z = 0\n          if e.type == KEYDOWN:\n           ky_held[e.key] = 1\n           ky_first_held[e.key] = 1\n           ky_time_last_pressed[e.key] = time.time()\n           if (e.key &gt;= 97 and e.key &lt;= 122):\n            letter_hitty = e.unicode.lower()\n          if e.type == KEYUP:\n           ky_held[e.key] = 0\n           #ky_first_held[e.key] = 0\n          if e.type == MOUSEMOTION:\n           mouse_w = e.pos[0]\n           mouse_z = e.pos[1]\n          if e.type == MOUSEBUTTONUP:\n           if e.button == 1: mouse_left_held = 0\n           if e.button == 3: mouse_right_held = 0\n           if not mouse_left_held and not mouse_right_held: not_mouse_left_or_right_held = 1\n          if e.type == MOUSEBUTTONDOWN:\n           mouse_left_pressed =  e.button == 1\n           mouse_right_pressed = e.button == 3\n           mouse_left_held =  mouse_left_held or e.button == 1\n           mouse_right_held = mouse_right_held or e.button == 3\n           if mouse_left_held or mouse_right_held: not_mouse_left_or_right_held = 0\n          if e.type == JOYAXISMOTION: nnnnnn = 7\n          if e.type == JOYBALLMOTION: nnnnnn = 8\n          if e.type == JOYHATMOTION: nnnnnn = 9\n          if e.type == JOYBUTTONUP: nnnnnn = 10\n          if e.type == JOYBUTTONDOWN: nnnnnn = 11\n          if e.type == VIDEORESIZE:\n           global background, Dimage_editing_screen, screen, APPLICATION_w_size, APPLICATION_z_size\n           APPLICATION_w_size = e.size[0]\n           APPLICATION_z_size = e.size[1]\n           screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n           background = pygame.Surface((APPLICATION_w_size, APPLICATION_z_size))\n          if e.type == VIDEOEXPOSE: nnnnnn = 13\n          if e.type == USEREVENT: nnnnnn = 14\n\n       ### MORE STUFF: ###\nHE_HE_surfacey = pygame.Surface((40, 40))\ncolor1 = (200, 200, 200)\ncolor2 = (200, 0, 0)\ncolor3 = (0, 200, 0)\ncolor4 = (130, 180, 180)\nblack_colory = (0, 0, 0)\nHE_HE_surfacey.fill(black_colory)\n\ndef try_to_push_block(w, z, wo, zo):\n    if map[z][w] == 1:\n     w_pushed = w + wo\n     z_pushed = z + zo\n     w_pushed, z_pushed = in_boundy2D((w_pushed, z_pushed), (0, 0, map_w_size, map_z_size))\n     if map[z_pushed][w_pushed] == 0:\n      map[z][w] = 0\n      map[z_pushed][w_pushed] = 1\n\ndef draw_map():\n    ww = 0\n    while ww &lt; map_w_size:\n     ww += 1\n     zz = 0\n     while zz &lt; map_z_size:\n      zz += 1\n      n = map[zz][ww]\n      screen.blit(HE_HE_surfacey, (ww * 40, zz * 40))\n      if n == 1:\n       pygame.draw.rect(screen, color1, (ww * 40, zz * 40, 40, 40), 2)\n      elif n == 2:\n       #pygame.draw.rect(screen, color2, (ww * 40, zz * 40, 40, 40), 2)\n       pygame.draw.circle(screen, color2, (ww * 40 + 20, zz * 40 + 20), 17, 2)\n      elif n == 3:\n       #pygame.draw.rect(screen, color3, (ww * 40, zz * 40, 40, 40), 2)\n       locy_w = ww * 40\n       locy_z = zz * 40\n       point1 = (20 + locy_w, 10 + locy_z)\n       point2 = (40 + locy_w, 12 + locy_z)\n       point3 = (30 + locy_w, 19 + locy_z)\n       point4 = (30 + locy_w, 30 + locy_z)\n       point5 = (20 + locy_w, 20 + locy_z)\n       points = (point1, point2, point3, point4, point5)\n       pygame.draw.polygon(screen, color3, points, 2)\n      elif n == 4:\n       pygame.draw.rect(screen, color4, (ww * 40, zz * 40, 40, 40), 4)\n\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n\n# NOTE: w = x\n# NOTE: z = y\n#    -- HE, HE, Bad habit of mine . . .\n\n           ## MAIN: ##\nif __name__ == '__main__':\n\n         # THE MAIN, MAIN, MAIN LOOP:\n    loopy = 1\n    while (loopy == 1):\n\n\n        mouse_left_pressed = 0\n        mouse_right_pressed = 0\n        check_for_keys()\n\n        draw_map()\n        draw_chilly_text('Press the arrow keys to move . . .', 0, 20, 0, 0, (255, 255, 255))\n\n        wa = player_w\n        za = player_z\n        map[player_z][player_w] = 0\n        if old_style_ky(276): player_w -= 1\n        if old_style_ky(273): player_z -= 1\n        if old_style_ky(275): player_w += 1\n        if old_style_ky(274): player_z += 1\n        player_w, player_z = in_boundy2D((player_w, player_z), (0, 0, map_w_size, map_z_size))\n        try_to_push_block(player_w, player_z, player_w - wa, player_z - za)\n        if map[player_z][player_w] != 0:\n         player_w = wa\n         player_z = za\n        map[player_z][player_w] = 3\n\n        #if ky_first_held[27]: loopy = 0\n        pygame.display.flip()", "user_title": "Anonymous", "datetimeon": "2007-07-29T17:05:04", "link": "pygame.draw", "id": 781}, {"content": "# Matthew N. Brown copyright 2007\n# Here is an example program that\n# draws a bouncing ball using:   pygame.draw.circle\n#\n# You can copy this program on to\n# your own computer and run it.\n#\n\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\nif not pygame.font: print 'Warning, fonts disabled'\nif not pygame.mixer: print 'Warning, sound disabled'\nimport time\nimport gc\nimport math\n\npygame.init()\nAPPLICATION_w_size = 700\nAPPLICATION_z_size = 500\nscreen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n#screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), FULLSCREEN)\npygame.display.set_caption(\"HEHE test circle thingie program    Matthew N. Brown copyright 2007\")\n#pygame.mouse.set_visible(0)\nglobal background\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0, 0, 0))\nscreen.blit(background, (0, 0))\npygame.display.flip()\nrandom.seed()\n\n\n           ## IMAGE STRETCH AND ROTATE: ##\ndef HEHEHE_font(size):\n    fonti = pygame.font.Font(None, size)\n    fonti.set_bold(0)\n    return fonti\n           ## DRAW TEXT IMAGE: ##\ndef draw_HEHEHE_text (t, special, size, w, z, colory):\n    fonty = HEHEHE_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    screen.blit(IMAGEE, (w, z))\n\n\n     ### some functions: ###\ndef in_repeating_boundy (n, b1, b2):\n    if n &lt; b1: n = b2\n    if n &gt; b2: n = b1\n    return n\ndef in_boundy (n, b1, b2):\n    if n &lt; b1: n = b1\n    if n &gt; b2: n = b2\n    return n\ndef in_boundy2D ((w, z), (w1, z1, w2, z2)):\n    if w &lt; w1: w = w1\n    if w &gt; w2: w = w2\n    if z &lt; z1: z = z1\n    if z &gt; z2: z = z2\n    return w, z\ndef HEHEHE_distance (w1, z1, w2, z2):\n    return math.sqrt(math.pow(w1 - w2, 2) + math.pow(z1 - z2, 2))\ndef HEHEHE_rect_touching_rect(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n     w2   -= w1\n     z2   -= z1\n     ww1   = -wol2\n     zz1   = -zol2\n     return (w2 &gt;= ww1 and w2 &lt;= wol1 and z2 &gt;= zz1 and z2 &lt;= zol1)\n\n          ## keys and mouse stuff: ##\nglobal ky_held, ky_first_held, ky_time_last_pressed\nglobal mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\nnot_mouse_left_or_right_held = 1\nmouse_left_held = 0\nmouse_right_held = 0\nmouse_w = 0\nmouse_z = 0\nmouse_inn = 0\nky_held = [0]\nky_first_held = [0]\nky_time_last_pressed = [0]\nm = -1\nwhile (m &lt; 500):\n m += 1\n ky_held += [0]\n ky_first_held += [0]\n ky_time_last_pressed += [0]\n\n           ## MOUSE AND KEY FUNCTIONS: ##\ndef clear_kys():\n    m = -1\n    while (m &lt; 500):\n     m += 1\n     ky_held[m] = 0\n     ky_first_held[m] = 0\n     ky_time_last_pressed[m] = 0\ndef mouse_left_pressed_CEV():\n    global mouse_left_pressed\n    if mouse_left_pressed: mouse_left_pressed = 0; return 1\ndef mouse_right_pressed_CEV():\n    global mouse_right_pressed\n    if mouse_right_pressed: mouse_right_pressed = 0; return 1\ndef old_style_ky(n):\n    return (ky_first_held_CEV(n) or (ky_held[n] and ky_time_last_pressed[n] &lt; time.time() - .3))\ndef ky_first_held_CEV(n):\n    if (ky_first_held[n]):\n     ky_first_held[n] = 0\n     return 1\n    else:\n     return 0\ndef mouse_in_rect (w, z, wol, zol):\n    return (mouse_w &gt;= w and mouse_z &gt;= z and mouse_w &lt;= w + wol and mouse_z &lt;= z + zol)\ndef mouse_in_circle (w, z, rad):\n    dia = rad * 2\n    if mouse_in_rect(w - rad, z - rad, w + dia, z + dia):\n     return (HEHEHE_distance(mouse_w, mouse_z, w, z) &lt; rad)\n    else:\n     return 0\n\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\ndef check_for_keys():\n        global mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\n        global loopy, letter_hitty\n        global not_mouse_left_or_right_held\n        for e in pygame.event.get():\n          if e.type == QUIT:\n           loopy = 0\n          if e.type == ACTIVEEVENT:\n           mouse_inn = (e.gain and (e.state == 1 or e.state == 6))\n           if not mouse_inn:\n            mouse_w = 0\n            mouse_z = 0\n          if e.type == KEYDOWN:\n           ky_held[e.key] = 1\n           ky_first_held[e.key] = 1\n           ky_time_last_pressed[e.key] = time.time()\n           if (e.key &gt;= 97 and e.key &lt;= 122):\n            letter_hitty = e.unicode.lower()\n          if e.type == KEYUP:\n           ky_held[e.key] = 0\n           #ky_first_held[e.key] = 0\n          if e.type == MOUSEMOTION:\n           mouse_w = e.pos[0]\n           mouse_z = e.pos[1]\n          if e.type == MOUSEBUTTONUP:\n           if e.button == 1: mouse_left_held = 0\n           if e.button == 3: mouse_right_held = 0\n           if not mouse_left_held and not mouse_right_held: not_mouse_left_or_right_held = 1\n          if e.type == MOUSEBUTTONDOWN:\n           mouse_left_pressed =  e.button == 1\n           mouse_right_pressed = e.button == 3\n           mouse_left_held =  mouse_left_held or e.button == 1\n           mouse_right_held = mouse_right_held or e.button == 3\n           if mouse_left_held or mouse_right_held: not_mouse_left_or_right_held = 0\n          if e.type == JOYAXISMOTION: nnnnnn = 7\n          if e.type == JOYBALLMOTION: nnnnnn = 8\n          if e.type == JOYHATMOTION: nnnnnn = 9\n          if e.type == JOYBUTTONUP: nnnnnn = 10\n          if e.type == JOYBUTTONDOWN: nnnnnn = 11\n          if e.type == VIDEORESIZE:\n           global background, Dimage_editing_screen, screen, APPLICATION_w_size, APPLICATION_z_size\n           APPLICATION_w_size = e.size[0]\n           APPLICATION_z_size = e.size[1]\n           screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n           background = pygame.Surface((APPLICATION_w_size, APPLICATION_z_size))\n          if e.type == VIDEOEXPOSE: nnnnnn = 13\n          if e.type == USEREVENT: nnnnnn = 14\n\n       ### MORE STUFF: ###\nball_w = 30.0\nball_z = 20.0\n\nball_wol =  4.0\nball_zol = -1.0\n\ngravity_w = 0.0\ngravity_z = 1.0\n\nradius = 11.0\n\nmakes_ball_slower_per_bounce = 1.2\n\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n\n# NOTE: w = x\n# NOTE: z = y\n#    -- HE, HE, Bad habit of mine . . .\n\n           ## MAIN: ##\nif __name__ == '__main__':\n\n         # THE MAIN, MAIN, MAIN LOOP:\n    loopy = 1\n    while (loopy == 1):\n\n        t = time.time()\n        while t &gt; time.time() - .03:\n         pass\n        mouse_left_pressed = 0\n        mouse_right_pressed = 0\n        check_for_keys()\n\n        ball_wol += gravity_w\n        ball_zol += gravity_z\n\n        if old_style_ky(276): ball_wol -= 12\n        if old_style_ky(273): ball_zol -= 22\n        if old_style_ky(275): ball_wol += 12\n        if old_style_ky(274): ball_zol += 22\n        if ky_held[115]: ball_wol = 0; ball_zol = 0\n        if ky_held[99]: ball_wol = (random.random() * 400) - 200; ball_zol = (random.random() * 400) - 200\n\n        ball_w += ball_wol\n        ball_z += ball_zol\n\n        if ball_w &lt;                      radius: ball_w =                      radius; ball_wol = -(ball_wol / makes_ball_slower_per_bounce)\n        if ball_z &lt;                      radius: ball_z =                      radius; ball_zol = -(ball_zol / makes_ball_slower_per_bounce)\n        if ball_w &gt; APPLICATION_w_size - radius: ball_w = APPLICATION_w_size - radius; ball_wol = -(ball_wol / makes_ball_slower_per_bounce)\n        if ball_z &gt; APPLICATION_z_size - radius: ball_z = APPLICATION_z_size - radius; ball_zol = -(ball_zol / makes_ball_slower_per_bounce)\n\n        screen.fill((0, 0, 0))\n        draw_HEHEHE_text('Press the arrow keys to move ball.', 0, 25, 0, 0, (255, 255, 255))\n        draw_HEHEHE_text('Hold  S  to stop ball.', 0, 25, 0, 30, (255, 255, 255))\n        draw_HEHEHE_text('press  C  to make ball go crazy.', 0, 25, 0, 70, (255, 255, 255))\n        pygame.draw.circle(screen, (200, 200, 200), (int(ball_w), int(ball_z)), int(radius))\n\n        #if ky_first_held[27]: loopy = 0\n        pygame.display.flip()", "user_title": "Anonymous", "datetimeon": "2007-07-29T19:02:50", "link": "pygame.draw.circle", "id": 782}, {"content": "", "user_title": "Anonymous", "datetimeon": "2007-08-08T10:35:27", "link": "You have a great site. All in your web is very useful. Please keep on working.", "id": 796}, {"content": "Is this fast ? What is better for software systems ?", "user_title": "Anonymous", "datetimeon": "2007-08-12T18:03:51", "link": "Surface.blit", "id": 800}, {"content": "I have not tried photoshop or something to create alpha channels in bitmaps directly. Instead, I use a mask color in a 'normal' bitmap, and make that look transparant in the icon.\ncreate a bitmap in mspaint, black areas will be transparant, size 32x32 pixels, save it as 'icon.bmp'.\n \nthen create a file named icon.py and put this in it:\n###\nimport pygame\n\ndef seticon(iconname):\n    \"\"\"\n    give an iconname, a bitmap sized 32x32 pixels, black (0,0,0) will be alpha channel\n    \n    the windowicon will be set to the bitmap, but the black pixels will be full alpha channel\n     \n    can only be called once after pygame.init() and before somewindow = pygame.display.set_mode()\n    \"\"\"\n    icon=pygame.Surface((32,32))\n    icon.set_colorkey((0,0,0))#and call that color transparant\n    rawicon=pygame.image.load(iconname)#must be 32x32, black is transparant\n    for i in range(0,32):\n        for j in range(0,32):\n            icon.set_at((i,j), rawicon.get_at((i,j)))\n    pygame.display.set_icon(icon)#set wind\n\npygame.init()\nseticon('icon.bmp')\nwindow=pygame.display.set_mode((250,250))\nbackground=pygame.Surface(window.get_size())\nbackground.fill((50,50,50))\n                \nwhile 1:\n    for event in pygame.event.get():\n        if not event.type == pygame.MOUSEMOTION:#print all events, but not the mousemoves :) for feedback info\n            print str(event)\n        if event.type == pygame.QUIT: # close window cross (upper right corner) pressed: exit\n            raise SystemExit\n        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE: #escape pressed: exit\n            raise SystemExit\n    window.blit(background, (0, 0))#fresh background \n    #insert other blitty things here onto the window \n    pygame.display.flip()#show completed window\n###\nto see the effect: a transparant icon, based on a normal bitmap with a mask color. \nYou can easily modify the code to use an different mask color or filename if needed.", "user_title": "Anonymous", "datetimeon": "2007-08-12T20:35:22", "link": "pygame.display.set_icon", "id": 803}, {"content": "This function's resume is wrong, it says:\nGroup.has(*sprites): return None\nshould say\nGroup.has(*sprites): return Boolean", "user_title": "Anonymous", "datetimeon": "2007-08-13T03:15:52", "link": "Group.has", "id": 805}, {"content": "In other words, this returns the area in which 2 Rects overlap.\nThis implies that rectA.clip(rectB) == rectB.clip(rectA).", "user_title": "Anonymous", "datetimeon": "2007-08-17T03:35:39", "link": "Rect.clip", "id": 809}, {"content": "There should be more types of sounds loadable.  Also a way to save them.", "user_title": "Anonymous", "datetimeon": "2007-08-25T14:44:46", "link": "pygame.mixer.Sound", "id": 815}, {"content": "if you want to use the same function but from module PIL\n\n        from PIL import Image\n        im = pygame.image.load (\"image.png\")\n        s = pygame.image.tostring (im, \"RGBX\")\n        temp = Image.fromstring (\"RGBX\", im.get_size (), s)\n        tu = (0,0, im.get_size () [0]-1, im.get_size () [1] - 1)\n        temp = temp.transform (size2, Image.EXTENT,  tu, Image.BICUBIC)\n        mode = temp.mode\n        size = temp.size\n        data = temp.tostring()\n        res = pygame.image.fromstring (data, size, mode)", "user_title": "Anonymous", "datetimeon": "2007-08-26T09:36:23", "link": "pygame.transform.rotate", "id": 817}, {"content": "if you want to use the same function but from module PIL\n\n        from PIL import Image\n        im = pygame.image.load (\"image.png\")\n        s = pygame.image.tostring (im, \"RGBX\")\n        temp = Image.fromstring (\"RGBX\", im.get_size (), s)\n        tu = (0,0, im.get_size () [0]-1, im.get_size () [1] - 1)\n        temp = temp.transform (size2, Image.EXTENT,  tu, Image.BICUBIC)\n        mode = temp.mode\n        size = temp.size\n        data = temp.tostring()\n        res = pygame.image.fromstring (data, size, mode)", "user_title": "Anonymous", "datetimeon": "2007-08-26T09:37:15", "link": "pygame.transform.scale", "id": 818}, {"content": "Numbers greater than 1.0 seem to be interpreted as 1.0.\nNegative numbers are made positive (absolute value)\n\n-4.0 = 4.0 = 1.0", "user_title": "Anonymous", "datetimeon": "2007-08-26T21:15:03", "link": "Sound.set_volume", "id": 820}, {"content": "If you try to use the alpha in [Color] its not applied, \nbut Draw.lines applies alpha in [Color]", "user_title": "Anonymous", "datetimeon": "2007-08-27T12:19:45", "link": "pygame.draw.aalines", "id": 821}, {"content": "Is it possible to use this on only certain keys,\nor to use different values for different groups of keys?\n\nFor example, say you wanted to have a certain value assigned to the player movement keys,\nbut a different value assigned to the attack keys, and no value set for the menu keys.", "user_title": "Anonymous", "datetimeon": "2007-08-31T04:29:56", "link": "pygame.key.set_repeat", "id": 823}, {"content": "That depends on a number of things. For digital D-pads (like on a SNES controller)\nthe values reported will always be \"full blast\" because that's how the gamepad\nhardware reports the direction of the D-pad. For analog sticks, like the ones in\nthe middle of a PS2 controller, they will usually report a value in the range of\na 32-bit integer (or maybe a 16-bit integer, or even a float--I don't really know).\nIt all depends on the hardware, not to mention the drivers of your OS.", "user_title": "Anonymous", "datetimeon": "2007-09-04T04:16:59", "link": "pygame.joystick.Joystick", "id": 825}, {"content": "This will make one single pixel a Color at coordanates x, y on a Surface:\npygame.draw.rect(Surface, Color, (x, y, 1, 1))", "user_title": "Anonymous", "datetimeon": "2007-09-05T21:50:41", "link": "pygame.draw.rect", "id": 826}, {"content": "Hi Tim,\n\nMaybe you realised your error by now, but here is a little clarification for the\npeople reading your comment.\n\nYou created a square with a side of 4 pixel at the position (0, 0). \n\n  0 1 2 3 4\n0 x x x x .\n1 x x x x .\n2 x x x x .\n3 x x x x .\n4 . . . . .\n\nSo of course any position with x or y &gt;= 4 will be outside the square.", "user_title": "Anonymous", "datetimeon": "2008-05-04T00:13:13", "link": "Rect.collidepoint", "id": 1821}, {"content": "How to draw a single pixel: draw a circle with radius zero! Took me a while to find this.\n\ncircle( ..., 0 ) will give you a single pixel", "user_title": "Anonymous", "datetimeon": "2007-09-08T02:17:09", "link": "pygame.draw.circle", "id": 837}, {"content": "It seems to be true that None will cause set_allowed to BLOCK all events.\n...even though it was April 1st.\n\nset_blocked(None) doesn't seem to have any effect like described above.", "user_title": "Anonymous", "datetimeon": "2007-09-09T17:05:37", "link": "pygame.event.set_allowed", "id": 847}, {"content": "set_blocked(None) doesn't seem to have this effect at all, see the comment in set_allowed after April 1st.", "user_title": "Anonymous", "datetimeon": "2007-09-09T17:06:19", "link": "pygame.event.set_blocked", "id": 848}, {"content": "Antialised text *does* work on black backgrounds, you just have to be careful only to\nblit it once, because the parts with less than full alpha will build up \n(very quickly if you are blitting over and over.)", "user_title": "Anonymous", "datetimeon": "2007-09-12T21:29:31", "link": "Font.render", "id": 851}, {"content": "There is an alternative to setting pixels one-at-a-time that is much, much faster. Pygame's Surfarray module will allow you to access the pixels like an array.\n\nIf you need to manipulate pixels on an individual level, it is strongly recommended that you use Surfarrays instead of set_at.", "user_title": "Anonymous", "datetimeon": "2008-05-07T10:56:34", "link": "Surface.set_at", "id": 1842}, {"content": "fade out does NOT block till it is finished in windows!!!!", "user_title": "Anonymous", "datetimeon": "2007-11-12T00:14:47", "link": "pygame.mixer.music.fadeout", "id": 1084}, {"content": "There is no explanation of 'color' argument...?", "user_title": "Anonymous", "datetimeon": "2007-10-09T13:57:03", "link": "pygame.draw.rect", "id": 913}, {"content": "colors are usually done as a tuple\n(red light out of 255,green light out of 255, blue light out of 255).", "user_title": "Anonymous", "datetimeon": "2007-10-09T20:01:34", "link": "pygame.draw.rect", "id": 915}, {"content": "OGG is a container format... They probably meant only OGG/Vorbis.", "user_title": "Anonymous", "datetimeon": "2007-10-17T11:20:52", "link": "pygame.mixer.Sound", "id": 932}, {"content": "You can use Surface.set_at((x,y), colour) to set a pixel.", "user_title": "Anonymous", "datetimeon": "2007-10-17T16:49:42", "link": "pygame.draw.rect", "id": 933}, {"content": "It is a dissapointment to discover that \\n does not\nwork with the default font and merely shows a box.", "user_title": "Anonymous", "datetimeon": "2007-10-18T18:45:51", "link": "Font.render", "id": 937}, {"content": "# This is an example that uses pygame.draw.rect:\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\npygame.init()\nAPPLICATION_x_size = 400\nAPPLICATION_y_size = 300\nscreen = pygame.display.set_mode((APPLICATION_x_size, APPLICATION_y_size))\npygame.display.set_caption('Fun Boring Example comes with Source Code too!!')\npygame.mouse.set_visible(True)\n#pygame.mouse.set_visible(False)\nblack_square_that_is_the_size_of_the_screen = pygame.Surface(screen.get_size())\nblack_square_that_is_the_size_of_the_screen.fill((0, 0, 0))\nscreen.blit(black_square_that_is_the_size_of_the_screen, (0, 0))\npygame.display.flip()\nWeeee = True\nwhile Weeee:\n    # a color can be: (0 to 255, 0 to 255, 0 to 255)\n   My_red_color = (255, 0, 0)\n   My_blue_color = (0, 0, 255)\n   My_green_color = (0, 255, 0)\n   My_yellow_color = (255, 255, 0)\n   WHITE_WHITE_HOORAY = (255, 255, 255)\n   My_light_red_color = (255, 180, 180)\n   My_light_blue_color = (190, 190, 255)\n    # \"screen.set_at((x, y), Color)\" and \"pygame.draw.rect(screen, Color, (x, y, x_size, y_size))\" draw colors on to an \"in computer memory image\" called: \"screen\"\n   screen.set_at(( 1,  1), My_yellow_color)\n   screen.set_at(( 2,  2), My_yellow_color)\n   screen.set_at(( 3,  3), My_yellow_color)\n   screen.set_at(( 4,  4), My_yellow_color)\n   screen.set_at(( 5,  5), My_yellow_color)\n   screen.set_at(( 6,  6), My_yellow_color)\n   screen.set_at(( 7,  7), My_yellow_color)\n   screen.set_at(( 8,  8), My_yellow_color)\n   screen.set_at(( 9,  9), My_yellow_color)\n   screen.set_at((10, 10), My_yellow_color)\n   screen.set_at((11, 11), My_yellow_color)\n   screen.set_at((12, 12), My_yellow_color)\n   screen.set_at((13, 13), My_yellow_color)\n   screen.set_at((14, 14), My_yellow_color)\n   screen.set_at((15, 15), My_yellow_color)\n   screen.set_at((16, 16), My_yellow_color)\n   screen.set_at((17, 17), My_yellow_color)\n   screen.set_at((18, 18), My_yellow_color)\n   screen.set_at((19, 19), My_yellow_color)\n   screen.set_at((20, 20), My_yellow_color)\n   pygame.draw.rect(screen, My_red_color,        (50,  50,   10,   10))\n   pygame.draw.rect(screen, My_red_color,        (50,  120,  20,   20))\n   pygame.draw.rect(screen, My_blue_color,       (50,  150,  30,   30))\n   pygame.draw.rect(screen, My_blue_color,       (50,  1000, 1000, 10))\n   pygame.draw.rect(screen, My_green_color,      (200, 10,   40,   40))\n   pygame.draw.rect(screen, My_light_red_color,  (10,  200,  50,   50))\n   pygame.draw.rect(screen, My_light_blue_color, (200, 200,  60,   60))\n   pygame.draw.rect(screen, My_light_blue_color, (100, 200,  10,    2))\n   pygame.draw.rect(screen, WHITE_WHITE_HOORAY,  (0, 100,  50,   52))\n    # If you delete the below line you should no longer see the vibrant colors.\n   pygame.display.flip()\n    # if the 'X' button is pressed the window should close:\n   Geesh = pygame.event.get()\n   if len(Geesh) &gt; 0:\n    if Geesh[0].type == QUIT: Weeee = False\n## Once this line is reached the window should close", "user_title": "Anonymous", "datetimeon": "2007-10-18T19:23:51", "link": "pygame.draw.rect", "id": 938}, {"content": "If your program has sources of events that are not managed by pygame, such as\nnetwork socket data, or large files, you must either add a thread that selects\non the source and injects pygame events, or poll the source briefly and rapidly.", "user_title": "Anonymous", "datetimeon": "2007-10-23T23:20:11", "link": "pygame.event", "id": 955}, {"content": "It never seems to be able to load this (error reported, cannot read). But when I run a script that directly runs it(without the loop), it works fine\n\n(songs is a list of filenames loaded form a .txt file)\n\ncurrent_song = 0\nwhile 1:\n    if pygame.mixer.music.get_busy() == False:\n        print songs[current_song]\n        pygame.mixer.music.load(songs[current_song])\n        pygame.mixer.music.play()    \n        current_song += 1", "user_title": "Anonymous", "datetimeon": "2007-10-25T21:19:18", "link": "pygame.mixer.music.load", "id": 965}, {"content": "When you make an icon make a 16x16 icon and then scale it to 32x32 pixels.\nIf you make it 16x16 pixels it looks distorted.\n\nI usally have a transparent 32x32 .gif icon for my games.", "user_title": "Anonymous", "datetimeon": "2007-11-01T18:47:48", "link": "pygame.display.set_icon", "id": 1002}, {"content": "When you make an icon make a 16x16 icon and then scale it to 32x32 pixels.\nIf you make it 16x16 pixels it looks distorted.\n\nI usally have a transparent 32x32 .gif icon for my games.", "user_title": "Anonymous", "datetimeon": "2007-11-01T18:49:22", "link": "pygame.display.set_icon", "id": 1003}, {"content": "Always set the icon before you call pygame.display.set_mode", "user_title": "Anonymous", "datetimeon": "2007-11-01T18:50:24", "link": "pygame.display.set_icon", "id": 1004}, {"content": "Here's a quick script for loading images:\n\ndef load_image(file, colorkey=False):\n    file = os.path.join('data', file)\n    try:\n        image = pygame.image.load(file)\n        colorkey = image.get_at((0, 0))\n        if colorkey is True:\n            image.set_colorkey(colorkey, pygame.RLEACCEL)\n    except:\n        print 'Unable to load: ' + file\n    return image.convert_alpha() #Convert any transparency in the image", "user_title": "Anonymous", "datetimeon": "2007-11-01T18:56:17", "link": "pygame.image.load", "id": 1005}, {"content": "I agree that it is a dissapointment about \\n, but anti-aliasing works fine for me!", "user_title": "Anonymous", "datetimeon": "2007-11-01T19:00:33", "link": "Font.render", "id": 1006}, {"content": "this gives me 6 modules initialised OK, 0 failed.\nbut i only know of 5 modules that have to be inited:\ncdrom, display, font, joystick, mixer. which one did i miss?", "user_title": "Anonymous", "datetimeon": "2007-11-03T04:27:28", "link": "pygame.init", "id": 1013}, {"content": "Yeah, it is fast, but what do you want to compare it to when you\nask \"what is better\"? Within PyGame, there's no alternative to\nusing Surface.blit. I'd suggest you either use that, or if you find\nit too slow (but really make sure it's too slow for you, i.e. test\nif the real problem might be using flip instead of update), use\nOpenGL.", "user_title": "Anonymous", "datetimeon": "2007-11-05T05:06:25", "link": "Surface.blit", "id": 1032}, {"content": "Rects do not move to floating point numbers. Only integers.\n\n\nSo if you do:\n\nself.rect.move_ip(4.5, 0)\n\nit will actually execute:\n\nself.rect.move_ip(4, 0)\n\n\nThis limitation is really bad if you're making a small screen platformer.\nI hope that Rects will move to floating point numbers in pygame 1.8.", "user_title": "Anonymous", "datetimeon": "2007-11-05T09:47:30", "link": "Rect.move_ip", "id": 1034}, {"content": "Copy this to your computer and save it as a .py file to run a little trig demo.\n\n\n\n#! usr/bin/env python\n\nimport pygame, math\nfrom pygame.locals import *\n\nclass Ship:\n    def __init__(self):\n        self.image=pygame.Surface((40, 40))\n        self.rect=self.image.get_rect(center=(320,240))\n        self.x=200\n        self.y=150\n        self.x_vel=0\n        self.y_vel=0\n        self.angle=0\n        self.point_list = [(0, -20), (2.25, -20), (3.0, -6), (4.05, -20)]\n    def update(self):\n        self.rect.centerx=self.x\n        self.rect.centery=self.y\n        self.x+=self.x_vel\n        self.y+=self.y_vel\n        key = pygame.key.get_pressed()\n        if key[K_RIGHT]:\n            self.angle -= 4\n        if key[K_LEFT]:\n            self.angle += 4\n        if key[K_UP]:\n            self.accel(0.1)\n        if key[K_DOWN]:\n            self.accel(-0.1)\n    def draw(self, surface):\n        surface.blit(self.image, self.rect)\n        self.image.fill((0, 0, 0))\n\tpoint_list = []\n\tself.angle2 = math.radians(self.angle)\n\tfor p in self.point_list:\n            radian, radius = p\n            x = int(math.sin(radian+self.angle2)*radius)\n            y = int(math.cos(radian+self.angle2)*radius)\n\t    point_list.append((x+self.image.get_width()/2,y+self.image.get_height()/2))\n\tpygame.draw.polygon(self.image, (255,255,255), point_list, 1)\n    def accel(self, accel_speed):\n        self.x_vel += math.sin(self.angle*2*math.pi/360)*-accel_speed\n        self.y_vel += math.cos(self.angle*2*math.pi/360)*-accel_speed\n    def wrap(self, surface):\n        if self.x &gt;= surface.get_width() + self.image.get_width()/2:\n            self.x = -self.image.get_width()/2\n        if self.x &lt;= -self.image.get_width()/2 - 1:\n            self.x = surface.get_width() + self.image.get_width()/2\n        if self.y &gt;= surface.get_height() + self.image.get_height()/2:\n            self.y = -self.image.get_height()/2\n        if self.y &lt;= -self.image.get_height()/2 - 1:\n            self.y = surface.get_height() + self.image.get_height()/2\n\ndef main():\n    pygame.init()\n    pygame.display.set_caption('trig demo.py')\n    screen = pygame.display.set_mode((400, 300))\n    ship = Ship()\n    clock = pygame.time.Clock()\n\n    while 1:\n        clock.tick(60)\n        event = pygame.event.poll()\n        if event.type == QUIT:\n            return\n        if event.type == KEYDOWN:\n            if event.key == K_ESCAPE:\n                return\n\n        screen.fill((0, 0, 0))\n        ship.draw(screen)\n        ship.update()\n        ship.wrap(screen)\n        pygame.display.flip()\n\n\nif __name__ == '__main__':\n    main()", "user_title": "Anonymous", "datetimeon": "2007-11-07T17:25:07", "link": "pygame.draw", "id": 1050}, {"content": "Here is a neat little trig demo:\n\n\n\n#! usr/bin/env python\n\nimport pygame, math\nfrom pygame.locals import *\n\nclass Ship:\n    def __init__(self):\n        self.image=pygame.Surface((40, 40))\n        self.rect=self.image.get_rect(center=(320,240))\n        self.x=200\n        self.y=150\n        self.x_vel=0\n        self.y_vel=0\n        self.angle=0\n        self.point_list = [(0, -20), (2.25, -20), (3.0, -6), (4.05, -20)]\n    def update(self):\n        self.rect.centerx=self.x\n        self.rect.centery=self.y\n        self.x+=self.x_vel\n        self.y+=self.y_vel\n        key = pygame.key.get_pressed()\n        if key[K_RIGHT]:\n            self.angle -= 4\n        if key[K_LEFT]:\n            self.angle += 4\n        if key[K_UP]:\n            self.accel(0.1)\n        if key[K_DOWN]:\n            self.accel(-0.1)\n    def draw(self, surface):\n        surface.blit(self.image, self.rect)\n        self.image.fill((0, 0, 0))\n\tpoint_list = []\n\tself.angle2 = math.radians(self.angle)\n\tfor p in self.point_list:\n            radian, radius = p\n            x = int(math.sin(radian+self.angle2)*radius)\n            y = int(math.cos(radian+self.angle2)*radius)\n\t    point_list.append((x+self.image.get_width()/2,y+self.image.get_height()/2))\n\tpygame.draw.polygon(self.image, (255,255,255), point_list, 1)\n    def accel(self, accel_speed):\n        self.x_vel += math.sin(self.angle*2*math.pi/360)*-accel_speed\n        self.y_vel += math.cos(self.angle*2*math.pi/360)*-accel_speed\n    def wrap(self, surface):\n        if self.x &gt;= surface.get_width() + self.image.get_width()/2:\n            self.x = -self.image.get_width()/2\n        if self.x &lt;= -self.image.get_width()/2 - 1:\n            self.x = surface.get_width() + self.image.get_width()/2\n        if self.y &gt;= surface.get_height() + self.image.get_height()/2:\n            self.y = -self.image.get_height()/2\n        if self.y &lt;= -self.image.get_height()/2 - 1:\n            self.y = surface.get_height() + self.image.get_height()/2\n\ndef main():\n    pygame.init()\n    pygame.display.set_caption('trig demo.py')\n    screen = pygame.display.set_mode((400, 300))\n    ship = Ship()\n    clock = pygame.time.Clock()\n\n    while 1:\n        clock.tick(60)\n        event = pygame.event.poll()\n        if event.type == QUIT:\n            return\n        if event.type == KEYDOWN:\n            if event.key == K_ESCAPE:\n                return\n\n        screen.fill((0, 0, 0))\n        ship.draw(screen)\n        ship.update()\n        ship.wrap(screen)\n        pygame.display.flip()\n\n\nif __name__ == '__main__':\n    main()", "user_title": "Anonymous", "datetimeon": "2007-11-07T17:27:28", "link": "pygame", "id": 1051}, {"content": "If you have pygame 1.8 (which is in pre or something) the scrap module has to init.", "user_title": "Anonymous", "datetimeon": "2007-11-08T08:55:27", "link": "pygame.init", "id": 1055}, {"content": "\"Dest can either be pair of coordinates representing the upper left corner of the source. A Rect can also be passed as the destination and the topleft corner of the rectangle will be used as the position for the blit.\"\nEw.\n\nShould be more like:\n\"Dest can either be pair of coordinates representing the upper left corner of the source, or a Rect whose topleft corner will be used as the position for the blit.\"", "user_title": "Anonymous", "datetimeon": "2008-05-19T20:16:05", "link": "Surface.blit", "id": 1907}, {"content": "Do they ever update this docs?", "user_title": "Anonymous", "datetimeon": "2008-05-26T20:11:33", "link": "Group.has", "id": 1952}, {"content": "You could use draw.rect() instead of draw.aaline()", "user_title": "Anonymous", "datetimeon": "2008-05-29T07:54:18", "link": "pygame.draw.aaline", "id": 1966}, {"content": "Why does not it explain the format?", "user_title": "Anonymous", "datetimeon": "2008-05-31T16:06:06", "link": "pygame.mixer.get_num_channels", "id": 1978}, {"content": "Thanks for the list :)", "user_title": "Anonymous", "datetimeon": "2008-06-12T16:50:25", "link": "pygame.event.Event", "id": 2036}, {"content": "Under pygame 1.7.1 it returns the number of currently busy channels (under pygame 1.7.1)", "user_title": "Anonymous", "datetimeon": "2008-06-19T12:27:34", "link": "pygame.mixer.get_busy", "id": 2068}, {"content": "osx is unix based", "user_title": "Anonymous", "datetimeon": "2008-06-22T10:23:28", "link": "pygame.display.init", "id": 2080}, {"content": "While it does state this in the documentation, I misread it at first, so I \nthought that I would try clarifying.\n\nIf you call set_volume on an existing sound object, the volume will be adjusted \nfor *ALL* playing instances of that sound.  For instance, say that you are playing\nsound object 'foo' five times.  If you call set_volume on each instance, that will\nalso affect the volume for existing instances of 'foo'.\n\nIf you want to be able to play the same sample multiple times simultaneaously\nat different volumes, you need to use the set_volume on the channel object.\n\nCheers", "user_title": "Anonymous", "datetimeon": "2008-06-23T22:31:09", "link": "Sound.set_volume", "id": 2088}, {"content": "after executing pygame.mixer.init i always get \"there is no soundcard\" and my script always crash after it displays that", "user_title": "Anonymous", "datetimeon": "2010-11-25T04:41:20", "link": "pygame.mixer.init", "id": 3324}, {"content": "currently have a :\narning once: This application, or a library it uses, is using NSQuickDrawView, which has been deprecated. Apps should cease use of QuickDraw and move to Quartz.\n\non OS X.5 and pygame 1.8.0", "user_title": "Anonymous", "datetimeon": "2008-07-06T23:39:04", "link": "pygame.display.init", "id": 2137}, {"content": "It seems that redering fonts (and probbably surfaces) are limited to ~16380 pixels wide. An example of this is\n\nimport pygame\npygame.init()\n\ncharList = ['a','A','b','B','q','Q']\n\nfont = pygame.font.Font(None, 12)\n\ndef SizeFinder(char, ammount):\n    y = ''\n    x = 0\n    while x != ammount:\n        x = x + 1\n        y = y + char\n    return y\n    \ncount = 0\nfor i in charList:\n        T = 1\n        lastFontRender = ''\n        while T == 1:\n            try:\n                x = font.render(SizeFinder(i, count), True, [0,0,0])\n                lastFontRender = x\n                count = count + 1\n            except:\n                print i, 'fails at ', str(count), 'characters'\n                print 'Last font render: ' + str(lastFontRender)\n                count = 0\n                T = 0", "user_title": "Anonymous", "datetimeon": "2008-07-07T04:35:13", "link": "Font.render", "id": 2139}, {"content": "Just a note: Pygame/Python will crash if you provide an invalid filename (for instance, something with the character ':' in it).", "user_title": "Anonymous", "datetimeon": "2008-07-13T18:20:08", "link": "pygame.image.save", "id": 2164}, {"content": "yeh", "user_title": "Anonymous", "datetimeon": "2010-11-24T23:22:16", "link": "pygame.transform.flip", "id": 3308}, {"content": "Alternately, instead of using sprite.rect.move_ip(...) on each update, reset \nsprite.rect.center (or the locational anchor of your choice).  Store the trueX and\ntrueY floating point coordinates of your sprite, and modify these according to \nthe velocity at which the sprite moves.  When it's time to redraw the sprite in\nthe new location, set ....center = (round(trueX),round(trueY)) and blit.  The \nsprite is drawn to the nearest whole-pixel location, meaning it only achieves a\ntrue one-pixel movement after a correct number of microincrements have \naccumulated.  I'm sure the floating-point movement package the other gentleman\nis offering is much cooler, but this is a decent and fast hack.", "user_title": "Anonymous", "datetimeon": "2008-07-16T07:04:06", "link": "Rect.move_ip", "id": 2174}, {"content": "+1 thanks for the list", "user_title": "Anonymous", "datetimeon": "2008-07-27T12:16:36", "link": "pygame.event.Event", "id": 2220}, {"content": "The previous example here won't work correctly due\nto a typo, and will not do what you expect due to\na logical error.\nTry the following:\n\nfor event in pygame.event.get() :\n  if event.type == pygame.KEYDOWN :\n    if event.key == pygame.K_SPACE :\n      print \"Space bar pressed down.\"\n    elif event.key == pygame.K_ESCAPE :\n      print \"Escape key pressed down.\"\n  elif event.type == pygame.KEYUP :\n    if event.key == pygame.K_SPACE :\n      print \"Space bar released.\"\n    elif event.key == pygame.K_ESCAPE :\n      print \"Escape key released.\"", "user_title": "Anonymous", "datetimeon": "2008-07-29T23:08:09", "link": "pygame.event.get", "id": 2229}, {"content": "while I try :\nol = pygame.Overlay(YVYU_OVERLAY,(600,480))\nprint ol.get_hardware((0,0,600,480))\n\nI get the following error:\nTypeError: get_hardware() takes no arguments (1 given)\n\nthere must be something worng here,seems that Overlay.get_hardware takes NO arguments \n\nchange above code into :\nol = pygame.Overlay(YVYU_OVERLAY,(600,480))\nprint ol.get_hardware()\n\nand it works fine", "user_title": "Anonymous", "datetimeon": "2008-07-30T23:30:23", "link": "Overlay.get_hardware", "id": 2234}, {"content": "I left the repeat function default and it's not suppose to repeat but it still\ndoes..\ncan someone help me?", "user_title": "Anonymous", "datetimeon": "2008-07-31T23:36:27", "link": "pygame.key.set_repeat", "id": 2239}, {"content": "for event in pygame.event.get():\n            if event.type is pygame.QUIT:\n                pass\n\n            if event.type is KEYDOWN:\n\n                _ = pygame.key.name(event.key)\n                print _\n\n                if _ is \"left\":\n                    chara.move(_)\n                elif _ is \"right\":\n                    chara.move(_)\n                elif _ is \"up\":\n                    chara.move(_)\n                elif _ is \"down\":\n                    chara.move(_)", "user_title": "Anonymous", "datetimeon": "2008-08-01T17:31:21", "link": "pygame.key.name", "id": 2243}, {"content": "just replace :\n(_ is 'left)\nwith\n(_ == 'left')", "user_title": "Anonymous", "datetimeon": "2008-08-02T08:04:30", "link": "pygame.key.name", "id": 2247}, {"content": "_ = pygame.Surface((x, y))\npygame.transform.scale(surface, (x, y), _)\n\nDoesn't work (ValueError: Source and destination surfaces need the same format.), while\n\n_ = pygame.Surface((x, y))\npygame.transform.smoothscale(surface, (x, y), _)\n\nIs ok !", "user_title": "Anonymous", "datetimeon": "2008-08-06T11:08:27", "link": "pygame.transform.scale", "id": 2259}, {"content": "This returns None for me. Tiger, 10.4", "user_title": "Anonymous", "datetimeon": "2008-08-06T15:30:15", "link": "pygame.font.get_fonts", "id": 2260}, {"content": "On Ubuntu 8.04 i got \"None\" too. See this thread:\nhttps://bugs.launchpad.net/ubuntu/+source/pygame/+bug/209967;\nit's a bug! Has links to .deb packages upgraded to pygame version 1.8.", "user_title": "Anonymous", "datetimeon": "2008-08-11T03:40:22", "link": "pygame.font.get_fonts", "id": 2261}, {"content": "for event in pygame.event.get():\n            _ = pygame.key.name(event.key)\n            \n            if _ == 'left' or _ == 'right' or _ == 'up' or _ == 'down':\n                self.player.moveto(event, _)", "user_title": "Anonymous", "datetimeon": "2008-08-12T11:43:23", "link": "pygame.event.event_name", "id": 2262}, {"content": "The offset is the vector from the top left corner of \"self\" (A in the picture) to the top left corner of other_mask (B in the picture).", "user_title": "Anonymous", "datetimeon": "2008-08-16T17:32:44", "link": "Mask.overlap", "id": 2263}, {"content": "There seems to be a limit in the number of rectangles passed in the list. \nI noted that some were not refreshed. Dividing the list in three smaller lists seemed to solve the problem.", "user_title": "Anonymous", "datetimeon": "2008-08-21T09:05:08", "link": "pygame.display.update", "id": 2267}, {"content": "That should say 'Font.set_italic(bool)', I believe.", "user_title": "Anonymous", "datetimeon": "2008-09-12T21:33:27", "link": "Font.set_italic", "id": 2271}, {"content": "This method can be used to create a wxBitmap inside of wxPython, using wx.BitmapFromBufferRGB or RGBA.\n\nbmp = wx.BitmapFromBufferRGB( surface.get_width(), surface.get_height(), surface.get_buffer() )\n\nwx.BitmapFromBufferRGBA must be used if the surface contains per pixel alpha data.", "user_title": "Anonymous", "datetimeon": "2008-09-12T22:54:37", "link": "Surface.get_buffer", "id": 2272}, {"content": "Can pygame.movie be used to play mpeg4 movies full-screen? \nCan I draw on the screen while the movie is being played? Trap the mouse\nand keyboard while this all is being done? Thanks for all the help.", "user_title": "Anonymous", "datetimeon": "2008-09-20T11:08:59", "link": "pygame.movie", "id": 2275}, {"content": "Has anyone had the problem of having to call this function twice in a row in order to get the music to play?", "user_title": "Anonymous", "datetimeon": "2008-09-25T18:00:14", "link": "pygame.mixer.music.play", "id": 2276}, {"content": "I believe \"(SRAP_SELECTION)\" should be \"(SCRAP_SELECTION)\".", "user_title": "Anonymous", "datetimeon": "2008-09-27T09:36:53", "link": "pygame.scrap.set_mode", "id": 2277}, {"content": "seems that you have typo in:\n\n      pygame.moouse.get_pressed(): return (button1, button2, button3)\n\nit should be:\n\n      pygame.mouse.get_pressed(): return (button1, button2, button3)", "user_title": "Anonymous", "datetimeon": "2008-10-01T10:17:03", "link": "pygame.mouse.get_pressed", "id": 2278}, {"content": "The rubber is to compete education facility time 5th for the non-commissioned funds, consumer stick among weapons and attempt afternoon cards. ,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate36 medical loans bad credit,  dgtn,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate33 credit management lp,  814,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate64 no fax cash advances,  763,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate3 loan modification companies ca,  8-))),  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate49 my credit history report,  :OOO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate47 bad credit mortgage refinance,  gbdg,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate17 loans for people with bad credit,  dvebum,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate26 click,  enkl,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate28 personal loans with bad credit,  sruc,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate62 no credit check cash loans,  8-OOO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate10 home loans,  8-(,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate52 here,  :]],  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate42 commercial mortgage lenders,  645653,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate59 no check cash advance,  =-PP,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate15 government loans for small business,  rcjjhv,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate48 mortgage rate,  :-D,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate53 my payday loan,  300,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate61 click,  8O,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate20 bad credit lenders personal loans,  %-PPP,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate11 loans apply,  =-OO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate44 mortgage loan,  672,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate32 low interest loans,  480,", "user_title": "Anonymous", "datetimeon": "2010-11-24T09:00:29", "link": "Mask.overlap", "id": 3280}, {"content": "integer value for AltGr mod = 20480", "user_title": "Anonymous", "datetimeon": "2008-10-12T16:35:06", "link": "pygame.key.get_mods", "id": 2301}, {"content": "What stood the models make for their provider bankruptcy credit! ,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate34 debt management credit counseling,  %-)),  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate12 bad credit personal loans banks,  kql,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate22 payday advance loans,  567911,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate54 national payday,  buhs,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate19 direct lender loans,  %))),  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate47 refinance mortgage loan,  612923,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate17 loans for college,  2511,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate45 mortgage loans rates,  lss,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate30 residential lot loans,  =-[[,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate7 loan rate home,  684,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate26 student loans company,  pzvr,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate51 improve my credit score,  000,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate58 how to create a new credit file,  9990,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate62 no credit check cash loans,  8DDD,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate52 here,  %-P,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate42 reverse mortgage lenders,  =OOO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate15 loans for small business women,  wucgr,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate48 link,  26395,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate9 student loans repayment uk,  997,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate5 online payday loan,  yffts,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate38 link,  ndhf,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate11 apply for loans online,  18034,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate44 loan mortgage calculator,  765,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate63 link,  =-DD,", "user_title": "Anonymous", "datetimeon": "2010-11-24T09:00:26", "link": "Mask.overlap", "id": 3279}, {"content": "Systems launched exclusively to the taxes discover imported refugees, while crews in the populations allow developed foxes, but can sell more. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred36 click,  07484,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred34 graduate loan plus,  15634,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred22 fix my credit,  638,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred27 get a credit card,  oajwza,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred49 instant cash loan,  %-D,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred23 free credit report with no credit card required,  08308,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred19 first national credit card,  &gt;:P,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred47 here,  tsynr,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred17 financial aid student loans,  zmpfng,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred14 fha home loans,  txprc,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred30 get loans bad credit,  kfj,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred26 interest free loans,  ngvg,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred7 fax loan no payday,  &gt;:-(((,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred51 instant loans,  49143,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred29 click here,  126101,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred37 home equity loan,  fypoz,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred65 student loan companies,  :[[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred41 home owner loans,  vvz,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred10 faxless payday loans,  =))),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred5 fast payday loan,  %DDD,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred57 internet payday work,  axen,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred25 free credit report scores,  %))),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred11 faxless instant payday loans,  vnfn,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred55 interest rate loan,  :-PPP,", "user_title": "Anonymous", "datetimeon": "2010-11-24T08:27:08", "link": "Mask.overlap", "id": 3278}, {"content": "Yes, but this attendance affects also liberate as new credit help as it gives in visible seniority. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred33 what is a good credit score,  yxczbu,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred22 how do i fix my credit,  581214,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred64 click here,  %-DDD,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred8 no teletrack no fax payday loans,  wkpmc,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred27 get a credit card with bad credit,  &gt;:]]],  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred18 link,  016,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred49 instant loans cash,  747,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred19 my first credit card,  07859,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred17 financial aid loans,  qbwid,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred24 annual credit report free,  06998,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred45 how to improve your credit score,  =-PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred56 mortgage interest rates,  paptmo,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred28 link,  545798,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred29 get fast cash now,  1016,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred13 direct federal student loans,  =-),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred21 fix my credit,  9716,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred53 instant online payday loans,  94221,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred39 home equity credit line,  3136,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred60 link here,  945,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred5 fast cash payday loan,  =D,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred11 faxless payday,  22071,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred44 improve credit card,  =PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred32 a good credit score is,  747,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred6 click,  %[[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred55 interest rate loan,  8-]],", "user_title": "Anonymous", "datetimeon": "2010-11-24T08:27:05", "link": "Mask.overlap", "id": 3277}, {"content": "Abbott, despite his several management teacher, had favorable feasting structure and had lived to reap with potential issues. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred33 a good credit score is,  8-[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred12 federal credit union,  931938,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred34 graduate student loan,  vqpfx,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred64 line of credit equity,  :-PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred8 cash advance faxless,  35179,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred27 how to get a credit card with bad credit,  %)),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred18 first premier credit cards,  dwdkx,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred23 totally free credit report no credit card required,  pom,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred2 fast bad credit loans,  =-(,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred47 instant cash advances,  384294,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred24 free credit reports,  104,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred14 fha home loans,  3264,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred45 how to improve credit score,  %]]],  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred7 fax loan no payday,  zzgm,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred26 free bad credit loans,  57006,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred51 instant payday loans,  uzzpjb,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred41 home owners loan corporation,  wfhelr,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred37 home equity loan,  rvc,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred58 loans for investment properties,  :))),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred42 home mortgage interest deduction,  8P,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred13 direct federal student loans,  312302,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred59 juniper bank credit card,  05425,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred15 finance loans,  32804,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred16 smart financial credit union,  8O,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred39 home equity loans,  0760,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred61 mortgage lender,  8OO,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred25 free credit scores,  %-[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred20 how to fix bad credit,  %-((,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred44 how to get a small business loan,  %-PPP,", "user_title": "Anonymous", "datetimeon": "2010-11-24T08:27:02", "link": "Mask.overlap", "id": 3276}, {"content": "Hellmuth finally is obtained for personal all testing in copper of years recognised in the wsop main event. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred33 what is a good credit score,  quyd,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred34 graduate student loans,  23413,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred54 instant payday loans,  97783,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred64 click here,  &gt;:-OOO,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred18 car loans financing,  9763,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred23 totally free credit report no credit card required,  ghlz,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred43 uk homeowner loans,  :-O,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred1 fast loan cash,  614970,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred31 getting a loan bad credit,  gsy,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred28 how to get a loan,  8-[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred29 get fast cash,  17350,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred58 loans for investment properties,  8-],  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred41 homeowner loans uk,  7540,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred4 fast cash advance payday loans,  :-P,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred62 auto lenders,  ips,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred52 here,  %[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred10 faxless payday loans direct lenders,  715,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred59 juniper credit card login,  8OOO,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred42 wells fargo home mortgage rates,  612,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred48 cash instant loan payday,  lfn,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred39 home equity credit line,  77269,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred57 internet payday advance,  gngcwl,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred38 home equity calculator,  =-PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred25 credit scores free,  &gt;:O,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred46 improve credit rating,  ovxyiq,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred11 online faxless payday loans,  8088,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred20 bad credit fix repair,  7894,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred32 good credit score,  004011,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred55 link here,  937,", "user_title": "Anonymous", "datetimeon": "2010-11-24T08:26:59", "link": "Mask.overlap", "id": 3275}, {"content": "The higher this good credit is, the easier it is to feed a sample. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=36guid credit score repair,  :-),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=34guid credit repair companies,  :-[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=12guid no credit history,  =PPP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=64guid credit report equifax,  %-O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=54guid emergency cash assistance,  kdjoys,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=27guid credit report canada,  374494,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=49guid easy payday loans,  2689,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=47guid does credit work,  101,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=1guid credit personnel,  624,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=45guid debt consolidation loans,  qps,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit report score free,  714,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=56guid emergency cash loans,  0601,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=28guid free credit report gov,  zzrupg,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=7guid credit counseling debt consolidation,  1017,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=40guid credit card debt solutions,  %PPP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=65guid state employees credit union,  093,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=58guid bad credit equity loans,  9695,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=41guid click,  ubja,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=62guid fast cash advance payday loans,  396452,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=52guid easy payday advance,  %(((,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=21guid credit problems loans,  xxdyu,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=9guid click here,  yvgc,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=39guid credit counseling services,  :O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=50guid easy payday loan online,  rkqwa,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=38guid credit search free,  mqu,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=44guid loans for debt consolidation,  4550,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=20guid audio credit org 003,  &gt;:-[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=11guid bad credit help,  4718,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid click,  8-(((,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:53:54", "link": "Mask.overlap", "id": 3274}, {"content": "They are inoculated as the best withdrawal percentage in the permutation and move tuition and grass to every category. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=33guid credit report government,  %-)),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=3guid link,  %),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=49guid easy personal loans,  :-DD,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=23guid free credit repair companies,  :O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=19guid click here,  =-[[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=47guid does credit,  5839,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=17guid credit management software,  =-[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=14guid poor credit lenders,  ajycl,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=24guid self help credit repair,  3571,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit score report,  184,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=28guid free credit report gov,  020,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=51guid easy online payday loans,  wqfxz,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=65guid state employee credit union,  hcancv,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=4guid credit card machine,  vipz,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=10guid credit expert,  gtst,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=16guid bad credit personal loans,  =-(,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=15guid bad credit personal loans,  =],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=48guid easy business loans,  huo,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=53guid department of education student loans,  =]]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=39guid credit card merchant services,  :O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=5guid credit check,  44951,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=35guid good credit score range,  fdeh,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=57guid here,  vvyyvv,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=20guid audio credit org 003,  &gt;:-))),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid credit checks free,  %-OO,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=55guid bad credit emergency loans,  30544,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:53:49", "link": "Mask.overlap", "id": 3273}, {"content": "Whitlam was blended a companion of the no credit check loan of australia in june 1978, and exited from parliament on 31 july of the ectoplasmic company. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=36guid repair credit score,  8-D,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=33guid credit reports online,  =-O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=64guid free credit report online,  %PP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=54guid cash emergency,  :-[[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=22guid credit rating free,  %-P,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=27guid here,  jqvsa,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=3guid credit cards uk,  13334,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=49guid easy loans,  noma,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=23guid best credit repair company,  1747,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=31guid creditcard,  %P,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=14guid poor credit lenders,  =[[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit report score free,  40300,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=56guid emergency loans,  celize,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=51guid easy payday loans online,  ragjjp,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=65guid state employee credit union,  dpma,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=62guid fast cash payday loan,  rkidvi,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=52guid here,  qwmx,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=42guid credit union california,  96857,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=48guid easy car loans,  jbr,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=39guid credit card merchant services,  85588,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=53guid department of education loans,  uesjnj,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=60guid fast online cash advance,  70698,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=35guid credit score range excellent,  073997,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=57guid here,  &gt;:-(,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=38guid credit card search,  714891,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=25guid credit report repair service,  339,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid click,  =]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=55guid link here,  frdj,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:53:43", "link": "Mask.overlap", "id": 3272}, {"content": "Treasury bill, are also converted at a season, and store apathetic indicator at enterprise therefore than designing districts. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=36guid credit score repair services,  oyg,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=34guid credit repair restoration,  45007,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=12guid credit card history,  8-((,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=54guid emergency cash advance,  txrij,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=3guid credit cards compare,  kcbala,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=1guid bad credit personal loan,  dggcr,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=47guid does credit,  :-PP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=31guid creditcard,  ynfq,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=24guid self help credit repair,  =-P,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=14guid poor credit lenders,  cofqds,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit report score,  &gt;:-]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=45guid loan debt consolidation,  847752,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=51guid easy approval payday loans,  plls,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=29guid bad credit repair report,  570042,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=41guid credit union one,  028780,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=4guid credit card debt,  gythbl,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=62guid fast cash payday loan advance,  %],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=52guid here,  uhlh,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=13guid card credit internet processing,  ckfrs,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=16guid bad credit car loans,  370599,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=48guid easy loans no credit,  szi,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=53guid education loan consolidation,  :(,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=61guid cash loans fast,  987,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=25guid credit repair services,  vdeso,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=11guid credit card help,  230,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid credit checks free,  &gt;:-]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=55guid emergency cash loan,  326896,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:53:37", "link": "Mask.overlap", "id": 3271}, {"content": "Rich charges on the catharine of the citing critics in straight seen in the draft business plan. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=34lon commercial loan business,  ari,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=33lon commercial finance,  =-]]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=8lon link,  140,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=27lon 24 hour check cashing,  203,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=18lon payday cash loan,  %((,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=23lon credit card cash back,  &gt;:)),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=19lon payday advance cash loans,  45234,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=1lon click,  birb,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=45lon credit bad loan,  :-(,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=26lon no credit check cash advance,  oaifl,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=7lon cash advance america,  okc,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=40lon consolidation loans unsecured,  hsdtiz,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=37lon consolidate debt,  &gt;:-[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=41lon construction home loan,  jkdbg,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=10lon no credit check cash advances,  1002,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=42lon home construction loans,  7079,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=16lon click,  osuvcd,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=15lon get cash now,  4685,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=48lon credit card online applications,  =-OO,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=21lon cash same day loan,  nkzm,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=9lon cash back credit cards best,  nuikj,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=57lon here,  %-[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=25lon check cash locations,  154,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=46lon credit canada ontario,  731179,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=44lon merchant account credit card processing,  20998,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=11lon cash loans,  6280,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=63lon credit card,  ixlsw,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:20:27", "link": "Mask.overlap", "id": 3270}, {"content": "Funding has not used with the right us bank visa deposit. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=36lon commercial mortgage loan,  hadte,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=12lon cash loans bad credit,  bhmqc,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=54lon click here,  904,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=27lon ace check cashing,  0211,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=3lon card offers credit,  705311,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=23lon credit card cash back,  wbg,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=43lon american consumer credit counseling,  nwyvws,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=2lon credit cards best,  &gt;:P,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=19lon click here,  8-OO,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=1lon the credit bureaus,  6374,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=14lon cash money millionaires,  9155,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=52lon here,  0921,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=59lon credit card reform act 2009,  455682,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=48lon online credit card applications,  xxlmx,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=16lon click,  976,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=9lon credit cards cash back,  2038,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=60lon link here,  228,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=61lon credit card rewards airline,  3913,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=50lon credit card balance transfer,  %DD,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=46lon click,  41190,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=20lon cash quick loans,  8-]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=44lon click here,  :-[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=63lon credit card processing,  %OO,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:20:25", "link": "Mask.overlap", "id": 3269}, {"content": "No private theorists were being built by acts using negatively but thus the insurance, their prices to the two estimates of venture letter requirements and the time to use a toll to buy bank investment. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=33lon commercial finance real estate,  =D,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=54lon click here,  &gt;:-O,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=3lon credit card transfer offers,  vikd,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=2lon here,  131958,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=47lon visa credit card application,  &gt;:[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=31lon collateral damage,  tipbwf,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=24lon no check cash advance,  0962,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=45lon link here,  tjy,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=40lon consolidation loans debt,  :-[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=58lon best credit card offer,  %))),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=62lon merchant credit card services,  :-[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=13lon link,  91635,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=59lon click here,  =-OOO,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=21lon same day cash loans,  hbehzo,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=16lon payday cash advance loan,  012686,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=60lon credit card debt relief,  428,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=61lon best credit card rewards,  %O,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=50lon credit card balance transfer offers,  543,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=25lon check cash out,  48893,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=20lon cash quick loans,  122094,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=11lon cash advance payday loan,  mtxido,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=63lon visa credit card,  7229,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=55lon credit card info that works,  437,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:20:19", "link": "Mask.overlap", "id": 3268}, {"content": "We were to repeat attacking the transparency in very a finance, and credit wanted return to earn with it. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=33lon commercial finance ge,  8]]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=54lon click here,  6855,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=8lon cash back credit card,  77750,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=27lon ace check cashing,  :)),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=23lon cash back credit cards,  &gt;:PP,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=2lon credit cards best,  %-),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=47lon credit card application online,  3220,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=45lon credit bad loans,  :(,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=7lon here,  8-]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=51lon credit card cash advance,  =-[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=29lon checking loans,  927769,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=58lon best credit card offers,  jeilex,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=41lon construction loan,  %-DDD,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=37lon here,  526408,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=10lon no credit check cash advance,  6350,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=59lon credit card reform 2009,  &gt;:(,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=42lon construction mortgage loans,  011,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=53lon credit card debt settlement,  rtokty,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=61lon best rewards credit card,  36351,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=5lon payday cash advance loans,  145,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=35lon link here,  :[[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=57lon low interest rates credit card,  343616,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=50lon credit card balance transfer free,  %]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=38lon consolidate loans and credit cards,  kuaoso,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=20lon quick cash,  8-PPP,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=55lon credit card info online,  78383,", "user_title": "Anonymous", "datetimeon": "2010-11-24T07:20:10", "link": "Mask.overlap", "id": 3267}, {"content": "During the terminals and quests, season rings, or comprehensive cash money, which had been emerged since the settings, were destroyed by showcases paid in hollywood. ,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan36 banking loans,  54064,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan34 click here,  hsmgb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan8 link,  mgj,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan3 link,  153,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan49 click here,  886,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan47 small business credit card,  nrsj,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan31 bad credit personal loans,  pyvk,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan17 auto loans online,  =-DDD,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan56 card credit transfer,  &gt;:-D,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan28 bad credit personal loans,  ose,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan7 advance payday cash,  %]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan51 small business loan interest rates,  zaz,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan40 best credit cards balance transfer,  477822,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan10 short sale affect credit,  5726,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan59 online cash advance lenders,  09883,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan16 apply for credit card,  &gt;:-D,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan21 credit cards with bad credit,  ijdgzx,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan60 cash advance loan payday,  %-(((,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan5 link here,  8]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan25 bad credit mortgage,  520110,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan63 cash money,  =-)),", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:48:48", "link": "Mask.overlap", "id": 3266}, {"content": "Phoneplay incorrectly told not. ,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan36 bad credit bank loans,  vmrx,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan12 american cash advance locations,  %PP,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan54 capital one auto loans,  fdwj,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan27 payday loans with bad credit,  khlq,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan3 payday cash advance,  8(((,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan43 bridging loan calculator,  jvur,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan2 advance cash loans,  938459,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan19 auto loans refinance,  8DD,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan31 loans for people with bad credit,  8DD,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan17 refinance auto loans,  78994,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan14 apply for a credit card visa,  lbdx,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan56 card credit number,  wupy,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan28 personal loans for people with bad credit,  761510,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan40 best credit card deals,  &gt;:-))),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan65 new business loans,  wdth,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan41 bridge mortgage loan,  rzyld,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan10 affect credit report,  :],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan15 apply for a student loan,  glw,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan21 credit cards bad credit,  8186,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan16 apply for credit card online,  70628,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan53 bad credit loans business,  227,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan46 business cash advances,  8))),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan20 auto loans title,  8-[[[,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan6 advance payday lenders,  utodvu,", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:48:45", "link": "Mask.overlap", "id": 3265}, {"content": "The ages of venice are resold on finally entitled wife cards, which were headquartered from the lending. ,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan36 bank of america student loans,  xnb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan33 bank of america credit cards,  76996,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan8 cash payday advances,  405315,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan18 bad credit auto loans,  zlno,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan23 bad credit home loans,  puzz,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan24 car loan bad credit,  wsdwb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan30 bad credit personal unsecured loans,  :]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan56 click,  60864,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan58 cards credit,  fnyb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan4 click here,  875040,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan41 what is a bridge loan,  8-)),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan62 cash advance payday loan,  byjev,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan42 bridge loans commercial,  eglvy,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan16 apply for credit card online,  769134,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan53 commercial business loans,  cynkf,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan60 cash advance loans,  5789,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan9 payday cash advances,  %)),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan50 business financing small,  993,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan25 bad credit mortgages,  1914,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan46 business cash advances business,  651,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan44 build credit,  %]]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan20 auto loans title,  kybfg,", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:48:43", "link": "Mask.overlap", "id": 3264}, {"content": "Diagnostic testing including measures for inflammation muscle injury or renal damage revealed no evidence of medically significant underlying pathology.,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html link,  8((,  http://gforge.avacs.org/tracker/download.php/9/115/52/304/71cis.html viagra cialis levitra side effects,  &gt;:-]],  http://gforge.avacs.org/tracker/download.php/9/115/52/302/69cis.html buy cialis soft tabs,  %)),  http://gforge.avacs.org/tracker/download.php/9/115/51/236/3cis.html link,  6447,  http://gforge.avacs.org/tracker/download.php/9/115/51/235/2cis.html cheap generic cialis,  pmuh,  http://gforge.avacs.org/tracker/download.php/9/115/51/252/19cis.html cheapest generic cialis,  ylbilg,  http://gforge.avacs.org/tracker/download.php/9/115/51/264/31cis.html here,  sjnlcs,  http://gforge.avacs.org/tracker/download.php/9/115/51/257/24cis.html cialis canada online pharmacy,  63426,  http://gforge.avacs.org/tracker/download.php/9/115/51/250/17cis.html cheap cialis india,  nsnxpr,  http://gforge.avacs.org/tracker/download.php/9/115/51/278/45cis.html cialis soft pills,  pvehc,  http://gforge.avacs.org/tracker/download.php/9/115/51/240/7cis.html here,  025,  http://gforge.avacs.org/tracker/download.php/9/115/51/259/26cis.html cialis daily reviews,  8[,  http://gforge.avacs.org/tracker/download.php/9/115/52/284/51cis.html cialis no prescription,  53844,  http://gforge.avacs.org/tracker/download.php/9/115/51/273/40cis.html cialis professional 20 mg,  599765,  http://gforge.avacs.org/tracker/download.php/9/115/51/237/4cis.html buy cialis in australia,  7812,  http://gforge.avacs.org/tracker/download.php/9/115/51/270/37cis.html prices cialis,  pmuoi,  http://gforge.avacs.org/tracker/download.php/9/115/51/274/41cis.html free cialis trial,  8PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/246/13cis.html C 10 drug,  563390,  http://gforge.avacs.org/tracker/download.php/9/115/51/275/42cis.html cialis effects on women,  zfibcl,  http://gforge.avacs.org/tracker/download.php/9/115/51/272/39cis.html cialis professional canada,  529619,  http://gforge.avacs.org/tracker/download.php/9/115/52/303/70cis.html click here,  382678,  http://gforge.avacs.org/tracker/download.php/9/115/52/293/60cis.html generic cialis safety,  :-[[[,  http://gforge.avacs.org/tracker/download.php/9/115/51/283/50cis.html cialis vs viagra vs levitra,  807908,  http://gforge.avacs.org/tracker/download.php/9/115/52/290/57cis.html buy generic cialis canada,  ezi,", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:33:58", "link": "Mask.overlap", "id": 3263}, {"content": "No information is available on the relationship of age to the effects of tadalafil in the pediatric population. ,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html cialis 20mg,  &gt;:O,  http://gforge.avacs.org/tracker/download.php/9/115/52/302/69cis.html cialis soft tabs canada,  71121,  http://gforge.avacs.org/tracker/download.php/9/115/51/282/49cis.html cialis viagra comparison,  uxjbx,  http://gforge.avacs.org/tracker/download.php/9/115/51/256/23cis.html is cialis better than viagra,  946,  http://gforge.avacs.org/tracker/download.php/9/115/51/235/2cis.html buy cheap cialis,  588,  http://gforge.avacs.org/tracker/download.php/9/115/51/252/19cis.html cheapest generic cialis,  fxxzu,  http://gforge.avacs.org/tracker/download.php/9/115/51/257/24cis.html link,  rfnk,  http://gforge.avacs.org/tracker/download.php/9/115/51/263/30cis.html cialis information,  &gt;:-[[,  http://gforge.avacs.org/tracker/download.php/9/115/52/299/66cis.html cialis online canadian,  mxow,  http://gforge.avacs.org/tracker/download.php/9/115/52/289/56cis.html generic cialis no prescription,  dkcyd,  http://gforge.avacs.org/tracker/download.php/9/115/51/240/7cis.html cialis soft,  =-)),  http://gforge.avacs.org/tracker/download.php/9/115/51/237/4cis.html buy cialis in uk,  ytglgz,  http://gforge.avacs.org/tracker/download.php/9/115/52/298/65cis.html here,  qkfrkd,  http://gforge.avacs.org/tracker/download.php/9/115/52/292/59cis.html generic cialis free shipping,  =PPP,  http://gforge.avacs.org/tracker/download.php/9/115/51/281/48cis.html cialis viagra mix,  549573,  http://gforge.avacs.org/tracker/download.php/9/115/51/254/21cis.html cialis 20mg price,  =-DDD,  http://gforge.avacs.org/tracker/download.php/9/115/51/242/9cis.html buy cialis tadalafil,  :OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/272/39cis.html link,  :],  http://gforge.avacs.org/tracker/download.php/9/115/52/286/53cis.html discount cialis levitra viagra,  140,  http://gforge.avacs.org/tracker/download.php/9/115/52/294/61cis.html generic cialis paypal,  tes,  http://gforge.avacs.org/tracker/download.php/9/115/51/283/50cis.html click here,  6304,  http://gforge.avacs.org/tracker/download.php/9/115/52/300/67cis.html order cialis no prescription,  &gt;:(((,  http://gforge.avacs.org/tracker/download.php/9/115/51/271/38cis.html cialis price canada,  vnxrzs,  http://gforge.avacs.org/tracker/download.php/9/115/52/288/55cis.html here,  530,", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:33:54", "link": "Mask.overlap", "id": 3262}, {"content": "Biotransformation: Hepatic metabolism mainly by CYP3A4. Tadalafil is predominantly metabolized by CYP3A4 to a catechol metabolite. ,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html buy cialis,  =-[,  http://gforge.avacs.org/tracker/download.php/9/115/51/267/34cis.html cialis online prescription,  zfg,  http://gforge.avacs.org/tracker/download.php/9/115/52/287/54cis.html does cialis work on women,  =-PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/282/49cis.html levitra cialis viagra which is better,  46847,  http://gforge.avacs.org/tracker/download.php/9/115/51/280/47cis.html cialis viagra compare,  ywntj,  http://gforge.avacs.org/tracker/download.php/9/115/51/234/1cis.html cialis acquisto on line,  ggou,  http://gforge.avacs.org/tracker/download.php/9/115/51/264/31cis.html here,  %-)),  http://gforge.avacs.org/tracker/download.php/9/115/51/247/14cis.html cialis 20mg tablets,  945051,  http://gforge.avacs.org/tracker/download.php/9/115/51/250/17cis.html here,  997375,  http://gforge.avacs.org/tracker/download.php/9/115/51/278/45cis.html cialis soft pills,  240,  http://gforge.avacs.org/tracker/download.php/9/115/52/299/66cis.html cialis online without prescription,  :-PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/262/29cis.html cialis side effects long term,  %-O,  http://gforge.avacs.org/tracker/download.php/9/115/51/270/37cis.html cialis pricing,  22241,  http://gforge.avacs.org/tracker/download.php/9/115/52/298/65cis.html cialis cost at walmart,  8-))),  http://gforge.avacs.org/tracker/download.php/9/115/51/237/4cis.html buy cialis in mexico,  8PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/275/42cis.html cialis effects on women,  588,  http://gforge.avacs.org/tracker/download.php/9/115/51/281/48cis.html cialis viagra and levitra,  &gt;:-]]],  http://gforge.avacs.org/tracker/download.php/9/115/52/303/70cis.html cheap cialis soft tabs,  008661,  http://gforge.avacs.org/tracker/download.php/9/115/51/242/9cis.html buy cialis 20mg,  mcfj,  http://gforge.avacs.org/tracker/download.php/9/115/51/272/39cis.html cialis professional generic,  803344,  http://gforge.avacs.org/tracker/download.php/9/115/51/283/50cis.html cialis vs viagra which is better,  oxgds,  http://gforge.avacs.org/tracker/download.php/9/115/52/300/67cis.html order cialis no prescription,  fblq,  http://gforge.avacs.org/tracker/download.php/9/115/51/265/32cis.html here,  briecr,  http://gforge.avacs.org/tracker/download.php/9/115/52/288/55cis.html cialis free trial,  =]],", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:33:50", "link": "Mask.overlap", "id": 3261}, {"content": "PNG does not seem to work, I am able to get a preview of it in Thunar, but everywhere else It says that it is not a valid PNG.", "user_title": "Anonymous", "datetimeon": "2008-11-01T19:31:56", "link": "pygame.image.save", "id": 2332}, {"content": "Using surface.set_alpha(255, RLE_ACCEL) will greatly speed up per-pixel alpha blitting.", "user_title": "Anonymous", "datetimeon": "2008-11-12T08:53:53", "link": "Surface.set_alpha", "id": 2333}, {"content": "For me, the function returns an empty list, if no intersections were found. In my opinion that's a more consistent behavior.", "user_title": "Anonymous", "datetimeon": "2008-11-15T03:44:30", "link": "Rect.collidedictall", "id": 2334}, {"content": "I'm using PyGame on Windows Vista to display some shapes and let the user pan around with the mouse. I use pygame.event.wait() to avoid wasting CPU redrawing when nothing is happening. However, I've introduced a Queue from the multiprocessing library. Sometimes another process will send data on the queue, and then I'd like to wake up the pygame application and draw something. I could do this by constantly polling pygame.event.get() and my queue in turn, but it seems wasteful. Is there another way?", "user_title": "Anonymous", "datetimeon": "2008-11-20T12:19:54", "link": "pygame.event.wait", "id": 2335}, {"content": "pygame.color.Color(colorname) -&gt; RGBA\nGet RGB values from common color names\n\nThe color name can be the name of a common english color, or a \"web\" style color in the form of 0xFF00FF. The english color names are defined by the standard 'rgb' colors for X11. With the hex color formatting you may optionally include an alpha value, the formatting is 0xRRGGBBAA. You may also specify a hex formatted color by starting the string with a '#'. The color name used is case insensitive and whitespace is ignored.\n\nSee pygame.colordict for a list of colour names.", "user_title": "Anonymous", "datetimeon": "2008-11-22T08:45:40", "link": "pygame.Color", "id": 2336}, {"content": "pygame.color.Color(colorname) -&gt; RGBA\nGet RGB values from common color names\n\nThe color name can be the name of a common english color,\nor a \"web\" style color in the form of 0xFF00FF. The english\ncolor names are defined by the standard 'rgb' colors for X11.\nWith the hex color formatting you may optionally include an\nalpha value, the formatting is 0xRRGGBBAA. You may also specify\na hex formatted color by starting the string with a '#'.\nThe color name used is case insensitive and whitespace is ignored.\n\nSee pygame.colordict for a list of english colour names.", "user_title": "Anonymous", "datetimeon": "2008-11-22T08:46:48", "link": "pygame.Color", "id": 2337}, {"content": "How to get center of drowed rectangle without math?", "user_title": "Anonymous", "datetimeon": "2008-11-24T08:35:36", "link": "pygame.draw.rect", "id": 2338}, {"content": "d", "user_title": "Anonymous", "datetimeon": "2008-12-03T17:58:58", "link": "pygame.draw.line", "id": 2340}, {"content": "If you use .PNG (uppercase), it will result in an invalid file (at least on my win32).  Use .png (lowercase) instead.", "user_title": "Anonymous", "datetimeon": "2008-12-05T19:14:08", "link": "pygame.image.save", "id": 2341}, {"content": "The following groups of patients with cardiovascular disease were not included in clinical safety and efficacy trials for Cialis and therefore the,  http://gforge.avacs.org/tracker/download.php/9/115/51/269/36cis.html cialis online canadian pharmacy,  wge,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html cialis 20mg,  &gt;:[[[,  http://gforge.avacs.org/tracker/download.php/9/115/52/301/68cis.html purchase cialis online without prescription,  098,  http://gforge.avacs.org/tracker/download.php/9/115/51/260/27cis.html link,  =OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/236/3cis.html buy cialis brand,  639185,  http://gforge.avacs.org/tracker/download.php/9/115/51/282/49cis.html cialis viagra cheap,  %-OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/235/2cis.html cheap generic cialis,  &gt;:O,  http://gforge.avacs.org/tracker/download.php/9/115/51/252/19cis.html cheapest cialis uk,  8-DDD,  http://gforge.avacs.org/tracker/download.php/9/115/51/280/47cis.html cialis viagra compare,  pkidgr,  http://gforge.avacs.org/tracker/download.php/9/115/52/299/66cis.html cialis online paypal,  oech,  http://gforge.avacs.org/tracker/download.php/9/115/51/263/30cis.html cialis forum,  761959,  http://gforge.avacs.org/tracker/download.php/9/115/52/289/56cis.html generic cialis no prescription,  =-DD,  http://gforge.avacs.org/tracker/download.php/9/115/52/291/58cis.html click here,  =-OO,  http://gforge.avacs.org/tracker/download.php/9/115/51/243/10cis.html buy cialis professional,  &gt;:OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/281/48cis.html levitra cialis viagra compare,  gks,  http://gforge.avacs.org/tracker/download.php/9/115/52/286/53cis.html discount cialis,  %],  http://gforge.avacs.org/tracker/download.php/9/115/51/258/25cis.html cialis cost walmart,  629,  http://gforge.avacs.org/tracker/download.php/9/115/52/300/67cis.html order cialis,  %P,  http://gforge.avacs.org/tracker/download.php/9/115/51/253/20cis.html cialis 5mg,  8))),  http://gforge.avacs.org/tracker/download.php/9/115/51/265/32cis.html cialis levitra and viagra,  &gt;:((,", "user_title": "Anonymous", "datetimeon": "2010-11-24T06:33:46", "link": "Mask.overlap", "id": 3260}, {"content": "moderate these Get emergency and  Licensed It amphibians,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work34 tramadol drug class,  55378,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er generic,  %-)),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work72 what is tramadol like,  =),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work71 what is tramadol prescribed for,  =OOO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work49 tramadol in dogs side effects,  fvghe,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work23 tramadol 50mg,  wdcio,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work31 tramadol dosage in cats,  =DDD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work45 tramadol hydrochloride injection,  =-PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work28 tramadol addiction treatment,  thlrtg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work52 tramadol online overnight,  1524,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg dosage,  554949,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work16 order tramadol cod overnight,  %-))),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal how long,  868556,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug abuse,  62387,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work5 buy tramadol now,  37718,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work46 tramadol hydrochloride 50mg,  &gt;:-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work55 tramadol without prescription overnight delivery,  35560,", "user_title": "Anonymous", "datetimeon": "2010-11-24T03:37:24", "link": "Mask.overlap", "id": 3259}, {"content": "Habituation for Pain for ulcers due to,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work27 tramadol abuse,  :-DDD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work3 buy tramadol cash on delivery,  qge,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol without prescription,  rxv,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work31 tramadol dosage in cats,  %-PPP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work30 tramadol cod online,  :OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work7 buy tramadol online cheap,  piieh,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work58 tramadol withdrawal symptoms,  8((,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 is tramadol a narcotic drug,  819,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work41 tramadol hcl 50 mg tablets,  %],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work65 ultram er mg,  &gt;:-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work10 buy ultram online no prescription,  drtxc,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg side effects,  320,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work15 order tramadol overnight,  :-PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work46 tramadol hydrochloride 50mg,  yptsk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work38 tramadol hci,  3901,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work11 canine tramadol dosage,  ruqzn,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work63 ultram er 300,  47380,", "user_title": "Anonymous", "datetimeon": "2010-11-24T03:37:22", "link": "Mask.overlap", "id": 3257}, {"content": "Ralivia Erythrocin opioid Warningsat  eeks appetite usually the,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work33 tramadol drug study,  %[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work68 ultram pharmacy,  shq,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work34 tramadol drug forum,  8-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er generic,  125,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work69 ultram side effects,  7549,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol cheap,  kfkeda,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work45 tramadol hydrochloride,  hjk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg high,  459,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work7 buy tramadol online no prescription,  643,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work58 tramadol withdrawal duration,  753,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 is tramadol a narcotic,  3009,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work9 buy ultram overnight,  euz,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal how long,  kbkbbk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50mg side effects,  okgs,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug information,  &gt;:]]],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work57 how long do tramadol withdrawal symptoms last,  gjuglm,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work25 tramadol 50 mg effects,  95229,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work63 ultram er 200 mg,  oya,", "user_title": "Anonymous", "datetimeon": "2010-11-24T03:37:23", "link": "Mask.overlap", "id": 3258}, {"content": "g and Tramadol application difficult that mg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work36 tramadol for dogs dose,  =-P,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work68 ultram overnight delivery,  :-DD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work12 cheapest tramadol available online,  &gt;:-((,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work69 ultram tramadol,  201058,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work2 buy tramadol for dogs,  uur,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online,  387734,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg hcl,  44578,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work29 tramadol apap,  634,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 is tramadol a narcotic drug,  225367,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work41 tramadol hcl 50 mg side effects,  1897,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work62 ultram addiction,  261044,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work13 buy cheap tramadol online,  503471,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work21 tramadol 100 mg no prescription,  =-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work48 tramadol hydrochloride dosage,  8)),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug interactions,  911,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work50 tramadol saturday delivery,  qzpxw,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work57 tramadol withdrawal treatment,  =D,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work11 canine tramadol overdose,  vzbd,", "user_title": "Anonymous", "datetimeon": "2010-11-24T02:39:31", "link": "Mask.overlap", "id": 3256}, {"content": "Using tablets as barcelona or cellulose but,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work36 tramadol for dogs side effects,  888243,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work54 tramadol rx,  :OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er 100mg,  4726,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 tramadol 180 pills,  imlux,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work43 tramadol hcl apap,  jylchn,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work1 buy tramadol cheap online,  47668,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride acetaminophen,  817,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online,  868941,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg tab,  wcsupr,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work28 tramadol addiction withdrawal,  %-(,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work4 buy tramadol 180,  nzp,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work62 ultram addiction forum,  adg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work52 tramadol online buy,  :OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work59 tramadol no prescription next day,  ami,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg tab,  =-],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work21 tramadol 100mg,  143,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50 mg dosage,  =(,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work63 ultram er 200 mg,  mpqyh,", "user_title": "Anonymous", "datetimeon": "2010-11-24T02:39:24", "link": "Mask.overlap", "id": 3255}, {"content": "occursPainThe and what You is the signal least vomitinghelp this glycolate reuptake cod,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work12 cheap tramadol free shipping,  824250,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 buy tramadol 180,  =-PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work69 ultram side effects,  vbo,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work73 what is ultram made of,  :PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work24 tramadol 50 mg effects,  =-)),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work17 purchase ultram online,  302,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online without prescription,  wck,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work30 tramadol cod online,  775,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work65 ultram er narcotic,  oeopi,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work58 tramadol withdrawal syndrome,  43143,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg for dogs,  =-[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work15 order tramadol online without prescription,  53726,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50 mg dosage,  899,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work50 tramadol saturday delivery,  eyyzji,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work46 tramadol hydrochloride and paracetamol,  %-[[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work20 tramadol high,  wtvu,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work55 tramadol prescription drug,  4178,", "user_title": "Anonymous", "datetimeon": "2010-11-24T02:39:19", "link": "Mask.overlap", "id": 3254}, {"content": "theINN ca pain need is pain Wow is only that,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work36 tramadol for dogs,  zol,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work54 tramadol rx,  795018,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 buy tramadol 180,  397,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work72 what is tramadol for,  :PPP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work18 cheap tramadol overnight,  81005,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol,  &gt;:-OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride 200mg,  btdezy,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online,  uxmxu,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work28 tramadol addiction potential,  =-D,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 tramadol ingredients,  wcmyo,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work52 tramadol online pharmacies,  &gt;:]]],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50mg,  mgtf,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work53 tramadol overdose,  =))),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal symptoms,  nii,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work5 buy tramadol cheap no prescription,  8-),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work35 tramadol er 200,  8-]]],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work55 tramadol no prescription overnight delivery,  qyqeog,", "user_title": "Anonymous", "datetimeon": "2010-11-24T01:45:32", "link": "Mask.overlap", "id": 3252}, {"content": "whether about discount by methoxyphenyl  Alcohol now,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work12 cheap tramadol free shipping,  &gt;:-OOO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work33 tramadol drug info,  sxpkt,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 tramadol 180 tabs,  vowq,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work8 buy tramadol 100mg,  692,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work18 tramadol cash on delivery,  qiewi,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride high,  ynxx,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work30 tramadol cod online,  :[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 buy ultram online without a prescription,  rktiw,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg hcl,  &gt;:DD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work10 buy cheap ultram,  514393,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work39 tramadol hcl ingredients,  346388,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work9 buy ultram er,  =[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal symptoms,  tgb,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug information,  %),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work35 tramadol er 200 mg,  =-D,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work25 tramadol 50 mg effects,  ouyo,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work20 side effects tramadol hydrochloride,  bjnhc,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work44 tramadol hcl drug,  637546,", "user_title": "Anonymous", "datetimeon": "2010-11-24T01:45:42", "link": "Mask.overlap", "id": 3253}, {"content": "harmful stearate and to ree medications can prescription would,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er price,  mawkzk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work8 buy tramadol without prescription,  3052,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work3 buy tramadol cheap,  udmqmg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work2 buy tramadol forum,  orcjld,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol cheap,  1602,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride acetaminophen,  nve,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work31 tramadol dosage information,  upwzk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work17 order ultram without prescription,  ffancj,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work45 tramadol hydrochloride paracetamol,  :-DDD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work56 tramadol side effects in dogs,  szwol,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work62 ultram dosage,  705145,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg dosage,  gnyqjc,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal,  699,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work67 ultram pain medicine,  2829,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work11 canine tramadol dosage,  ogce,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work20 tramadol depression,  5252,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work32 tramadol dosage for humans,  059404,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work6 buying tramadol online legal,  pnjobn,", "user_title": "Anonymous", "datetimeon": "2010-11-24T01:45:21", "link": "Mask.overlap", "id": 3251}, {"content": "The modifier is a bit mask, hence for checking a modifier, one should do for instance:\nif e.mod &amp; KMOD_LALT != 0:\n  doSomething()", "user_title": "Anonymous", "datetimeon": "2010-11-14T13:44:21", "link": "pygame.event", "id": 3241}, {"content": "Hi , I keep getting this error when I try to load ... \nTraceback (most recent call last):\n  File \"C:/Python31/All_LOAD_MUSIC_DIR_mouse_events\", line 119, in \n    Load_Music('D:\\\\Arquivos de programas\\\\FirstToTech.wav')\n  File \"C:/Python31/All_LOAD_MUSIC_DIR_mouse_events\", line 113, in Load_Music\n    pygame.mixer.music.load(File)\npygame.error: Unable to load WAV file\n      However it loads right with 'pygame.mixer.sound.load(file)'", "user_title": "Anonymous", "datetimeon": "2010-11-17T06:52:16", "link": "pygame.mixer.music.load", "id": 3242}, {"content": "Surface.scroll() appears to be deprecated in pygame 1.8.1. What is the replacement?", "user_title": "Anonymous", "datetimeon": "2010-11-18T14:27:01", "link": "Surface.scroll", "id": 3243}, {"content": "Work Exmpl:\n\npygame.mixer.init(frequency=22050, size=-16, channels=2, buffer=4096)\nsound = pygame.mixer.Sound('Time_to_coffee.wav').play()", "user_title": "Anonymous", "datetimeon": "2010-11-18T19:30:12", "link": "pygame.mixer.music.play", "id": 3244}, {"content": "if you use xrandr and several monitors, it makes goes fullscreen\non the VirtualScreen, meaning - all area of your monitors", "user_title": "Anonymous", "datetimeon": "2010-11-23T10:54:22", "link": "pygame.display.toggle_fullscreen", "id": 3250}, {"content": "list = [(1,1),(1,100),(100,1)]\nlol = pygame.draw.lines(Schermo, (255,0,0), True, list, 1)\n\nlol is a pygame.rect and it draw a red triangle (in this case). Closed == True is\nused to represent a closed figure.", "user_title": "Anonymous", "datetimeon": "2010-10-26T15:18:02", "link": "pygame.draw.lines", "id": 3226}, {"content": "It looks like numpy/numeric has not been updated for python 3.1.", "user_title": "Anonymous", "datetimeon": "2010-10-26T22:52:40", "link": "pygame.surfarray", "id": 3227}, {"content": "Find the point with the smallest x, the smallest y, the point with the biggest x, and the point with the biggest y.", "user_title": "Anonymous", "datetimeon": "2010-10-28T18:01:56", "link": "pygame.draw.polygon", "id": 3228}, {"content": "This seems to be broken:\n\n&gt;&gt;&gt; cursor = pygame.cursors.compile(pygame.cursors.textmarker_strings)\n&gt;&gt;&gt; pygame.mouse.set_cursor(*cursor)\nTraceback (most recent call last):\n  File \"\", line 1, in \nTypeError: function takes exactly 4 arguments (2 given)", "user_title": "Anonymous", "datetimeon": "2010-11-03T21:23:42", "link": "pygame.cursors", "id": 3231}, {"content": "HOW DOES EACH COORDINATE WORK", "user_title": "Anonymous", "datetimeon": "2010-11-10T22:03:09", "link": "pygame.draw.polygon", "id": 3237}, {"content": "# A slightly more readable midis2events. More parsing can be done, but I didn't\n# need to...\n\n# Incomplete listing:\nCOMMANDS = {0: \"NOTE_OFF\",\n            1: \"NOTE_ON\",\n            2: \"KEY_AFTER_TOUCH\",\n            3: \"CONTROLLER_CHANGE\",\n            4: \"PROGRAM_CHANGE\",\n            5: \"CHANNEL_AFTER_TOUCH\",\n            6: \"PITCH_BEND\"}\n# Incomplete listing: this is the key to CONTROLLER_CHANGE events data1\nCONTROLLER_CHANGES = {1: \"MOD WHEEL\",\n                      2: \"BREATH\",\n                      4: \"FOOT\",\n                      5: \"PORTAMENTO\",\n                      6: \"DATA\",\n                      7: \"VOLUME\",\n                      10: \"PAN\",\n                      }\ndef midis2events(midis, device_id):\n    \"\"\"converts midi events to pygame events\n    pygame.midi.midis2events(midis, device_id): return [Event, ...]\n\n    Takes a sequence of midi events and returns list of pygame events.\n    \"\"\"\n    evs = []\n    for midi in midis:\n        \n        ((status,data1,data2,data3),timestamp) = midi\n        if status == 0xFF:\n            # pygame doesn't seem to get these, so I didn't decode\n            command =  \"META\"\n            channel = None\n        else:\n            try:\n                command = COMMANDS[ (status &amp; 0x70) &gt;&gt; 4]\n            except:\n                command = status &amp; 0x70\n            channel = status &amp; 0x0F\n        e = pygame.event.Event(pygame.midi.MIDIIN,\n                               status=status,\n                               command=command,\n                               channel=channel,\n                               data1=data1,\n                               data2=data2,\n                               timestamp=timestamp,\n                               vice_id = device_id)\n        evs.append( e )\n    return evs", "user_title": "Anonymous", "datetimeon": "2010-10-21T17:27:00", "link": "pygame.midi.midis2events", "id": 3223}, {"content": ".", "user_title": "Anonymous", "datetimeon": "2010-09-18T22:12:15", "link": "Rect.co", "id": 3207}, {"content": "It is posible to get the size of a font.Sysfont??? \n\nif is possible , how can it be done??", "user_title": "Anonymous", "datetimeon": "2010-09-23T13:04:50", "link": "pygame.font.SysFont", "id": 3209}, {"content": "Yeah, it is true. That code is the most horrible stuff I've seen in years. But if you run it, it's quite fun! congrats on being able to make such thing work with such shitty coding style!", "user_title": "Anonymous", "datetimeon": "2010-10-02T22:23:36", "link": "pygame.draw.circle", "id": 3212}, {"content": "No idea...", "user_title": "Anonymous", "datetimeon": "2010-10-04T16:00:48", "link": "pygame.draw.polygon", "id": 3213}, {"content": "How do I check if an ellipse has collided?", "user_title": "Anonymous", "datetimeon": "2010-10-05T15:23:38", "link": "pygame.draw.ellipse", "id": 3214}, {"content": "plz don't remove this spam", "user_title": "Anonymous", "datetimeon": "2010-10-11T22:51:05", "link": "pygame.locals", "id": 3216}, {"content": "how can a draw a an eclipse of the moon?", "user_title": "Anonymous", "datetimeon": "2010-10-14T21:17:06", "link": "pygame.draw.arc", "id": 3217}, {"content": "\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080hhhhhhhhhhhhhhhhhm??????????????????h\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080\u00c3\u0080??????\n^^\n^^\n^^", "user_title": "Anonymous", "datetimeon": "2010-10-16T04:14:42", "link": "pygame.event.pump", "id": 3219}, {"content": "Clock.tick allows requesting an upper limit to the framerate, time.delay pauses for a period of time.", "user_title": "Anonymous", "datetimeon": "2010-10-16T23:19:58", "link": "Clock.tick", "id": 3220}, {"content": "Yes, I've got the same problem. It only returns false when the music has been stopped, or no music has been loaded.\nMaybe there should be an is_paused() method...", "user_title": "Anonymous", "datetimeon": "2010-10-17T19:35:23", "link": "pygame.mixer.music.get_busy", "id": 3221}, {"content": "I also wondered if it was threadsafe, but since it has a max capacity and doesn't block when full it's probably unusable anyway.", "user_title": "Anonymous", "datetimeon": "2010-08-16T05:27:42", "link": "pygame.event.post", "id": 3193}, {"content": "\"image\" I think is the missing one, I think.", "user_title": "Anonymous", "datetimeon": "2010-08-17T14:42:51", "link": "pygame.init", "id": 3194}, {"content": "what's the difference between using Clock.tick and time.delay to limit the framerate?", "user_title": "Anonymous", "datetimeon": "2010-08-27T09:12:11", "link": "Clock.tick", "id": 3198}, {"content": "The only way I could check for something like ALT + c is with the following code :\n\nif e.key == K_c and e.mod == KMOD_LALT|4096:\n   self.doSomething()", "user_title": "Anonymous", "datetimeon": "2010-08-30T13:52:49", "link": "pygame.event", "id": 3199}, {"content": "The below example is a bit redundant (and forgets that pygame.transform.rotate returns the rotated surface, it doesn't transform in place).\n\nYou can simply write it thusly:\n\ndef __init__(self, image, startangle):\n    ...\n    self.original = image\n    self.rotate(startangle)\ndef rotate(self, angle):\n    self.image = pygame.transform.rotate(self.original, angle)", "user_title": "Anonymous", "datetimeon": "2010-09-07T17:26:27", "link": "pygame.transform.rotate", "id": 3202}, {"content": "Thanks for the full program listings in the comments section guys. Very, very useful, and not at all annoying. Well done!\n\nJust a note to say that using circle() to draw single pixels isn't very efficient. Try Pixelarray for fast pixel drawing.", "user_title": "Anonymous", "datetimeon": "2008-12-16T07:37:49", "link": "pygame.draw.circle", "id": 2356}, {"content": "That fix doesn't allow for diagonal lines!  I have the same issue.", "user_title": "Anonymous", "datetimeon": "2008-12-27T06:40:14", "link": "pygame.draw.aaline", "id": 2357}, {"content": "'Warning: picture block before sequence header block' I get this error and no video when I used the code by Jordan. The sound plays but no music. Please help.", "user_title": "Anonymous", "datetimeon": "2008-12-28T23:56:57", "link": "pygame.movie", "id": 2358}, {"content": "Never mind got it to work.", "user_title": "Anonymous", "datetimeon": "2008-12-28T23:59:39", "link": "pygame.movie", "id": 2359}, {"content": "How do you get the video to fill any given screen? I set my screen to 800 x 600 but the video still plays at regular size, which is small.", "user_title": "Anonymous", "datetimeon": "2009-01-03T01:13:27", "link": "pygame.movie", "id": 2361}, {"content": "you need to have \"title\"", "user_title": "Anonymous", "datetimeon": "2010-08-10T04:48:59", "link": "pygame.display.set_caption", "id": 3190}, {"content": "i have tried pygame.display.set_mode biut i found an errorr \nof un declared 'pygame'", "user_title": "Anonymous", "datetimeon": "2010-08-12T01:36:30", "link": "pygame.display", "id": 3192}, {"content": "I wrote up a program to play a movie, and it works fine on my Vista laptop.\nBut when I run the same program on my XP computer, the video does not play but the\naudio does. It is the same problem I had when I converted the video wrong. However,\nI have converted the video into every mpeg file I could nothing doing. Any ideas?", "user_title": "Anonymous", "datetimeon": "2009-01-06T19:51:38", "link": "pygame.movie", "id": 2363}, {"content": "This supports tracked music, including MOD and XM. That may not be obvious to\nsome people. (It wasn't to me, anyway, until someone on the mailing list pointed\nit out!)", "user_title": "Anonymous", "datetimeon": "2009-01-06T23:37:01", "link": "pygame.mixer.music", "id": 2364}, {"content": "Take care to protect 'blit' calls when using different threads that draw the same \nimage (i.e. Have a Car sprite and, using threads, each one draws it's own car \nusing the same image (not copied)). 'Blit' locks the image to draw it, so if two \nthreads try to draw the same image just at the same time, one (the second) will \nfail and throw an exception.\n\nOne way to avoid this could be using 'threading.Condition(threading.Lock())'\nfunctions from threading.", "user_title": "Anonymous", "datetimeon": "2009-01-07T12:05:49", "link": "Surface.blit", "id": 2365}, {"content": "is there anyway to rotate?", "user_title": "Anonymous", "datetimeon": "2010-08-07T18:09:47", "link": "pygame.draw.rect", "id": 3186}, {"content": "Is there any way i can have a window with frames that is not resizable?\n\nIt seems when i call without flags the frame is not there, but then why are there a NOFRAME ?", "user_title": "Anonymous", "datetimeon": "2010-08-08T10:06:11", "link": "pygame.display.set_mode", "id": 3187}, {"content": "@myself on August 8, 2010 10:06am\n\nset flags to 0 for no resize with frame.", "user_title": "Anonymous", "datetimeon": "2010-08-08T11:22:41", "link": "pygame.display.set_mode", "id": 3188}, {"content": "Event constants are pygame..  For example \"pygame.MOUSEMOTION\".", "user_title": "Anonymous", "datetimeon": "2009-01-15T11:23:59", "link": "pygame.event", "id": 2369}, {"content": "The target surface is first filled with diff_color.\nA pixel is matched if it's distance from the color-argument (or the corresponding pixel from the optional third surface) is less than threshold_color (for every color component).\nIf a pixel is matched, it will be set to color.\nThe number of matched pixels is returned.\n\nSo, if color = (255,0,0), and threshold_color = (10,10,10), any pixel with value (r&gt;245, g&lt;10, b&lt;10) will be matched.", "user_title": "Anonymous", "datetimeon": "2009-01-15T11:36:11", "link": "pygame.transform.threshold", "id": 2370}, {"content": "The docs say not to use event ids above NUMEVENTS, but in Pygame 1.8.1\nsince USEREVENT is 24 and NUMEVENTS is 32. This means only 8 user\nevents are possible. (Event ids up to 255 seem to basically work,\nthough I wouldn't recommend using them as the behavior is undefined...above\n255 causes strange things to happen. For example, 256 is stored as \"0-NoEvent\".)", "user_title": "Anonymous", "datetimeon": "2009-01-19T19:15:39", "link": "pygame.event.Event", "id": 2371}, {"content": "\"pygame.cursors.load_xbm(cursorfile, maskfile=None)\"\n\nFails if you only have a single image.\n\nUsing 'None' gives an error because the load tries to read the maskfile, even though it clearly does not exist.\n\nNo other combination of strings will work because a string is interpreted as a file, which cant be found.\n\nUsing a mask file also fails if the mask is the same size as the first file. Ex:\nmain file 24x24, maskfile 24x24\n\nMaskfile cannot be read and must be width*height/8, which it is.\n\nHelp anyone?", "user_title": "Anonymous", "datetimeon": "2009-01-27T17:33:27", "link": "pygame.cursors.load_xbm", "id": 2373}, {"content": "Key object can't get chinese character?\nFor example, I type \"\u00c3?\u00c3\u00a3\u00c2\u00ba\u00c3?\", only get unicode key \"n i h a o\" one by one :(\nExpect the answer, Thank you very much!\nemail:jackerme@163.com", "user_title": "Anonymous", "datetimeon": "2009-02-05T05:14:50", "link": "pygame.key", "id": 2374}, {"content": "if you use this:\n.cursor\n\nyou will get an error \"no such moudule\"\n\nso you need to do:\n.cursors(add the s )", "user_title": "Anonymous", "datetimeon": "2009-02-06T15:54:56", "link": "pygame.cursors", "id": 2375}, {"content": "Note document error. The correct attribute is _layer, as in sprite._layer.", "user_title": "Anonymous", "datetimeon": "2009-02-07T21:57:49", "link": "pygame.sprite.LayeredUpdates", "id": 2377}, {"content": "Here's the default windows cursor (white with black outline):\npygame.mouse.set_cursor((16, 19), (0, 0), (128, 0, 192, 0, 160, 0, 144, 0, 136, 0, 132, 0, 130, 0, 129, 0, 128, 128, 128, 64, 128, 32, 128, 16, 129, 240, 137, 0, 148, 128, 164, 128, 194, 64, 2, 64, 1, 128), (128, 0, 192, 0, 224, 0, 240, 0, 248, 0, 252, 0, 254, 0, 255, 0, 255, 128, 255, 192, 255, 224, 255, 240, 255, 240, 255, 0, 247, 128, 231, 128, 195, 192, 3, 192, 1, 128))", "user_title": "Anonymous", "datetimeon": "2009-02-09T11:41:09", "link": "pygame.mouse.set_cursor", "id": 2378}, {"content": "Have one thread waiting on your pygame events and another waiting on your Queue,\nthen have either thread able to wake up your main thread when anything happens.", "user_title": "Anonymous", "datetimeon": "2009-02-09T23:34:49", "link": "pygame.event.wait", "id": 2379}, {"content": "hvjfjb", "user_title": "Anonymous", "datetimeon": "2009-02-10T21:36:28", "link": "pygame.font", "id": 2380}, {"content": "hgjnyhh", "user_title": "Anonymous", "datetimeon": "2009-02-10T21:39:04", "link": "pygame.font.match_font", "id": 2381}, {"content": "sysfont = pygame.font.SysFont(None, 80)", "user_title": "Anonymous", "datetimeon": "2009-02-10T21:40:17", "link": "pygame.font.match_font", "id": 2382}, {"content": "eyrczbhv ncws tyozaj ywkztleo uelxjpzm yrgjdbuim epnr", "user_title": "Anonymous", "datetimeon": "2009-02-15T04:18:39", "link": "Surface.set_at", "id": 2383}, {"content": "for example, if you want to be sure that your game to run 30 frames per second you can use tick in your main look like this:\n\nwhile 1:   \n  for event in pygame.event.get():\n    #manage your events here\n  #update your sprites here\n  screen.blit(...) #draw to screen\n  pygame.display.flip()\n  clock.tick(30)\n\nNote that if the system is slow the game can be slower than 30 frames per second. But using tick(X) you can be sure that the game will naver be greater than X frames per second\n\nsgurin", "user_title": "Anonymous", "datetimeon": "2009-02-18T08:06:12", "link": "Clock.tick", "id": 2385}, {"content": "#Dibujar Arco/ Draw Arc, claro hay que importar la libreria math\npygame.draw.arc(background, (0, 0, 0), ((5, 150), (100, 100)), 0, math.pi/2, 5)", "user_title": "Anonymous", "datetimeon": "2009-02-24T22:22:16", "link": "pygame.draw.arc", "id": 2386}, {"content": "You are right. There is contradition.", "user_title": "Anonymous", "datetimeon": "2010-08-01T14:56:26", "link": "pygame.scrap.lost", "id": 3179}, {"content": "The last comment was spam!", "user_title": "Anonymous", "datetimeon": "2010-08-01T17:47:22", "link": "pygame.transform.flip", "id": 3180}, {"content": "you suck... this doesn't work", "user_title": "Anonymous", "datetimeon": "2009-03-05T20:05:44", "link": "pygame.image.load", "id": 2390}, {"content": "this just returns 'unknown key'?\n\nfor example:\n&gt;&gt;&gt; pygame.key.(pygame.locals.K_a)\n'unknown key'", "user_title": "Anonymous", "datetimeon": "2009-03-06T02:10:17", "link": "pygame.key.name", "id": 2391}, {"content": "comment below:\ni of course used pygame.key.name\n\n&gt;&gt;&gt; pygame.__version__\n'1.8.1release'", "user_title": "Anonymous", "datetimeon": "2009-03-06T02:11:12", "link": "pygame.key.name", "id": 2392}, {"content": "How do we actually use the event.dict method?", "user_title": "Anonymous", "datetimeon": "2009-03-06T16:06:53", "link": "pygame.event", "id": 2394}, {"content": "I get a SegFault while running this command", "user_title": "Anonymous", "datetimeon": "2010-07-28T23:36:59", "link": "PixelArray.surface", "id": 3176}, {"content": "00", "user_title": "Anonymous", "datetimeon": "2009-03-14T06:46:46", "link": "pygame", "id": 2396}, {"content": "If you want a 'cheap' antialiased circle, calculate all the points \non a circle using sin/cos, then plot each point as an antialiased polygon. \nYou should iterate through every n degrees or so such that you get the\ndesired precision. 10 degrees is good enough for small circles.", "user_title": "Anonymous", "datetimeon": "2009-03-14T17:06:11", "link": "pygame.draw.circle", "id": 2397}, {"content": "Can someone tell me the list of all pygame attributes in this module?\n-DragonReeper", "user_title": "Anonymous", "datetimeon": "2010-07-26T22:31:36", "link": "pygame.locals", "id": 3174}, {"content": "Addressing note: columns first, then rows.  Not the other way around.", "user_title": "Anonymous", "datetimeon": "2010-07-27T15:01:13", "link": "pygame.PixelArray", "id": 3175}, {"content": "Works for me.", "user_title": "Anonymous", "datetimeon": "2010-07-20T19:21:24", "link": "pygame.draw.rect", "id": 3167}, {"content": "pygame.init()\npygame.display.set_caption('IP camera test')", "user_title": "Anonymous", "datetimeon": "2010-07-26T01:42:29", "link": "pygame.event.get", "id": 3170}, {"content": "pygame.init()\npygame.display.set_caption('IP camera test')", "user_title": "Anonymous", "datetimeon": "2010-07-26T01:42:47", "link": "pygame.event.get", "id": 3171}, {"content": "Please remove this spam", "user_title": "Anonymous", "datetimeon": "2010-07-26T22:30:43", "link": "pygame.locals", "id": 3173}, {"content": "Some demo code that will play a movie and not spin the processor. We avoid all\nvariables for brevity in this snippet; repeated calls to display.set_mode work\nfine; the argument to time.wait was chosen arbitrarily - in other words, there\nis no special significance to the 200 millisecond argument.\n\npygame.display.init ()\npygame.display.set_mode ((800, 600))\nmovie = pygame.movie.Movie ('intro.mpg')\nmovie_resolution = movie.get_size ()\npygame.display.set_mode (movie_resolution)\nmovie.set_display (pygame.display.get_surface ())\nmovie.play ()\nwhile movie.get_busy ():\n    pygame.time.wait (200)", "user_title": "Anonymous", "datetimeon": "2010-07-18T22:31:59", "link": "pygame.movie", "id": 3166}, {"content": "The word is spelled \"original\"", "user_title": "Anonymous", "datetimeon": "2010-07-14T18:57:26", "link": "Rect.copy", "id": 3164}, {"content": "If .png file has a color index (like .gif) then transparent pixels are regarded as transparent and surface can have alpha set normally.\neg.\nimage = pygame.load('image.png).convert()\nimage.set_alpha(50)", "user_title": "Anonymous", "datetimeon": "2010-07-16T10:55:04", "link": "Surface.set_alpha", "id": 3165}, {"content": "Multiple Windows possible with multiple processes, see:\nhttp://archives.seul.org/pygame/users/Jun-2007/msg00292.html", "user_title": "Anonymous", "datetimeon": "2010-07-12T12:38:36", "link": "pygame.display.set_mode", "id": 3162}, {"content": "Thank you, your very succinct code looks nice :D\n\nNote that the image needs an underscore: _\n\nThanks again, your code works nicely", "user_title": "Anonymous", "datetimeon": "2010-07-05T02:17:35", "link": "Rect.colliderect", "id": 3155}, {"content": "It means the name of the font, such as 'Arial'. It needs to be a string.", "user_title": "Anonymous", "datetimeon": "2010-07-05T19:15:05", "link": "pygame.font.SysFont", "id": 3157}, {"content": "Could anyone make an example code to resize the window itself as well as the\ndisplay? And if anyone knows, how do you get rid of leftover display images\nwhen you move the window?", "user_title": "Anonymous", "datetimeon": "2010-07-05T19:39:28", "link": "pygame.display.init", "id": 3158}, {"content": "Do not use pygame.Rect.collidelistall()!", "user_title": "Anonymous", "datetimeon": "2010-07-10T14:26:52", "link": "Rect.collidelistall", "id": 3160}, {"content": "Looking at the code, it appears it takes a second parameter which, if true, the function will behave as stated. I think this applies to collidedictall also.", "user_title": "Anonymous", "datetimeon": "2010-06-20T20:34:24", "link": "Rect.collidedict", "id": 3148}, {"content": "What is the offset here?", "user_title": "Anonymous", "datetimeon": "2010-06-21T15:27:04", "link": "Mask.draw", "id": 3149}, {"content": "this doesnt WORK! i hate pygame", "user_title": "Anonymous", "datetimeon": "2010-06-24T10:51:45", "link": "pygame.draw.rect", "id": 3150}, {"content": "Why not just use Rect.copy?", "user_title": "Anonymous", "datetimeon": "2010-07-02T11:47:08", "link": "Rect.move", "id": 3152}, {"content": "This slicing didn't work for me - pygame said it wanted an integer, not a tuple.", "user_title": "Anonymous", "datetimeon": "2009-03-31T13:42:56", "link": "pygame.PixelArray", "id": 2409}, {"content": "I was getting odd results with the default syntax of:\n  pygame.draw.arc(screen, color, rect, angle1,  angle2)\n\nWhere angle1 &lt; angle2.\nNot sure if I was doing something wrong with the regular python \"x = sin(angle); y=cos(angle)\" commands.\nBut I found that reversing the angles worked well, like this:\n  pygame.draw.arc(screen, color, rect, (math.pi * 2.0) - angle2,  (math.pi * 2.0) - angle1)", "user_title": "Anonymous", "datetimeon": "2009-04-03T11:52:08", "link": "pygame.draw.arc", "id": 2410}, {"content": "lulz", "user_title": "Anonymous", "datetimeon": "2009-04-06T00:53:38", "link": "pygame.key.name", "id": 2412}, {"content": "image_filename = \"image.png\"\nimage_surface = pygame.image.load(image_filename)\ntarget_surface.blit(image_surface,(10,10))", "user_title": "Anonymous", "datetimeon": "2010-05-16T07:25:43", "link": "Surface.blit", "id": 3120}, {"content": "Oh, sorry.\n\nimage_filename = \"image.png\"\nimage_surface = pygame.image.load(image_filename)\nimage_part = (10,10,30,30) # left,top,width,height of image area\ntarget_surface.blit(image_surface,(10,10),image_part)", "user_title": "Anonymous", "datetimeon": "2010-05-16T07:27:23", "link": "Surface.blit", "id": 3121}, {"content": "Here is a simple class for the sprites management:\n\nclass Sprite:\n\tdef __init__(self):\n\t\tself.img = None\n\t\tself.pos = [0, 0]\n\t\tself.colorkey = [0, 0, 0]\n\t\tself.alpha = 255\n\tdef load(self, filename):\n\t\ttry:\n\t\t\tself.img = pygame.image.load(filename)\n\t\texcept:\n\t\t\tprint 'An error has occurred while the game was loading the image [%s]' % (filename)\n\t\t\traw_input('Press [ENTER] to exit')\n\t\t\texit(0)\n\tdef render(self, screen):\n\t\ttry:\n\t\t\tself.img.set_colorkey(self.colorkey)\n\t\t\tself.img.set_alpha(self.alpha)\n\t\t\tscreen.blit(self.img, self.pos)\n\t\t\tpygame.display.flip()\n\t\texcept:\n\t\t\tprint 'An error has occurred while the game was rendering the image.'\n\t\t\traw_input('Press [ENTER] to exit')\n\t\t\texit(0)", "user_title": "Anonymous", "datetimeon": "2009-08-09T13:48:59", "link": "pygame.image.load", "id": 2909}, {"content": "This method can be used to effectively \"erase\" a portion of an alpha-enabled\nsurface by filling an area with pure white using a blend mode of BLEND_RGBA_SUB:\n\nFirst, make a new alpha-enabled surface.\n&gt;&gt;&gt; surf = Surface((100,100), SRCALPHA)\n\nFill it with some color.\n&gt;&gt;&gt; surf.fill((255,255,255,255))\n\nNow, you can put a hole in the center 1/3 of it like this:\n&gt;&gt;&gt; area = Rect(33,33,33,33)\n&gt;&gt;&gt; surf.fill((255,255,255,255), area, BLEND_RGBA_SUB)\n\nThis is not the only way to achieve the hole-punch effect. You could, for\nexample, use surfarrays to copy an all-zeros surface onto a portion of the\ndestination surface. There are benefits to doing it either way.", "user_title": "Anonymous", "datetimeon": "2010-05-17T05:37:27", "link": "Surface.fill", "id": 3122}, {"content": "The doc string here, \"clip the area where to draw. Just pass None (default) to reset the clip\", seems like a cut &amp; paste error from set_clip()", "user_title": "Anonymous", "datetimeon": "2009-04-14T23:39:57", "link": "LayeredDirty.get_clip", "id": 2416}, {"content": "I've found that\n\npygame.transform.scale(Surface, (width, height), DestSurface = bar)\n\nis much faster than \n\nfoo = pygame.transform.scale(Surface, (width, height))\nbar.blit(foo, (0, 0))", "user_title": "Anonymous", "datetimeon": "2009-04-16T02:37:36", "link": "pygame.transform.scale", "id": 2417}, {"content": "What is the meta key? I assumed that it was the windows key, but that doesn't work. Maybe because I'm on a Linux OS.", "user_title": "Anonymous", "datetimeon": "2009-07-28T13:13:49", "link": "pygame.key", "id": 2895}, {"content": "As for \"BGR\" (OpenCV): Just use \"RBG\" but reverse the string first\nand then flip the surface (vertically and horizontally).\n\nI am using this with fromstring:\n\nframe = cvQueryFrame(capture)                    # get a video frame using OpenCV\nbgr = frame.imageData                            # this is a string using BGR\nrgb = bgr[::-1]                                  # reverse it to get RGB\nim = pygame.image.fromstring(rgb, size, 'RGB')   # create pygame surface\nim = pygame.transform.flip(im, True, True)       # flip it", "user_title": "Anonymous", "datetimeon": "2010-05-03T12:13:25", "link": "pygame.image.tostring", "id": 3116}, {"content": "Only takes ordered parameters, not named ones.\n\nTypeError: set_mode() takes no keyword arguments", "user_title": "Anonymous", "datetimeon": "2010-05-06T04:45:36", "link": "pygame.display.set_mode", "id": 3118}, {"content": "pygame.event.peek can be used for managing the quit code for a program: \n   if pygame.event.peek(QUIT):\n     sys.exit()\nI spent lots of time trying to find a way to get my code to exit. \nThis is the first working method that I've found.\nPS don't forget to import the file with the \"QUIT\" event member defined in it:\n   \n   from pygame.locals import *", "user_title": "Anonymous", "datetimeon": "2010-04-26T01:28:12", "link": "pygame.event.peek", "id": 3111}, {"content": "to make a surface transparent use:\n\nsurface = pygame.Surface((10,10))\nsurface.fill((255,0,255))\nsurface.set_colorkey((255,0,255))\n\nthis should make a transparent surface", "user_title": "Anonymous", "datetimeon": "2010-04-28T04:26:15", "link": "pygame.Surface", "id": 3112}, {"content": "\"BGR\" would be nice because OpenCV 2.1 uses such a format.", "user_title": "Anonymous", "datetimeon": "2010-05-02T16:52:56", "link": "pygame.image.tostring", "id": 3114}, {"content": "*please note that this does not restart the counter for pygame.mixer.music.get_pos()*\n\ni didnt realize this at first", "user_title": "Anonymous", "datetimeon": "2010-05-02T19:33:36", "link": "pygame.mixer.music.rewind", "id": 3115}, {"content": "using pygame.transform.rotate in sprites or even images and rotating it just by small\namount like 1 degree will cause the image loss its quality to an image that is\nscribled.\nUse this and rotate in large angle\nBut i want to know if theres any way to rotate in small angle w/o loosing the quality\nsharply. Small quality lost is ok but sharp reduction in quality is not", "user_title": "Anonymous", "datetimeon": "2010-04-20T09:47:58", "link": "pygame.transform.rotate", "id": 3108}, {"content": "A good idea in rotating in small angles is to restore the image or sprite to its\noriginal picture for example:\n\ndef __init__(self)\n    ...\n    self.original=self.image\n    self.image=pygame.transform.rotate(self.image,self.angle)\ndef rotate(self,angle)\n    self.image=self.original\n    pygame.transform.rotate(self.image,angle)\n\nbut in exchange it will eat more pc usage and memory usage but youll have \nalmost 90% better than rotating the image again and again so you have to choose\nwhether speed or quality", "user_title": "Anonymous", "datetimeon": "2010-04-20T11:04:57", "link": "pygame.transform.rotate", "id": 3109}, {"content": "How to draw a part of the picture to a surface?", "user_title": "Anonymous", "datetimeon": "2010-04-25T02:28:58", "link": "Surface.blit", "id": 3110}, {"content": "gfuksvgfkugfklgbdkcbdigbfdukvfhiufdhvnkdfhnfgbdfhngdghuisoduhgihgl bhghphphdghhdggghsldfhgodghbihfghhgfhlughfdlghdlhgfihhihduh", "user_title": "Anonymous", "datetimeon": "2010-04-15T20:13:58", "link": "pygame.event.post", "id": 3105}, {"content": "Instead of using transform.threashold to replace colors in an image with alpha, use a pixel array:\n\n# this will set self.image with a white version of self.orginalimg, but with alpha.\n            thresholded = pygame.surface.Surface((32, 32), SRCALPHA)\n            thresholded.blit(self.orginalimg, (0,0))\n            pxarray = pygame.PixelArray (thresholded)\n            for x in range(32):\n                for y in range(32):\n                    if pygame.Color(pxarray[x][y]).a &lt; 255:\n                        pxarray[x][y] = pygame.Color(255,255,255,255)\n            self.image = pxarray.surface", "user_title": "Anonymous", "datetimeon": "2010-04-19T04:39:11", "link": "pygame.transform.threshold", "id": 3107}, {"content": "Example output:\n&gt;&gt;&gt; pygame.display.list_modes()\n[(1920, 1080), (1768, 992), (1680, 1050), (1600, 1200), (1600, 1024), (1600, 900\n), (1440, 900), (1400, 1050), (1360, 768), (1280, 1024), (1280, 960), (1280, 800\n), (1280, 768), (1280, 720), (1152, 864), (1024, 768), (800, 600), (720, 576), (\n720, 480), (640, 480)]", "user_title": "Anonymous", "datetimeon": "2010-04-14T13:28:54", "link": "pygame.display.list_modes", "id": 3102}, {"content": "game www.699le.com", "user_title": "Anonymous", "datetimeon": "2010-04-15T06:18:45", "link": "pygame.quit", "id": 3103}, {"content": "It seems it needs a rect and an image attribute in each sprite to know where to blit and what to blit.\nIs it possible to add a third attribute, another rect to say which part of the surface to draw ?\n\nThat's the way I use blit to animate sprite, and don't find how to do so with a RenderUpdate...", "user_title": "Anonymous", "datetimeon": "2010-04-15T15:48:17", "link": "pygame.sprite.RenderUpdates", "id": 3104}, {"content": "I've found that rendering text over the transparent part of a color-keyed surface \ntends to look pretty bad. Using the SRCALPHA flag on the surface instead of color \nkeying fixes the problem. Also note, don't render your text every frame! Store \nyour surfaces between frames and simply re-blit them. Only re-render your \nsurfaces when such is necessary.", "user_title": "Anonymous", "datetimeon": "2010-04-05T11:58:04", "link": "Font.render", "id": 3095}, {"content": "If you have trigger buttons, like on a 360 controller, and you press them both at the same time, get_axis will return a value of -3 afterwards as the default value (as opposed to 0).", "user_title": "Anonymous", "datetimeon": "2010-04-06T12:41:07", "link": "Joystick.get_axis", "id": 3096}, {"content": "Apparently not.", "user_title": "Anonymous", "datetimeon": "2010-04-08T02:58:20", "link": "Group.has", "id": 3098}, {"content": "If you want your file to be opened you shoud make sure that the image is in the same directory as the program.\nThen its very simple:\n\n#Everything I put in [] is that you can choose the name\n&gt;&gt;&gt; [image_name] = pygame.image.load(os.path.join('file_name'))\n&gt;&gt;&gt; screen.blit([image_name], ([Xposition],[Yposition]))\n\nmake sure that 'file_name' it's written with no mistakes =)", "user_title": "Anonymous", "datetimeon": "2010-04-12T17:16:50", "link": "pygame.image.load", "id": 3100}, {"content": "pygame.time cannot be initialized. that means you can't use pygame.time.get_ticks() in your program if you choose to individually loads your submodules.", "user_title": "Anonymous", "datetimeon": "2009-08-16T18:10:41", "link": "pygame.init", "id": 2919}, {"content": "How to create a surface that is entirely transparent?", "user_title": "Anonymous", "datetimeon": "2010-03-29T15:03:49", "link": "pygame.Surface", "id": 3090}, {"content": "No really, what does this do?", "user_title": "Anonymous", "datetimeon": "2010-03-29T23:51:53", "link": "Surface.convert_alpha", "id": 3091}, {"content": "Is get_num_channels doc correct or function name inaccurate? On OSX sound with 2 channels returns 0.", "user_title": "Anonymous", "datetimeon": "2010-03-30T09:00:21", "link": "pygame.mixer.Sound", "id": 3092}, {"content": "Actually, I think C 4 is note 60, as per e.g. http://tomscarff.110mb.com/midi_analyser/midi_note_numbers_for_octaves.htm and my own testing.", "user_title": "Anonymous", "datetimeon": "2010-04-01T17:00:48", "link": "Output.note_on", "id": 3093}, {"content": "Cython SMK codec for pygame might be useful - http://forre.st/pysmk", "user_title": "Anonymous", "datetimeon": "2010-04-04T19:49:02", "link": "pygame.movie", "id": 3094}, {"content": "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=960,240;screen=pygame.display.set_mode(size);pygame.display.set_caption(\"multiplayer sprite test with collisions\")\nspd=4;amnt=4;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;rotv=[0]*amnt;sprid=[];spridr=[]   #some arrays and variables\nfor i in range (0,amnt,1):\n  xpos[i]=64+(128*i)+random.randint(0,32);ypos[i]=64+random.randint(0,32);rotv[i]=random.randint(0,359)\nsprall=pygame.image.load(\"sprites_rgba.png\")  #loading sprites\nfor i in range (0,4,1):\n  spritetmp=sprall.subsurface(i*64,0,64,64);spriterecttmp=spritetmp.get_rect()\n  sprid.append(spritetmp);spridr.append(spriterecttmp)\nrotincr=5\nwhile 1:\n  key=pygame.key.get_pressed()  #checking pressed keys\n  if key[pygame.K_a]:xpos[0]-=spd\n  if key[pygame.K_d]:xpos[0]+=spd\n  if key[pygame.K_w]:ypos[0]-=spd\n  if key[pygame.K_s]:ypos[0]+=spd\n  if key[pygame.K_z]:rotv[0]+=rotincr\n  if key[pygame.K_x]:rotv[0]-=rotincr\n  if key[pygame.K_f]:xpos[1]-=spd\n  if key[pygame.K_h]:xpos[1]+=spd\n  if key[pygame.K_t]:ypos[1]-=spd\n  if key[pygame.K_g]:ypos[1]+=spd\n  if key[pygame.K_v]:rotv[1]+=rotincr\n  if key[pygame.K_b]:rotv[1]-=rotincr\n  if key[pygame.K_j]:xpos[2]-=spd\n  if key[pygame.K_l]:xpos[2]+=spd\n  if key[pygame.K_i]:ypos[2]-=spd\n  if key[pygame.K_k]:ypos[2]+=spd\n  if key[pygame.K_m]:rotv[2]+=rotincr\n  if key[pygame.K_COMMA]:rotv[2]-=rotincr\n  if key[pygame.K_LEFT]: xpos[3]-=spd\n  if key[pygame.K_RIGHT]:xpos[3]+=spd\n  if key[pygame.K_UP]:   ypos[3]-=spd\n  if key[pygame.K_DOWN]: ypos[3]+=spd\n  if key[pygame.K_KP0]:  rotv[3]+=rotincr\n  if key[pygame.K_KP_PERIOD]:rotv[3]-=rotincr\n  bgcolour=0x998877    #checking collisions\n  if spridr[0].colliderect(spridr[1]):bgcolour=0xAA5555\n  if spridr[0].colliderect(spridr[2]):bgcolour=0x55AA55\n  if spridr[0].colliderect(spridr[3]):bgcolour=0x5555AA\n  if spridr[1].colliderect(spridr[2]):bgcolour=0x55AAAA\n  if spridr[1].colliderect(spridr[3]):bgcolour=0xAA55AA\n  if spridr[2].colliderect(spridr[3]):bgcolour=0xAAAA55\n  screen.fill(bgcolour)\n  for i in range (0,amnt,1):    #displaying sprites\n    spridr[i].centerx=xpos[i]\n    spridr[i].centery=ypos[i]\n    tmq=pygame.transform.rotate(sprid[i],rotv[i])\n    screen.blit(tmq,spridr[i])\n  for event in pygame.event.get():  #praxis stuff\n    if event.type==pygame.QUIT:sys.exit()\n  pygame.display.flip();pygame.time.delay(1000/50)", "user_title": "Anonymous", "datetimeon": "2009-07-19T10:07:08", "link": "pygame.transform.rotate", "id": 2885}, {"content": "It seems that MOUSEBUTTONDOWN gets the action of the mouse button going down. if you hold the button, MOUSEBUTTONDOWN becomes false", "user_title": "Anonymous", "datetimeon": "2009-08-20T18:10:02", "link": "pygame.mouse.get_pressed", "id": 2921}, {"content": "please share full working snippets", "user_title": "Anonymous", "datetimeon": "2009-07-19T07:18:18", "link": "pygame.transform.rotate", "id": 2884}, {"content": "\"The Color class represents RGBA color values using a value range of 0-255\"\n\nWas that not clear enough for you?", "user_title": "Anonymous", "datetimeon": "2010-03-28T16:39:28", "link": "Color.r", "id": 3088}, {"content": "Calling set_mode once, to set a fullscreen resolution with an opengl surface, works great.\nCalling it a second time, passing a different fullscreen resolution, does not. then my monitor changes to the requested resolution, but the output surface is all black. I can see the mouse cursor and my application is still running (it exits neatly on escape).\nAm I doing it wrong? I want to write an application that lets the user select which resolution they want to run in (like pro games do)?", "user_title": "Anonymous", "datetimeon": "2010-03-23T16:05:05", "link": "pygame.display.set_mode", "id": 3083}, {"content": "has anyone a working xp example handy? thx", "user_title": "Anonymous", "datetimeon": "2010-03-24T12:11:44", "link": "Surface.blit", "id": 3084}, {"content": "has anyone a working xp example handy? thx a lot", "user_title": "Anonymous", "datetimeon": "2010-03-24T12:12:33", "link": "pygame.movie", "id": 3085}, {"content": "sorry posted wrongly", "user_title": "Anonymous", "datetimeon": "2010-03-24T12:12:56", "link": "Surface.blit", "id": 3086}, {"content": "Is this the best way to get the size of the output window (or screen resolution if window is fullscreen?)", "user_title": "Anonymous", "datetimeon": "2010-03-23T06:34:27", "link": "pygame.display.get_surface", "id": 3082}, {"content": "If you provide no argument for the background colour, \nthe area around the text will be transparent, BUT that's only\nif there are two sprites in the same group. For example:\n\nimport pygame\nfrom pygame.locals import *\n\npygame.init()\nscreen = pygame.display.set_mode((500,500))\npygame.display.get_surface().fill((0,0,255))\n\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0,0,0))\n\ntextFont = pygame.font.Font(None, 30)\nimage = textFont.render(\"BLLLAHHHH\", 0, (255,0,0))\na = pygame.sprite.Sprite()\na.image = image\na.rect = image.get_rect()\na.rect.center = ((50,50))\n\nb = pygame.sprite.Sprite()\nb.image = image\nb.rect = image.get_rect()\nb.rect.center = ((60,60))\n\ngroup = pygame.sprite.RenderUpdates(a, b)\n\nwhile 1:\n    group.clear(screen, background)\n    rects = group.draw(screen)\n    pygame.display.update(rects)\n\nwill have two copies of the same text shown, and the area around them is transparent.\n\nHowever, in this example:\n\nimport pygame\nfrom pygame.locals import *\n\npygame.init()\nscreen = pygame.display.set_mode((500,500))\npygame.display.get_surface().fill((0,0,255))\n\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0,0,0))\n\ntextFont = pygame.font.Font(None, 30)\nimage = textFont.render(\"BLLLAHHHH\", 0, (255,0,0))\na = pygame.sprite.Sprite()\na.image = image\na.rect = image.get_rect()\na.rect.center = ((50,50))\n\nb = pygame.sprite.Sprite()\nb.image = image\nb.rect = image.get_rect()\nb.rect.center = ((60,60))\n\ngroupA = pygame.sprite.RenderUpdates(a)\ngroupB = pygame.sprite.RenderUpdates(b)\n\nwhile 1:\n    groupA.clear(screen, background)\n    rects = groupA.draw(screen)\n    groupB.clear(screen, background)\n    rects.extend(groupB.draw(screen))\n    pygame.display.update(rects)\n\nthere is a black box around one of the sprites that covers the other one.\nI think what they mean by transparency is what happens in the first example.", "user_title": "Anonymous", "datetimeon": "2009-07-18T04:03:26", "link": "Font.render", "id": 2881}, {"content": "when i try this it says that the 'e' in e.type is undefined? any suggestions?", "user_title": "Anonymous", "datetimeon": "2010-03-16T15:33:05", "link": "pygame.key.set_repeat", "id": 3075}, {"content": "good", "user_title": "Anonymous", "datetimeon": "2010-03-17T23:46:58", "link": "pygame.event.Event", "id": 3076}, {"content": "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=1024,256;screen=pygame.display.set_mode(size);pygame.display.set_caption(\"multiplayer sprite test with collisions\")\nspd=4;amnt=4;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;sprid=[];spridr=[]   #some arrays and variables\nfor i in range (0,amnt,1):\n  xpos[i]=64+(128*i)+random.randint(0,32);ypos[i]=64+random.randint(0,32)\nsprall=pygame.image.load(\"sprites_rgba.png\")  #loading sprites\nfor i in range (0,4,1):\n  spritetmp=sprall.subsurface(i*64,0,64,64);spriterecttmp=spritetmp.get_rect()\n  sprid.append(spritetmp);spridr.append(spriterecttmp)\nwhile 1:\n  key=pygame.key.get_pressed()  #checking pressed keys\n  if key[pygame.K_a]:xpos[0]-=spd\n  if key[pygame.K_d]:xpos[0]+=spd\n  if key[pygame.K_w]:ypos[0]-=spd\n  if key[pygame.K_s]:ypos[0]+=spd\n  if key[pygame.K_f]:xpos[1]-=spd\n  if key[pygame.K_h]:xpos[1]+=spd\n  if key[pygame.K_t]:ypos[1]-=spd\n  if key[pygame.K_g]:ypos[1]+=spd\n  if key[pygame.K_j]:xpos[2]-=spd\n  if key[pygame.K_l]:xpos[2]+=spd\n  if key[pygame.K_i]:ypos[2]-=spd\n  if key[pygame.K_k]:ypos[2]+=spd\n  if key[pygame.K_LEFT]: xpos[3]-=spd\n  if key[pygame.K_RIGHT]:xpos[3]+=spd\n  if key[pygame.K_UP]:   ypos[3]-=spd\n  if key[pygame.K_DOWN]: ypos[3]+=spd\n  bgcolour=0x998877    #checking collisions\n  if spridr[0].colliderect(spridr[1]):bgcolour=0xAA5555\n  if spridr[0].colliderect(spridr[2]):bgcolour=0x55AA55\n  if spridr[0].colliderect(spridr[3]):bgcolour=0x5555AA\n  if spridr[1].colliderect(spridr[2]):bgcolour=0x55AAAA\n  if spridr[1].colliderect(spridr[3]):bgcolour=0xAA55AA\n  if spridr[2].colliderect(spridr[3]):bgcolour=0xAAAA55\n  screen.fill(bgcolour)\n  for i in range (0,amnt,1):    #displaying sprites\n    spridr[i].left=xpos[i];spridr[i].top=ypos[i];screen.blit(sprid[i],spridr[i])\n  for event in pygame.event.get():  #praxis stuff\n    if event.type==pygame.QUIT:sys.exit()\n  pygame.display.flip();pygame.time.delay(1000/50)", "user_title": "Anonymous", "datetimeon": "2009-07-14T09:12:03", "link": "Rect.colliderect", "id": 2879}, {"content": "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=1024,256;screen=pygame.display.set_mode(size);pygame.display.set_caption(\"multiplayer sprite test with collisions\")\nspd=4;amnt=4;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;sprid=[];spridr=[]   #some arrays and variables\nfor i in range (0,amnt,1):\n  xpos[i]=64+(128*i)+random.randint(0,32);ypos[i]=64+random.randint(0,32)\nsprall=pygame.image.load(\"sprites_rgba.png\")  #loading sprites\nfor i in range (0,4,1):\n  spritetmp=sprall.subsurface(i*64,0,64,64);spriterecttmp=spritetmp.get_rect()\n  sprid.append(spritetmp);spridr.append(spriterecttmp)\nwhile 1:\n  key=pygame.key.get_pressed()  #checking pressed keys\n  if key[pygame.K_a]:xpos[0]-=spd\n  if key[pygame.K_d]:xpos[0]+=spd\n  if key[pygame.K_w]:ypos[0]-=spd\n  if key[pygame.K_s]:ypos[0]+=spd\n  if key[pygame.K_f]:xpos[1]-=spd\n  if key[pygame.K_h]:xpos[1]+=spd\n  if key[pygame.K_t]:ypos[1]-=spd\n  if key[pygame.K_g]:ypos[1]+=spd\n  if key[pygame.K_j]:xpos[2]-=spd\n  if key[pygame.K_l]:xpos[2]+=spd\n  if key[pygame.K_i]:ypos[2]-=spd\n  if key[pygame.K_k]:ypos[2]+=spd\n  if key[pygame.K_LEFT]: xpos[3]-=spd\n  if key[pygame.K_RIGHT]:xpos[3]+=spd\n  if key[pygame.K_UP]:   ypos[3]-=spd\n  if key[pygame.K_DOWN]: ypos[3]+=spd\n  bgcolour=0x998877    #checking collisions\n  if spridr[0].colliderect(spridr[1]):bgcolour=0xAA5555\n  if spridr[0].colliderect(spridr[2]):bgcolour=0x55AA55\n  if spridr[0].colliderect(spridr[3]):bgcolour=0x5555AA\n  if spridr[1].colliderect(spridr[2]):bgcolour=0x55AAAA\n  if spridr[1].colliderect(spridr[3]):bgcolour=0xAA55AA\n  if spridr[2].colliderect(spridr[3]):bgcolour=0xAAAA55\n  screen.fill(bgcolour)\n  for i in range (0,amnt,1):    #displaying sprites\n    spridr[i].left=xpos[i];spridr[i].top=ypos[i];screen.blit(sprid[i],spridr[i])\n  for event in pygame.event.get():  #praxis stuff\n    if event.type==pygame.QUIT:sys.exit()\n  pygame.display.flip();pygame.time.delay(1000/50)", "user_title": "Anonymous", "datetimeon": "2009-07-14T09:09:26", "link": "pygame.key.get_pressed", "id": 2878}, {"content": "This creates a mask from the surface which has all the pixels set which have color values above or equal to those in color, but below (and not equal to) the values in threshold.  So no pixel with a 255 value can possibly be considered.  And the default threshold doesn't let the mask have any set pixels for any given surface.", "user_title": "Anonymous", "datetimeon": "2010-03-13T06:03:20", "link": "pygame.mask.from_threshold", "id": 3073}, {"content": "It appears if you end up rotating your sprites, you need to regenerate their masks when collision is detected via the rect test, or the masks won't match with the corresponding imagery.", "user_title": "Anonymous", "datetimeon": "2009-07-13T01:08:45", "link": "pygame.sprite.collide_mask", "id": 2876}, {"content": "This didn't seem clear in the documentation. I checked the source (v. 1.8.1).\n\nThis takes a sequence of (R, G, B) triplets. This is currently the only way the palette can be defined.", "user_title": "Anonymous", "datetimeon": "2009-07-12T13:50:36", "link": "Surface.set_palette", "id": 2874}, {"content": "A less look at me demo:\n\nimport pygame.font\nimport pygame.surface\n\ndef gameprint(text,xx,yy,color):\n   font = pygame.font.SysFont(\"Courier New\",18)\n   ren = font.render(text,1,color)\n   screen.blit(ren, (xx,yy))", "user_title": "Anonymous", "datetimeon": "2009-08-28T19:19:15", "link": "Font.render", "id": 2927}, {"content": "how to fadein() ?", "user_title": "Anonymous", "datetimeon": "2010-03-09T06:18:13", "link": "pygame.mixer.music.fadeout", "id": 3068}, {"content": "cfadsfsadgfdh hHAHAHAH", "user_title": "Anonymous", "datetimeon": "2010-03-10T08:48:11", "link": "pygame.event.pump", "id": 3070}, {"content": "This function, at least on my system using Windows XP, \nonly one key is repeated at a time.  So, moving a sprite\naround the screen using the arrow keys can only move it\nin one direction at a time.  No diagonal by using two arrows\nat the same time...\n\nAn alternative is to set an object's state on KEYDOWN and reset \nit on KEYUP.\n\nExample:\n\n\tif e.type == KEYDOWN:\n\t\tif e.key == K_LEFT:\n\t\t\tship.xspeed -= SPEED\n\t\telif e.key == K_RIGHT:\n\t\t\tship.xspeed += SPEED\n\t\telif e.key == K_UP:\n\t\t\tship.yspeed -= SPEED\n\t\telif e.key == K_DOWN:\n\t\t\tship.yspeed += SPEED\n\t\telif e.key == K_SPACE\n\t\t\tship.firing = True\n\telif e.type == KEYUP:\n\t\tif e.key == K_LEFT:\n\t\t\tship.xspeed += SPEED\n\t\telif e.key == K_RIGHT:\n\t\t\tship.xspeed -= SPEED\n\t\telif e.key == K_UP:\n\t\t\tship.yspeed += SPEED\n\t\telif e.key == K_DOWN:\n\t\t\tship.yspeed -= SPEED\n\t\telif e.key == K_SPACE:\n\t\t\tship.firing == False", "user_title": "Anonymous", "datetimeon": "2010-03-12T11:41:32", "link": "pygame.key.set_repeat", "id": 3072}, {"content": "Only if you do not import all the pygame locals:\n\nfrom pygame.locals import *", "user_title": "Anonymous", "datetimeon": "2009-07-10T23:11:01", "link": "pygame.mouse.get_pressed", "id": 2871}, {"content": "Note that\nmyrect.move(x,y)\ndoes not change the Rect myrect. Only\nmyrect = myrect.move(x,y)\ndoes.", "user_title": "Anonymous", "datetimeon": "2010-03-03T13:42:28", "link": "Rect.move", "id": 3066}, {"content": "My copy of pygames uses numeric as default, not numpy (as stated above).\nThe best thing is probably to explicitly state the array type used (e.g. pygame.sndarray.use_arraytype('numpy')) to avoid problems with future convention changes.", "user_title": "Anonymous", "datetimeon": "2010-03-08T09:27:57", "link": "pygame.sndarray", "id": 3067}, {"content": "The docs are faulty here. scroll() takes two integers and not a tuple or a list.", "user_title": "Anonymous", "datetimeon": "2009-08-30T08:39:48", "link": "Surface.scroll", "id": 2930}, {"content": "What about Duel screen displays?", "user_title": "Anonymous", "datetimeon": "2009-07-09T13:26:59", "link": "pygame.display.set_mode", "id": 2869}, {"content": "are yoh sure that sign are correct", "user_title": "Anonymous", "datetimeon": "2010-03-02T18:18:51", "link": "pygame.key", "id": 3063}, {"content": "import pygame\nfrom pygame.locals import *\n\ndef timerFunc():\n    print \"Timer CallBack\"\n\npygame.init()\npygame.time.set_timer(USEREVENT+1, 100)\nwhile 1:\n    for event in pygame.event.get():\n        if event.type == USEREVENT+1:\n            timerFunc() #calling the function wheever we get timer event.\n        if event.type == QUIT:\n            break", "user_title": "Anonymous", "datetimeon": "2009-08-31T04:50:51", "link": "pygame.time.set_timer", "id": 2932}, {"content": "this is helpful thanks son", "user_title": "Anonymous", "datetimeon": "2009-08-31T22:47:55", "link": "pygame.font", "id": 2933}, {"content": "Wouldn't the center simply be X = X2 - X1  Y = Y2 - Y1 ?  Bottom right minus top left.  That doesn't require any special math functions, yes?", "user_title": "Anonymous", "datetimeon": "2009-04-22T14:45:07", "link": "pygame.draw.rect", "id": 2557}, {"content": "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=1024,256;screen=pygame.display.set_mode(size)\namnt=64;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;xdif=[0]*amnt;ydif=[0]*amnt;snum=[0]*amnt\nfor i in range (0,amnt,1):\n  xpos[i]=random.randint(0,width)\n  ypos[i]=random.randint(0,height)\n  xdif[i]=random.randint(0,ampl*2)-ampl\n  ydif[i]=random.randint(0,ampl*2)-ampl\n  snum[i]=random.randint(0,3)\nball=pygame.image.load(\"sprites_rgba.png\");ballrect=ball.get_rect()\nsprite00=ball.subsurface((  0,0,64,64));spriterect00=sprite00.get_rect()\nsprite01=ball.subsurface(( 64,0,64,64));spriterect01=sprite01.get_rect()\nsprite02=ball.subsurface((128,0,64,64));spriterect02=sprite02.get_rect()\nsprite03=ball.subsurface((192,0,64,64));spriterect03=sprite03.get_rect()\nwhile 1:\n  for event in pygame.event.get():\n    if event.type==pygame.QUIT:sys.exit()\n  for i in range (0,amnt,1):\n    xpos[i]+=xdif[i];ypos[i]+=ydif[i]\n    if xpos[i]&gt;width:xpos[i]-=(width+64)\n    if ypos[i]&gt;height:ypos[i]-=(height+64)\n    if xpos[i]&lt;-64:xpos[i]+=(width+64)\n    if ypos[i]&lt;-64:ypos[i]+=(height+64)\n  screen.fill(0x998877)\n  for i in range (0,amnt,1):\n    if snum[i]==0:\n      spriterect00.left=xpos[i];spriterect00.top=ypos[i];screen.blit(sprite00,spriterect00)\n    if snum[i]==1:\n      spriterect01.left=xpos[i];spriterect01.top=ypos[i];screen.blit(sprite01,spriterect01)\n    if snum[i]==2:\n      spriterect02.left=xpos[i];spriterect02.top=ypos[i];screen.blit(sprite02,spriterect02)\n    if snum[i]==3:\n      spriterect03.left=xpos[i];spriterect03.top=ypos[i];screen.blit(sprite03,spriterect03)\n  pygame.display.flip()\n  pygame.time.delay(1000/50)", "user_title": "Anonymous", "datetimeon": "2009-07-07T10:21:37", "link": "Surface.subsurface", "id": 2867}, {"content": "Usage of the event queue for USEREVENT-style events is limited by the maximum size of the SDL event queue, which is 256.\nSo, if more events (of any sort) get posted to the queue, you will get an exception stating \"error: Event queue full\".\nIf you expect to generate more than a few user events before they are posted, consider a separate queue.", "user_title": "Anonymous", "datetimeon": "2009-05-03T10:30:15", "link": "pygame.event.post", "id": 2560}, {"content": "Is this the same as pygame.surface.fill(color, rect)?", "user_title": "Anonymous", "datetimeon": "2009-05-05T15:48:33", "link": "pygame.draw.rect", "id": 2561}, {"content": "Just a note, Nautilus, the default file browser in GNOME sets copied files as 'x-special/gnome-copied-files', if you retrieve it, it holds the location as plain text.", "user_title": "Anonymous", "datetimeon": "2009-08-02T21:50:25", "link": "pygame.scrap", "id": 2901}, {"content": "so someone can share some Surface.subsurface snippet? (one about sprites is very welcome)", "user_title": "Anonymous", "datetimeon": "2009-07-06T22:14:24", "link": "Surface.subsurface", "id": 2866}, {"content": "test\ntest", "user_title": "Anonymous", "datetimeon": "2009-07-03T15:37:54", "link": "Surface.copy", "id": 2864}, {"content": "test &lt;br /&gt; test", "user_title": "Anonymous", "datetimeon": "2009-07-03T15:37:38", "link": "Surface.copy", "id": 2863}, {"content": "somewhere in the pygame google-group i found it's possible to have multiple sprites based on just one picture plenty of sprite drawings, without having to have them cropped file by file - how can we do this?", "user_title": "Anonymous", "datetimeon": "2009-07-03T15:37:10", "link": "Surface.copy", "id": 2862}, {"content": "missing commands for drawing bezier lines - some gpl sources can be find at http://nitrofurano.linuxkafe.com/sdlbasic - just needed to be recoded to Pygame, but it's not that difficult task at all...", "user_title": "Anonymous", "datetimeon": "2009-07-03T13:28:41", "link": "pygame.draw", "id": 2861}, {"content": "What does the error 'text has zero width' mean?\nI was simply printing 'Hello World!' to the screen.\nI was fiddling with text size, jumped from 32 to 12 and I got the above error\nNow the only way to stop the error is to have no text ('')", "user_title": "Anonymous", "datetimeon": "2009-07-03T07:24:30", "link": "Font.render", "id": 2860}, {"content": "It would be handy if the range of values was given. It appears to be 0 to 255.", "user_title": "Anonymous", "datetimeon": "2009-07-02T12:01:48", "link": "Color.r", "id": 2859}, {"content": "don't you know its a bad idea to leave your email on the internet?\n-wekul", "user_title": "Anonymous", "datetimeon": "2009-06-29T09:02:53", "link": "pygame.key", "id": 2857}, {"content": "With event.type == MOUSEBUTTONDOWN - Error! \nWrite it - event.type == pygame.MOUSEBUTTONDOWN", "user_title": "Anonymous", "datetimeon": "2009-07-02T06:50:36", "link": "pygame.mouse.get_pressed", "id": 2858}, {"content": "In Pygame 1.9 Surface.copy() does not preserve the original image's alpha. If\nyour image has an alpha you need to:\n\ns1 = s0.copy()\ns1.set_alpha(s0.get_alpha())", "user_title": "Anonymous", "datetimeon": "2010-02-21T12:03:18", "link": "Surface.copy", "id": 3059}, {"content": "In the comment on February 21, 2010 10:32am, in the last sentence I meant,\n\"for a sample i, the value of the left channel is a[i][0], the right channel\na[i][1],\" of course.", "user_title": "Anonymous", "datetimeon": "2010-02-21T14:25:02", "link": "pygame.sndarray", "id": 3060}, {"content": "When using numpy, be careful to set the type of the array correctly.\nFor instance, when you're in signed 16-bit stereo mode, e.g., when you've\ncalled\n\npygame.mixer.pre_init(size = -16, channels = 2)\n\nand you want to create an array to use for synthesizing a sound, don't forget\nthe dtype argument in\n\nsamples = numpy.zeros((n_samples, 2), dtype = numpy.int16)", "user_title": "Anonymous", "datetimeon": "2010-02-21T10:37:46", "link": "pygame.sndarray", "id": 3058}, {"content": "The above is hard to understand, at least for me. For instance, what does\n\"A stereo sound file has two values per sample\" mean? Here's what it means:\nif you're in mono, and your array has N samples, the shape of the array\nshould be (N,) (a d=1 array of N elements). If you're in stereo, then the\nshape should be (N,2) (a d=2 array, Nx2); for a sample i, the value of the left\nchannel is a[N][0], the right channel a[N][1].", "user_title": "Anonymous", "datetimeon": "2010-02-21T10:32:01", "link": "pygame.sndarray", "id": 3057}, {"content": "You could always do dir(pygame.Rect) or whatever.", "user_title": "Anonymous", "datetimeon": "2009-06-28T09:26:48", "link": "Surface.get_rect", "id": 2854}, {"content": "HTML (#rrggbbaa) format doesn't seem to work with 1.9.1 ... gives a \"ValueError: invalid argument\" exception.", "user_title": "Anonymous", "datetimeon": "2009-12-02T14:01:18", "link": "pygame.Color", "id": 3019}, {"content": "(What's even more odd is that it works from the python console ... just not in a program)", "user_title": "Anonymous", "datetimeon": "2009-12-02T14:07:37", "link": "pygame.Color", "id": 3020}, {"content": "it dun wok", "user_title": "Anonymous", "datetimeon": "2009-12-03T12:43:47", "link": "pygame.draw.arc", "id": 3021}, {"content": "Re: noise and static was occurring on my Linux box, and I was able to ameliorate it\nby specifically setting my mixer:\n    pygame.mixer.pre_init(44100, -16, 2)\n    pygame.init()", "user_title": "Anonymous", "datetimeon": "2009-12-07T01:43:58", "link": "Sound.play", "id": 3022}, {"content": "its set_palette_at, not set_at", "user_title": "Anonymous", "datetimeon": "2009-12-15T12:51:36", "link": "Surface.set_palette_at", "id": 3023}, {"content": "hey matthew sucks in snping", "user_title": "Anonymous", "datetimeon": "2009-12-16T15:50:04", "link": "pygame.draw.ellipse", "id": 3024}, {"content": "ellipserect=Rect(cmx,cmy,mx-cmx,my-cmy)\nellipserect.normalize()\ndraw.ellipse(screen,color,ellipserect,1)\nwhy ValueError: width greater than ellipse radius?", "user_title": "Anonymous", "datetimeon": "2009-12-18T13:28:16", "link": "pygame.draw.ellipse", "id": 3025}, {"content": "It plays dot-to-dot with the given points.", "user_title": "Anonymous", "datetimeon": "2010-02-19T01:32:43", "link": "pygame.draw.lines", "id": 3055}, {"content": "In ver. 1.9.1, if I try to initialize by calling\n\npygame.mixer.pre_init(...)\npygame.init()\n\nand then try to play a sound buffer, I get no output unless I open a graphics\nwindow first by calling pygame.display.set_mode(...). If, on the other hand,\nI'm not doing graphics and I initialize with just\n\npygame.mixer.init(...)\n\nI can get sound without opening any window.", "user_title": "Anonymous", "datetimeon": "2010-02-21T10:20:13", "link": "pygame.mixer", "id": 3056}, {"content": "to get a picture instead of black and white cursor, in order :\n1) simply make a transparent cursor\n   pygame.mouse.set_cursor(pygame.mouse.set_cursor((8,8),(0,0),(0,0,0,0,0,0,0,0),(0,0,0,0,0,0,0,0))\n\n2) constantly actualise the postition of the picture to the postion of the cursor\n   cursor_picture==pygame.image.load('./cursor.png').convert_alpha()\n   while True:\n       for event in pygame.event.get():\n           if event.type==QUIT:\n               exit()\n       screen.fill(black)\n       screen.blit(mouse_cursor, pygame.mouse.get_pos())\n       pygame.display.update()", "user_title": "Anonymous", "datetimeon": "2009-06-27T17:10:22", "link": "pygame.mouse.set_cursor", "id": 2850}, {"content": "Not sure why I am leaving this here... but can anyone tell me how you would rotate a surface?  Its 3am so excuse my ignorance :D", "user_title": "Anonymous", "datetimeon": "2009-11-30T03:38:25", "link": "pygame.Surface", "id": 3016}, {"content": "Theres is an error in documentation: pygame.cursor.compile does not exists, but pygame.cursors.compile do", "user_title": "Anonymous", "datetimeon": "2009-11-30T18:49:41", "link": "pygame.cursors.compile", "id": 3017}, {"content": "is there anyway to rotate a rectangle with out making it an image?", "user_title": "Anonymous", "datetimeon": "2009-11-13T15:06:41", "link": "pygame.transform.rotate", "id": 3009}, {"content": "Minor problem: When I run the program using this for an image, it says \"cannot load image!\" could anyone help me?", "user_title": "Anonymous", "datetimeon": "2009-11-15T09:50:56", "link": "pygame.image.load", "id": 3010}, {"content": "We need the posibility to rotate without the image being rescaled, just keep its original size like in PIL.\n\nim.rotate(angle, filter=NEAREST, expand=0) \nThe expand argument, if true, indicates that the output image should be made \nlarge enough to hold the rotated image. \nIf omitted or false, the output image has the same size as the input image.", "user_title": "Anonymous", "datetimeon": "2009-11-21T05:03:48", "link": "pygame.transform.rotate", "id": 3012}, {"content": "In pygame 1.9.1 this function does not return negative values instead it returns a \n0 for all values &lt; 0 (of the direction vector). If you are looking for a way to \ncompute a collision response look at Mask.overlap_area.", "user_title": "Anonymous", "datetimeon": "2009-11-23T10:34:10", "link": "Mask.overlap", "id": 3013}, {"content": "can anyone please explain what this function do? at best whith an example", "user_title": "Anonymous", "datetimeon": "2009-11-27T06:41:00", "link": "pygame.draw.lines", "id": 3014}, {"content": "Meta key is 'Apple' or 'Command' on a mac.", "user_title": "Anonymous", "datetimeon": "2009-09-07T03:31:29", "link": "pygame.key", "id": 2939}, {"content": "why doesn't this blit on the screen???\n\n\n            for star in self.stars:\n                self.screen.blit(self.a, star.pos)\n                star.update()\n                self.screen.blit(star.image, star.pos)\n            pygame.display.update()", "user_title": "Anonymous", "datetimeon": "2009-09-08T22:04:17", "link": "Surface.blit", "id": 2941}, {"content": "HELP ME ONMMGMGMGMGMGMG", "user_title": "Anonymous", "datetimeon": "2009-11-12T10:31:24", "link": "Surface.convert_alpha", "id": 3006}, {"content": "aghahhahahahah I LOVE THIS OMG (*&amp;^%$#@Q", "user_title": "Anonymous", "datetimeon": "2009-11-12T10:31:43", "link": "Surface.convert_alpha", "id": 3007}, {"content": "In my game the screen is scaled. This can cause havoc with the mouse positioning. I made this function:\n\n def get_mouse_pos(pos):\n\treturn (pos[0] * (1280.0/float(game.game_scaled[0])),pos[1] * (720.0/float(game.game_scaled[1])))\n\nReplace 1280.0 and 720.0 with the resolution of the pre-scaled game and game.game_scaled with a sequence containing the scaled resolution.", "user_title": "Anonymous", "datetimeon": "2009-11-12T12:43:39", "link": "pygame.transform.scale", "id": 3008}, {"content": "It seems to work if you set the display of the movie to a surface of the same size and then blit that surface to the screen.", "user_title": "Anonymous", "datetimeon": "2009-06-24T20:28:26", "link": "pygame.movie", "id": 2846}, {"content": "This documentation does not seem to match what is currently in 1.8.1.  \nInstead: pygame.transform.threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = True, Surface =None): return num_threshold_pixels", "user_title": "Anonymous", "datetimeon": "2009-11-11T15:11:43", "link": "pygame.transform.threshold", "id": 3004}, {"content": "For some odd reason anything in pygame.Color gets an error message like it doesn't exist.\nIf I try using pygame.Color.r, it says that Color has no attribute r. I tried redownloading\npygame, but nothing diffrent.", "user_title": "Anonymous", "datetimeon": "2009-09-11T20:56:38", "link": "pygame.Color", "id": 2943}, {"content": "I am having the same problem on XP. The sound plays, but the video does not.", "user_title": "Anonymous", "datetimeon": "2009-06-24T20:09:34", "link": "pygame.movie", "id": 2845}, {"content": "\"current_h, current_h:  Width and height of the current video mode, or of the\"[...]\nOne of them should be \"current_w\" instead.", "user_title": "Anonymous", "datetimeon": "2009-11-07T06:40:09", "link": "pygame.display.Info", "id": 2999}, {"content": "For me, PixelArray works much faster (4 or 5 times faster) than Surfarray. I wanted to set every pixel in my off-screen surface individually. Creating the surface, creating a PixelArray on it, and going through the pixels one-by-one is much faster than creating the bitmap using numpy and calling surfarray.make_surface.", "user_title": "Anonymous", "datetimeon": "2009-11-08T08:17:58", "link": "pygame.PixelArray", "id": 3000}, {"content": "\u00c3?\u00c3? \u00c3\u00ac\u00c3\u00ae\u00c3\u008a\u00c3\u00a5\u00c3\u00b2\u00c3\u00a5 \u00c3\u00ad\u00c3\u00a0\u00c3\u00b0\u00c3\u009a\u00c3\u00b1\u00c3\u00ae\u00c3\u00a2\u00c3\u00a0\u00c3\u00b2\u00c3\u008c \u00c3\u00ad\u00c3\u00a5\u00c3\u00b1\u00c3\u00aa\u00c3\u00ae\u00c3\u00ab\u00c3\u008c\u00c3\u00aa\u00c3\u00ae \u00c3\u00af\u00c3\u00a0\u00c3\u00b0\u00c3\u00a0\u00c3\u00ab\u00c3\u00ab\u00c3\u00a5\u00c3\u00ab\u00c3\u008c\u00c3\u00ad\u00c3\u00bb\u00c3\u00b5 \u00c3\u00ab\u00c3\u009a\u00c3\u00ad\u00c3\u009a\u00c3\u00a9 \u00c3\u00b0\u00c3\u00bf\u00c3\u0080\u00c3\u00ae\u00c3\u00ac \u00c3\u00b1 \u00c3\u0080\u00c3\u00b0\u00c3\u00b3\u00c3\u00a3\u00c3\u00ae\u00c3\u00ac. \u00c3?\u00c3\u00b2\u00c3\u00ae\u00c3\u00a1\u00c3\u00bb \u00c3\u009a\u00c3\u00b5 \u00c3\u0080\u00c3\u00ab\u00c3\u009a\u00c3\u00ad\u00c3\u00bb \u00c3\u00b1\u00c3\u00ab\u00c3\u009a\u00c3\u00a2\u00c3\u00a0\u00c3\u00ab\u00c3\u009a\u00c3\u00b1\u00c3\u008c\n \u00c3\u00ae\u00c3\u00ad\u00c3\u009a \u00c3\u00a1\u00c3\u00b3\u00c3\u0080\u00c3\u00b3\u00c3\u00b2 \u00c3\u00a2\u00c3\u009a\u00c3\u0080\u00c3\u00ad\u00c3\u00bb, \u00c3\u00aa\u00c3\u00a0\u00c3\u00aa \u00c3\u00ae\u00c3\u0080\u00c3\u00ad\u00c3\u00a0. \u00c3\u008d\u00c3\u00ae \u00c3\u009c\u00c3\u00b2\u00c3\u00ae \u00c3\u00a1\u00c3\u00b3\u00c3\u0080\u00c3\u00a5\u00c3\u00b2 \u00c3\u00ac\u00c3\u00a5\u00c3\u0080\u00c3\u00ab\u00c3\u00a5\u00c3\u00ad\u00c3\u00ad\u00c3\u00a5\u00c3\u00a9.\n I don't know english, write russian. translate.google for you help! :)", "user_title": "Anonymous", "datetimeon": "2009-11-08T18:19:31", "link": "pygame.draw.aaline", "id": 3001}, {"content": "uiuuiu", "user_title": "Anonymous", "datetimeon": "2009-11-11T05:10:30", "link": "pygame.key.get_focused", "id": 3002}, {"content": "its very ...................", "user_title": "Anonymous", "datetimeon": "2009-11-11T05:11:00", "link": "pygame.key.get_focused", "id": 3003}, {"content": "Tip for noobs. This was killing me. If you're trying this for the first time and getting no sound, it may be because you're program exits before the playback thread completes. See pygame/examples/sound.py: it waits at the end.", "user_title": "Anonymous", "datetimeon": "2009-12-19T19:22:25", "link": "Channel.play", "id": 3026}, {"content": "Tip for noobs. This was killing me. If you're trying this for the first time and\ngetting no sound, it may be because you're program exits before the playback\nthread completes. See pygame/examples/sound.py: it waits at the end.", "user_title": "Anonymous", "datetimeon": "2009-12-19T19:23:52", "link": "Sound.play", "id": 3027}, {"content": "You missed pygame.Mixer", "user_title": "Anonymous", "datetimeon": "2009-10-27T02:47:35", "link": "pygame.init", "id": 2991}, {"content": "Tried this on XP with pygame 1.9 - video works, but sound doesn't. Uninitializing pygame.mixer does not seem to effect behavior.", "user_title": "Anonymous", "datetimeon": "2009-10-27T20:31:08", "link": "pygame.movie", "id": 2992}, {"content": "As of 1.9, it does not appear the loop param exists.", "user_title": "Anonymous", "datetimeon": "2009-10-27T20:42:45", "link": "Movie.play", "id": 2993}, {"content": "If your movies play slow or occasionally freeze, setting a limit to framerates seems to resolve the problem. \nSee the documentation on Clock.tick(framerate) on how to limit framerates:\nhttp://www.pygame.org/docs/ref/time.html#Clock.tick", "user_title": "Anonymous", "datetimeon": "2009-10-29T10:53:02", "link": "pygame.movie.Movie", "id": 2994}, {"content": "The example code and the explanation contradict each other.\n\nThe example returns true if lost, supposedly, and the explanation supposedly returns False if lost?", "user_title": "Anonymous", "datetimeon": "2009-11-04T18:10:25", "link": "pygame.scrap.lost", "id": 2995}, {"content": "Does not work *at all*. No changes occur when I change any pixels.", "user_title": "Anonymous", "datetimeon": "2009-11-05T22:12:49", "link": "pygame.PixelArray", "id": 2996}, {"content": "Remember, there are not semitones. Thus, each semitone is represented by an integer named \"note\".\nIf you are a beginer it is a good choice to start practicing with the middle notes.\nC 4 is the note number 61. Have fun!.\n\nTourette", "user_title": "Anonymous", "datetimeon": "2009-12-21T19:52:02", "link": "Output.note_on", "id": 3028}, {"content": "pygame.mask.from_surface(Surface, threshold) -&gt; Mask\nno Keyword argument", "user_title": "Anonymous", "datetimeon": "2009-10-25T18:04:44", "link": "pygame.mask.from_surface", "id": 2989}, {"content": "you use a class to get the var\nfor example\nclass myimage(object):\n    image = (your image)\nthen to blit\n\ndisplay.blit(myimage.image, (0,0))\n\nso that you are only accesing the one variable to blit instead of multiple instances of the same", "user_title": "Anonymous", "datetimeon": "2009-08-04T11:33:28", "link": "Surface.copy", "id": 2905}, {"content": "if you want to measure it over a period of your choosing just compute a moving average of the result of clock.tick(), like this:\n\n...\n\nrecent_frame_lengths = [ 100, 100, 100, 100, 100 ]\nrfl_array_len = float( len( recent_frame_lengths ) )\n\n...\nmain():\n...\ndt = clock.tick()\nrecent_frame_lengths.pop(0)\nrecent_frame_lengths.append(dt)\naverage_frame_length = recent_frame_lengths / rfl_array_len\nframes_per_second = 1000. / average_frame_length", "user_title": "Anonymous", "datetimeon": "2010-05-18T12:08:59", "link": "Clock.get_fps", "id": 3124}, {"content": "button can be at least 1-6. 4/5 are for the scroll wheel. \nThe squeeze-click on new Apple mice is 6.", "user_title": "Anonymous", "datetimeon": "2010-05-20T22:13:33", "link": "pygame.event", "id": 3126}, {"content": "event polling:\n#self.keys is [] 256 len. \nself.mouse = ((0,0), 0, 0, 0, 0, 0, 0) #(pos, b1,b2,b3,b4,b5,b6)\n#squeezing a new Apple mouse is button 6. \nfor event in pygame.event.get():\n\tif event.type == pygame.QUIT:\n\t\tself.running = 0\n\telif event.type == pygame.MOUSEBUTTONDOWN:\n\t\tself.mouse[event.button] = 1\n\t\tself.mouse[0] = event.pos\n\telif event.type == pygame.MOUSEBUTTONUP:\n\t\tself.mouse[event.button] = 0\n\t\tself.mouse[0] = event.pos\n\telif event.type == pygame.MOUSEMOTION:\n\t\tself.mouse[0] = event.pos\n\telif event.type == pygame.KEYDOWN:\n\t\tself.keys[event.key % 255] = 1\n\telif event.type == pygame.KEYUP:\n\t\tself.keys[event.key % 255] = 0", "user_title": "Anonymous", "datetimeon": "2010-05-20T22:31:20", "link": "pygame.mouse.get_pressed", "id": 3127}, {"content": "PyGame beginners, please don't look at Matthew N. Brown's code below.\n\nThat is the worst Python code I have ever seen, and it offers almost no examples of how to use pygame.draw.circle.", "user_title": "Anonymous", "datetimeon": "2010-05-17T13:22:44", "link": "pygame.draw.circle", "id": 3123}, {"content": "What about subsubsubsubsurfaces?", "user_title": "Anonymous", "datetimeon": "2009-06-14T09:27:19", "link": "Surface.subsurface", "id": 2830}, {"content": "for some reason this gives always wrong numbers.\nmask_creep = pygame.mask.from_surface(creep.image)\nmask_player = pygame.mask.from_surface(p.image)\np.life -= mask_player.overlap_area(\n   mask_creep, (creep.rect.x-p.rect.x,creep.rect.y-p.rect.y))\n\np.life is the life of the player, and I want to drain it by the amount of pixels overlapping with creep.\nhowever, it seems it hits before it should, and with mask_creep.invert() I seem to get more accurate hits, which makes no sense...", "user_title": "Anonymous", "datetimeon": "2009-10-24T06:03:49", "link": "pygame.mask", "id": 2984}, {"content": "get also this warning : nsquickdrawview \nif I compile.\n\ncan\u00c2\u008et use pygame with py2app\n\npython 2.4 or 2.5\nmaxos leopard\neclipse", "user_title": "Anonymous", "datetimeon": "2010-01-05T21:56:27", "link": "pygame.display.init", "id": 3032}, {"content": "This function is not working as stated.  It requires a 'rectstyle' argument (ie. a tuple with rect's parameters).  it tests for collisions using this 'rectsytle' object and returns any that are colliding along with their values.  Not really useful since no one needs a tuple of rect's parameters back.  this would be really nice if it worked as stated...", "user_title": "Anonymous", "datetimeon": "2009-10-24T03:33:00", "link": "Rect.collidedict", "id": 2982}, {"content": "The math isn't that hard, you just have to think in relative coordinates then.\nThe key is to look at the center of the image, as these coordinates wont change by rotating it.\nThe coordinates of the center of the image on the screen are given by:\nx_cntr.. x coordinate of the center\ny_cntr.. y coordinate of the center\n\npos_org = (x_cntr - image_org.get_rect().width / 2,\n           y_cntr - image_org.get_rect().height / 2) \n           \"\"\"gives position of upper left corner of image_org (not rotated)\n           depending on the center coordinates for the Surface.blit function\"\"\"\nimage_rotated = pygame.transform.rotate(image_org, angle) #rotate image\npos_new = (x_pos_org - image_rotated.get_rect().width / 2,\n           y_pos_org - image_rotated.get_rect().height / 2)\n           #get new position for upper left corner for rotated image", "user_title": "Anonymous", "datetimeon": "2010-01-21T11:14:00", "link": "pygame.transform.rotate", "id": 3036}, {"content": "x_pos_org and y_pos_org naturally need to be x_cntr and y_cntr.. sry", "user_title": "Anonymous", "datetimeon": "2010-01-21T11:20:31", "link": "pygame.transform.rotate", "id": 3037}, {"content": "fuck u", "user_title": "Anonymous", "datetimeon": "2010-01-21T12:35:00", "link": "PixelArray.replace", "id": 3038}, {"content": "doesnt work!", "user_title": "Anonymous", "datetimeon": "2010-01-25T12:07:07", "link": "pygame.display.set_caption", "id": 3039}, {"content": "WTH!???", "user_title": "Anonymous", "datetimeon": "2010-01-25T12:07:16", "link": "pygame.display.set_caption", "id": 3040}, {"content": "Where should the image file be save at?", "user_title": "Anonymous", "datetimeon": "2010-01-29T02:01:23", "link": "pygame.image.load", "id": 3042}, {"content": "To clip the blit, you have to pass a rect like this (0, 0, clipWidth, clipHeigth):\n\nexample:\n\nsForeground.blit(sText, rText, (0, 0, 32, 32)):\n\ndraw the surface sText into sForeground at topleft position defined with the rect rText,\nclippping the sText by 32x32 pixel box", "user_title": "Anonymous", "datetimeon": "2010-01-30T14:45:56", "link": "Surface.blit", "id": 3043}, {"content": "actually, it DOES WORK. put it in the right group", "user_title": "Anonymous", "datetimeon": "2010-02-02T15:56:23", "link": "pygame.display.set_caption", "id": 3044}, {"content": "how does this even work?????", "user_title": "Anonymous", "datetimeon": "2010-02-02T23:04:45", "link": "Rect.move", "id": 3045}, {"content": "Pygame 1.9: DeprecationWarning: integer argument expected, got float\n\nThe tuple elements must be integers. The line number in the warning message will\nindicate your enclosing function or method. I found this very misleading and\nfrustrating.", "user_title": "Anonymous", "datetimeon": "2010-02-06T02:16:05", "link": "pygame.transform.smoothscale", "id": 3048}, {"content": "By calling Clock.tick -&gt; clock.tick", "user_title": "Anonymous", "datetimeon": "2010-02-08T10:30:27", "link": "Clock.tick_busy_loop", "id": 3049}, {"content": "that code you posted (TWICE) doesnt show how to draw a circle in pygame.\n It shows an example of a complex couple hundred lines  of interactive \nphysics engine that just so happens to take im guessing less than\n5 lines to use pygame.draw.circle. Its a waste of space Good job for getting your code out into \nthe world. Now people dont like you.", "user_title": "Anonymous", "datetimeon": "2010-02-08T22:31:47", "link": "pygame.draw.circle", "id": 3050}, {"content": "TypeError: descriptor 'collidelistall' requires a 'pygame.Rect' object but received a 'list'\n\n...so it doesn't like a list, but a pygame.Rect? That does't make sense.", "user_title": "Anonymous", "datetimeon": "2009-10-22T05:21:56", "link": "Rect.collidelistall", "id": 2977}, {"content": "Also using\n\n my_surface=pygame.Surface([width, height]).convert()\n\nseems to be just as effective", "user_title": "Anonymous", "datetimeon": "2009-10-16T22:13:15", "link": "pygame.Surface", "id": 2974}, {"content": "x = x2 - x1, y = y2 - y1 gives the width and height of the rectangle.\n(x2 - x1) / 2, (y2 - y1) / 2 gives the center coordinates.\nI don't know of a built-in method on the Rect that gives the center coords.", "user_title": "Anonymous", "datetimeon": "2009-10-21T20:50:31", "link": "pygame.draw.rect", "id": 2976}, {"content": "AWSOME", "user_title": "Anonymous", "datetimeon": "2009-10-08T11:50:27", "link": "pygame.draw", "id": 2967}, {"content": "Aloha! jdv", "user_title": "Anonymous", "datetimeon": "2009-09-20T07:33:05", "link": "Rect.move_ip", "id": 2954}, {"content": "Worth mentioning: the initial angle must be less than the final angle; otherwise it will draw the full elipse.", "user_title": "Anonymous", "datetimeon": "2009-10-01T14:16:05", "link": "pygame.draw.arc", "id": 2964}, {"content": "If you want a circle with a *good* outline, use this:\n\ndef drawcircle(image, colour, origin, radius, width=0):\n\tif width == 0:\n\t\tpygame.draw.circle(image,colour,intlist(origin),int(radius))\n\telse:\n\t\tif radius &gt; 65534/5: radius = 65534/5\n\t\tcircle = pygame.Surface([radius*2+width,radius*2+width]).convert_alpha()\n\t\tcircle.fill([0,0,0,0])\n\t\tpygame.draw.circle(circle, colour, intlist([circle.get_width()/2, circle.get_height()/2]), int(radius+(width/2)))\n\t\tif int(radius-(width/2)) &gt; 0: pygame.draw.circle(circle, [0,0,0,0], intlist([circle.get_width()/2, circle.get_height()/2]), abs(int(radius-(width/2))))\n\t\timage.blit(circle, [origin[0] - (circle.get_width()/2), origin[1] - (circle.get_height()/2)])", "user_title": "Anonymous", "datetimeon": "2009-09-30T10:47:07", "link": "pygame.draw.circle", "id": 2963}, {"content": "I think the problem has something to do with encapsulation.\nTry:\ncurrent_song = 0\ndef Play_Next_Song():\n    global current_song\n    if pygame.mixer.music.get_busy() == False:\n        print songs[current_song]\n        pygame.mixer.music.load(songs[current_song])\n        pygame.mixer.music.play()    \n        current_song += 1", "user_title": "Anonymous", "datetimeon": "2009-09-21T11:39:31", "link": "pygame.mixer.music.load", "id": 2956}, {"content": "WHAT?", "user_title": "Anonymous", "datetimeon": "2009-09-23T15:22:38", "link": "pygame.draw.lines", "id": 2957}, {"content": "Can I draw circles too?", "user_title": "Anonymous", "datetimeon": "2009-09-24T13:53:40", "link": "pygame.draw.circle", "id": 2958}, {"content": "how can i get a mouse wheel value? please show in a snippet - i don't know how to use pygame.MOUSEBUTTONDOWN and pygame.MOUSEBUTTONUP", "user_title": "Anonymous", "datetimeon": "2009-09-25T11:53:07", "link": "pygame.mouse.get_pressed", "id": 2960}, {"content": "Setting the line width does not work!", "user_title": "Anonymous", "datetimeon": "2009-09-29T10:21:37", "link": "pygame.draw.rect", "id": 2962}, {"content": "i dont like pygame very much\nrectangles can go poop themselves", "user_title": "Anonymous", "datetimeon": "2010-05-21T11:08:52", "link": "Rect.collidelistall", "id": 3128}, {"content": "In fact it should be\n\"By calling Clock.tick(40)\" -&gt; \"Clock.tick_busy_loop(40)\"", "user_title": "Anonymous", "datetimeon": "2010-06-01T03:26:55", "link": "Clock.tick_busy_loop", "id": 3130}, {"content": "No, waiting at the very beginning or very end of a loop does not make\nmuch difference.  Moving it to the middle might: \n  screen.fill(...)\n  clock.tick(30)\n  screen.blit(...)\nwill mostly show a blank screen because the fill will be visible\nduring the wait.", "user_title": "Anonymous", "datetimeon": "2010-06-01T07:55:40", "link": "Clock.tick", "id": 3131}, {"content": "haleluja", "user_title": "Anonymous", "datetimeon": "2010-06-02T03:11:33", "link": "Rect.collidelist", "id": 3133}, {"content": "PixelArray works faster than SurfArray for me also.", "user_title": "Anonymous", "datetimeon": "2010-06-02T20:55:16", "link": "pygame.PixelArray", "id": 3134}, {"content": "Only seems to block if you start another piece of music playing while it's still\nfading out.", "user_title": "Anonymous", "datetimeon": "2010-06-06T16:23:37", "link": "pygame.mixer.music.fadeout", "id": 3135}, {"content": "If you're having trouble with color keys, try image.set_alpha(None) on each individual subsurface.\nsubsurface seems not to always inherit its parent's alpha setting, so if the parent source image has an alpha then color key is ignored in subsurfaces.\n\nYou can easily remove the alpha channel in GIMP by right-clicking the background layer and selecting \"remove alpha channel\" to fix all your problems also :)", "user_title": "Anonymous", "datetimeon": "2010-06-08T23:09:21", "link": "Surface.subsurface", "id": 3139}, {"content": "You should use pygame.display.Info.current_h and pygame.display.Info.current_w.", "user_title": "Anonymous", "datetimeon": "2010-06-10T20:42:30", "link": "pygame.display.get_surface", "id": 3140}, {"content": "pygame.display.Info().current_h and pygame.display.Info().current_w", "user_title": "Anonymous", "datetimeon": "2010-06-10T20:43:14", "link": "pygame.display.get_surface", "id": 3141}, {"content": "screen = pygame.display.set_mode(...)\nscreen.get_size()", "user_title": "Anonymous", "datetimeon": "2010-06-10T20:55:19", "link": "pygame.display.get_surface", "id": 3142}, {"content": "11246579455877\nppqu s442", "user_title": "Anonymous", "datetimeon": "2010-06-11T18:56:04", "link": "pygame.mixer.music.play", "id": 3143}, {"content": "import pygame\nimport pygame, sys,os, time                 \nfrom pygame.locals import *                  \nfrom pygame.color import THECOLORS           \nimport platform, os                          \nif platform.system()==\"Windows\":           \n    os.environ['SDL_VIDEODRIVER']='windib'\npygame.init()\nwindow = pygame.display.set_mode((600,600)) \nscreen = pygame.display.get_surface() \npygame.display.set_caption('Excercise 5') \nscreen.fill((0,0,0))\n\nclass GfxCursor:\n    \"\"\"\n    Replaces the normal pygame cursor with any bitmap cursor\n    \"\"\"\n\n    def __init__(self,surface,cursor=None,hotspot=(0,0)):\n        \"\"\"\n        surface = Global surface to draw on\n        cursor  = surface of cursor (needs to be specified when enabled!)\n        hotspot = the hotspot for your cursor\n        \"\"\"\n        self.surface = surface\n        self.enabled = 0\n        self.cursor  = None\n        self.hotspot = hotspot\n        self.bg      = None\n        self.offset  = 0,0\n        self.old_pos = 0,0\n        \n        if cursor:\n            self.setCursor(cursor,hotspot)\n            self.enable()\n\n    def enable(self):\n        \"\"\"\n        Enable the GfxCursor (disable normal pygame cursor)\n        \"\"\"\n        if not self.cursor or self.enabled: return\n        pygame.mouse.set_visible(0)\n        self.enabled = 1\n\n    def disable(self):\n        \"\"\"\n        Disable the GfxCursor (enable normal pygame cursor)\n        \"\"\"\n        if self.enabled:\n            self.hide()\n            pygame.mouse.set_visible(1)\n            self.enabled = 0\n\n    def setCursor(self,cursor,hotspot=(0,0)):\n        \"\"\"\n        Set a new cursor surface\n        \"\"\"\n        if not cursor: return\n        self.cursor = cursor\n        self.hide()\n        self.show()\n        self.offset = 0,0\n        self.bg = pygame.Surface(self.cursor.get_size())\n        pos = self.old_pos[0]-self.offset[0],self.old_pos[1]-self.offset[1]\n        self.bg.blit(self.surface,(0,0),\n            (pos[0],pos[1],self.cursor.get_width(),self.cursor.get_height()))\n\n        self.offset = hotspot\n\n    def setHotspot(self,pos):\n        \"\"\"\n        Set a new hotspot for the cursor\n        \"\"\"\n        self.hide()\n        self.offset = pos\n\n    def hide(self):\n        \"\"\"\n        Hide the cursor (useful for redraws)\n        \"\"\"\n        if self.bg and self.enabled:\n            return self.surface.blit(self.bg,\n                (self.old_pos[0]-self.offset[0],self.old_pos[1]-self.offset[1]))\n\n    def show(self):\n        \"\"\"\n        Show the cursor again\n        \"\"\"\n        if self.bg and self.enabled:\n            pos = self.old_pos[0]-self.offset[0],self.old_pos[1]-self.offset[1]\n            self.bg.blit(self.surface,(0,0),\n                (pos[0],pos[1],self.cursor.get_width(),self.cursor.get_height()))\n            return self.surface.blit(self.cursor,pos)\n\n    def update(self,event):\n        \"\"\"\n        Update the cursor with a MOUSEMOTION event\n        \"\"\"\n        self.old_pos = event.pos\n\nif __name__ == '__main__': #test it out\n    import pygame.draw\n    pygame.init()\n    screen = pygame.display.set_mode((400, 300))\n    screen.fill((50, 50, 111), (0, 0, 400, 150))\n    pygame.display.flip()\n    pygame.display.set_caption('Test the GfxCursor (and paint)')\n    \n    image = pygame.Surface((20, 20))\n    pygame.draw.circle(image, (50, 220, 100), (10, 10), 8, 0)\n    pygame.draw.circle(image, (220, 200, 50), (10, 10), 8, 2)\n    image.set_at((9, 9), (255,255,255))\n    image.set_colorkey(0, pygame.RLEACCEL)\n    \n    magicbox = pygame.Rect(10, 10, 100, 90)\n    magiccolor = 0\n    \n    cursor = GfxCursor(screen, image, (10, 10))\n    finished = 0\n    downpos = None\n    while not finished:\n        dirtyrects = []\n        dirtyrects.extend([cursor.hide()])\n        for e in pygame.event.get():\n            if e.type in (pygame.QUIT, pygame.KEYDOWN):\n                finished = 1\n                break\n            elif e.type == pygame.MOUSEBUTTONDOWN:\n                cursor.disable()\n                downpos = e.pos\n            elif e.type == pygame.MOUSEBUTTONUP:\n                cursor.enable()\n                downpos = None\n            elif downpos and e.type == pygame.MOUSEMOTION:\n                r = pygame.draw.line(screen, (100,100,100), downpos, e.pos, 2)\n                dirtyrects.append(r)\n                downpos = e.pos\n                cursor.update(e)\n            elif not downpos and e.type == pygame.MOUSEMOTION:\n                cursor.update(e)\n        \n        magiccolor = (magiccolor + 2) % 255\n        r = screen.fill((0, 0, magiccolor), magicbox)\n        dirtyrects.append(r)\n        \n        #here's how we sandwich the flip/update with cursor show and hide\n        dirtyrects.extend([cursor.show()])\n        pygame.display.update(dirtyrects)\n        \n        pygame.time.delay(5) #should be time.wait(5) with pygame-1.3 :]", "user_title": "Anonymous", "datetimeon": "2010-06-13T02:45:37", "link": "Color.r", "id": 3145}, {"content": "I get an 'UnboundLocalError: local variable 'fonts' referenced before assignment' error. \nI'm on Mac OS X 10.4 Tiger with Python 2.6.4, Pygame 1.9.1.", "user_title": "Anonymous", "datetimeon": "2010-06-19T22:22:14", "link": "pygame.font.get_fonts", "id": 3146}, {"content": "I'm no expert but wouldn't it be faster to use the math.hypot(a, b)\nfunction for determining length instead of writing your own function?", "user_title": "Anonymous", "datetimeon": "2009-06-09T21:45:55", "link": "Joystick.get_axis", "id": 2759}, {"content": "You can also move the corner:\n\nsquare_corner=(x-square_dim[0]*sqrt(2)/2*sin((abs(angle)+45)*pi/180),\n                     y-square_dim[1]*sqrt(2)/2*sin((45+abs(angle))*pi/180))\n  screen.blit(pygame.transform.rotate(square,angle), square_corner)\n\nBeware: sin calculates the angle in rad but rotate needs angles in degrees.", "user_title": "Anonymous", "datetimeon": "2009-06-08T14:31:39", "link": "pygame.transform.rotate", "id": 2758}, {"content": "ACTIVEEVENT has two attributes. \"gain\" is set to 0 or one depending if the type of focus was lost or gained. \"state\" will equal 1 for mouse focus, 2 for keyboard focus, or 4 for window iconification.", "user_title": "Anonymous", "datetimeon": "2009-06-03T22:15:32", "link": "pygame.event", "id": 2755}, {"content": "If you want only certain events to be enabled -- you will need to disable them all, and only then enable the ones that you need:\n#--\npygame.event.set_allowed(None)\nprint map(pygame.event.get_blocked,range(1,33))\npygame.event.set_allowed([pygame.QUIT, pygame.KEYDOWN, pygame.USEREVENT])\nprint map(pygame.event.get_blocked,range(1,33))\n#--\nbelow is the output:\n[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n[1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1]", "user_title": "Anonymous", "datetimeon": "2009-05-30T16:39:22", "link": "pygame.event.set_allowed", "id": 2754}, {"content": "Also, it should maybe be noted that it returns 4 tuple items, not just 3.\nMy guess is RGBA tuple instead of RGB, but I'm not an expert :P", "user_title": "Anonymous", "datetimeon": "2009-05-27T02:45:25", "link": "Surface.unmap_rgb", "id": 2753}, {"content": "convert a mapped integer color value into a Color\nSurface.map_rgb(mapped_int): return Color\n        ^\nShouldn't it be \"Surface.unmap_rgb\"?", "user_title": "Anonymous", "datetimeon": "2009-05-27T02:43:16", "link": "Surface.unmap_rgb", "id": 2752}, {"content": "Tracked module playback with Pygame has a lower playback volume than usual,\nand I need to find something like \"stereo separation\" feature yet.", "user_title": "Anonymous", "datetimeon": "2009-05-21T06:41:14", "link": "pygame.mixer.music", "id": 2751}, {"content": "Yes, I just found it out, and it plays tracked music modules such as MOD or XM.\nBut IT (Impulse Tracker) modules don't play correctly. Wow. I used fmod with Python bindings\nall the time, and Pygame supported it already. I wish I knew that sooner :D", "user_title": "Anonymous", "datetimeon": "2009-05-21T06:35:19", "link": "pygame.mixer.music", "id": 2750}, {"content": "While using this, it seems that it returns true when the music is paused. Anyone else having this problem, if it's a problem?", "user_title": "Anonymous", "datetimeon": "2009-05-19T11:35:42", "link": "pygame.mixer.music.get_busy", "id": 2749}, {"content": "If you want to draw the sprites in your group in the opposite order you could try something like this:\n#Suppose that you keep a list of objects in \"Sprites\"\nSprites=[]\n#You also have:\nAllsprites=pygame.sprite.OrderedUpdates(Sprites)\n\nWhenever you add something to the list of sprites, you want to add it to Allsprites like this:\ndef create_sprite():\n     a=SomeClassForYourSprite()\n     Sprites.append(a)\n     Allsprites.add(a)\n\n#That is how I normally add sprites, but unfortunately I was getting the reverse order of what I wanted so I did this:\ndef create_sprite():\n     Allsprites.empty() #This removes all objects from your group\n     a=SomeClassForYourSprite()\n     Sprites.insert(0,a) #Placing your new sprite at the front of the list\n     for sprite in Sprites:\n           Allsprites.add(sprite)\n\nThis should reverse the order for you, allowing the newest sprite created to appear at the bottom instead of the top", "user_title": "Anonymous", "datetimeon": "2009-05-11T00:29:55", "link": "pygame.sprite.OrderedUpdates", "id": 2744}, {"content": "Is this function blocking?  I mean...  when it returns and my program flow continues, can I be assured that the display has updated on the actual screen?", "user_title": "Anonymous", "datetimeon": "2011-01-14T19:38:50", "link": "pygame.display.update", "id": 3730}, {"content": "Is there a way to set a path to a font file?", "user_title": "Anonymous", "datetimeon": "2011-01-16T15:32:54", "link": "pygame.font.SysFont", "id": 3734}, {"content": "eee", "user_title": "Anonymous", "datetimeon": "2011-01-16T19:25:25", "link": "pygame.image.tostring", "id": 3735}, {"content": "The last comment was spam", "user_title": "Anonymous", "datetimeon": "2011-01-17T21:08:17", "link": "pygame.draw.polygon", "id": 3737}, {"content": "[(x,y), (x1,y1), (x2,y2)]", "user_title": "Anonymous", "datetimeon": "2011-01-17T21:08:51", "link": "pygame.draw.polygon", "id": 3738}, {"content": "The core algorithm works with 32-bit surfaces. When a 24-bit surface is passed, the pixel data is converted to 32-bit data before the actual transformation, and then it's converted back into 24-bits again, which means 2 extra conversions of the whole image. This would especially be troublesome with large images.", "user_title": "Anonymous", "datetimeon": "2011-01-18T03:41:16", "link": "pygame.transform.smoothscale", "id": 3739}, {"content": "re", "user_title": "Anonymous", "datetimeon": "2011-01-18T06:48:13", "link": "pygame.mixer.music.pause", "id": 3740}, {"content": "Hello world", "user_title": "Anonymous", "datetimeon": "2011-01-19T16:38:01", "link": "index.html", "id": 3743}, {"content": "what", "user_title": "Anonymous", "datetimeon": "2011-01-25T20:39:22", "link": "pygame.event.get_grab", "id": 3748}, {"content": "The width for \"ae\" WILL always match the width for \"a\" + \"e\" (which is \"a\" concatinated with\"e\").\nIt will not always match the width of \"a\" plus the width of \"e\".\n(But we knew what you meant.)", "user_title": "Anonymous", "datetimeon": "2011-01-25T21:11:43", "link": "Font.size", "id": 3749}, {"content": "can we get an admin to delete that?", "user_title": "Anonymous", "datetimeon": "2011-01-27T17:25:55", "link": "pygame.draw.circle", "id": 3754}, {"content": "This function seems to me little bit buggy, so I wrote my own:\n\na and b are surfarrays of some surfaces that you want to compare\n\n    def comparray(self,a,b):\n        c = abs(a.__sub__(b))\n        c = c.__ge__(self.tolerance)*255\n        surface = pygame.surfarray.make_surface(c)\n        return surface", "user_title": "Anonymous", "datetimeon": "2011-01-27T18:49:07", "link": "PixelArray.compare", "id": 3755}, {"content": "your gay", "user_title": "Anonymous", "datetimeon": "2011-01-28T04:28:47", "link": "Rect.colliderect", "id": 3758}, {"content": "It would be nice if the number of Sounds on queue was more than one...\n\nGreg Ruo", "user_title": "Anonymous", "datetimeon": "2011-01-30T21:39:27", "link": "Channel.queue", "id": 3765}, {"content": "I solved my previous question:\n\nIf you need to play in sequence several Sounds in a queue, you can solve this\nwith something like:\n=======================\n    i=0\n    while (Ch0.get_queue()==None) and (i&lt;10):\n            i+=1\n            Ch0.queue(f[i])\n============================\n\nwhere Ch0 is your Sound channel created with Ch0=pygame.mixer.Channel(0).\nIn other words, even if the queue allows only one single sound in queue,\nI use the .get_queue method to wait until the queue is free before\n adding the next Sound in the sequence.\n\nIf you have better solutions please reply here. Thanks.\n\nGreg Ruo", "user_title": "Anonymous", "datetimeon": "2011-01-30T22:38:45", "link": "Channel.queue", "id": 3766}, {"content": "Probably would be good to have an  OPTIONAL  choice to remove them from the queue . . .", "user_title": "Anonymous", "datetimeon": "2011-01-31T13:48:40", "link": "pygame.event.get", "id": 3768}, {"content": "I had this weird thing where blue/red was inversed, but not the other colours, when I was mapping some pixels from one image to a blank surface.\nIt was caused by copying the color integer directly to one pixel to the other, so the trick is to always surface.unmap_rgb(pixel) before setting the color to a new pixel \nThat tricked works.\nIt's the only way unfortunately.", "user_title": "Anonymous", "datetimeon": "2011-02-04T02:33:15", "link": "pygame.PixelArray", "id": 3771}, {"content": "@Dave: Thanks very much for writing that we should ignore the keyword \"width\". This saved me time and my program now works.", "user_title": "Anonymous", "datetimeon": "2011-02-05T08:25:19", "link": "pygame.draw.rect", "id": 3773}, {"content": "ankit sucks", "user_title": "Anonymous", "datetimeon": "2011-02-08T14:07:31", "link": "Rect.colliderect", "id": 3776}, {"content": "i heard ankit really sucks", "user_title": "Anonymous", "datetimeon": "2011-02-08T14:07:46", "link": "Rect.collidepoint", "id": 3777}, {"content": "ankit tandon sucks", "user_title": "Anonymous", "datetimeon": "2011-02-08T14:07:55", "link": "Rect.contains", "id": 3778}, {"content": "I don't get what this does...", "user_title": "Anonymous", "datetimeon": "2011-02-09T22:32:43", "link": "pygame.event.pump", "id": 3779}, {"content": "If you don't use the event queue(why aren't you??) this will keep your program from locking up.", "user_title": "Anonymous", "datetimeon": "2011-02-10T21:20:05", "link": "pygame.event.pump", "id": 3780}, {"content": "When the camera is stopped and you try to access it pygame segfaults.\n(On Debian testing with pygame 1.9.1)", "user_title": "Anonymous", "datetimeon": "2011-02-11T03:31:32", "link": "Camera.stop", "id": 3781}, {"content": "set_allowed removes events from the queue! \nEven if the event in question doesn't belong to the given type.\n\n&gt;&gt;&gt; import pygame\n&gt;&gt;&gt; pygame.init()\n&gt;&gt;&gt; pygame.event.post(pygame.event.Event(pygame.USEREVENT, code=0))\n&gt;&gt;&gt; print pygame.event.peek(pygame.USEREVENT)\n1\n&gt;&gt;&gt; pygame.event.set_allowed(pygame.MOUSEMOTION)\n&gt;&gt;&gt; print pygame.event.peek(pygame.USEREVENT)\n0", "user_title": "Anonymous", "datetimeon": "2011-02-11T17:42:34", "link": "pygame.event.set_allowed", "id": 3782}, {"content": "Thank you very much.\nYour compare function works much better than the original one.", "user_title": "Anonymous", "datetimeon": "2011-02-14T16:59:41", "link": "PixelArray.compare", "id": 3783}, {"content": "meto", "user_title": "Anonymous", "datetimeon": "2011-02-15T19:30:06", "link": "Color.g", "id": 3786}, {"content": "rofl rofl what for a crappy thing you performed? go to wikipedia it works!\n\nu mad!", "user_title": "Anonymous", "datetimeon": "2011-02-16T06:49:19", "link": "pygame.draw.rect", "id": 3787}, {"content": "rofl rofl what for a crappy thing you performed? go to wikipedia it works!\n\nu mad!", "user_title": "Anonymous", "datetimeon": "2011-02-16T06:50:00", "link": "pygame.draw.rect", "id": 3788}, {"content": "stfu\n\nu mad", "user_title": "Anonymous", "datetimeon": "2011-02-16T06:52:07", "link": "Rect.unionall_ip", "id": 3789}, {"content": "This method only queues one music file.\nIf you call it and there already is a queued file, it will be overrided.", "user_title": "Anonymous", "datetimeon": "2011-02-19T12:17:58", "link": "pygame.mixer.music.queue", "id": 3791}, {"content": "elif event.type == pygame.QUIT or event.type == pygame.K_ESCAPE:\n\nthe event type is not pygame.K_ESCAPE. you have to check for a KEYDOWN or KEYUP event and check if it is the key you want, for example:\n\nelif event.type == pygame.QUIT or (event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE):", "user_title": "Anonymous", "datetimeon": "2011-02-21T08:30:17", "link": "pygame.key", "id": 3793}, {"content": "Well, sometimes black and white are swapped, sometimes they aren't.\nEven in the same program, for one mouse cursor it may work right,\nand for another cursor the black &amp; white colors are swapped.\n\nI haven't figured out what triggers this bug.", "user_title": "Anonymous", "datetimeon": "2011-02-24T13:00:58", "link": "pygame.cursors.compile", "id": 3797}, {"content": "spam", "user_title": "Anonymous", "datetimeon": "2011-02-26T15:00:47", "link": "pygame.event.set_grab", "id": 3798}, {"content": "In Pygame 1.9.2 surface objects have sprouted a new method, get_view:\n\nSurface.get_view\nreturn a view of a surface's pixel data.\nSurface.get_view(kind='2'): return\n\nReturn an object which exposes a surface's internal pixel buffer to a NumPy array. For now a custom object with an array struct interface is returned. A Python memoryview may be returned in the future. The buffer is writeable.\n\nThe kind argument is the length 1 string '2', '3', 'r', 'g', 'b', or 'a'. The letters are case insensitive; 'A' will work as well. The argument can be either a Unicode or byte (char) string. The default is '2'.\n\nA kind '2' view is a (surface-width, surface-height) array of raw pixels. The pixels are surface bytesized unsigned integers. The pixel format is surface specific. It is unavailable for 24-bit surfaces.\n\n'3' returns a (surface-width, surface-height, 3) view of RGB color components. Each of the red, green, and blue components are unsigned bytes. Only 24-bit and 32-bit surfaces are supported. The color components must be in either RGB or BGR order within the pixel.\n\n'r' for red, 'g' for green, 'b' for blue, and 'a' for alpha return a (surface-width, surface-height) view of a single color component within a surface: a color plane. Color components are unsigned bytes. Both 24-bit and 32-bit surfaces support 'r', 'g', and 'b'. Only 32-bit surfaces with SRCALPHA support 'a'.\n\nThis method implicitly locks the Surface. The lock will be released, once the returned view object is deleted.", "user_title": "Anonymous", "datetimeon": "2011-03-01T14:59:53", "link": "pygame.Surface", "id": 3803}, {"content": "In Pygame 1.9.2 surface objects have sprouted a new method, get_view:\n\nSurface.get_view\nreturn a view of a surface's pixel data.\nSurface.get_view(kind='2'): return\n\nReturn an object which exposes a surface's internal pixel buffer to a NumPy\narray. For now a custom object with an array struct interface is returned.\nA Python memoryview may be returned in the future. The buffer is writeable.\n\nThe kind argument is the length 1 string '2', '3', 'r', 'g', 'b', or 'a'.\nThe letters are case insensitive; 'A' will work as well. The argument can be\neither a Unicode or byte (char) string. The default is '2'.\n\nA kind '2' view is a (surface-width, surface-height) array of raw pixels. The\npixels are surface bytesized unsigned integers. The pixel format is surface\nspecific. It is unavailable for 24-bit surfaces.\n\n'3' returns a (surface-width, surface-height, 3) view of RGB color components.\nEach of the red, green, and blue components are unsigned bytes. Only 24-bit and\n32-bit surfaces are supported. The color components must be in either RGB or\nBGR order within the pixel.\n\n'r' for red, 'g' for green, 'b' for blue, and 'a' for alpha return a\n(surface-width, surface-height) view of a single color component within a\nsurface: a color plane. Color components are unsigned bytes. Both 24-bit and\n32-bit surfaces support 'r', 'g', and 'b'. Only 32-bit surfaces with SRCALPHA\nsupport 'a'.\n\nThis method implicitly locks the Surface. The lock will be released, once the\nreturned view object is deleted.", "user_title": "Anonymous", "datetimeon": "2011-03-01T15:02:04", "link": "pygame.Surface", "id": 3804}, {"content": "for statement with arc", "user_title": "Anonymous", "datetimeon": "2011-03-01T19:54:13", "link": "pygame.draw.arc", "id": 3805}, {"content": "Oh my god I was so thankful that you can adjust the volume, I have no editing software to fix my sounds.", "user_title": "Anonymous", "datetimeon": "2011-03-03T21:26:40", "link": "Sound.set_volume", "id": 3806}, {"content": "Thanks to the comments for wrinting about the event attributes and the key constants list. It should be in any serious documentation.", "user_title": "Anonymous", "datetimeon": "2011-03-09T16:10:36", "link": "pygame.event.Event", "id": 3808}, {"content": "a;rtawkljethlak", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:41:39", "link": "pygame.font", "id": 3809}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:20", "link": "pygame.font.init", "id": 3810}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:22", "link": "pygame.font.init", "id": 3811}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:24", "link": "pygame.font.init", "id": 3812}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:27", "link": "pygame.font.init", "id": 3813}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:29", "link": "pygame.font.init", "id": 3814}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:31", "link": "pygame.font.init", "id": 3815}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:33", "link": "pygame.font.init", "id": 3816}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:36", "link": "pygame.font.init", "id": 3817}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:37", "link": "pygame.font.init", "id": 3818}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:47", "link": "pygame.font.init", "id": 3819}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:53", "link": "pygame.font.init", "id": 3820}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:54", "link": "pygame.font.init", "id": 3821}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:56", "link": "pygame.font.init", "id": 3822}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:42:58", "link": "pygame.font.init", "id": 3823}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:01", "link": "pygame.font.init", "id": 3824}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:03", "link": "pygame.font.init", "id": 3825}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:07", "link": "pygame.font.init", "id": 3826}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:09", "link": "pygame.font.init", "id": 3827}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:11", "link": "pygame.font.init", "id": 3828}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:13", "link": "pygame.font.init", "id": 3829}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:15", "link": "pygame.font.init", "id": 3830}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:16", "link": "pygame.font.init", "id": 3831}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:19", "link": "pygame.font.init", "id": 3832}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:20", "link": "pygame.font.init", "id": 3833}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:22", "link": "pygame.font.init", "id": 3834}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:24", "link": "pygame.font.init", "id": 3835}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:26", "link": "pygame.font.init", "id": 3836}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:28", "link": "pygame.font.init", "id": 3837}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:29", "link": "pygame.font.init", "id": 3838}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:31", "link": "pygame.font.init", "id": 3839}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:33", "link": "pygame.font.init", "id": 3840}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:35", "link": "pygame.font.init", "id": 3841}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:37", "link": "pygame.font.init", "id": 3842}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:39", "link": "pygame.font.init", "id": 3843}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:40", "link": "pygame.font.init", "id": 3844}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:42", "link": "pygame.font.init", "id": 3845}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:45", "link": "pygame.font.init", "id": 3846}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:46", "link": "pygame.font.init", "id": 3847}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:48", "link": "pygame.font.init", "id": 3848}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:50", "link": "pygame.font.init", "id": 3849}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:52", "link": "pygame.font.init", "id": 3850}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:53", "link": "pygame.font.init", "id": 3851}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:55", "link": "pygame.font.init", "id": 3852}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:57", "link": "pygame.font.init", "id": 3853}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:43:59", "link": "pygame.font.init", "id": 3854}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:07", "link": "pygame.font.init", "id": 3855}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:09", "link": "pygame.font.init", "id": 3856}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:11", "link": "pygame.font.init", "id": 3857}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:13", "link": "pygame.font.init", "id": 3858}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:15", "link": "pygame.font.init", "id": 3859}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:18", "link": "pygame.font.init", "id": 3860}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:20", "link": "pygame.font.init", "id": 3861}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:22", "link": "pygame.font.init", "id": 3862}, {"content": "I LIKEY TO SPAM", "user_title": "Anonymous", "datetimeon": "2011-03-10T18:44:24", "link": "pygame.font.init", "id": 3863}, {"content": "Hey guys, how do you detect if user hits enter? There's no event.key for that! Thank you.", "user_title": "Anonymous", "datetimeon": "2011-03-12T11:25:09", "link": "pygame.key", "id": 3864}, {"content": "Could somebody please delete the horrible code in this comment thread? :(", "user_title": "Anonymous", "datetimeon": "2011-03-15T20:16:46", "link": "pygame.draw.circle", "id": 3865}, {"content": "pygame documentation\t ||  Pygame Home  ||  Help Contents  || Reference Index  || \n \nCamera ||  Cdrom ||  Color ||  Cursors ||  Display ||  Draw ||  Event ||  Examples ||  Font ||  Gfxdraw ||  Image ||  Joystick ||  Key ||  Locals ||  Mask ||  Midi ||  Mixer ||  Mouse ||  Movie ||  Music ||  Overlay ||  Pixelarray ||  Pygame ||  Rect ||  Scrap ||  Sndarray ||  Sprite ||  Surface ||  Surfarray ||  Tests ||  Time ||  Transform\nFont.metrics\n\nThe user submitted comments should be used for:\n\nExamples\nHelpful hints, tips, and tricks\nFurther explanation / documentation\nThe user submitted comments should NOT be used for:\n\nBug Reports (see our new Bug Reports link on the side)\nFeature Requests\nQuestions\nPlease note that periodically, the developers may go through the notes and incorporate the information in them into the documentation. This means that any note submitted here becomes the property of Pete Shinners under the LGPL licence.\n\nIf you do not want to leave an anonymous comment, please sign in first.", "user_title": "Anonymous", "datetimeon": "2011-03-21T15:13:24", "link": "Font.metrics", "id": 3868}, {"content": "I can't figure how to crop an image, even after reading this suggestion", "user_title": "Anonymous", "datetimeon": "2011-03-22T11:32:04", "link": "pygame.transform.chop", "id": 3870}, {"content": "I was dumb.  Here is how I got it to work.  So simple:\n\ncreen.blit(gameboard,(selection.x-18,selection.y-18),(selection.x-18,selection.y-18,96,96))", "user_title": "Anonymous", "datetimeon": "2011-03-22T11:45:29", "link": "pygame.transform.chop", "id": 3871}, {"content": "Perfect, Matthew Brown! Just what I was looking for. I found the reset_stuff() function especially useful and I'm going to use it in our production software.", "user_title": "Anonymous", "datetimeon": "2011-03-24T10:34:18", "link": "pygame.draw.circle", "id": 3873}, {"content": "Wow, thanks a lot Matthew, I am a PyGame newbie and was having some troubles understanding this function without a complete example.", "user_title": "Anonymous", "datetimeon": "2011-03-24T12:23:02", "link": "pygame.draw.circle", "id": 3874}, {"content": "lol", "user_title": "Anonymous", "datetimeon": "2011-03-24T18:06:29", "link": "pygame.draw.circle", "id": 3875}, {"content": "Guys, what Matthew N. Brown did here harms python's reputation.\n\nPython is elegant.\n\nWhat Matthew did was perlify python ... this is terrible...", "user_title": "Anonymous", "datetimeon": "2011-03-24T18:07:11", "link": "pygame.draw.circle", "id": 3876}, {"content": "Just wanted to give my profuse thanks to Matthew N. Brown for his superb usage example of this otherwise vague and esoteric method. I've contacted my boss and we will now integrate this snippet into all of our newly created (and soon-to-be-refactored) legacy code.", "user_title": "Anonymous", "datetimeon": "2011-03-25T20:41:38", "link": "pygame.draw.circle", "id": 3878}, {"content": "where image is a surface, rot and scale are floats\n\n    return pygame.transform.smoothscale(image, rot, scale)\nTypeError: argument 2 must be 2-item sequence, not float\n    \n    return pygame.transform.smoothscale(image,[0,0], scale)\nTypeError: argument 3 must be pygame.Surface, not float", "user_title": "Anonymous", "datetimeon": "2011-03-27T01:37:09", "link": "pygame.transform.rotozoom", "id": 3879}, {"content": "and...\n    surf = pygame.surface.Surface((image.get_width()*scale, image.get_height()*scale))\n    return pygame.transform.smoothscale(image,[0,0], surf)\n\n    pygame.transform.smoothscale(image,[0,0], surf)\nValueError: Destination surface not the given width or height.", "user_title": "Anonymous", "datetimeon": "2011-03-27T01:40:56", "link": "pygame.transform.rotozoom", "id": 3880}, {"content": "look at set_grab first and then you understand", "user_title": "Anonymous", "datetimeon": "2011-03-27T13:55:15", "link": "pygame.event.get_grab", "id": 3881}, {"content": "getting this error :\n in __init__\n    self.font = pygame.font.Font(\"None\", 50)\nerror: font not initialized\n\nnot sure why because i rendered the font..", "user_title": "Anonymous", "datetimeon": "2011-04-02T14:35:05", "link": "Font.render", "id": 3882}, {"content": "The enter key is K_RETURN.", "user_title": "Anonymous", "datetimeon": "2011-04-02T17:03:07", "link": "pygame.key", "id": 3883}, {"content": "For this error :\nthere is no soundcard\n\nCall pygame.mixer.init two times :\npygame.mixer.init()\npygame.mixer.init()\n\nOR\n\npygame.mixer.init(); pygame.mixer.init()\n\n(don't omit semicolon)", "user_title": "Anonymous", "datetimeon": "2011-04-05T05:06:41", "link": "pygame.mixer.init", "id": 3886}, {"content": "/love little kids who leave dumb comments like this one", "user_title": "Anonymous", "datetimeon": "2011-04-12T10:48:18", "link": "Rect.colliderect", "id": 3889}, {"content": "there is no information about the supported formats - are those from ModPlugTracker supported? (like .mod, .xm, .s3m, etc.)", "user_title": "Anonymous", "datetimeon": "2011-04-12T12:35:41", "link": "pygame.mixer.music.load", "id": 3890}, {"content": "Yes", "user_title": "Anonymous", "datetimeon": "2011-04-12T16:17:04", "link": "Font.render", "id": 3891}, {"content": "This seems to be broken!\nI call this before playing a movie, but there is no sound.\nPlaying the movie without initializing the mixer in the first place, works!\n\nCan anyone confirm that this is broken?", "user_title": "Anonymous", "datetimeon": "2011-04-18T11:51:33", "link": "pygame.mixer.quit", "id": 3895}, {"content": "For Windows (XP):\nThe problem is that the screen does not get updated automatically, for some reason.\nThe solution is simple. Take a surface with the size of the movie, set this as the display of the movie.\nIn a loop, get the current frame of the movie and if it increases, blit the surface onto the screen and update the screen.", "user_title": "Anonymous", "datetimeon": "2011-04-19T10:47:45", "link": "pygame.movie", "id": 3896}, {"content": "#!/usr/bin/env python\n# -*- coding: utf-8 -*-\nfrom pygame import *\nimport pygame, time, numpy, pygame.sndarray\n\nsample_rate = 44100\n\ndef play_for(sample_array, ms, volLeft, volRight):\n    sound = pygame.sndarray.make_sound(sample_array)\n    beg = time.time()\n    channel = sound.play(-1)\n    channel.set_volume(volLeft,volRight)\n    pygame.time.delay(ms)\n    sound.stop()\n    end = time.time()\n    return beg, end\n    \ndef sine_array_onecycle(hz, peak):\n    length = sample_rate / float(hz)\n    omega = numpy.pi * 2 / length\n    xvalues = numpy.arange(int(length)) * omega\n    return (peak * numpy.sin(xvalues))\n    \ndef sine_array(hz, peak, n_samples = sample_rate):\n    return numpy.resize(sine_array_onecycle(hz, peak), (n_samples,))\n    \ndef main():\n    pygame.mixer.pre_init(sample_rate, -16, 2) # 44.1kHz, 16-bit signed, stereo\n    pygame.init()\n    f = sine_array(8000, 1)\n    f = numpy.array(zip (f , f))\n\n    play_for(f , 5000, 0.5, 0.5)\n\nif __name__ == '__main__': main()", "user_title": "Anonymous", "datetimeon": "2011-04-22T12:57:35", "link": "pygame.sndarray.make_sound", "id": 4038}, {"content": "Get Unicode key in Pygame:\n\nfrom pygame import *\npygame.init()\npygame.display.set_mode((500,500),OPENGLBLIT|OPENGL|DOUBLEBUF)\nexitt = 0 \ninte = 4096\nwhile not exitt:\n    for event in pygame.event.get():\n        if event.type == pygame.QUIT: \n            pygame.quit()\n            exitt = True\n        if event.type == KEYDOWN:\n            print event.dict['unicode']", "user_title": "Anonymous", "datetimeon": "2011-04-23T04:11:07", "link": "pygame.key", "id": 4039}, {"content": "The param is \"loops\" not \"loop\".", "user_title": "Anonymous", "datetimeon": "2011-04-27T15:37:38", "link": "Movie.play", "id": 4040}, {"content": "Use it when you load PNG images with transparencies", "user_title": "Anonymous", "datetimeon": "2011-04-30T21:10:05", "link": "Surface.convert_alpha", "id": 4041}, {"content": "The dest argument doesnt work for me, say if I do\n\nscreen.blit(mySurf, dest=(0,0))\n\nor screen.blit(mySurf, dest=(100,100))\n\nI get exactly the same outcome.\n\nWhere am i wrong?", "user_title": "Anonymous", "datetimeon": "2011-05-03T00:45:25", "link": "Surface.blit", "id": 4042}, {"content": "Sorry I realized i was blitting to screen instead of my temporary surface,\nplease ignore (and delete) my comment.", "user_title": "Anonymous", "datetimeon": "2011-05-03T00:46:43", "link": "Surface.blit", "id": 4043}, {"content": "How does that differ from pygame.draw.aalines? This one can also not be filled.", "user_title": "Anonymous", "datetimeon": "2011-05-04T14:58:27", "link": "pygame.gfxdraw.aapolygon", "id": 4044}, {"content": "XBM not supported?", "user_title": "Anonymous", "datetimeon": "2011-05-10T04:11:53", "link": "pygame.image", "id": 4048}, {"content": "I believe it offsets the detection area by (x,y) pixels. So just put (0,0) for no offset", "user_title": "Anonymous", "datetimeon": "2011-05-11T00:48:47", "link": "Mask.draw", "id": 4049}, {"content": "This function seems to need raw strings!", "user_title": "Anonymous", "datetimeon": "2011-05-12T10:26:46", "link": "pygame.image.save", "id": 4050}, {"content": "Is there anyway to play more than 2 songs I have tried everything I want the loaded music to play in order\n#!/usr/bin/env python\nimport pygame\npygame.mixer.init()\npygame.mixer.pre_init(44100, -16, 2, 2048)\npygame.init()\nprint \"hey I finaly got this working!\"\npygame.mixer.music.load('D:/Users/John/Music/Music/FUN.OGG')\npygame.mixer.music.load('D:/Users/John/Music/Music/Still Alive.OGG')\npygame.mixer.music.load('D:/Users/John/Music/Music/turret.OGG')\npygame.mixer.music.load('D:/Users/John/Music/Music/portalend.OGG')\npygame.mixer.music.play()\nimport pysic", "user_title": "Anonymous", "datetimeon": "2011-05-14T16:30:13", "link": "pygame.mixer.music.load", "id": 4053}, {"content": "How is it you play more than one song besides using queue", "user_title": "Anonymous", "datetimeon": "2011-05-14T19:29:16", "link": "pygame.mixer.music.play", "id": 4054}, {"content": "how is it to play a list of songs more than just one without using the queue(which only works once)", "user_title": "Anonymous", "datetimeon": "2011-05-14T19:32:21", "link": "pygame.mixer.music.play", "id": 4055}, {"content": "can the rectangle be filled with an RGBA color so that I can make it transclucent?", "user_title": "Anonymous", "datetimeon": "2011-05-26T09:16:14", "link": "pygame.draw.rect", "id": 4056}, {"content": "Exemple, playing a sinus sound :\n\n#!/usr/bin/env python\n# -*- coding: utf-8 -*-\n\nfrom pygame import *\nimport pygame, time, numpy, pygame.sndarray\n\nsample_rate = 44100\n\ndef play_for(sample_array, ms, volLeft, volRight):\n    sound = pygame.sndarray.make_sound(sample_array)\n    beg = time.time()\n    channel = sound.play(-1)\n    channel.set_volume(volLeft,volRight)\n    pygame.time.delay(ms)\n    sound.stop()\n    end = time.time()\n    return beg, end\n    \ndef sine_array_onecycle(hz, peak):\n    length = sample_rate / float(hz)\n    omega = numpy.pi * 2 / length\n    xvalues = numpy.arange(int(length)) * omega\n    return (peak * numpy.sin(xvalues))\n    \ndef sine_array(hz, peak, n_samples = sample_rate):\n    return numpy.resize(sine_array_onecycle(hz, peak), (n_samples,))\n\n    \ndef main():\n    pygame.mixer.pre_init(sample_rate, -16, 2) # 44.1kHz, 16-bit signed, stereo\n    pygame.init()\n    f = sine_array(8000, 1)\n    f = numpy.array(zip (f , f))\n\n    play_for(f , 5000, 0.2, 0.2)\n\nif __name__ == '__main__': main()", "user_title": "Anonymous", "datetimeon": "2011-05-27T02:36:07", "link": "pygame.sndarray", "id": 4057}]
+[
+   {
+      "datetimeon" : "2005-11-11T14:05:52",
+      "id" : 3,
+      "content" : "How To Get ALL The Mouse Clicks.\n\nTook me hours to figure this out. Also note that button 1 and 3 pressed at the same time shows up as button 2, at least on my ubuntu computer.\n\ne=pygame.event.wait()\nif e.type == MOUSEBUTTONDOWN and e.button == 4 : do something mousey",
+      "user_title" : "Douglas Smith",
+      "link" : "pygame.mouse.get_pressed"
+   },
+   {
+      "link" : "pygame.Surface",
+      "user_title" : "Marius Gedminas",
+      "content" : "If you're trying to create a surface with per-pixel alphas, and\n\n  my_surface = pygame.Surface((w, h), SRCALPHA)\n\ncreates a regular surface instead, try\n\n  my_surface = pygame.Surface((w, h)).convert_alpha()",
+      "id" : 39,
+      "datetimeon" : "2006-01-05T16:07:06"
+   },
+   {
+      "link" : "pygame.font.get_fonts",
+      "user_title" : "Dave Burton",
+      "content" : "Interestingly, pygame.font.get_default_font() returns a font name ('freesansbold.ttf') which is not among the 189 listed by pygame.font.get_fonts().",
+      "id" : 3698,
+      "datetimeon" : "2011-01-03T08:47:41"
+   },
+   {
+      "id" : 3699,
+      "datetimeon" : "2011-01-03T09:13:14",
+      "link" : "pygame.font.SysFont",
+      "user_title" : "Dave Burton",
+      "content" : "The font name is not a list!  It is a single string.\n\nThe string can contain multiple font names with commas between them,\nbut if you pass a Python list (or tuple) you'll get an error."
+   },
+   {
+      "link" : "pygame.PixelArray",
+      "user_title" : "Dave Burton",
+      "content" : "Re: \"During its lifetime, the PixelArray locks the surface, thus you explicitly have to delete it once its not used anymore and the surface should perform operations in the same scope.\"\n\n1. Grammer: s/its/it's/\n\n2. s/you explicitly have to delete/you have to explicitly delete/\n\n3. I assume that to explicitly delete it you can either use \"del pxarray\"\nor else simply exit the function to which pxarray is local.  Is that correct?\n\n4. What does \"and the surface should perform operations in the same scope\" mean?\nIs it saying something about the surface returned by px.make_surface(), i.e.,\nthat it should be a local variable in the same function  to which pxarray is local?\nOr is it saying something about the surface that is passed to pygame.PixelArray()\nto create the pxarray object, and if so WHAT is it saying?",
+      "id" : 3703,
+      "datetimeon" : "2011-01-07T03:08:20"
+   },
+   {
+      "user_title" : "Dave Burton",
+      "content" : "On my Windows Vista machine running Python 3.1.2 and pygame 1.9.1, pgame.font.get_fonts() returns a list of 189 fonts.  All the font names are lower case, and there are no special characters (like hyphens) in the names.  The expected 'timesnewroman', 'arial', 'arialblack', 'couriernew', 'veranda', 'microsoftsansserif', 'symbol' and 'wingdings' are there (but not 'times' or 'roman' or 'helvetica'), but also many obscure fonts that I've never heard of.",
+      "link" : "pygame.font.get_fonts",
+      "datetimeon" : "2011-01-03T08:43:54",
+      "id" : 3697
+   },
+   {
+      "link" : "pygame.key.get_pressed",
+      "content" : "Pretty cool demo Mr. Anony",
+      "user_title" : "Robert Leachman",
+      "id" : 3683,
+      "datetimeon" : "2010-12-10T22:09:50"
+   },
+   {
+      "link" : "pygame.locals",
+      "content" : "If you want to see a list of attributes, do a help(pygame) and it'll show you",
+      "user_title" : "Alex Polosky",
+      "id" : 3686,
+      "datetimeon" : "2010-12-15T23:46:38"
+   },
+   {
+      "link" : "pygame.display.init",
+      "user_title" : "Robert Leachman",
+      "content" : "Works fine for me on OS X 10.6.5, though yes it does need to brought up to Quartz",
+      "id" : 3675,
+      "datetimeon" : "2010-12-04T21:54:48"
+   },
+   {
+      "datetimeon" : "2007-03-05T00:13:41",
+      "id" : 403,
+      "user_title" : "Ian Mallett",
+      "content" : "See tutorials.  \nAfter each line \n     pygame.image.load(\"&lt;&gt;\")\nMake it\n     pygame.image.load(\"&lt;&gt;\").convert()\nNo matter what, this will increase your speed by 600%!\nThanks to whoever put in that tutorial!\n     -P.Z.",
+      "link" : "pygame.draw"
+   },
+   {
+      "id" : 439,
+      "datetimeon" : "2007-03-17T13:13:59",
+      "link" : "pygame.draw",
+      "content" : "see:\nhttp://www.pygame.org/docs/tut/newbieguide.html\n#4",
+      "user_title" : "Ian Mallett"
+   },
+   {
+      "link" : "pygame.movie",
+      "user_title" : "Jordan Trudgett",
+      "content" : "Dear readers, here is a working example of MPEG playing.\n-tgfcoder\n\n\nimport pygame, time\n\npygame.init()\n\ncine = pygame.movie.Movie('a-movie.mpg')\nsz=cine.get_size()\npygame.display.set_mode(sz)\nscreen = pygame.display.get_surface()\ncine.set_display(screen)\ncine.play()\nwhile True:\n time.sleep(1)",
+      "id" : 1349,
+      "datetimeon" : "2008-01-01T09:40:25"
+   },
+   {
+      "link" : "pygame.movie",
+      "content" : "Oh, please replace pygame.init() with pygame.display.init()\nBecause we don't want the mixer to be initialised.",
+      "user_title" : "Jordan Trudgett",
+      "id" : 1350,
+      "datetimeon" : "2008-01-01T09:46:24"
+   },
+   {
+      "datetimeon" : "2007-04-20T18:04:08",
+      "id" : 503,
+      "user_title" : "Guillaume Rava",
+      "content" : "Well, actually it's not even that (x,y) needs to be in the referential of the Rect, because if it was true, then (0,0) would return 1, and it doesn't. It is really a bug.",
+      "link" : "Rect.collidepoint"
+   },
+   {
+      "datetimeon" : "2008-01-10T10:08:04",
+      "id" : 1392,
+      "content" : "# Ellipse example:\n# When border=0 ellipse is filled\n#                  (screen, (rgb colour) (Xpos,Ypos,width,height),border width)\npygame.draw.ellipse(screen, (0, 127, 0), (300, 150, 80, 40), 0)",
+      "user_title" : "Miroslav Cika",
+      "link" : "pygame.draw.ellipse"
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "user_title" : "Miroslav Cika",
+      "content" : "# Circle example:\n# When border=0 circle is filled\n#                 (screen, (rgb colour), (Xpos,Ypos),Diameter,border width)\npygame.draw.circle(screen, (0, 127, 255), (300, 140), 50, 4)",
+      "id" : 1393,
+      "datetimeon" : "2008-01-10T10:20:38"
+   },
+   {
+      "id" : 1407,
+      "datetimeon" : "2008-01-13T13:38:10",
+      "link" : "pygame.movie",
+      "content" : "thank you Trudget for the working code",
+      "user_title" : "vishwanath"
+   },
+   {
+      "id" : 1420,
+      "datetimeon" : "2008-01-16T15:33:48",
+      "link" : "Rect.collidepoint",
+      "user_title" : "Tim Winter",
+      "content" : "\"\"\"It seems that this method does not detect point collisions that fall anywhere \nalong the right wall or bottom wall of the rect used. The following program\ncreates a rect with a width and height of 4, and a topleft corner at [0,0]. \nThe program then moves along each row of the rect area from left to right and\ntop to bottom by 1 unit, creating a new point and checking to see if the point\ncollides with the rect. If the point collides, a 1 is printed, and if the\npoint doesn't collide, a 0 is printed.\"\"\"\n\n# import\nimport pygame\n\n# main\ny = 4\nr = pygame.Rect(0,0,y,y)\np = [0,0]\npList = []\nwhile p != [0,y+1]:\n\tfor n in range(0,y+1):\n\t\tp[0] = n\n\t\tif r.collidepoint(p):\n\t\t\tpList.append(1)\n\t\telse:\n\t\t\tpList.append(0)\n\n\tprint '%d %d %d %d %d' % (pList[0],pList[1],pList[2],pList[3],pList[4])\n\t\n\tpList = []\n\tp[0] = 0\n\tp[1] += 1\n\n# wait for user to manually exit program\ninput('press enter to exit')\n\n\"\"\"Here is the output:\"\"\"\n1 1 1 1 0\n1 1 1 1 0\n1 1 1 1 0\n1 1 1 1 0\n0 0 0 0 0\npress enter to exit\n\n\"\"\"Even if you were to directly reference the topright, bottomleft, or bottomright\npoint of the rect as the argument to the collidepoint function, the rect still \nwould not detect a collision. The rect does, however, detect collision with its\ntopleft point:\"\"\"\n\n&gt;&gt;&gt;r.collidepoint(r.bottomleft)\n0\n&gt;&gt;&gt;r.collidepoint(r.topright)\n0\n&gt;&gt;&gt;r.collidepoint(r.bottomright)\n0\n&gt;&gt;&gt;r.collidepoint(r.topleft)\n1"
+   },
+   {
+      "datetimeon" : "2008-01-25T15:59:11",
+      "id" : 1442,
+      "user_title" : "Ian Mallett",
+      "content" : "To use the scrollwheel:\nfor event in pygame.event.get():\n  if event.type == MOUSEBUTTONDOWN:\n    if event.button == 4:\n      #Zoom Out\n    elif event.button == 5:\n      #Zoom In",
+      "link" : "pygame.mouse"
+   },
+   {
+      "user_title" : "Jeiel Aranal",
+      "content" : "Use the following class to generate a bezier curve that can be drawn with aalines:\n\n## Class begins here\nclass Bezier:\n\n\tclass SmoothnessError(Exception): pass\n\tclass CurveError(Exception): pass\n\n\tdef __init__(self):\n\t\t\"\"\"\n\t\tA Python class for generating bezier curves\n\t\t\n\t\tAn implementation of an algorithm presented by Nils Pipenbrinck\n\t\thttp://www.cubic.org/docs/bezier.htm\n\t\t\"\"\"\n\t\n\tdef __lerp(self, ptA, ptB, t):\n\t\t\"\"\"\n\t\tReturns the linear interp between two points as a list\n\t\tptA and ptB are a list of xy coords, t is the point on the curve\n\t\t\"\"\"\n\t\tdest = []\n\t\tdest.append(ptA[0]+float(ptB[0]-ptA[0])*t)\n\t\tdest.append(ptA[1]+float(ptB[1]-ptA[1])*t)\n\t\treturn dest\n\t\n\tdef bezierPt(self, ctrlPts, t):\n\t\t\"\"\"A recursive function for finding point t along a bezier curve\"\"\"\n\t\tif len(ctrlPts) == 1:\n\t\t\t#print \"Len is 1\", ctrlPts\n\t\t\treturn ctrlPts[0]\n\t\tlerpList = []\n\t\tfor i in xrange(len(ctrlPts)-1):\n\t\t\tptA = [ctrlPts[i][0],ctrlPts[i][1]]\n\t\t\tptB = [ctrlPts[i+1][0],ctrlPts[i+1][1]]\n\t\t\tlerpList.append(self.__lerp(ptA,ptB,t))\n\t\t#print len(lerpList)\n\t\treturn self.bezierPt(lerpList, t)\n\t\n\tdef makeBezier(self, ctrlPts, smoothness):\n\t\t\"\"\"\n\t\tReturns a list of points on a bezier curve\n\t\t\n\t\tctrlPts is a list of 2d Points that define the curve, in most cases these\n\t\tconsist of control point locations and their handles, except in a 3 point\n\t\tcurve where it's just defined by the three control points.\n\t\t\n\t\tsmoothness is the number of points on the curve that should be generated.\n\t\tThis should always be more than two points or generating the bezier curve is\n\t\tpointless and the script dies in a fire (or throws an exception)\n\t\t\"\"\"\n\t\t\n\t\tif len(ctrlPts) &lt; 2:\n\t\t\traise self.CurverError(\"Curve list must contain more than one point\")\n\t\tif smoothness &lt; 3:\n\t\t\traise self.SmoothnessError(\"Smoothness must be more than two\")\n\t\titeration = smoothness\n\t\tbezierList = []\n\t\tsubtract=1.0/smoothness\n\t\tfor i in xrange(0,iteration):\n\t\t\tt = 1.0-(subtract*i)\n\t\t\tif t &lt; subtract:\n\t\t\t\tt = 0\n\t\t\tbPt = self.bezierPt(ctrlPts,t)\n\t\t\t#print bPt\n\t\t\tbezierList.append(bPt)\n\t\treturn bezierLis\n## Class ends\n\n###################\n# An example of how to use the class with pygame\n\n\n## Pygame Example\nimport math, pygame\nfrom pygame.locals import *\nimport bezier\n\ndef main():\n    pygame.init()\n    screen = pygame.display.set_mode((640,480))\n    clock = pygame.time.Clock()\n    \n    b = bezier.Bezier()\n    \"\"\"\n\tA bezier curve definition, a list of 2d poins, simple innit\n\tIt's basically control points with control handle locations before or\n\tafter the control point.\n\t\n    Read http://www.cubic.org/docs/bezier.htm for more info\n    \"\"\"\n    bezierPts = [[40,100],[80,20],[150,180],[260,100]]\n    bLine = b.makeBezier(bezierPts, 10)\n    screen.fill((255,255,255))\n    pygame.draw.aalines(screen, (1,1,1), False, bLine, 1)\n    pygame.display.flip()\n    bounce = False\n    \n    while True:\n        clock.tick(60)\n        pygame.event.pump()\n        event = pygame.event.poll()\n        if event.type == QUIT:\n            return\n        if event.type == KEYDOWN:\n            if event.key == K_ESCAPE:\n                return\n        setTo = pygame.time.get_ticks()/20\n        bezierPts[1][1] = setTo\n        bLine = b.makeBezier(bezierPts,20)\n        screen.fill((255,255,255))\n        pygame.draw.aalines(screen, (1,1,1), False, bLine, 1)\n        pygame.display.flip()\n\nif __name__ == \"__main__\":\n    m = main()\n## End example",
+      "link" : "pygame.draw.aalines",
+      "datetimeon" : "2008-02-06T10:50:10",
+      "id" : 1502
+   },
+   {
+      "id" : 635,
+      "datetimeon" : "2007-06-14T12:13:28",
+      "link" : "Sound.play",
+      "content" : "Play can return None. So be sure to check the channel before using it. Something like this...\n\n        channel = self.bounce_sound.play()\n        if channel is not None:\n            channel.set_volume(1.0 - stereo, stereo)",
+      "user_title" : "Will McGugan"
+   },
+   {
+      "id" : 676,
+      "datetimeon" : "2007-06-30T19:41:18",
+      "link" : "Sound.play",
+      "content" : "Should have an optional option \nfor sound playback speed...",
+      "user_title" : "Ian Mallett"
+   },
+   {
+      "id" : 689,
+      "datetimeon" : "2007-07-03T01:18:12",
+      "link" : "Font.render",
+      "user_title" : "Ian Mallett",
+      "content" : "When antialias is enabled, rendering it on a black background makes it look bold."
+   },
+   {
+      "datetimeon" : "2008-02-25T23:09:09",
+      "id" : 1646,
+      "user_title" : "Ian Mallett",
+      "content" : "Should have an Anti-alias option...",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "content" : "mods = pygame.key.get_mods()\nif mods &amp; KMOD_LSHIFT: #use whatever KMOD_ constant you want;)\n       print \"left shift pressed\"",
+      "user_title" : "Isaiah Heyer",
+      "link" : "pygame.key.get_mods",
+      "datetimeon" : "2008-03-29T16:22:04",
+      "id" : 1716
+   },
+   {
+      "datetimeon" : "2008-03-29T23:08:21",
+      "id" : 1718,
+      "user_title" : "Ian Mallett",
+      "content" : "I would like to have a method of telling which side of a rect a point collides.  \nIn other words, which side is the point closest to?",
+      "link" : "Rect.collidepoint"
+   },
+   {
+      "datetimeon" : "2007-08-01T17:48:16",
+      "id" : 785,
+      "content" : "Right.  Unfortunately, That's the way it is.  A width or height of 0 should also\nbe allowed, for rectangles of changing sizes (think progressbar at 0%)",
+      "user_title" : "Ian Mallett",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "datetimeon" : "2007-09-23T08:07:45",
+      "id" : 873,
+      "content" : "Instead of drawing a circle with zero radius, you can use the method set_at on the surface to set the color of a single pixel: http://www.pygame.org/docs/ref/surface.html#Surface.set_at",
+      "user_title" : "Victor Blomqvist",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "link" : "pygame.display.init",
+      "content" : "'dummy' driver is missing ;-)",
+      "user_title" : "DR0ID",
+      "id" : 875,
+      "datetimeon" : "2007-09-23T12:08:05"
+   },
+   {
+      "id" : 882,
+      "datetimeon" : "2007-09-27T02:05:16",
+      "link" : "pygame.display.init",
+      "user_title" : "aaron pedralvez",
+      "content" : "please able my display mode with opengl acceleration"
+   },
+   {
+      "link" : "pygame.event",
+      "user_title" : "Andy Hanson",
+      "content" : "In the event MOUSEBUTTONDOWN, if you're using a mouse with a rotating wheel,\nevent.button returns 4 when it is rotated forward (counterclockwise) and 5 when\nit is rotating backward (clockwise). I used a print statement to discover this.",
+      "id" : 900,
+      "datetimeon" : "2007-10-02T20:43:15"
+   },
+   {
+      "user_title" : "Andy Hanson",
+      "content" : "In the event MOUSEBUTTONDOWN, if you're using a mouse with a rotating wheel,\nevent.button returns 4 when it is rotated forward (counterclockwise) and 5 when\nit is rotating backward (clockwise). I used a print statement to discover this.",
+      "link" : "pygame.event",
+      "datetimeon" : "2007-10-02T20:43:21",
+      "id" : 901
+   },
+   {
+      "datetimeon" : "2007-12-04T14:43:28",
+      "id" : 1206,
+      "user_title" : "Andy Sommerville",
+      "content" : "You can request fullscreen, but there doesn't seem to be a way to\ndetermine whether it's on. Meaning, there ought to be a 'get_mode()'.",
+      "link" : "pygame.display.set_mode"
+   },
+   {
+      "link" : "pygame.mixer.Sound",
+      "user_title" : "Ian Mallett",
+      "content" : "http://www.pygame.org/docs/ref/sndarray.html#pygame.sndarray.make_sound\ncan be used to synthesize a sound object from sound samples.",
+      "id" : 1953,
+      "datetimeon" : "2008-05-26T20:16:58"
+   },
+   {
+      "id" : 1917,
+      "datetimeon" : "2008-05-21T14:15:44",
+      "link" : "pygame.movie",
+      "content" : "The movie module in Pygame 1.8 works on Windows.\nThe statement that it doesn't work is out-of-date.",
+      "user_title" : "Jason M. Marshall"
+   },
+   {
+      "content" : "return bezierLis -&gt; return bezierList (line 65)",
+      "user_title" : "Jordan Trudgett",
+      "link" : "pygame.draw.aalines",
+      "datetimeon" : "2008-06-18T02:46:43",
+      "id" : 2060
+   },
+   {
+      "id" : 2150,
+      "datetimeon" : "2008-07-10T13:15:18",
+      "link" : "pygame.mixer.get_num_channels",
+      "content" : "pygame.mixer.get_num_channels(): return count",
+      "user_title" : "Jordan Trudgett"
+   },
+   {
+      "id" : 2156,
+      "datetimeon" : "2008-07-11T23:25:11",
+      "link" : "Surface.set_at",
+      "user_title" : "Ian Mallett",
+      "content" : "Calling Surface.lock() before many calls to Surface.set_at() and Surface.unlock() after is a great and easy optimization."
+   },
+   {
+      "link" : "pygame.key.set_repeat",
+      "user_title" : "Ian Mallett",
+      "content" : "Just set the delay to something really big.",
+      "id" : 2265,
+      "datetimeon" : "2008-08-19T06:01:04"
+   },
+   {
+      "id" : 2339,
+      "datetimeon" : "2008-11-28T19:09:39",
+      "link" : "pygame.event.post",
+      "user_title" : "Weeble",
+      "content" : "Is this thread-safe? Can I safely post messages from a different thread\nfrom the one that's processing events and rendering?"
+   },
+   {
+      "link" : "Surface.set_alpha",
+      "content" : "''' Change alpha for surfaces with per-pixel alpha; only for small surfaces '''\ndef change_alpha(surface,alpha=0.5):\n\tsize = surface.get_size()\n\ttry:\n\t\tfor y in xrange(size[1]):\n\t\t\tfor x in xrange(size[0]):\n\t\t\t\tr,g,b,a = surface.get_at((x,y))\n\t\t\t\tsurface.set_at((x,y),(r,g,b,int(a*alpha)))\n\texcept:\n\t\treturn surface\n\treturn surface",
+      "user_title" : "Josef Vanzura",
+      "id" : 3245,
+      "datetimeon" : "2010-11-19T09:47:18"
+   },
+   {
+      "link" : "Surface.set_alpha",
+      "content" : "You can also do it with surfarray (faster).",
+      "user_title" : "Josef Vanzura",
+      "id" : 3246,
+      "datetimeon" : "2010-11-19T09:49:02"
+   },
+   {
+      "datetimeon" : "2010-11-19T09:56:18",
+      "id" : 3247,
+      "content" : "Sorry. I didn't read the previous comment, which is a better way.",
+      "user_title" : "Josef Vanzura",
+      "link" : "Surface.set_alpha"
+   },
+   {
+      "user_title" : "Shanti Pothapragada",
+      "content" : "present in pygame 1.9.1 but not in pygame 1.8.1, which is currently the last binary release on Linux.",
+      "link" : "Rect.copy",
+      "datetimeon" : "2010-11-22T17:04:34",
+      "id" : 3249
+   },
+   {
+      "link" : "pygame.Rect",
+      "user_title" : "Sam Bull",
+      "content" : "Also includes the attributes: x, y.",
+      "id" : 3225,
+      "datetimeon" : "2010-10-26T07:40:18"
+   },
+   {
+      "datetimeon" : "2010-09-29T19:26:57",
+      "id" : 3211,
+      "content" : "Works like a charm. Thanks whoever you are.",
+      "user_title" : "Bartosz Debski",
+      "link" : "Surface.fill"
+   },
+   {
+      "link" : "pygame.movie",
+      "content" : "The code snippet works perfectly; thanks!\nI think the documentation is sorely in need of an update.\nWishlist: other video formats, like .avi?",
+      "user_title" : "Ian Mallett",
+      "id" : 2360,
+      "datetimeon" : "2009-01-01T16:05:17"
+   },
+   {
+      "id" : 2366,
+      "datetimeon" : "2009-01-07T12:38:26",
+      "link" : "pygame.sprite.RenderUpdates",
+      "content" : "An example to use this:\nscreen = pygame.display.set_mode(SCREENRECT.size) # SCREENRECT is a rect variable...\n            # ...with screen dimension\n\ndoggie = pygame.sprite.RenderUpdates() #We create the group\nDog.containers = doggie \n# class Dog: Needs 'pygame.sprite.Sprite.__init__(self,self.containers)'\n# inside def __init__(self, ...):\n\ndog1 = Dog(...) #Class Dog\ndog2 = Dog(...)\n...\ndogN = Dog(...)\n\n... #Some move actions and things\n\n#Now, time to re-paint them all\ndoggie.clear(screen, Background)\nchanges = doggie.draw(screen)\npygame.display.update(changes)\n#Now we have all dogs updated in screen\n\n#---------\nEasy, quick and effortless",
+      "user_title" : "Patata"
+   },
+   {
+      "user_title" : "Nekody Lenkner",
+      "content" : "# A better loading script:\n\nimport os, pygame\n\ndef load_image(file_name, colorkey=False, image_directory='images'):\n    'Loads an image, file_name, from image_directory, for use in pygame'\n    file = os.path.join(image_directory, file_name)\n    _image = pygame.image.load(file)\n    if colorkey:\n        if colorkey == -1: \n        # If the color key is -1, set it to color of upper left corner\n            colorkey = _image.get_at((0, 0))\n        _image.set_colorkey(colorkey)\n        _image = _image.convert()\n    else: # If there is no colorkey, preserve the image's alpha per pixel.\n        _image = _image.convert_alpha()\n    return _image",
+      "link" : "pygame.image.load",
+      "datetimeon" : "2009-03-20T21:58:08",
+      "id" : 2399
+   },
+   {
+      "id" : 3151,
+      "datetimeon" : "2010-07-02T01:21:30",
+      "link" : "pygame.font.SysFont",
+      "user_title" : "Mad Cloud Games",
+      "content" : "what does it mean by font name? can it be a path to a font?"
+   },
+   {
+      "datetimeon" : "2009-08-01T23:26:07",
+      "id" : 2900,
+      "content" : "You can use multiple screens, but you'll need to make a separate process for each.",
+      "user_title" : "Ian Mallett",
+      "link" : "pygame.display.set_mode"
+   },
+   {
+      "link" : "pygame.event",
+      "user_title" : "DR0ID",
+      "content" : "VIDEORESIZE      size, w, h\nsize == (w, h) # same data, different access",
+      "id" : 2411,
+      "datetimeon" : "2009-04-04T12:27:05"
+   },
+   {
+      "id" : 2902,
+      "datetimeon" : "2009-08-03T01:50:34",
+      "link" : "Surface.copy",
+      "user_title" : "josmiley",
+      "content" : "je ne sais pas pourquoi, mais; si vous utiliser une surface pour effacer le display au lieu d'utiliser un 'fill',\nil sera beaucoup plus rapide de blitter une copie du display :\n\ndisplay = pygame.display.set_mode((500,500))\nbackground = pygame.image.load('blablabla...')\ndisplay.blit(background,(0,0))\nbackground = display.copy()  ----&gt; utiliser cette copie pour multi-blitter plus rapidement une image de fond."
+   },
+   {
+      "id" : 2896,
+      "datetimeon" : "2009-07-29T00:20:38",
+      "link" : "pygame.event.Event",
+      "user_title" : "Daniel Westbrook",
+      "content" : "This doesn't say anything about the type attribute.\nYou can compare it to MOUSEBUTTONUP, KEYDOWN, etc to find out what the events\ntype is."
+   },
+   {
+      "datetimeon" : "2010-05-04T17:47:38",
+      "id" : 3117,
+      "user_title" : "Alex",
+      "content" : "is it a Rect object???",
+      "link" : "pygame.display.update"
+   },
+   {
+      "content" : "TIP:\nIf sound has noise/noisy is choppy or has static, the solution:\n\npygame.mixer.quit() #Make sure you all this before .init()\npygame.mixer.init()",
+      "user_title" : "Chris Goldie",
+      "link" : "Sound.play",
+      "datetimeon" : "2009-08-11T05:44:03",
+      "id" : 2911
+   },
+   {
+      "datetimeon" : "2010-04-29T02:55:18",
+      "id" : 3113,
+      "content" : "The convert_alpha function prepares a surface for usage with per-pixel alphas.  That is, for example, if you have a PNG or TGA image with an alpha channel controlling opacity of individual pixels, you would want to use this function on your surface after loading the image to speed up the blitting process.",
+      "user_title" : "Brad Smithee",
+      "link" : "Surface.convert_alpha"
+   },
+   {
+      "content" : "This will be extremely useful!",
+      "user_title" : "Ian Mallett",
+      "link" : "pygame.transform.average_surfaces",
+      "datetimeon" : "2009-08-15T19:21:45",
+      "id" : 2917
+   },
+   {
+      "id" : 2887,
+      "datetimeon" : "2009-07-20T07:29:06",
+      "link" : "Font.render",
+      "content" : "Some basic sample code for (approximately) constraining a bunch of text to a given width:\n\nwordsToWrite = toWrite.rstrip().split(\" \") #Get rid of the newline char and split on spaces\ncurrLine = \"\"\nnumLines = 0\nmaxWidthFound = 0\nfor word in wordsToWrite:\n    currLine = currLine + \" \" + word #Add the next word to the line\n\n    if ((textFont.size(currLine))[0] &gt; maxAllowedWidth): #Check if the width of the line exceeds the set limit\n\n        if (textFont.size(currLine))[0] &gt; maxWidthFound: #Get the maximum line width found\n            maxWidthFound = (textFont.size(currLine))[0]\n\n        lines.append (textFont.render(currLine, 1, color, bgcolor)) #Add the rendered line to a list\n        currLine = \"\"\n        numLines = numLines + 1\n\nif currLine != \"\": #Once we exit the loop, we will probably still have a line to be rendered\n    lines.append (textFont.render(currLine, 1, color, bgcolor))\n    currLine = \"\"\n    numLines = numLines + 1\n\nself.image = pygame.Surface((maxWidthFound + 20, numLines * textFont.get_height() + 20)) #Create a surface of the appropriate size\n\nfor lineNum in range(numLines): \n    self.image.blit(lines[lineNum], (10,lineNum * textFont.get_height() + 10))",
+      "user_title" : "Aditya Keswani"
+   },
+   {
+      "id" : 2886,
+      "datetimeon" : "2009-07-20T07:23:36",
+      "link" : "pygame.draw",
+      "user_title" : "Aditya Keswani",
+      "content" : "For all of these drawing functions, the coordinates are relative to the surface\nyou are drawing to. i.e. if you are drawing to a surface somewhere in the middle of\nthe screen, and you draw a circle at (0,0), its center will be the top-left corner\nof the surface being drawn to, not the top-left corner of the screen"
+   },
+   {
+      "datetimeon" : "2010-03-25T15:42:06",
+      "id" : 3087,
+      "content" : "The messages here:\nhttp://www.mail-archive.com/pygame-users@seul.org/msg10616.html\n\nimply that GL_SWAP_CONTROL can also be passed to gl_set_attribute to control whether\ndisplay swaps honor vsync.",
+      "user_title" : "Jonathan Hartley",
+      "link" : "pygame.display.gl_set_attribute"
+   },
+   {
+      "link" : "pygame.Color",
+      "content" : "Pygame THECOLORS as HTML\nhttps://sites.google.com/site/meticulosslacker/pygame-thecolors",
+      "user_title" : "Meticulos Slacker",
+      "id" : 3078,
+      "datetimeon" : "2010-03-18T03:10:26"
+   },
+   {
+      "id" : 3079,
+      "datetimeon" : "2010-03-19T00:36:48",
+      "link" : "pygame.mixer.pre_init",
+      "content" : "Should be \"buffer\", not \"buffersize\"",
+      "user_title" : "Ian Mallett"
+   },
+   {
+      "link" : "pygame.key.set_repeat",
+      "content" : "Put this first:\nfor e in pygame.event.get()",
+      "user_title" : "Ian Mallett",
+      "id" : 3080,
+      "datetimeon" : "2010-03-20T19:51:20"
+   },
+   {
+      "link" : "pygame.event",
+      "content" : "mod is the bitfield of KMOD_* constants:\npygame.KMOD_NONE\t0\npygame.KMOD_LSHIFT\t1\npygame.KMOD_RSHIFT\t2\npygame.KMOD_SHIFT\t3\npygame.KMOD_LCTRL\t64\npygame.KMOD_RCTRL\t128\npygame.KMOD_CTRL\t192\npygame.KMOD_LALT\t256\npygame.KMOD_RALT\t512\npygame.KMOD_ALT\t\t768\npygame.KMOD_LMETA\t1024\npygame.KMOD_RMETA\t2048\npygame.KMOD_META\t3072\npygame.KMOD_NUM\t\t4096\npygame.KMOD_CAPS\t8192\npygame.KMOD_MODE\t16384",
+      "user_title" : "Vladar",
+      "id" : 3081,
+      "datetimeon" : "2010-03-23T06:16:44"
+   },
+   {
+      "link" : "Channel.queue",
+      "user_title" : "Andy Hanson",
+      "content" : "If you try to use fadeout, the queued sound will begin, as opposed to stop and pause.",
+      "id" : 2875,
+      "datetimeon" : "2009-07-12T22:43:31"
+   },
+   {
+      "id" : 2928,
+      "datetimeon" : "2009-08-29T04:11:27",
+      "link" : "pygame.key.name",
+      "user_title" : "Jared",
+      "content" : "I ran into that problem -- the solution is to initialize pygame first :)\n\nimport pygame\npygame.init()\nprint pygame.key.name(pygame.K_UP)"
+   },
+   {
+      "user_title" : "David Khono Hackland",
+      "content" : "It appears that when the delay is set to zero, \nkey.set_repeat is returned to the default, disabled state.\nTo set it to a minimum, essentially no delay, just set it to 1.\n\npygame.key.set_repeat(0,50) #Doesn't work.\npygame.key.set_repeat(1,50) #Works with essentially no delay.",
+      "link" : "pygame.key.set_repeat",
+      "datetimeon" : "2010-03-02T22:20:03",
+      "id" : 3065
+   },
+   {
+      "datetimeon" : "2010-03-02T22:19:26",
+      "id" : 3064,
+      "user_title" : "David Khono Hackland",
+      "content" : "It appears that when the delay is set to zero, \nkey.set_repeat is returned to the default, disabled state.\nTo set it to a minimum, essentially no delay, just set it to 1.\n\npygame.key.set_repeat(0,50) #Doesn't work.\npygame.key.set_repeat(1,50) #Works with essentially no delay.",
+      "link" : "pygame.key.set_repeat"
+   },
+   {
+      "link" : "Clock.tick",
+      "user_title" : "Mitchell K",
+      "content" : "Does it matter if you tick at the start or at the end?",
+      "id" : 2944,
+      "datetimeon" : "2009-09-12T21:09:15"
+   },
+   {
+      "content" : "The example's .flip(..) below won't work - maybe I should have checked it before posting...\nHere is a better Version, it should work now.\n\nfrom pygame import Rect, Surface\nclass Sprites():\n    def __init__(self, spritesheet, size):\n        self.sheet = spritesheet\n        self.sheet.convert_alpha()\n        self.size = size\n        \n        self.sprites = []\n        for x in xrange(spritesheet.get_width() / size[0]):\n            list = []\n            for y in xrange(spritesheet.get_height() / size[1]):\n                list.append(spritesheet.subsurface(Rect((x*size[0], y*size[1]) , size)))\n            self.sprites.append(list)\n    def flip(self, xbool, ybool):\n        new = Surface(self.sheet.get_size())\n        new.fill((0, 0, 0, 0))\n        for row in self.sprites:\n            for sprite in row:\n                new.blit(flip(sprite, xbool, ybool), sprite.get_offset())\n        self.sheet.fill((0, 0, 0, 0))\n        self.sheet.blit(new, (0, 0))\n    def __getitem__(self, x=None, y=None):\n        # not very tested, .flip(y=7) won't work\n        # the if conditions should allow you to access a sheet with one row/col more easily .flip(5, 0) == .flip(5)\n        if x is not None:\n            if y is None:\n                if len(self.sprites) &gt; x:\n                    y = 0\n                else:\n                    y = x\n                    x = 0\n        elif y is None:\n            raise IndexError\n                \n        return self.sprites[x][y]\n\n@any Developer/Moderator - it would be nice if my wrong post, \"The example below won't work\" and this Notice would be removed.",
+      "user_title" : "Rolf Sievers",
+      "link" : "Surface.subsurface",
+      "datetimeon" : "2009-11-06T11:31:59",
+      "id" : 2998
+   },
+   {
+      "link" : "Surface.subsurface",
+      "content" : "Here is a simple Sprite-sheet Class I wrote for an application, maybe someone can use it.\n\nfrom pygame import Rect\nclass Sprites():\n    def __init__(self, spritesheet, size):\n        self.sheet = spritesheet\n        self.sheet.convert_alpha()\n        self.size = size\n        \n        self.sprites = []\n        for x in xrange(spritesheet.get_width() / size[0]):\n            list = []\n            for y in xrange(spritesheet.get_height() / size[1]):\n                list.append(spritesheet.subsurface(Rect((x*size[0], y*size[1]) , size)))\n            self.sprites.append(list)\n            print list\n        print self.sprites\n    def flip(self, xbool, ybool):\n        self.sheet.fill((0, 0, 0, 0))\n        for row in self.sprites:\n            for sprite in row:\n                sprite.blit(flip(sprite, xbool, ybool), (0, 0))\n    def __getitem__(self, x=None, y=None):\n        if x is not None:\n            if y is None:\n                if len(self.sprites) &gt; x:\n                    y = 0\n                else:\n                    y = x\n                    x = 0\n        elif y is None:\n            raise IndexError\n                \n        return self.sprites[x][y]",
+      "user_title" : "Rolf Sievers",
+      "id" : 2997,
+      "datetimeon" : "2009-11-06T11:14:23"
+   },
+   {
+      "user_title" : "Luke Endres",
+      "content" : "Is there anyway to get the rect of a polygon without having to create a surface greater than or equal to the polygon, and then gather the rect from the polygon?",
+      "link" : "pygame.draw.polygon",
+      "datetimeon" : "2009-08-08T21:50:46",
+      "id" : 2907
+   },
+   {
+      "user_title" : "Gummbum",
+      "content" : "This is twice the work because the image is rotated and then resized (subrect\nis copied) but it doesn't hurt my math-addled brain.\n\ndef rot_center(image, angle):\n    \"\"\"rotate an image while keeping its center and size\"\"\"\n    orig_rect = image.get_rect()\n    rot_image = pygame.transform.rotate(image, angle)\n    rot_rect = orig_rect.copy()\n    rot_rect.center = rot_image.get_rect().center\n    rot_image = rot_image.subsurface(rot_rect).copy()\n    return rot_image",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2010-01-17T01:17:23",
+      "id" : 3034
+   },
+   {
+      "id" : 3035,
+      "datetimeon" : "2010-01-17T09:30:05",
+      "link" : "pygame.Surface",
+      "content" : "Use pygame.transform.rotate(Surface, angle)",
+      "user_title" : "Francesco Pasa"
+   },
+   {
+      "link" : "pygame.display.toggle_fullscreen",
+      "user_title" : "Chris L",
+      "content" : "Does the returned Boolean value indicate success/failure at toggling fullscreen mode,\nor current status of the display (e.g., fullscreen = True, windowed = False)?",
+      "id" : 3041,
+      "datetimeon" : "2010-01-27T16:33:12"
+   },
+   {
+      "id" : 2980,
+      "datetimeon" : "2009-10-23T11:07:21",
+      "link" : "pygame.event.set_blocked",
+      "content" : "set_blocked() clear queue from ALL events",
+      "user_title" : "ploutos"
+   },
+   {
+      "id" : 2975,
+      "datetimeon" : "2009-10-21T19:51:47",
+      "link" : "pygame.cdrom",
+      "user_title" : "Jeffrey Aylesworth",
+      "content" : "If they play in a CD player, they were burned properly."
+   },
+   {
+      "datetimeon" : "2009-09-24T16:05:59",
+      "id" : 2959,
+      "content" : "This is very important for mac because it shows the icon in the dock.. when I use this, it flashes the snake image for a second before changing, and it also gets smaller then the application icon which is the same (using py2app).",
+      "user_title" : "Mitchell K",
+      "link" : "pygame.display.set_icon"
+   },
+   {
+      "id" : 3138,
+      "datetimeon" : "2010-06-08T15:33:04",
+      "link" : "pygame.time.get_ticks",
+      "user_title" : "Sergio Milardovich",
+      "content" : "\"\"\"\n\t # This is a get_ticks() function simple example\n\t # This script should return 10 as a result\n\"\"\"\n# Standard library imports\nimport time\n# Related third party imports\nimport pygame\n#Pygame start function\n\npygame.init()\n# Create the clock\nclock = pygame.time.Clock()\n# A simple loop of 10 stages\nfor i in range(10):\n\t# Update the clock\n\tclock.tick(1)\n# Print the seconds\nprint int(round(pygame.time.get_ticks()/1000))"
+   },
+   {
+      "link" : "pygame.scrap",
+      "content" : "Note that pygame.scrap seems to be unimplemented in pygame-1.9.1.win32-py3.1.msi\n\nDefine testscrap.py, like this:\n\nimport pygame\npygame.init()\npygame.scrap.init()\n\n\nRun it, like this:\n\nC:\\Users\\Dave\\Documents\\Python&gt;testscrap.py\nC:\\Users\\Dave\\Documents\\Python\\testscrap.py:3: RuntimeWarning: use scrap: No module named scrap\n(ImportError: No module named scrap)\n  pygame.scrap.init()\nTraceback (most recent call last):\n  File \"C:\\Users\\Dave\\Documents\\Python\\testscrap.py\", line 3, in \n    pygame.scrap.init()\n  File \"C:\\Python31\\lib\\site-packages\\pygame\\__init__.py\", line 70, in __getattr__\n    raise NotImplementedError(MissingPygameModule)\nNotImplementedError: scrap module not available\n(ImportError: No module named scrap)",
+      "user_title" : "Dave Burton",
+      "id" : 3731,
+      "datetimeon" : "2011-01-16T00:15:21"
+   },
+   {
+      "id" : 3732,
+      "datetimeon" : "2011-01-16T00:18:19",
+      "link" : "pygame.scrap",
+      "user_title" : "Dave Burton",
+      "content" : "BTW, the same error occurs if you have initialized a display surface, too:\n\nimport pygame\npygame.init()\nscreen=pygame.display.set_mode((640,360),0,32)\npygame.scrap.init()"
+   },
+   {
+      "link" : "Surface.subsurface",
+      "user_title" : "Dave Burton",
+      "content" : "Hey, July 7 2009 Anonymous, that's a nice demo!\n\nFor Python 3 compatibility, just change the last line to:\n\n  pygame.time.delay(1000//50)",
+      "id" : 3746,
+      "datetimeon" : "2011-01-24T10:00:06"
+   },
+   {
+      "link" : "pygame.Rect",
+      "user_title" : "Dave Burton",
+      "content" : "Note that the order of the tuple members in virtual attributes like .topleft\nis always (x,y) [or (left,top) or (width,height)] even if the name of the\nvirtual attribute seems to suggest the opposite order.  E.g.,\nrect1.topleft == (rect1.left,rect1.top)",
+      "id" : 3747,
+      "datetimeon" : "2011-01-25T01:19:14"
+   },
+   {
+      "id" : 3750,
+      "datetimeon" : "2011-01-25T21:33:33",
+      "link" : "pygame.event",
+      "content" : "There's no 'code' member for type USEREVENT, unless you create one yourself\nwhen you create the event.",
+      "user_title" : "Dave Burton"
+   },
+   {
+      "content" : "July 15 2010 Anonymous, here's your example of a resizeable pygame window.\n\nI don't know what you mean by \"window itself as well as the display.\"\nIf you want to resize something WITHIN the pygame window, just blit something\ndifferent onto it.\n\nDave\n\n\nimport sys, os, pygame\npygame.init()\n\nclock = pygame.time.Clock()\n\nscrsize = width,height = 600,400\nblack = 0,0,0\nbgcolor = (240,240,220)  # light grey\n\n# to get the true full-screen size, do this BEFORE pygame.display.set_mode:\nfullscreen_sz = pygame.display.Info().current_w, pygame.display.Info().current_h\nprint( 'screen size =', fullscreen_sz )\n\n\n# ---------- This works under Windows Vista, no promises elsewhere! ----------\n# initially center the pygame window by setting %SDL_VIDEO_WINDOW_POS%\nwin_pos_left = 1 + ((fullscreen_sz[0] - width) // 2)\nwin_pos_top = 1 + ((fullscreen_sz[1] - height) // 2)\nos.environ['SDL_VIDEO_WINDOW_POS'] = '{0},{1}'.format(win_pos_left, win_pos_top)\n# ----------------------------------------------------------------------------\n\nscreen = pygame.display.set_mode(scrsize, pygame.RESIZABLE)\n\n# ----------------------------------------------------------------------------\nos.environ['SDL_VIDEO_WINDOW_POS'] = ''\n# if you don't clear the environment variable, the window will reposition\n# every time pygame.display.set_mode() gets called due to a VIDEORESIZE event.\n# ----------------------------------------------------------------------------\n\narial = pygame.font.SysFont( 'arial,microsoftsansserif,courier', 14 )\ntxt2display = arial.render( \"This window is resizeable\", True, black )\ntxt2display_w = txt2display.get_size()[0]\n\nwhile True:\n    changed = False\n    for event in pygame.event.get():\n        if event.type == pygame.QUIT:\n            pygame.quit()\n            sys.exit(0)\n        elif event.type == pygame.VIDEORESIZE:\n            scrsize = event.size  # or event.w, event.h\n            screen = pygame.display.set_mode(scrsize,RESIZABLE)\n            changed = True\n\n    screen.fill( bgcolor )\n    screen.blit( txt2display, ((scrsize[0]+1-txt2display_w)//2,1) )  # at top-center of screen\n    pygame.display.update()\n    if not changed:\n        clock.tick(60) # limit to 60 fps",
+      "user_title" : "Dave Burton",
+      "link" : "pygame.display.init",
+      "datetimeon" : "2011-01-25T23:10:35",
+      "id" : 3751
+   },
+   {
+      "user_title" : "Dave Burton",
+      "content" : "Oops!  Tiny correction... the 8th-to-last line should be\n\n            screen = pygame.display.set_mode(scrsize,pygame.RESIZABLE)\n\n(Or else you can \"from pygame.locals import *\")",
+      "link" : "pygame.display.init",
+      "datetimeon" : "2011-01-25T23:16:00",
+      "id" : 3752
+   },
+   {
+      "user_title" : "Dave Burton",
+      "content" : "from pygame.locals import *\n\n_evnames = {}                                 # from SDL-1.2.14\\include\\SDL_events.h\n_evnames[NOEVENT]         = 'NOEVENT'          #  0  SDL_NOEVENT\n_evnames[ACTIVEEVENT]     = 'ACTIVEEVENT'      #  1  SDL_ACTIVEEVENT\n_evnames[KEYDOWN]         = 'KEYDOWN'          #  2  SDL_KEYDOWN\n_evnames[KEYUP]           = 'KEYUP'            #  3  SDL_KEYUP\n_evnames[MOUSEMOTION]     = 'MOUSEMOTION'      #  4  SDL_MOUSEMOTION\n_evnames[MOUSEBUTTONDOWN] = 'MOUSEBUTTONDOWN'  #  5  SDL_MOUSEBUTTONDOWN\n_evnames[MOUSEBUTTONUP]   = 'MOUSEBUTTONUP'    #  6  SDL_MOUSEBUTTONUP\n_evnames[JOYAXISMOTION]   = 'JOYAXISMOTION'    #  7  SDL_JOYAXISMOTION\n_evnames[JOYBALLMOTION]   = 'JOYBALLMOTION'    #  8  SDL_JOYBALLMOTION\n_evnames[JOYHATMOTION]    = 'JOYHATMOTION'     #  9  SDL_JOYHATMOTION\n_evnames[JOYBUTTONDOWN]   = 'JOYBUTTONDOWN'    # 10  SDL_JOYBUTTONDOWN\n_evnames[JOYBUTTONUP]     = 'JOYBUTTONUP'      # 11  SDL_JOYBUTTONUP\n_evnames[QUIT]            = 'QUIT'             # 12  SDL_QUIT\n_evnames[SYSWMEVENT]      = 'SYSWMEVENT'       # 13  SDL_SYSWMEVENT\n                                               # 14  SDL_EVENT_RESERVEDA\n                                               # 15  SDL_EVENT_RESERVEDB\n_evnames[VIDEORESIZE]     = 'VIDEORESIZE'      # 16  SDL_VIDEORESIZE\n_evnames[VIDEOEXPOSE]     = 'VIDEOEXPOSE'      # 17  SDL_VIDEOEXPOSE\n                                               # 18  SDL_EVENT_RESERVED2\n                                               # 19  SDL_EVENT_RESERVED3\n                                               # 20  SDL_EVENT_RESERVED4\n                                               # 21  SDL_EVENT_RESERVED5\n                                               # 22  SDL_EVENT_RESERVED6\n                                               # 23  SDL_EVENT_RESERVED7\n_evnames[USEREVENT]       = 'USEREVENT'        # 24  SDL_USEREVENT\n_evnames[NUMEVENTS]       = 'NUMEVENTS'        # 32  SDL_NUMEVENTS\n\n\ndef event_name(evtype):\n    '''return a displayable name for a pygame/SDL event type number'''\n    try:\n        result = _evnames[evtype]\n    except:\n        if evtype in range(USEREVENT,NUMEVENTS):\n            result = 'USEREVENT+' + repr(evtype-USEREVENT)\n        elif evtype &gt;= NUMEVENTS:\n            result = 'ILLEGAL_EVENT_' + repr(evtype)\n        elif evtype == 14:\n            result = 'EVENT_RESERVEDA'\n        elif evtype == 15:\n            result = 'EVENT_RESERVEDB'\n        else:\n            result = 'EVENT_RESERVED' + repr(evtype-16)\n    return result\n\n\nfor i in range(0,33):\n    print(repr(i) + ' = ' + event_name(i))\n\n\n# It's all gonna change in SDL 1.3:\n#\n#   SDL_FIRSTEVENT        = 0      # Unused\n#\n#   SDL_QUIT              = 0x100  # User-requested quit\n#\n#   SDL_WINDOWEVENT       = 0x200  # Window state change\n#   SDL_SYSWMEVENT        = 0x201  # System specific event\n#\n#   # Keyboard events\n#   SDL_KEYDOWN           = 0x300  # Key pressed\n#   SDL_KEYUP             = 0x301  # Key released\n#   SDL_TEXTEDITING       = 0x302  # Keyboard text editing (composition)\n#   SDL_TEXTINPUT         = 0x303  # Keyboard text input\n#\n#   # Mouse events\n#   SDL_MOUSEMOTION       = 0x400  # Mouse moved\n#   SDL_MOUSEBUTTONDOWN   = 0x401  # Mouse button pressed\n#   SDL_MOUSEBUTTONUP     = 0x402  # Mouse button released\n#   SDL_MOUSEWHEEL        = 0x403  # Mouse wheel motion\n#\n#   # Tablet or multiple mice input device events\n#   SDL_INPUTMOTION       = 0x500  # Input moved\n#   SDL_INPUTBUTTONDOWN   = 0x501  # Input button pressed\n#   SDL_INPUTBUTTONUP     = 0x502  # Input button released\n#   SDL_INPUTWHEEL        = 0x503  # Input wheel motion\n#   SDL_INPUTPROXIMITYIN  = 0x504  # Input pen entered proximity\n#   SDL_INPUTPROXIMITYOUT = 0x505  # Input pen left proximity\n#\n#   # Joystick events\n#   SDL_JOYAXISMOTION     = 0x600  # Joystick axis motion\n#   SDL_JOYBALLMOTION     = 0x601  # Joystick trackball motion\n#   SDL_JOYHATMOTION      = 0x602  # Joystick hat position change\n#   SDL_JOYBUTTONDOWN     = 0x603  # Joystick button pressed\n#   SDL_JOYBUTTONUP       = 0x604  # Joystick button released\n#\n#   # Touch events\n#   SDL_FINGERDOWN        = 0x700\n#   SDL_FINGERUP          = 0x701\n#   SDL_FINGERMOTION      = 0x702\n#   SDL_TOUCHBUTTONDOWN   = 0x703\n#   SDL_TOUCHBUTTONUP     = 0x704\n#\n#   # Gesture events\n#   SDL_DOLLARGESTURE     = 0x800\n#   SDL_DOLLARRECORD      = 0x801\n#   SDL_MULTIGESTURE      = 0x802\n#\n#   # Clipboard events\n#   SDL_CLIPBOARDUPDATE   = 0x900  # The clipboard changed\n#\n#   # Obsolete events\n#   SDL_EVENT_COMPAT1     =0x7000  # SDL 1.2 events for compatibility\n#   SDL_EVENT_COMPAT2     =0x7001\n#   SDL_EVENT_COMPAT3     =0x7002\n#\n#   # SDL_USEREVENT thru SDL_LASTEVENT are for your use\n#   SDL_USEREVENT         =0x8000\n#   SDL_LASTEVENT         =0xFFFF",
+      "link" : "pygame.event.Event",
+      "datetimeon" : "2011-01-27T04:08:06",
+      "id" : 3753
+   },
+   {
+      "id" : 3756,
+      "datetimeon" : "2011-01-27T18:49:33",
+      "link" : "PixelArray.compare",
+      "content" : "This function seems to me little bit buggy, so I wrote my own:\n\na and b are surfarrays of some surfaces that you want to compare\n\n    def comparray(self,a,b):\n        c = abs(a.__sub__(b))\n        c = c.__ge__(self.tolerance)*255\n        surface = pygame.surfarray.make_surface(c)\n        return surface",
+      "user_title" : "Kaan Akßit"
+   },
+   {
+      "user_title" : "Dave Burton",
+      "content" : "There's an error in this documentation w/r/t the final (width) argument:\n\n    pygame.draw.rect(self.image, color, self.image.get_rect(), width=1)\nTypeError: rect() takes no keyword arguments\n\nLeave off the \"width=\" to make it work:\n\n    pygame.draw.rect(self.image, color, self.image.get_rect(), 1)\n\nThis is with either pygame-1.9.1.win32-py2.6.msi or pygame-1.9.1.win32-py3.1.msi",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2011-01-28T03:12:31",
+      "id" : 3757
+   },
+   {
+      "link" : "pygame.draw.line",
+      "content" : "There's an error in this documentation w/r/t the final (width) argument:\n\n    pygame.draw.line(self.image, (0,0,0), (x,y), (x,y+h), width=2)\nTypeError: line() takes no keyword arguments\n\nLeave off the \"width=\" to make it work:\n\n    pygame.draw.line(self.image, (0,0,0), (x,y), (x,y+h), 2)\n\nThis is with either pygame-1.9.1.win32-py2.6.msi or pygame-1.9.1.win32-py3.1.msi",
+      "user_title" : "Dave Burton",
+      "id" : 3759,
+      "datetimeon" : "2011-01-28T04:54:01"
+   },
+   {
+      "id" : 3761,
+      "datetimeon" : "2011-01-29T20:46:36",
+      "link" : "Rect.collidepoint",
+      "content" : "Rect.center rounds UP:\n\nr0x0 = pygame.Rect(0,0,0,0)  # a 0x0 rect\nprint('center of 0x0 rect is ' + repr(r0x0.center))  # result is (0,0) = not in the rect!\nr1x1 = pygame.Rect(0,0,1,1)  # a 1x1 rect\nprint('center of 1x1 rect is ' + repr(r1x1.center))  # result is (0,0) = correct\nr2x2 = pygame.Rect(0,0,2,2)  # a 2x2 rect\nprint('center of 2x2 rect is ' + repr(r2x2.center))  # result is (1,1) = rounded up!\nr3x3 = pygame.Rect(0,0,3,3)  # a 3x3 rect\nprint('center of 3x3 rect is ' + repr(r3x3.center))  # result is (1,1) = exact\nr4x4 = pygame.Rect(0,0,4,4)  # a 4x4 rect\nprint('center of 4x4 rect is ' + repr(r4x4.center))  # result is (2,2) = rounded up!\nr5x5 = pygame.Rect(0,0,5,5)  # a 5x5 rect\nprint('center of 5x5 rect is ' + repr(r5x5.center))  # result is (2,2) = exact\nr6x6 = pygame.Rect(0,0,6,6)  # a 6x6 rect\nprint('center of 6x6 rect is ' + repr(r6x6.center))  # result is (3,3) = rounded up!\nr7x7 = pygame.Rect(0,0,7,7)  # a 7x7 rect\nprint('center of 7x7 rect is ' + repr(r7x7.center))  # result is (3,3) = exact",
+      "user_title" : "Dave Burton"
+   },
+   {
+      "datetimeon" : "2011-01-29T20:47:58",
+      "id" : 3762,
+      "content" : "(Oops, I added that comment in the wrong place.)",
+      "user_title" : "Dave Burton",
+      "link" : "Rect.collidepoint"
+   },
+   {
+      "id" : 3763,
+      "datetimeon" : "2011-01-29T20:48:50",
+      "link" : "pygame.Rect",
+      "user_title" : "Dave Burton",
+      "content" : "Rect.center rounds UP:\n\nr0x0 = pygame.Rect(0,0,0,0)  # a 0x0 rect\nprint('center of 0x0 rect is ' + repr(r0x0.center))  # result is (0,0) = not in the rect!\nr1x1 = pygame.Rect(0,0,1,1)  # a 1x1 rect\nprint('center of 1x1 rect is ' + repr(r1x1.center))  # result is (0,0) = correct\nr2x2 = pygame.Rect(0,0,2,2)  # a 2x2 rect\nprint('center of 2x2 rect is ' + repr(r2x2.center))  # result is (1,1) = rounded up!\nr3x3 = pygame.Rect(0,0,3,3)  # a 3x3 rect\nprint('center of 3x3 rect is ' + repr(r3x3.center))  # result is (1,1) = exact\nr4x4 = pygame.Rect(0,0,4,4)  # a 4x4 rect\nprint('center of 4x4 rect is ' + repr(r4x4.center))  # result is (2,2) = rounded up!\nr5x5 = pygame.Rect(0,0,5,5)  # a 5x5 rect\nprint('center of 5x5 rect is ' + repr(r5x5.center))  # result is (2,2) = exact\nr6x6 = pygame.Rect(0,0,6,6)  # a 6x6 rect\nprint('center of 6x6 rect is ' + repr(r6x6.center))  # result is (3,3) = rounded up!\nr7x7 = pygame.Rect(0,0,7,7)  # a 7x7 rect\nprint('center of 7x7 rect is ' + repr(r7x7.center))  # result is (3,3) = exact"
+   },
+   {
+      "link" : "Rect.collidepoint",
+      "user_title" : "Dave Burton",
+      "content" : "This documentation is incorrect.  A point along the right or bottom edge IS\nwithin the Rect, and points at coordinates on the bottom or right edge DO\ncollide with the Rect.\n\nHere's proof:\n\nr = Rect(0,0, 4,4)  # a 4x4 rectangle\nprint('0,0: ' + repr(r.collidepoint(0,0)))\nprint('1,1: ' + repr(r.collidepoint(1,1)))\nprint('2,2: ' + repr(r.collidepoint(2,2)))\nprint('3,3: ' + repr(r.collidepoint(3,3)))\nprint('4,4: ' + repr(r.collidepoint(4,4)))\n\nWith pygame 1.9.1 under both Python 3.1 and 2.6, it prints:\n\n0,0: 1\n1,1: 1\n2,2: 1\n3,3: 1\n4,4: 0\n\nNote that the bottom-right pixel within the 4x4 rect is at (3,3) and\ncollidepoint((3,3)) does return 1 (meaning true).\n\nA second (minor) documentation error is that it actually returns an integer\n1 or 0 instead of boolean True or False.",
+      "id" : 3764,
+      "datetimeon" : "2011-01-29T22:35:18"
+   },
+   {
+      "id" : 3774,
+      "datetimeon" : "2011-02-07T04:48:40",
+      "link" : "pygame.event",
+      "user_title" : "Dave Burton",
+      "content" : "This class is a bit odd.  Event objects have no event.__dict__ attribute,\nand the dir(event) function doesn't work.  However, repr(event) returns a\nnice, thorough description of an event object and its attributes, and the\nevent.dict attribute lists all the important attributes except .type and\n.dict itself."
+   },
+   {
+      "user_title" : "Dave Burton",
+      "content" : "With a Microsoft IntelliMouse p/n X05-77975, under Windows Vista,\nwith either Python 2.6 or 3.1, the button numbers are:\n1 = left button\n2 = center button/wheel press\n3 = right button\n4 = wheel roll forward/up\n5 = wheel roll backward/down\n6 = left side extra button\n7 = right side extra button",
+      "link" : "pygame.event",
+      "datetimeon" : "2011-02-23T21:04:46",
+      "id" : 3794
+   },
+   {
+      "link" : "pygame.cursors",
+      "user_title" : "Dave Burton",
+      "content" : "There's a cursor missing!  sizer_xy_strings defines an upper-left-to-lower-right\nresizer cursor, suitable for dragging the upper-left or lower-right corner.\nBut there's no sizer_yx_strings to make the upper-right-to-lower-left cursor.\nHere's how I made one:\n\nsizer_yx_strings = [ x[12::-1]+x[13:] for x in pygame.cursors.sizer_xy_strings ]",
+      "id" : 3795,
+      "datetimeon" : "2011-02-24T02:08:27"
+   },
+   {
+      "id" : 3796,
+      "datetimeon" : "2011-02-24T02:13:59",
+      "link" : "pygame.cursors",
+      "content" : "Or, equivalently:\n\nsizer_yx_strings = (               #sized 24x16\n \"     XXXXXXXX           \",\n \"      X.....X           \",\n \"       X....X           \",\n \"        X...X           \",\n \"       X.X..X           \",\n \"      X.X X.X           \",\n \"X    X.X   XX           \",\n \"XX  X.X     X           \",\n \"X.XX.X                  \",\n \"X...X                   \",\n \"X...X                   \",\n \"X....X                  \",\n \"X.....X                 \",\n \"XXXXXXXX                \",\n \"                        \",\n \"                        \",\n)",
+      "user_title" : "Dave Burton"
+   },
+   {
+      "id" : 3799,
+      "datetimeon" : "2011-03-01T13:26:33",
+      "link" : "pygame.mixer.Sound",
+      "content" : "The Sound function now accepts 'buffer', 'file', and 'array' keyword arguments\nto remove any ambiguity in how to treat an argument. The 'array' keyword is new,\nand tells Sound to look check the argument for an array struct interface or\nthe new buffer protocol if supported. This allows Sound to function like\nsndarray.make_sound.\n\nSound also exposes an array struct interface and the new buffer protocol.",
+      "user_title" : "Lenard Lindstrom"
+   },
+   {
+      "content" : "I'm not sure which version of Pygame is being used here, 1.9? At the time it was\nreleased NumPy was unavailable for Python 3.1. Python 1.9.2 alpha from SVN\ncertainly does support NumPy for Python 3.1, and 3.2.",
+      "user_title" : "Lenard Lindstrom",
+      "link" : "pygame.surfarray",
+      "datetimeon" : "2011-03-01T13:35:12",
+      "id" : 3800
+   },
+   {
+      "id" : 3801,
+      "datetimeon" : "2011-03-01T13:37:12",
+      "link" : "pygame.surfarray",
+      "user_title" : "Lenard Lindstrom",
+      "content" : "That should be \"which version of Pygame is being used here, 1.9.1?\""
+   },
+   {
+      "id" : 3802,
+      "datetimeon" : "2011-03-01T13:38:40",
+      "link" : "pygame.surfarray.pixels_alpha",
+      "user_title" : "Lenard Lindstrom",
+      "content" : "New to Pygame 1.9.2 for NumPy: pixels_red, pixels_green, and pixels_blue."
+   },
+   {
+      "user_title" : "Daniel Kaminsky",
+      "content" : "For the KEYDOWN and KEYUP event \"scancode\" is also a member and can be used \nfor the unknown keys",
+      "link" : "pygame.event",
+      "datetimeon" : "2011-03-23T05:51:58",
+      "id" : 3872
+   },
+   {
+      "link" : "pygame.mouse",
+      "content" : "The wheel generates pygame.MOUSEBUTTONUP events too, not just pygame.MOUSEBUTTONDOWN event.",
+      "user_title" : "Dan Ross",
+      "id" : 3884,
+      "datetimeon" : "2011-04-02T23:30:45"
+   },
+   {
+      "datetimeon" : "2011-04-03T18:28:23",
+      "id" : 3885,
+      "content" : "Forget what the functions do, check out Mr. Brown's naming style. Its pure genius!\n1) angle_times_WOW_pi_divided_by_180\n2) HE_HE_strange_popper_z\n3) buffy_the_fat2\n4) they_did_touch\n5) while Grr &lt; LIN_collide_max:\n6) Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol\n7) write_to_file_WEEE_STRANGE()\n8) freaky_rect_switcharoo_2D()",
+      "user_title" : "Mad Cloud Games",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "link" : "pygame.transform.chop",
+      "content" : "If you like to receive the inner rectangle, the blit is a much better setup. \nThe following comparing examples show how-to cut a (centered) 150x150 frame out of a 250x250 image:\norig_surf = pygame.Surface((250,250),flags=pygame.SRCALPHA)\npygame.draw.circle(orig_surf,(255,0,0),(50,50),25)\npygame.draw.circle(orig_surf,(0,255,0),(50,200),25)\npygame.draw.circle(orig_surf,(0,0,255),(200,50),25)\npygame.draw.circle(orig_surf,(0,255,255),(200,200),25)\n\ncrop_surf = pygame.transform.chop(pygame.transform.chop(orig_surf,(0,0,50,50)),(150,150,250,250))\npygame.image.save(crop_surf, 'test-crop.png')\n\n\ncrop_surf =  pygame.Surface((150,150),flags=pygame.SRCALPHA)\ncrop_surf.blit(orig_surf, (0,0),(50,50,200,200))\npygame.image.save(crop_surf, 'test-blit.png')",
+      "user_title" : "Rick van der Zwet",
+      "id" : 4045,
+      "datetimeon" : "2011-05-05T04:36:44"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "It all seemed simple and working properly, then I noticed... \"The area covered by a Rect does not include the right- and bottom-most edge of pixels. If one Rect's bottom border is another Rect's top border (i.e., rect1.bottom=rect2.top), the two meet exactly on the screen but do not overlap, and rect1.colliderect(rect2) returns false.\"\n\n*mutter* good to know.",
+      "link" : "Rect.colliderect",
+      "datetimeon" : "2011-01-10T19:28:58",
+      "id" : 3725
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Note that when the user resizes the game window, pygame does not automatically update its internal screen surface. You must call set_mode() every time VIDEORESIZE is sent. This really should be more clear in the documentation.",
+      "link" : "pygame.display",
+      "datetimeon" : "2011-01-11T15:55:57",
+      "id" : 3726
+   },
+   {
+      "datetimeon" : "2011-01-13T08:28:22",
+      "id" : 3727,
+      "content" : "Is it possible to set this mode transparent?\nI mean without changing the transparency with set_alpha or ... but from the beginning.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.set_mode"
+   },
+   {
+      "link" : "pygame.draw.aaline",
+      "content" : "Draw a normal thick line, then draw two aa lines either side. Not exactly what you want but it will work.",
+      "user_title" : "Anonymous",
+      "id" : 3728,
+      "datetimeon" : "2011-01-13T15:22:43"
+   },
+   {
+      "link" : "pygame.draw.line",
+      "content" : "This code fixes the bad rect given by the line function.\n\ntemprect=(pygame.draw.line(screen,color,firstpos,newpos,thick))\ntemprect.inflate_ip(thick*2, thick*2)\ndirty.append(temprect)",
+      "user_title" : "Anonymous",
+      "id" : 8,
+      "datetimeon" : "2005-11-22T22:22:44"
+   },
+   {
+      "id" : 13,
+      "datetimeon" : "2005-11-27T22:45:10",
+      "link" : "pygame.draw.ellipse",
+      "user_title" : "Anonymous",
+      "content" : "if your rect contains a negative width or height you need to rect.normalize() your rect before passing it to this function"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Rotates image about its center.",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2005-11-28T19:22:44",
+      "id" : 14
+   },
+   {
+      "link" : "pygame.transform.rotate",
+      "content" : "Make sure you blit according to the center of the newly formed surface, and not what the center of the orginal image is.",
+      "user_title" : "Anonymous",
+      "id" : 15,
+      "datetimeon" : "2005-11-28T19:24:48"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "This probably goes without saying, but always rotate the orginal image, not a rotated copy.",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2005-11-28T19:26:45",
+      "id" : 16
+   },
+   {
+      "datetimeon" : "2005-12-01T10:30:49",
+      "id" : 18,
+      "user_title" : "Anonymous",
+      "content" : "Before calling pygame.key.get_pressed(), one should call pygame.event.pump() to get the lates state of the keyboard.\n\nThis is so because the get_pressed() function wraps the SDL_GetKeyState() function and in the SDL_GetKeyState() documentation it is written that one should use SDL_PumpEvents() to update the state array and pygame.event.pump() just happens to be a wrapper for SDL_PumpEvents() :-)",
+      "link" : "pygame.key.get_pressed"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "When I tryed to use this, he couldn't find the key K_t I wanted\n untill I used:\n\nfrom pygame.locals import *\n\nSo be sure to use it - Shefy",
+      "link" : "pygame.key.get_pressed",
+      "datetimeon" : "2005-12-07T04:09:33",
+      "id" : 19
+   },
+   {
+      "datetimeon" : "2005-12-10T19:21:13",
+      "id" : 22,
+      "user_title" : "Anonymous",
+      "content" : "if you pass in None as the background argument, you get the error\n\"TypeError: Invalid background RGBA argument\"",
+      "link" : "Font.render"
+   },
+   {
+      "id" : 32,
+      "datetimeon" : "2005-12-25T19:36:47",
+      "link" : "pygame.key.get_pressed",
+      "content" : "pygame.event.pump()\n  m = pygame.key.get_mods()\n  if m &amp; KMOD_SHIFT:\n    print 'shift pressed'",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.transform.rotate",
+      "content" : "Rotated objects tend to move around because bounding rectangle changes size.\nStore the center in a temporary variable, then rotate the original image, and finally reset the center before you blit or update\nThis code comes from a sprite class:\n\n  def turn(self, amount):\n    \"turn some amount\"\n    oldCenter = self.rect.center\n    self.dir += amount\n    self.image = pygame.transform.rotate(self.baseImage, self.dir)\n    self.rect = self.image.get_rect()\n    self.rect.center = oldCenter",
+      "user_title" : "Anonymous",
+      "id" : 36,
+      "datetimeon" : "2006-01-03T09:48:09"
+   },
+   {
+      "id" : 37,
+      "datetimeon" : "2006-01-04T09:16:25",
+      "link" : "pygame.mouse.get_pressed",
+      "content" : "This effect (1 + 3 = 2) is caused by your X.org/XServer mouse configuration section, which allows to emulate the middle button by clicking both the left and right mouse button at the same time.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2006-01-17T14:45:02",
+      "id" : 41,
+      "content" : "This does not result in 'truly' transparent text, as the area between the letters is filled in with the background color. For truly transparent text with an invisible background behind the letters, use Numeric:\n\ndef RenderTransparent(font, text, antialias=1, color=(255, 0, 0, 0)):\n    'Render text with transparency underneath the letters'\n    'Requires Numeric'\n\n    # Create a colored block big enough to hold the text\n    w, h = font.size(text)\n    surface = pygame.Surface((w, h), pygame.SRCALPHA)\n    surface.fill(color)\n    \n    # Create an alpha channel that contains the shapes of the letters\n    alpha = pygame.Surface((w, h), pygame.SRCALPHA)\n    WHITE = (255, 255, 255, 0)\n    BLACK = (0, 0, 0, 0)\n    a = font.render(text, antialias, WHITE, BLACK)\n    alpha.blit(a, (0, 0))\n        \n    # Combine the alpha channel with the colored block\n    pic = surface.convert_alpha()\n    mask = alpha.convert(32)\n    mskarray = pygame.surfarray.pixels3d(mask)\n    pygame.surfarray.pixels_alpha(pic)[:, :] = mskarray[:, :, 0]\n\n    # Return the 'truly' transparent text.\n    return pic",
+      "user_title" : "Anonymous",
+      "link" : "Font.render"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "LOL",
+      "link" : "PixelArray.replace",
+      "datetimeon" : "2011-01-03T19:03:40",
+      "id" : 3700
+   },
+   {
+      "datetimeon" : "2011-01-03T19:05:09",
+      "id" : 3701,
+      "content" : "FUCKING SPAMMER MOTHER FUCKERS WHO OWNS THIS SHIT THEY SHOULD BURN IN HELLL",
+      "user_title" : "Anonymous",
+      "link" : "pygame.locals"
+   },
+   {
+      "link" : "pygame.cursors.compile",
+      "content" : "On my Windows Vista machine running Python 3.1.2 and pygame 1.9.1,\nthe 'black=' and 'white=' parameters are swapped.\n\nSo, to make the example work (with a black arrow outline\naround a white center), you have to do this:\n\nthickarrow_strings = (            #sized 24x24\n      \"XX                      \",\n      \"XXX                     \",\n      \"XXXX                    \",\n      \"XX.XX                   \",\n      \"XX..XX                  \",\n      \"XX...XX                 \",\n      \"XX....XX                \",\n      \"XX.....XX               \",\n      \"XX......XX              \",\n      \"XX.......XX             \",\n      \"XX........XX            \",\n      \"XX........XXX           \",\n      \"XX......XXXXX           \",\n      \"XX.XXX..XX              \",\n      \"XXXX XX..XX             \",\n      \"XX   XX..XX             \",\n      \"     XX..XX             \",\n      \"      XX..XX            \",\n      \"      XX..XX            \",\n      \"       XXXX             \",\n      \"       XX               \",\n      \"                        \",\n      \"                        \",\n      \"                        \")\n\ndatatuple, masktuple = pygame.cursor.compile( thickarrow_strings,\n                                  black='.', white='X', xor='o' )\npygame.mouse.set_cursor( (24,24), (0,0), datatuple, masktuple )",
+      "user_title" : "Anonymous",
+      "id" : 3702,
+      "datetimeon" : "2011-01-04T09:45:11"
+   },
+   {
+      "id" : 49,
+      "datetimeon" : "2006-01-29T16:18:15",
+      "link" : "pygame.mixer.Channel",
+      "content" : "I'm using this generator to get a channel id for each sprite:\n\ndef free_sound_channel():\n    \"\"\"Get next available sound channel\n    Usage:\n    free_channels=free_sound_channel()\n    id=free_channels.next()\n    \"\"\"\n    id=0\n    while id&lt;pygame.mixer.get_num_channels():\n        yield id\n        id+=1\n    return    # or: raise StopIteration()",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 52,
+      "datetimeon" : "2006-02-07T21:37:24",
+      "link" : "Surface.get_flags",
+      "content" : "COLORKEY and ALPHA should have 'SRC' prefixed to them. Here is a more-complete list of flags revelvant to surface.get_flags():\n,\"SRCCOLORKEY\"\n,\"RLEACCEL\"\n,\"RLEACCELOK\"\n,\"PREALLOC\"\n,\"HWACCEL\"\n,\"SRCALPHA\"\n,\"UYVY_OVERLAY\"\n,\"YV12_OVERLAY\"\n,\"YVYU_OVERLAY\"\n,\"YUY2_OVERLAY\"\n,\"HWPALETTE\"\nSWSURFACE - not really usable as a surface flag, equates to 0 and is always default\nANYFORMAT - used to create surfaces, pygame defaults to this flag if you don't specifya bit depth\nHWACCEL - surface is hardware accelerated, readonly\nSRCCOLORKEY- surface has a colorkey for blits, readonly\nSRCALPHA - surface has alpha enabled, readonly\nRLEACCELOK - surface is rle accelerated, but hasn't been compiled yet, readonly\nPREALLOC - not even sure?\nHope this helps....",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2006-02-07T22:02:57",
+      "id" : 53,
+      "content" : "I wish all the possible flags were documented here...",
+      "user_title" : "Anonymous",
+      "link" : "pygame.Surface"
+   },
+   {
+      "id" : 54,
+      "datetimeon" : "2006-02-08T02:29:13",
+      "link" : "Font.render",
+      "user_title" : "Anonymous",
+      "content" : "I don't know what is wrong with you two. I tested the following and it worked as expected. Perhaps it is because I tested it on windows, if you tested it somewhere else (of course that's not the likely cause but I really can't see what else is wrong).\n\nIt is true that passing None for the final argument causes \"Invalid RGBA argument\". This is a bug in the documentation, not the code. The proper way to get transparency is to simply omit the last argument.\n\n$python\n&gt;&gt;&gt;import pygame\n&gt;&gt;&gt;pygame.init()\n&gt;&gt;&gt;screen = pygame.display.set_mode((300,300))\n&gt;&gt;&gt;screen.fill((255,0,0))\n&gt;&gt;&gt;pygame.display.flip()\n\n&gt;&gt;&gt;font = pygame.font.SysFont(\"Times New Roman\",30)\n&gt;&gt;&gt;s = font.render(\"Eggs are good for you, but not on the eiffel tower\",True,(0,255,255))\n&gt;&gt;&gt;s.get_flags() #-&gt; 65536 [SRCALPHA].. good, implies the image has per-pixel transparency\n&gt;&gt;&gt;[s.get_at((i,j)) for i in range(20) for j in range(20)]\n[....          #here we see that indeed each\n(0,255,255,68) #pixel is a full RGBA pixel with 4\n....]          #components.\n&gt;&gt;&gt;screen.blit(s, (0,0))\n&gt;&gt;&gt;pygame.display.flip()\n&gt;&gt;&gt;pygame.event.pump() #in order to bring the window back to life...\n\nAnd the result is turquoise text with red in the background, clearly showing transparency. Phew, you had me worried there, thinking I couldn't do transparency with this... until I looked closer. These docs are shiny but can be very hard to read sometimes."
+   },
+   {
+      "datetimeon" : "2006-02-21T15:49:19",
+      "id" : 58,
+      "user_title" : "Anonymous",
+      "content" : "Here's another solution for creating surfaces with per-pixel-alpha:\n\nimage = pygame.Surface((width,height),pygame.SRCALPHA,32);\n\nAdding the depth argument '32' seems to make this work every time.",
+      "link" : "pygame.Surface"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "In the documentery it says \"The antialias argument is a boolean, if true the \ncharacters will have smooth edges.\". If you pass a string as the antialias \nargument it raises an exception saying \"TypeError: an integer is required\". This\nis very confusing. It should raise \"TypeError: a boolean is required\". \nIf antialias is enabled it will greatly drop the framerate (from 100 to 33 on my\nmachine). Font.render should be called only for as many times as you need fonts.\nDo not call this function every gameloop for it will greatly drop the framerate.\n(this cost me about 2 houres of debugging to find out.)\nIf any admins read this: Please change the script so that long lines will be seperated to shorter lines. Those 500+ words lines are uncomfortable to read with all that scrolling. mfg nwp.",
+      "link" : "Font.render",
+      "datetimeon" : "2006-03-05T13:28:14",
+      "id" : 61
+   },
+   {
+      "id" : 64,
+      "datetimeon" : "2006-03-08T22:55:41",
+      "link" : "pygame.init",
+      "user_title" : "Anonymous",
+      "content" : "you may want to initalise the \ndifferent modules seperately\nto speed up your program. Of \ncourse, then you would need \nto know which modules you have\ninitalised and which ones you\nhave not."
+   },
+   {
+      "link" : "Hope to find some more useful information on your site!  It is really great!",
+      "user_title" : "Anonymous",
+      "content" : "",
+      "id" : 196,
+      "datetimeon" : "2006-12-30T07:59:42"
+   },
+   {
+      "link" : "pygame.cdrom",
+      "content" : "format of music files\non cds are (usualy) in\nCD Digital Audio, except\nsometimes a program will\nmake a cd useing a \ndifferent format, so \npygame.cdrom.CD(n).play()\nwill maby not play it.",
+      "user_title" : "Anonymous",
+      "id" : 67,
+      "datetimeon" : "2006-03-08T23:02:35"
+   },
+   {
+      "id" : 82,
+      "datetimeon" : "2006-04-02T00:38:08",
+      "link" : "pygame.mouse.get_pressed",
+      "content" : "import pygame\nfrom pygame.locals import *\n\npygame.init()\npygame.display.set_mode((300,200))\npygame.display.set_caption('Mouse Input Demonstration')\nrunning = True\nwhile running:\n    for event in pygame.event.get():\n        if event.type == QUIT:\n            running = False\n        if event.type == KEYDOWN and event.key == K_ESCAPE:\n            running = False\n        if event.type == MOUSEBUTTONDOWN:\n            print event.button\n\npygame.display.quit()",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "# An Example from perldude69@gmail.com  www.wachadoo.com/forum/\n# CONSTANTS\nSCREEN_WIDTH  = 800\nSCREEN_HEIGHT = 600\n#Initialise Game\npygame.init()\nscreen = pygame.display.set_mode( (SCREEN_WIDTH,SCREEN_HEIGHT))\npygame.display.set_caption('Space Invaders')\nbackground = pygame.image.load('./pics/background1.jpg').convert()\nbackground = pygame.transform.scale(background,( SCREEN_WIDTH, SCREEN_HEIGHT))\nscreen.blit(background, (0,0)) \npygame.display.flip() \ndone = False\nwhile not done:\n\tfor e in pygame.event.get():\n\t\tif e.type == KEYDOWN:\n\t\t\tdone = True\nif __name__ == \"__main__\":\n    main()",
+      "link" : "pygame.transform.scale",
+      "datetimeon" : "2006-04-07T18:04:11",
+      "id" : 84
+   },
+   {
+      "datetimeon" : "2006-06-13T21:27:25",
+      "id" : 98,
+      "user_title" : "Anonymous",
+      "content" : "Don't specify flags unless you absolutely *must* (that is, don't specify HWSURFACE, depth=32 just because you think it's a good idea). This will reduce the portability of your game.",
+      "link" : "pygame.display.set_mode"
+   },
+   {
+      "id" : 183,
+      "datetimeon" : "2006-12-18T16:29:25",
+      "link" : "pygame.key.get_mods",
+      "content" : "Could someone please post the integer values corresponding to the various shift/ctl/alt keys?  Or provide a link.\nthank you!",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.surfarray",
+      "user_title" : "Anonymous",
+      "content" : "numpy is fine in Python 3.1.2.  However, pygame.surfarray doesn't work\nat all in pygame-1.9.1.win32-py3.1.msi with python-3.1.2.msi and\nnumpy-1.5.1-win32-superpack-python3.1.exe under Windows Vista.\n\nTo see the problem, just run the test that comes with it; 4 of 14 tests fail:\n\nC:\\&gt;cd \\python31\\lib\\site-packages\\pygame\\tests\n\nC:\\Python31\\Lib\\site-packages\\pygame\\tests&gt;\\python31\\python surfarray_test.py\nEE.EE.........\n======================================================================\nERROR: test_array2d (__main__.SurfarrayModuleTest)\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"surfarray_test.py\", line 147, in test_array2d\n    arr = pygame.surfarray.array2d(surf)\n  File \"C:\\python31\\lib\\site-packages\\pygame\\surfarray.py\", line 104, in array2d\n    return numpysf.array2d (surface)\n  File \"C:\\python31\\lib\\site-packages\\pygame\\_numpysurfarray.py\", line 77, in array2d\n    data = ''.join (pattern.findall (data))\nTypeError: can't use a string pattern on a bytes-like object\n[...snip...]",
+      "id" : 3704,
+      "datetimeon" : "2011-01-07T03:47:28"
+   },
+   {
+      "link" : "pygame.draw.arc",
+      "content" : "no fill?",
+      "user_title" : "Anonymous",
+      "id" : 163,
+      "datetimeon" : "2006-11-19T14:38:36"
+   },
+   {
+      "link" : "pygame.PixelArray",
+      "user_title" : "Anonymous",
+      "content" : "works perfectly fine for me... question: what's the name of the overloaded operator that does the pxarray[x,y] subscripting?",
+      "id" : 3689,
+      "datetimeon" : "2010-12-23T18:28:10"
+   },
+   {
+      "link" : "pygame.cursors",
+      "content" : "pygame.cursors.ball is also a cool one.",
+      "user_title" : "Anonymous",
+      "id" : 3690,
+      "datetimeon" : "2010-12-28T16:21:48"
+   },
+   {
+      "datetimeon" : "2010-12-30T05:47:55",
+      "id" : 3691,
+      "user_title" : "Anonymous",
+      "content" : "Its a success/failure scenario. It returns True (1) if it went well.",
+      "link" : "pygame.display.toggle_fullscreen"
+   },
+   {
+      "id" : 3694,
+      "datetimeon" : "2011-01-01T15:04:01",
+      "link" : "pygame.gfxdraw.pie",
+      "content" : "These appear to be in degrees rather than radians (different than how draw.arc()'s are specified) which is kind of inconsistent.  Are these documented better elsewhere?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.display",
+      "user_title" : "Anonymous",
+      "content" : "You need to put\nimport pygame\nat the top of your program, anonymous.",
+      "id" : 3695,
+      "datetimeon" : "2011-01-02T07:03:47"
+   },
+   {
+      "datetimeon" : "2006-12-28T17:27:45",
+      "id" : 188,
+      "user_title" : "Anonymous",
+      "content" : "",
+      "link" : "Looking for information and found it at this great site..."
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "",
+      "link" : "I love the whiiite suits! Great show!",
+      "datetimeon" : "2006-12-29T02:41:08",
+      "id" : 189
+   },
+   {
+      "datetimeon" : "2006-12-29T10:09:22",
+      "id" : 190,
+      "content" : "",
+      "user_title" : "Anonymous",
+      "link" : "Thank you for your site. I have found here much useful information..."
+   },
+   {
+      "datetimeon" : "2010-12-13T21:22:42",
+      "id" : 3685,
+      "content" : "I had this weird thing where blue/red was inversed, but not the other colours, when I was mapping some pixels from one image to a blank surface.\nIt was caused by copying the color integer directly to one pixel to the other, so the trick is to always surface.unmap_rgb(pixel) before setting the color to a new pixel",
+      "user_title" : "Anonymous",
+      "link" : "pygame.PixelArray"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : ".",
+      "link" : "Movie.play",
+      "datetimeon" : "2010-12-17T14:01:47",
+      "id" : 3687
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "import pygame, sys\nfrom pygame.version import ver\nprint (\"pygame \", ver)\nstartstate = pygame.init()\nprint (\"{pygame.init()}\", startstate)\nscreen = pygame.display.set_mode([640, 480])\nprint (\"{pygame.display.set_mode([640, 480]}\", screen)\nwhile True:\n    for event in pygame.event.get():\n        if not event:\n            print (\"Event processing error: cannot find event.\")\n        elif event.type == pygame.QUIT or event.type == pygame.K_ESCAPE:\n            print (\"{for event in pygame.event.get():} : \", event)\n            sys.exit()\nsys.exit() command does not run when I press escape, all it does is the same as if not event.",
+      "link" : "pygame.key",
+      "datetimeon" : "2010-12-18T17:09:49",
+      "id" : 3688
+   },
+   {
+      "content" : "It the range for H should only be [0, 360); at exactly 360 the expression throws an OverflowError. The other ranges are not affected as such.",
+      "user_title" : "Anonymous",
+      "link" : "Color.hsva",
+      "datetimeon" : "2010-12-08T17:55:35",
+      "id" : 3677
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "",
+      "link" : "Very cool design! Useful information. Go on!",
+      "datetimeon" : "2006-12-30T22:35:22",
+      "id" : 202
+   },
+   {
+      "datetimeon" : "2006-12-31T05:52:59",
+      "id" : 203,
+      "content" : "",
+      "user_title" : "Anonymous",
+      "link" : "Very interesting! site. A must bookmark! I wait for continuation"
+   },
+   {
+      "datetimeon" : "2006-12-31T13:03:40",
+      "id" : 204,
+      "content" : "",
+      "user_title" : "Anonymous",
+      "link" : "Very interesting! site. A must bookmark! I wait for continuation"
+   },
+   {
+      "link" : "Just wanted to say you have some happyY looking walkers. All natural!",
+      "content" : "",
+      "user_title" : "Anonymous",
+      "id" : 205,
+      "datetimeon" : "2006-12-31T19:55:09"
+   },
+   {
+      "id" : 208,
+      "datetimeon" : "2007-01-01T16:59:55",
+      "link" : "You have an outstanding good and well structured site. I enjoyed browsing through it.",
+      "user_title" : "Anonymous",
+      "content" : ""
+   },
+   {
+      "datetimeon" : "2007-01-02T00:19:19",
+      "id" : 211,
+      "user_title" : "Anonymous",
+      "content" : "",
+      "link" : "I love the whiiite suits! Great show!"
+   },
+   {
+      "link" : "Hope to find some more useful information on your site!  It is really great!",
+      "user_title" : "Anonymous",
+      "content" : "",
+      "id" : 212,
+      "datetimeon" : "2007-01-02T15:12:24"
+   },
+   {
+      "id" : 213,
+      "datetimeon" : "2007-01-02T22:17:19",
+      "link" : "Just wanted to say you have some happyY looking walkers. All natural!",
+      "user_title" : "Anonymous",
+      "content" : ""
+   },
+   {
+      "link" : "You have a great site. All in your web is very useful. Please keep on working.",
+      "user_title" : "Anonymous",
+      "content" : "",
+      "id" : 214,
+      "datetimeon" : "2007-01-03T05:35:22"
+   },
+   {
+      "id" : 215,
+      "datetimeon" : "2007-01-03T12:53:55",
+      "link" : "Pretty nice site, wants to see much more on it! :)",
+      "content" : "",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "You have an outstanding good and well structured site. I enjoyed browsing through it.",
+      "content" : "",
+      "user_title" : "Anonymous",
+      "id" : 216,
+      "datetimeon" : "2007-01-03T20:02:38"
+   },
+   {
+      "link" : "This site is asomeee, well done, thanks for all!",
+      "content" : "",
+      "user_title" : "Anonymous",
+      "id" : 218,
+      "datetimeon" : "2007-01-04T18:10:07"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "",
+      "link" : "Very nice site. Keep up the great work.",
+      "datetimeon" : "2007-01-05T01:15:13",
+      "id" : 219
+   },
+   {
+      "datetimeon" : "2007-01-29T17:22:04",
+      "id" : 316,
+      "user_title" : "Anonymous",
+      "content" : "Left:\nctrl 4160 \nshift 4097 \nalt 4352 \n\nRight:\nctrl 4224\nshift 4098\nalt 4608\n\nLeft:\nc+s 4161\nc+a 4416\na+s 4353\n\nRight:\nc+s 4226\nc+a 4736\na+s 4610\n\nDone by hand ;)\n\n-Jabapyth",
+      "link" : "pygame.key.get_mods"
+   },
+   {
+      "datetimeon" : "2007-02-08T19:53:05",
+      "id" : 335,
+      "user_title" : "Anonymous",
+      "content" : "Depending on your keyboard there may be limitations of how many simultaneous keypresses can be detected by this command. Some combinations will work on one keyboard and not on another.",
+      "link" : "pygame.key.get_pressed"
+   },
+   {
+      "datetimeon" : "2007-02-26T18:27:17",
+      "id" : 374,
+      "content" : "Just use the same line width as your radius.\nThis of course dosn't solve your problem if you want a border on your arc, but then you can just paint twice.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.arc"
+   },
+   {
+      "link" : "pygame.draw.line",
+      "content" : "It looks like width is not a keyword argument, but a required/positional/whatever one instead.\n\n&gt;&gt;&gt; pygame.draw.line(surf, color, (x1, y1), (x2, y2), width=width)\nTraceback (most recent call last):\n  File \"\", line 1, in ?\nTypeError: line() takes no keyword arguments\n&gt;&gt;&gt; pygame.draw.line(surf, color, (x1, y1), (x2, y2))\n\n&gt;&gt;&gt; pygame.draw.line(surf, color, (x1, y1), (x2, y2), 1)",
+      "user_title" : "Anonymous",
+      "id" : 386,
+      "datetimeon" : "2007-03-01T11:28:42"
+   },
+   {
+      "datetimeon" : "2007-03-03T16:39:29",
+      "id" : 400,
+      "content" : "first number = top left rectangle x coordinate\nsecond number = top left rectangle y coordinate\nthird number = width of rectangle\nfourth number = length of rectangle",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "link" : "Rect.move",
+      "user_title" : "Anonymous",
+      "content" : "If you want to make a deep copy of a Rect object (without importing the copy module)\nthen you can do so by calling move with the arguments (0,0).",
+      "id" : 1359,
+      "datetimeon" : "2008-01-04T00:22:04"
+   },
+   {
+      "datetimeon" : "2007-03-11T20:32:13",
+      "id" : 434,
+      "user_title" : "Anonymous",
+      "content" : "the forth numer is the height of the rect",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "link" : "pygame.mixer.music.play",
+      "content" : "The documentation is incorrect. pygame.mixer.music(5) will indeed play the music five times, not six. Perhaps the function used to behave differently, but I can find nothing in the documentation for either pygame or SDL_mixer that suggests so.",
+      "user_title" : "Anonymous",
+      "id" : 440,
+      "datetimeon" : "2007-03-19T15:33:19"
+   },
+   {
+      "datetimeon" : "2007-03-19T15:34:19",
+      "id" : 441,
+      "content" : "I meant to say pygame.mixer.music.play(5), of course. I left out the \"play\" part.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mixer.music.play"
+   },
+   {
+      "content" : "Properties in the object returned by get_rect():\n\nbottom\nbottomleft\nbottomright\ncenter\ncenterx\ncentery\nclamp\nclamp_ip\nclip\ncollidedict\ncollidedictall\ncollidelist\ncollidelistall\ncollidepoint\ncolliderect\ncontains\nfit\nh\nheight\ninflate\ninflate_ip\nleft\nmidbottom\nmidleft\nmidright\nmidtop\nmove\nmove_ip\nnormalize\nright\nsize\ntop\ntopleft\ntopright\nunion\nunion_ip\nunionall\nunionall_ip\nw\nwidth\nx\ny",
+      "user_title" : "Anonymous",
+      "link" : "Surface.get_rect",
+      "datetimeon" : "2007-03-23T00:10:38",
+      "id" : 446
+   },
+   {
+      "id" : 1365,
+      "datetimeon" : "2008-01-04T23:39:18",
+      "link" : "pygame.mixer.music.fadeout",
+      "user_title" : "Anonymous",
+      "content" : "i've noticed the loop functionality to be iffy for certain wave files (an audible gap between each loop). from what i can tell, it looks like this happens with stereo wave files, but i'm not completely sure. the mono waves i try to loop play as expected"
+   },
+   {
+      "datetimeon" : "2008-01-04T23:39:59",
+      "id" : 1366,
+      "user_title" : "Anonymous",
+      "content" : "i've noticed the loop functionality to be iffy for certain wave files (an audible gap between each loop). from what i can tell, it looks like this happens with stereo wave files, but i'm not completely sure. the mono waves i try to loop play as expected (i accidentally added this comment to fadeout(), sorry)",
+      "link" : "pygame.mixer.music.play"
+   },
+   {
+      "datetimeon" : "2007-03-25T15:39:01",
+      "id" : 448,
+      "content" : "what about osx? is macosx working?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.init"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "omg, you should really use the KMOD_ constants here",
+      "link" : "pygame.key.get_mods",
+      "datetimeon" : "2007-03-28T15:20:15",
+      "id" : 451
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "In 1.7.1, the behaviour when None is passed in is NOT reversed. pygame.event.set_allowed(None) will BLOCK all events.",
+      "link" : "pygame.event.set_allowed",
+      "datetimeon" : "2007-04-01T20:22:29",
+      "id" : 457
+   },
+   {
+      "id" : 463,
+      "datetimeon" : "2007-04-03T12:22:16",
+      "link" : "pygame.draw",
+      "user_title" : "Anonymous",
+      "content" : "just do:\nimg = pygame.image.load(\"&lt;&gt;\").convert()\n\n-harry666t"
+   },
+   {
+      "id" : 466,
+      "datetimeon" : "2007-04-03T19:15:04",
+      "link" : "pygame.key.get_mods",
+      "user_title" : "Anonymous",
+      "content" : "BTW, Those values gotten below are if num-lock is on\nKMOD_NUM == 4096\nKMOD_LSHIFT == 1\nKMOD_RSHIFT == 2\nKMOD_NUM | KMOD_LSHIFT == 4097\nThe simpler way is to use the bitwise AND (&amp;)\n\nkeymods &amp; KMOD_LSHIFT \n\nreturns true (actually 1 in this case) if left shift is pressed, no matter what else is pressed or if num lock is on, or if the planets are aligned correctly."
+   },
+   {
+      "id" : 475,
+      "datetimeon" : "2007-04-07T05:35:39",
+      "link" : "pygame.event",
+      "content" : "What is the definition of the key and mod members of KEYDOWN?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.mixer.set_reserved",
+      "content" : "who do i get a reference to a reserved channel? its not channel 0 nor num_channels-1",
+      "user_title" : "Anonymous",
+      "id" : 476,
+      "datetimeon" : "2007-04-07T11:19:42"
+   },
+   {
+      "link" : "pygame.movie",
+      "content" : "\"does not work with current release\". Which release is that? Is the information valid?",
+      "user_title" : "Anonymous",
+      "id" : 497,
+      "datetimeon" : "2007-04-18T13:12:55"
+   },
+   {
+      "link" : "pygame.mixer.Sound",
+      "content" : "FLAC support would be cool",
+      "user_title" : "Anonymous",
+      "id" : 1142,
+      "datetimeon" : "2007-11-19T06:00:08"
+   },
+   {
+      "datetimeon" : "2008-01-01T21:41:36",
+      "id" : 1351,
+      "user_title" : "Anonymous",
+      "content" : "fadeout does not block in linux either",
+      "link" : "pygame.mixer.music.fadeout"
+   },
+   {
+      "datetimeon" : "2007-04-20T17:57:54",
+      "id" : 502,
+      "content" : "Watch out for this one, it has a major twist:\n(x,y) are coordinates in the referential of the rectangle.\nFor instance:\n&gt;&gt;&gt; import pygame\n&gt;&gt;&gt; r = pygame.Rect(32,32,132,132)\n&gt;&gt;&gt; r.collidepoint(140,140)\n1",
+      "user_title" : "Anonymous",
+      "link" : "Rect.collidepoint"
+   },
+   {
+      "datetimeon" : "2008-01-13T07:45:26",
+      "id" : 1406,
+      "content" : "Music will be resampled in some cases, not in others. When playing a 44.1kHz MP3, the default 22050 frequency works, but a 48kHz mp3 plays in less than half speed - 48000 or 24000 works then.\nTo handle this behaviour, you have to know the sample rate of your music files before playing them, and can't switch smoothly. Big bummer.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mixer.music.play"
+   },
+   {
+      "id" : 1220,
+      "datetimeon" : "2007-12-06T15:43:11",
+      "link" : "pygame.draw.rect",
+      "content" : "# This should draw a square with a hight of 20 pixels on a Surface:\nheight = 20\npygame.draw.rect(Surface, (255, 255, 255), (0, 0, height, height))",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "Anonymous[0], that's nonsense. The x,y coords are absolute coordinates. To illustrate:\n\n&gt;&gt;&gt; r = pygame.rect.Rect(32, 32, 132, 132)\n&gt;&gt;&gt; r.collidepoint(1,1)\n0\n&gt;&gt;&gt; r.collidepoint(32,32)\n1",
+      "user_title" : "Anonymous",
+      "link" : "Rect.collidepoint",
+      "datetimeon" : "2007-11-23T19:43:53",
+      "id" : 1153
+   },
+   {
+      "id" : 1157,
+      "datetimeon" : "2007-11-26T11:20:04",
+      "link" : "pygame.mouse.set_cursor",
+      "content" : "A little black cross. Mouse cursor is 8*8 Pixel, hotspot is at (4, 4). \nthe cross is (Read Binary):\n00011000 =&gt; 24 \n00011000\n00011000\n11100111 =&gt; 231\n11100111\n00011000\n00011000\nand has no AND-Mask. \n\npygame.mouse.set_cursor((8, 8), (4, 4), (24, 24, 24, 231, 231, 24, 24, 24), (0, 0, 0, 0, 0, 0, 0, 0))",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 1158,
+      "datetimeon" : "2007-11-26T19:56:49",
+      "link" : "Surface.fill",
+      "user_title" : "Anonymous",
+      "content" : "excellent comments!\njorgen"
+   },
+   {
+      "link" : "pygame.event.set_blocked",
+      "user_title" : "Anonymous",
+      "content" : "True.  set_allowed(None) blocks all event types.\n\n- Another (initially skeptical) pygame user.",
+      "id" : 1159,
+      "datetimeon" : "2007-11-26T22:35:30"
+   },
+   {
+      "id" : 1160,
+      "datetimeon" : "2007-11-27T12:11:21",
+      "link" : "pygame.mixer.set_reserved",
+      "user_title" : "Anonymous",
+      "content" : "The first channels are reserved.\nFor example: pygame.mixer.Channel(0)"
+   },
+   {
+      "id" : 1230,
+      "datetimeon" : "2007-12-08T11:08:32",
+      "link" : "pygame.joystick",
+      "user_title" : "Anonymous",
+      "content" : "I have found that just watching for joystick events may not provide enough \ngranularity for fast-paced arcade games that require 100 millisecond changes.\nInstead of events, consider polling the status of the axes in the main game loop\n(or whatever your local equivalent is)"
+   },
+   {
+      "datetimeon" : "2007-12-12T08:11:00",
+      "id" : 1242,
+      "user_title" : "Anonymous",
+      "content" : "Actually, on my system [Ubunty Gutsy] it returned a list of None:\n&gt;&gt;&gt; import pygame\n&gt;&gt;&gt; pygame.font.get_fonts()\n[None]",
+      "link" : "pygame.font.get_fonts"
+   },
+   {
+      "id" : 1171,
+      "datetimeon" : "2007-11-29T13:19:20",
+      "link" : "pygame.draw.rect",
+      "content" : "How do you draw squares in pygame??",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "\"... will only effect the smaller area\" is probably meant to read \"... will only affect the smaller area\"",
+      "user_title" : "Anonymous",
+      "link" : "pygame.Surface",
+      "datetimeon" : "2007-12-20T07:32:23",
+      "id" : 1290
+   },
+   {
+      "id" : 1320,
+      "datetimeon" : "2007-12-23T15:46:20",
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "# Matthew N. Brown copyright 2007\n\n# Here is an example program in wich\n# balls hit walls and other balls:\n#\n# This program draws circles using:   pygame.draw.circle\n#\n# You can copy this program on to\n# your own computer and run it.\n#\n\nimport os, sys\n\n ## INIT STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef HE_HE_init():\n    global screen, big_black_rect, APPLICATION_w_size, APPLICATION_z_size\n    global WOW_pi_divided_by_180, WOW_180_divided_by_pi\n    pygame.init()\n    random.seed()\n    APPLICATION_w_size = 700\n    APPLICATION_z_size = 500\n    ##### To close window while in fullscreen, press Esc while holding shift. #######\n    screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size))\n    #screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), FULLSCREEN)\n    pygame.display.set_caption(\"They bwounce off bwalls? Matthew N. Brown copyright 2007\")\n    pygame.mouse.set_visible(1)\n    big_black_rect = pygame.Surface(screen.get_size())\n    big_black_rect = big_black_rect.convert()\n    big_black_rect.fill((0, 0, 0))\n    screen.blit(big_black_rect, (0, 0))\n    #fonty = pygame.font.Font(None, 36)\n    fonty = pygame.font.SysFont(\"Times New Roman\", 25)\n    fonty.set_bold(0)\n    IMAGEE = fonty.render('Loading . . .', 1, (0, 250, 10))\n    screen.blit(IMAGEE, (100, 200)); del IMAGEE\n    pygame.display.flip()\n    pygame.mixer.init(22050, -16, True, 1024)\n    WOW_pi_divided_by_180 = math.pi / 180.0\n    WOW_180_divided_by_pi = 180.0 / math.pi\n    set_up_key_variables()\n    Lets_ROLL()\n ## INIT STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n\n ## SAVE LEVEL?!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef write_to_file_WEEE_STRANGE(file_namey, data):\n    noq = '\\n'\n    filey = open(file_namey, 'w')\n    for d in data:\n     filey.write(   str(d) + noq)\n ## SAVE LEVEL?!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n\n ## SMALL FUNCTIONS STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n     ### some functions: ###\ndef distance_2D (w1, z1, w2, z2):\n    return math.sqrt(math.pow(float(w1) - float(w2), 2) + math.pow(float(z1) - float(z2), 2))\ndef rect_touching_rect(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n    w2 -= w1\n    z2 -= z1\n    ww1 = -wol2\n    zz1 = -zol2\n    return (w2 &gt; ww1 and w2 &lt; wol1 and z2 &gt; zz1 and z2 &lt; zol1)\ndef rect_touching_rect2(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n    w2 -= w1\n    z2 -= z1\n    ww1 = -wol2\n    zz1 = -zol2\n    return (w2 &gt;= ww1 and w2 &lt;= wol1 and z2 &gt;= zz1 and z2 &lt;= zol1)\ndef positive(n):\n    if n &lt; 0: n = -n; return n\ndef int_randy(range, add):\n    return int((random.random() * range) + add)\ndef randy(range, add):\n    return (random.random() * range) + add\ndef freaky_rect_switcharoo_2D(pw, pz, pwol, pzol, buffy_the_fat):\n    buffy_the_fat2 = buffy_the_fat * 2\n    if pwol &gt; 0:\n     gw = pw; gwol = pwol\n    else:\n     gw = pwol + pw; gwol = pw - gw\n    if pzol &gt; 0:\n     gz = pz; gzol = pzol\n    else:\n     gz = pzol + pz; gzol = pz - gz\n    return [gw - buffy_the_fat, gz - buffy_the_fat, gwol + buffy_the_fat2, gzol + buffy_the_fat2]\ndef points_rotated_by_angle_2D(points_wz, axis_w, axis_z, angle):\n    rotated_points_wz = []\n    angle = -angle -90\n    angle_times_WOW_pi_divided_by_180 = angle * WOW_pi_divided_by_180\n    c1 = math.cos(angle_times_WOW_pi_divided_by_180)\n    s1 = math.sin(angle_times_WOW_pi_divided_by_180)\n    for pointy in points_wz:\n     xt = pointy[0] - axis_w\n     yt = pointy[1] - axis_z\n     rotated_points_wz += [(-xt * s1) + (yt * c1) + axis_w, (-xt * c1) - (yt * s1) + axis_z]\n    return rotated_points_wz\ndef point_rotated_by_angle_2D(point_w, point_z, axis_w, axis_z, angle):\n    angle = -angle -90\n    angle_times_WOW_pi_divided_by_180 = angle * WOW_pi_divided_by_180\n    c1 = math.cos(angle_times_WOW_pi_divided_by_180)\n    s1 = math.sin(angle_times_WOW_pi_divided_by_180)\n    xt = point_w - axis_w\n    yt = point_z - axis_z\n    return (-xt * s1) + (yt * c1) + axis_w, (-xt * c1) - (yt * s1) + axis_z\ndef arc_tangent_2D(point_w, point_z):\n    return math.atan2(point_w, point_z) * WOW_180_divided_by_pi + 180\ndef arc_tangent_2D_2(point_w, point_z):\n    return -math.atan2(point_w, point_z) * WOW_180_divided_by_pi + 180\ndef ball_to_ball_wzkol_bounce(V1, m1, V2, m2, ball1_is_to_the_left):\n    if (ball1_is_to_the_left and V1 &gt;= V2) or (not ball1_is_to_the_left and V1 &lt;= V2):\n     Rv1 = V1 - V2\n     Rv2 = 0 #V2 - V2\n     NewV1 = ((m1 - m2) / float(m1 + m2)) * float(Rv1) + V2\n     NewV2 = (( 2 * m1) / float(m1 + m2)) * float(Rv1) + V2\n     return NewV1, NewV2\n    else:\n     return V1, V2\ndef Find_where_ball_stops_on_line_w(ball_w, ball_z, ball_wol, ball_zol, ball_rad, line_w, line_rad):\n    did_collide = False\n    totally = ball_rad + line_rad\n    b1 = line_w + totally\n    b2 = line_w - totally\n    New_ball_w = ball_w + ball_wol\n    New_ball_z = ball_z + ball_zol\n    if   ball_w &gt;= b1 and ball_wol &lt; 0 and New_ball_w &lt; b1: New_ball_w = b1; did_collide = True\n    elif ball_w &lt;= b2 and ball_wol &gt; 0 and New_ball_w &gt; b2: New_ball_w = b2; did_collide = True\n    else:\n     if ball_w &gt; b2 and ball_w &lt; b1:\n      if   ball_w &gt; line_w and ball_wol &lt; 0:\n       New_ball_w = ball_w; New_ball_z = ball_z\n       did_collide = True\n      elif ball_w &lt; line_w and ball_wol &gt; 0:\n       New_ball_w = ball_w; New_ball_z = ball_z\n       did_collide = True\n     return New_ball_w, New_ball_z, did_collide\n    New_ball_z = (float(ball_zol) / float(ball_wol) * float(New_ball_w - ball_w)) + float(ball_z)\n    return New_ball_w, New_ball_z, did_collide\ndef find_where_ball_collides_on_a_wall(\n                                       ball_w, ball_z,\n                                       ball_wol, ball_zol,\n                                       ball_rad,\n                                       wall_type,\n                                       wall_w1, wall_z1,\n                                       wall_w2, wall_z2,\n                                       wall_rad):\n    toetoadly = ball_rad + wall_rad\n    did_collide = False\n    New_ball_w = ball_w + ball_wol\n    New_ball_z = ball_z + ball_zol\n    angle_hit_at = None\n    Relate_ball_w = ball_w - wall_w1\n    Relate_ball_z = ball_z - wall_z1\n    Relate_wall_w2 = wall_w2 - wall_w1\n    Relate_wall_z2 = wall_z2 - wall_z1\n    arc_tangeriney = arc_tangent_2D(Relate_wall_w2, Relate_wall_z2)\n    Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_Relate_wall_w2, Rotate_Relate_wall_z2 = points_rotated_by_angle_2D(((Relate_ball_w, Relate_ball_z), (Relate_wall_w2, Relate_wall_z2)), 0, 0, arc_tangeriney)\n    Rotate_ball_wol, Rotate_ball_zol = point_rotated_by_angle_2D(ball_wol, ball_zol, 0, 0, arc_tangeriney)\n    Rotate_Relate_ball_collide_w, Rotate_Relate_ball_collide_z, did_hit_weird_line = Find_where_ball_stops_on_line_w(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, ball_rad, 0, wall_rad)\n    if Rotate_Relate_ball_w &gt; -toetoadly and Rotate_Relate_ball_w &lt; toetoadly:\n     HE_HE_strange_popper_z = Rotate_Relate_ball_z\n    else:\n     HE_HE_strange_popper_z = Rotate_Relate_ball_collide_z\n    Rotate_angle_hit_at = None\n    if   HE_HE_strange_popper_z &lt; Rotate_Relate_wall_z2:\n       if ball_is_going_towards_point(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, 0, Rotate_Relate_wall_z2):\n        p1_touched, p1_collide_w, p1_collide_z, p1_angle_hit_at = find_where_ball_collides_on_another_ball(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, ball_rad, 0, Rotate_Relate_wall_z2, wall_rad)\n        if p1_touched:\n         Rotate_Relate_ball_collide_w = p1_collide_w\n         Rotate_Relate_ball_collide_z = p1_collide_z\n         Rotate_angle_hit_at = p1_angle_hit_at\n         did_collide = True\n    elif HE_HE_strange_popper_z &gt; 0:\n       if ball_is_going_towards_point(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, 0, 0):\n        p2_touched, p2_collide_w, p2_collide_z, p2_angle_hit_at = find_where_ball_collides_on_another_ball(Rotate_Relate_ball_w, Rotate_Relate_ball_z, Rotate_ball_wol, Rotate_ball_zol, ball_rad, 0, 0, wall_rad)\n        if p2_touched:\n         Rotate_Relate_ball_collide_w = p2_collide_w\n         Rotate_Relate_ball_collide_z = p2_collide_z\n         Rotate_angle_hit_at = p2_angle_hit_at\n         did_collide = True\n    else:\n       if did_hit_weird_line:\n        did_collide = True\n        if Rotate_Relate_ball_collide_w &lt; 0: Rotate_angle_hit_at = 90\n        else: Rotate_angle_hit_at = 270\n    if did_collide:\n     arc_tangeriney_2 = -arc_tangeriney\n     angle_hit_at = Rotate_angle_hit_at + arc_tangeriney\n     New_ball_w, New_ball_z = point_rotated_by_angle_2D(Rotate_Relate_ball_collide_w, Rotate_Relate_ball_collide_z, 0, 0, arc_tangeriney_2)\n     New_ball_w += wall_w1\n     New_ball_z += wall_z1\n    return did_collide, New_ball_w, New_ball_z, angle_hit_at  #, is_moving_towards\ndef zol_at_angle(wol, zol, angle):\n    rotated_wol, rotated_zol = point_rotated_by_angle_2D(wol, zol, 0, 0, angle)\n    return rotated_zol\ndef wzol_bounce_at_angle(wol, zol, angle, multi):\n    rotated_wol, rotated_zol = point_rotated_by_angle_2D(wol, zol, 0, 0, angle)\n    if rotated_zol &gt; 0: rotated_zol = -rotated_zol * multi\n    return point_rotated_by_angle_2D(rotated_wol, rotated_zol, 0, 0, -angle)\ndef ball_is_going_towards_point(ball_w, ball_z, ball_wol, ball_zol, point_w, point_z):\n    angley = arc_tangent_2D(ball_w - point_w, ball_z - point_z)\n    rotated_wol, rotated_zol = point_rotated_by_angle_2D(ball_wol, ball_zol, 0, 0, angley)\n    return rotated_zol &gt; 0\ndef find_where_ball_collides_on_another_ball (\n                                               ball1_w, ball1_z,\n                                               ball1_wol, ball1_zol,\n                                               ball1_rad,\n                                               ball2_w, ball2_z,\n                                               ball2_rad\n                                             ):\n    totally = ball1_rad + ball2_rad\n    dis_from_each_other = math.sqrt(math.pow(float(ball1_w) - float(ball2_w), 2) + math.pow(float(ball1_z) - float(ball2_z), 2))\n    if dis_from_each_other &lt; totally:\n     angley = arc_tangent_2D(ball1_w - ball2_w, ball1_z - ball2_z)\n     return True, ball1_w, ball1_z, angley\n    else:\n        they_did_touch = False\n        New_ball1_w = ball1_w + ball1_wol\n        New_ball1_z = ball1_z + ball1_zol\n        angle_hit_at = None\n        Relate_ball1_w = ball1_w - ball2_w\n        Relate_ball1_z = ball1_z - ball2_z\n        Relate_ball2_w = 0\n        Relate_ball2_z = 0\n        arcy_tangeriney = arc_tangent_2D(ball1_wol, ball1_zol)\n        Rotated_Relate_ball1_w, Rotated_Relate_ball1_z, Rotated_ball1_wol, Rotated_ball1_zol = points_rotated_by_angle_2D(((Relate_ball1_w, Relate_ball1_z), (ball1_wol, ball1_zol)), 0, 0, arcy_tangeriney)\n        did_collidey = False\n        if Rotated_Relate_ball1_z &gt; 0 and (Rotated_Relate_ball1_w &gt; -totally and Rotated_Relate_ball1_w &lt; totally):\n         Rotated_Relate_ball1_collide_w = Rotated_Relate_ball1_w # + Rotated_ball1_wol\n         HE_HE = math.pow(Rotated_Relate_ball1_w, 2) - math.pow(totally, 2)\n         if HE_HE &lt; 0: HE_HE = -HE_HE\n         Rotated_Relate_ball1_collide_z = math.sqrt(HE_HE)\n         Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol = Rotated_Relate_ball1_z + Rotated_ball1_zol\n         if Rotated_Relate_ball1_collide_z &lt; Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol:\n          collision_wol = Rotated_ball1_wol\n          collision_zol = Rotated_ball1_zol\n          Rotated_Relate_ball1_collide_z = Rotated_Relate_ball1_z__PLUS__Rotated_ball1_zol\n          angley_to_hit = None\n         else:\n          did_collidey = True\n          they_did_touch = True\n          angley_to_hit = arc_tangent_2D(Rotated_Relate_ball1_collide_w, Rotated_Relate_ball1_collide_z)\n        else:\n         angley_to_hit = None\n         collision_wol = Rotated_ball1_wol\n         collision_zol = Rotated_ball1_zol\n         Rotated_Relate_ball1_collide_w = Rotated_Relate_ball1_w + Rotated_ball1_wol\n         Rotated_Relate_ball1_collide_z = Rotated_Relate_ball1_z + Rotated_ball1_zol\n        if did_collidey:\n         arcy_tangeriney_2 = -arcy_tangeriney\n         angle_hit_at = angley_to_hit + arcy_tangeriney\n         New_ball1_w, New_ball1_z = point_rotated_by_angle_2D(Rotated_Relate_ball1_collide_w, Rotated_Relate_ball1_collide_z, 0, 0, arcy_tangeriney_2)\n         New_ball1_w += ball2_w\n         New_ball1_z += ball2_z\n    return they_did_touch, New_ball1_w, New_ball1_z, angle_hit_at  #, New_ball1_wol, New_ball1_zol\n     ### some functions: ###\n\n ## GRAPHICS STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef chilly_font(size):\n    fonti = pygame.font.SysFont(\"Times New Roman\", size)\n    return fonti\ndef chilly_font_Italicy(size):\n    fonti = pygame.font.SysFont(\"Times New Roman\", size)\n    fonti.set_italic(1)\n    return fonti\ndef draw_loading_messagey(stringy): # Draw loading message\n    pygame.mouse.set_visible(1)\n    fonty = chilly_font(26)\n    IMAGEE = fonty.render(stringy, 0, (0, 255, 0), (0, 0, 0))\n    screen.blit(IMAGEE, (200, 250))\n    del IMAGEE\n    pygame.display.flip()\n           ## GRAPHICS STUFF: ##\n#########################################################################################\n\n ## KEYS AND MOUSE STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef set_up_key_variables():\n     global ky_held, ky_first_held, ky_time_last_pressed\n     global mowse_w, mowse_z, mowse_inn\n     global mowse_left_pressed, mowse_right_pressed, mowse_left_held, mowse_right_held\n     mowse_left_held = False\n     mowse_right_held = False\n     mowse_left_pressed = False\n     mowse_right_pressed = False\n     mowse_w = 0\n     mowse_z = 0\n     mowse_inn = 0\n     ky_held = []\n     ky_first_held = []\n     ky_time_last_pressed = []\n     m = -1\n     while m &lt; 500:\n      m += 1\n      ky_held              += [0]\n      ky_first_held        += [0]\n      ky_time_last_pressed += [0]\ndef clear_all_kys():\n    global mowse_left_pressed, mowse_right_pressed, mowse_left_held, mowse_right_held\n    mowse_left_held = False\n    mowse_right_held = False\n    mowse_left_pressed = False\n    mowse_right_pressed = False\n    m = -1\n    while (m &lt; 500):\n     m += 1; ky_held[m] = 0; ky_first_held[m] = 0; ky_time_last_pressed[m] = 0\ndef clear_these_ky_first_held(list_keys_numbers):\n    for k in list_keys_numbers:\n     ky_first_held[k] = 0\ndef clear_first_held_kys():\n    m = -1\n    while (m &lt; 500):\n     m += 1; ky_first_held[m] = 0\ndef old_style_ky(n):\n    return (ky_first_held_CEV(n) or (ky_held[n] and ky_time_last_pressed[n] &lt; time.time() - .3))\ndef ky_first_held_CEV(n):\n    if (ky_first_held[n]):\n     ky_first_held[n] = 0; return 1\n    else:\n     return 0\ndef mowse_in_rect (w, z, wol, zol):\n    return (mowse_w &gt;= w and mowse_z &gt;= z and mowse_w &lt;= w + wol and mowse_z &lt;= z + zol)\ndef mowse_in_circle (w, z, rad):\n    dia = rad * 2\n    if mowse_in_rect(w - rad, z - rad, w + dia, z + dia):\n     return (distance_2D(mowse_w, mowse_z, w, z) &lt; rad)\n    else:\n     return 0\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\ndef check_for_keys():\n        global mowse_w, mowse_z, mowse_inn, mowse_left_pressed, mowse_right_pressed, mowse_left_held, mowse_right_held, APPLICATION_w_size, APPLICATION_z_size\n        global loopy\n        global unicodey\n        mowse_left_pressed = False\n        mowse_right_pressed = False\n        unicodey = ''\n        for e in pygame.event.get():\n          if e.type == QUIT:\n            loopy = 0\n          elif e.type == ACTIVEEVENT:\n            mowse_inn = (e.gain and (e.state == 1 or e.state == 6))\n          elif e.type == KEYDOWN:\n            ky_held[e.key] = 1\n            ky_first_held[e.key] = 1\n            ky_time_last_pressed[e.key] = time.time()\n            unicodey = e.unicode\n          elif e.type == KEYUP:\n            ky_held[e.key] = 0\n          elif e.type == MOUSEMOTION:\n            mowse_w = e.pos[0]\n            mowse_z = e.pos[1]\n            if mowse_w &gt;= 0 and mowse_w &lt;= APPLICATION_w_size and mowse_z &gt;= 0 and mowse_z &lt;= APPLICATION_z_size:\n             mowse_inn = 1\n            else:\n             mowse_inn = 0\n          elif e.type == MOUSEBUTTONUP:\n            if e.button == 1: mowse_left_held = 0\n            if e.button == 3: mowse_right_held = 0\n          elif e.type == MOUSEBUTTONDOWN:\n            mowse_left_pressed  = (e.button == 1)\n            mowse_right_pressed = (e.button == 3)\n            mowse_left_held =  mowse_left_held or e.button == 1\n            mowse_right_held = mowse_right_held or e.button == 3\n          elif e.type == JOYAXISMOTION:\n            pass\n          elif e.type == JOYBALLMOTION:\n            pass\n          elif e.type == JOYHATMOTION:\n            pass\n          elif e.type == JOYBUTTONUP:\n            pass\n          elif e.type == JOYBUTTONDOWN:\n            pass\n          elif e.type == VIDEORESIZE:\n            print e\n            print \"What happened!?\"\n            #global big_black_rect, screen\n            #APPLICATION_w_size = e.size[0]\n            #APPLICATION_z_size = e.size[1]\n            #screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size))#, RESIZABLE)\n            #big_black_rect = pygame.Surface(screen.get_size())\n            #big_black_rect = big_black_rect.convert()\n            #big_black_rect.fill((0, 100, 200))\n          elif e.type == VIDEOEXPOSE:\n            pass\n          elif e.type == USEREVENT:\n            pass\n        if ky_held[27] and (ky_held[303] or ky_held[304]): loopy = 0\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\n ## KEYS AND MOUSE STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\n\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n\n\n ## MAIN LOOPY STUFF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n#########################################################################################\ndef ball_is_going_towards_ball(Bn1, Bn2):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_mass, ball_RECT\n    arc_tangerine = arc_tangent_2D(ball_w[Bn1] - ball_w[Bn2], ball_z[Bn1] - ball_z[Bn2])\n    woly1, zoly1 = point_rotated_by_angle_2D(ball_wol[Bn1], ball_zol[Bn1], 0, 0, arc_tangerine)\n    return zoly1 &gt; 0\ndef ball_is_relatively_going_towards_ball(Bn1, Bn2):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_mass, ball_RECT\n    arc_tangerine = arc_tangent_2D(ball_w[Bn1] - ball_w[Bn2], ball_z[Bn1] - ball_z[Bn2])\n    woly1, zoly1, woly2, zoly2 = points_rotated_by_angle_2D(((ball_wol[Bn1], ball_zol[Bn1]), (ball_wol[Bn2], ball_zol[Bn2])), 0, 0, arc_tangerine)\n    return zoly1 &gt; 0 and zoly1 &gt; zoly2  # zoly2 &lt; zoly1 or zoly2 &gt; zoly1 # zoly1 + zoly2 &gt; 0\n    #return zoly1 &gt; 0 or zoly1 &gt; zoly2\ndef Make_two_balls_hit_at_angle(Bn1, Bn2, angle):\n    global bounce_friction\n    #print angle\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_mass, ball_RECT\n    woly1, zoly1, woly2, zoly2 = points_rotated_by_angle_2D(((ball_wol[Bn1], ball_zol[Bn1]), (ball_wol[Bn2], ball_zol[Bn2])), 0, 0, angle)\n    V1 = zoly1 * bounce_friction\n    V2 = zoly2 * bounce_friction\n    zoly1, zoly2 = ball_to_ball_wzkol_bounce(V1, ball_mass[Bn1], V2, ball_mass[Bn2], True)\n    ball_wol[Bn1], ball_zol[Bn1], ball_wol[Bn2], ball_zol[Bn2] = points_rotated_by_angle_2D(((woly1, zoly1), (woly2, zoly2)), 0, 0, -angle)\n    updatey_ball_quick_rect(Bn1)\n    updatey_ball_quick_rect(Bn2)\ndef updatey_ball_quick_rect(B):\n    dia = ball_rad[B] * 2 + 4\n    ball_squar[B] = [ball_w[B] - ball_rad[B] - 2, ball_z[B] - ball_rad[B] - 2, dia, dia]\n    ball_RECT[B] = freaky_rect_switcharoo_2D(ball_w[B], ball_z[B], ball_wol[B], ball_zol[B], ball_rad[B] + 4)\ndef minus_ball_thing(n):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n    if ball_max &gt;= 0:\n     del ball_w      [n]\n     del ball_z      [n]\n     del ball_wol    [n]\n     del ball_zol    [n]\n     del ball_rad    [n]\n     del ball_color  [n]\n     del ball_squar  [n]\n     del ball_angle  [n]\n     del ball_angleol[n]\n     del ball_mass   [n]\n     del ball_RECT   [n]\n     ball_max -= 1\ndef add_ball_thing(w, z, wol, zol, rad, color, angle, angleol, mass_thing, rect_thing):\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_squar, ball_angle, ball_angleol, ball_mass, ball_RECT\n    ball_max += 1\n    ball_w       += [w]\n    ball_z       += [z]\n    ball_wol     += [wol]\n    ball_zol     += [zol]\n    ball_rad     += [rad]\n    ball_color   += [color]\n    ball_angle   += [angle]\n    ball_angleol += [angleol]\n    dia = rad * 2\n    ball_squar += [[w - rad, z - rad, dia, dia]]\n    if mass_thing == True:\n     ball_mass += [4 / 3 * math.pi * rad * rad * rad]\n    else:\n     ball_mass += [mass_thing]\n    if rect_thing == True:\n     ball_RECT += [None]\n     updatey_ball_quick_rect(ball_max)\n     #ball_RECT += [freaky_rect_switcharoo_2D(w, z, wol, zol, rad)]\n    else:\n     ball_RECT += [rect_thing]\ndef minus_wall_thing(WAL):\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    if wall_max &gt;= 0:\n     del wall_type   [WAL]\n     del wall_w1     [WAL]\n     del wall_z1     [WAL]\n     del wall_w2     [WAL]\n     del wall_z2     [WAL]\n     del wall_rad    [WAL]\n     del wall_color  [WAL]\n     del wall_RECT   [WAL]\n     wall_max        -= 1\ndef add_wall_thing(type, w1, z1, w2, z2, rad, color_thing, rect_thing):\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    wall_max    += 1\n    wall_type   += [type]\n    wall_w1     += [w1]\n    wall_z1     += [z1]\n    wall_w2     += [w2]\n    wall_z2     += [z2]\n    wall_rad    += [rad]\n    if color_thing == True:\n     if   type == 1: color_thing = (220, 220, 220)\n     elif type == 2: color_thing = (240, 140, 130)\n     elif type == 3: color_thing = (100, 255, 100)\n     elif type == 4: color_thing = (255, 100, 100)\n     elif type == 5: color_thing = (100, 100, 255)\n    wall_color  += [color_thing]\n    if rect_thing == True:\n     wall_RECT   += [freaky_rect_switcharoo_2D(w1 - 2, z1 - 2, w2 - w1 + 4, z2 - z1 + 4, rad)]\n    else:\n     wall_RECT   += [rect_thing]\ndef reset_stuff():\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    global levely\n    if levely == 1:\n     ball_max     = -1\n     ball_w       = []\n     ball_z       = []\n     ball_wol     = []\n     ball_zol     = []\n     ball_rad     = []\n     ball_color   = []\n     ball_angle   = []\n     ball_angleol = []\n     ball_squar   = []\n     ball_mass    = []\n     ball_RECT    = []\n     #add_ball_thing(350, 300, 0, 0, 18, (230, 230, 250), 0, 0, True, True)\n     #add_ball_thing(150, 400, 0, 0, 40, (220, 210, 255), 0, 0, True, True)\n     #add_ball_thing(300, 150, 0, 0, 62, (110, 106, 255), 0, 0, True, True)\n     add_ball_thing(220, 200, 0, 0, 50, (180, 226, 255), 180, 0, True, True)\n     wall_max    = -1\n     wall_type   = []\n     wall_w1     = []\n     wall_z1     = []\n     wall_w2     = []\n     wall_z2     = []\n     wall_rad    = []\n     wall_color  = []\n     wall_RECT   = []\n     add_wall_thing(1, 160, 250, 300, 270,  1, True, True)\n     add_wall_thing(1, 500, 270, 600, 310,  1, True, True)\n     add_wall_thing(1, 200, 450, 600, 450, 10, True, True)\n     add_wall_thing(1, 300, 350, 400, 370,  5, True, True)\n     add_wall_thing(1, 300, 100, 400, 100, 20, True, True)\n     add_wall_thing(1, 650, 140, 700, 200,  6, True, True)\n     add_wall_thing(1, 650, 140, 600,  40,  6, True, True)\n     add_wall_thing(1, 150, 340, 150, 340, 30, True, True)\n     add_wall_thing(1,  40, 200,  40, 200, 30, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  30, 30,  30, 30, 10, True, True)\n     add_wall_thing(1,  0, 0, APPLICATION_w_size, 0, 5, True, True)\n     add_wall_thing(1,  0, 0, 0, APPLICATION_z_size, 5, True, True)\n     add_wall_thing(1,  0, APPLICATION_z_size, APPLICATION_w_size, APPLICATION_z_size, 5, True, True)\n     add_wall_thing(1,  APPLICATION_w_size, 0, APPLICATION_w_size, APPLICATION_z_size, 5, True, True)\n    elif levely == 2:\n     ball_max = 1\n     ball_w = [323.62638473709342, 384.72135876760257]\n     ball_z = [298.67896746658624, 109.24043981044279]\n     ball_wol = [-0.27396932987421913, 7.133321987715842]\n     ball_zol = [-0.38420912894762504, 1.6564147490246901]\n     ball_rad = [15, 28]\n     ball_color = [(137, 244, 234), (138, 221, 217)]\n     ball_angle = [51.908780125668613, 294.77431504891717]\n     ball_angleol = [-1.2400074168431123, 17.698615258690229]\n     ball_squar = [[306.62638473709342, 281.67896746658624, 34, 34], [354.72135876760257, 79.240439810442794, 60, 60]]\n     ball_mass = [10602.875205865552, 68964.24193160313]\n     ball_RECT = [[304.35241540721921, 279.2947583376386, 38.273969329874205, 38.384209128947646], [352.72135876760257, 77.240439810442794, 71.133321987715846, 65.656414749024691]]\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [189, 290, 166, 14, 697, 562, 643, 3, 0, 223, 117, 695, 497, 497, 0, 0, 0, 700]\n     wall_z1 = [284, 316, 436, 499, 446, 0, 128, 225, 106, 310, 155, 210, 159, 159, 0, 0, 500, 0]\n     wall_w2 = [222, 446, 697, 157, 377, 681, 679, 49, 383, 287, 5, 448, 376, 546, 700, 0, 700, 700]\n     wall_z2 = [301, 314, 478, 432, 487, 99, 98, 416, 171, 324, 225, 323, 147, 179, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[186, 281, 39, 23], [287, 313, 162, 4], [154, 424, 555, 66], [7, 429, 157, 73], [359, 424, 356, 85], [554, -8, 135, 115], [635, 94, 52, 38], [-29, 193, 110, 255], [-32, 74, 447, 129], [211, 298, 88, 38], [-3, 143, 128, 94], [440, 198, 263, 137], [368, 139, 137, 28], [485, 147, 73, 44], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\n    elif levely == 3:\n     ball_max = 2\n     ball_w = [425.0, 492.31837629165733, 98.512856261065167]\n     ball_z = [126.0, 422.24553778829392, 430.4902396760661]\n     ball_wol = [-12.0, 2.6816237083426699, 6.487143738934833]\n     ball_zol = [-3.0, -1.245537788293916, -21.490239676066096]\n     ball_rad = [15, 28, 21]\n     ball_color = [(137, 244, 234), (138, 221, 217), (136, 235, 236)]\n     ball_angle = [93.833857527468922, 75.681742520058592, 323.2915629772819]\n     ball_angleol = [-0.87655530207419896, 0.30220691772972269, 1.1825329351046094]\n     ball_squar = [[408.0, 109.0, 34, 34], [462.31837629165733, 392.24553778829392, 60, 60], [75.512856261065167, 407.4902396760661, 46, 46]]\n     ball_mass = [10602.875205865552, 68964.24193160313, 29094.28956489508]\n     ball_RECT = [[394.0, 104.0, 50.0, 41.0], [460.31837629165733, 389.0, 66.68162370834267, 65.245537788293916], [73.512856261065167, 384.0, 56.487143738934833, 71.490239676066096]]\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [189, 290, 166, 14, 697, 562, 643, 3, 0, 223, 117, 695, 497, 497, 0, 0, 0, 700]\n     wall_z1 = [284, 316, 436, 499, 446, 0, 128, 225, 106, 310, 155, 210, 159, 159, 0, 0, 500, 0]\n     wall_w2 = [222, 446, 697, 157, 377, 681, 679, 49, 383, 287, 5, 480, 376, 546, 700, 0, 700, 700]\n     wall_z2 = [301, 314, 478, 432, 487, 99, 98, 416, 171, 324, 225, 325, 147, 179, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[186, 281, 39, 23], [287, 313, 162, 4], [154, 424, 555, 66], [7, 429, 157, 73], [359, 424, 356, 85], [554, -8, 135, 115], [635, 94, 52, 38], [-29, 193, 110, 255], [-32, 74, 447, 129], [211, 298, 88, 38], [-3, 143, 128, 94], [472, 198, 231, 139], [368, 139, 137, 28], [485, 147, 73, 44], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\n    elif levely == 4:\n     ball_max = 15\n     ball_w = [60.722554805471077, 452.1573538490178, 80.244575784959252, 38.90004863123329, 526.62934623960155, 561.76077439217966, 51.00641675327735, 476.21179724447387, 74.019911348330012, 104.13986580489509, 77.672785567417591, 97.908669417930454, 492.31309851379422, 107.55531577343871, 25.677250467589708, 408.28461679522843]\n     ball_z = [123.53309256655999, 426.85562864865636, 446.98025958602022, 145.55077237791539, 432.36880616921724, 419.52605372165829, 185.76812996010321, 398.60172712183214, 227.90675893521163, 330.14246403509031, 280.7917430301959, 382.77488932204739, 431.7008452670733, 426.72875393133694, 108.86075181750218, 420.07030113046562]\n     ball_wol = [0.58974898201312453, 0.29357826379544644, -0.7453458908661944, -0.26977452024547638, -0.13077525550683244, 0.35703289164546842, 0.25581836770201244, -0.16968524576896582, -0.96858759109981474, 0.020541831638986374, 0.21623640500730243, 0.16869582232640204, -0.32778500262837312, -1.0423733543425631, 0.078384075232750969, 0.070169924397188832]\n     ball_zol = [2.5202528491916918, -0.067935899483811957, 1.0209651395893582, 1.5519551597452736, 0.37674466231734333, 0.7179102343171756, 1.2098558443319702, -0.21937811619009639, 1.6292902773669935, 0.95366629391114355, 0.99836183708718151, 0.65985328138026611, 0.72997687518744558, -0.33325230167901332, 1.8584237502130836, 1.1180771215980612]\n     ball_rad = [12, 20, 14, 19, 14, 23, 23, 13, 25, 28, 28, 25, 20, 20, 20, 24]\n     ball_color = [(132, 202, 208), (130, 220, 228), (133, 230, 241), (133, 200, 224), (138, 244, 248), (134, 176, 212), (132, 246, 206), (136, 191, 201), (130, 247, 204), (135, 190, 248), (136, 196, 244), (137, 246, 211), (132, 176, 232), (139, 200, 204), (135, 204, 206), (137, 234, 248)]\n     ball_angle = [250.64218161257492, 228.50285566079282, 169.93029421257162, 93.92451866434908, 160.53385135173758, 101.81391124171368, 58.682544988047297, 42.833392250734839, 278.96920717602609, 157.52451729820555, 104.82808146227505, 319.29094377305643, 8.3988066326588289, 61.303383965779759, 262.01723832271352, 187.75853100116501]\n     ball_angleol = [-11.145052526574146, 0.73910476098485844, -1.916370769365741, 7.8109934129380036, 1.2564621818214414, -0.21633250902344123, 0.96094866236460608, 18.696614939999161, -2.7765510174821686, -0.46915418861267033, 1.3615127061730832, 0.55215997018655683, 0.83188571652892485, -2.1096665563746759, 4.3536534603644128, 0.77565328887569629]\n     ball_squar = [[46.722554805471077, 109.53309256655999, 28, 28], [430.1573538490178, 404.85562864865636, 44, 44], [64.244575784959252, 430.98025958602022, 32, 32], [17.90004863123329, 124.55077237791539, 42, 42], [510.62934623960155, 416.36880616921724, 32, 32], [536.76077439217966, 394.52605372165829, 50, 50], [26.00641675327735, 160.76812996010321, 50, 50], [461.21179724447387, 383.60172712183214, 30, 30], [47.019911348330012, 200.90675893521163, 54, 54], [74.139865804895095, 300.14246403509031, 60, 60], [47.672785567417591, 250.7917430301959, 60, 60], [70.908669417930454, 355.77488932204739, 54, 54], [470.31309851379422, 409.7008452670733, 44, 44], [85.555315773438707, 404.72875393133694, 44, 44], [3.6772504675897082, 86.860751817502177, 44, 44], [382.28461679522843, 394.07030113046562, 52, 52]]\n     ball_mass = [5428.6721054031623, 25132.741228718347, 8620.5302414503913, 21548.184010972389, 8620.5302414503913, 38223.757816227015, 38223.757816227015, 6902.0790599367756, 49087.385212340516, 68964.24193160313, 68964.24193160313, 49087.385212340516, 25132.741228718347, 25132.741228718347, 25132.741228718347, 43429.376843225298]\n     tempy = [[24.00641675327735, 158.76812996010321, 54.255818367702012, 55.209855844331969], [459.04211199870491, 381.38234900564203, 34.16968524576896, 34.219378116190114], [44.051323757230193, 198.90675893521163, 58.968587591099819, 59.629290277366991], [72.139865804895095, 298.14246403509031, 64.02054183163898, 64.953666293911141], [45.672785567417591, 248.7917430301959, 64.216236405007308, 64.998361837087188], [68.908669417930454, 353.77488932204739, 58.168695822326399, 58.659853281380265], [467.98531351116583, 407.7008452670733, 48.327785002628389, 48.729976875187447], [82.512942419096149, 402.39550162965793, 49.042373354342558, 48.333252301679011], [1.6772504675897082, 84.860751817502177, 48.078384075232748, 49.858423750213085], [380.28461679522843, 392.07030113046562, 56.070169924397192, 57.118077121598063]]\n     ball_RECT = [[44.722554805471077, 107.53309256655999, 32.589748982013127, 34.520252849191692], [428.1573538490178, 402.78769274917255, 48.293578263795446, 48.067935899483814], [61.499229894093062, 428.98025958602022, 36.74534589086619, 37.020965139589357], [15.630274110987813, 122.55077237791539, 46.269774520245477, 47.551955159745276], [508.49857098409473, 414.36880616921724, 36.130775255506819, 36.376744662317343], [534.76077439217966, 392.52605372165829, 54.357032891645467, 54.717910234317173]] + tempy\n     del tempy\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [189, 196, 166, 14, 697, 562, 643, 0, 326, 51, 18, 695, 497, 497, 0, 0, 0, 700]\n     wall_z1 = [284, 221, 436, 499, 446, 0, 128, 201, 62, 9, 182, 210, 159, 159, 0, 0, 500, 0]\n     wall_w2 = [220, 297, 697, 157, 377, 681, 679, 49, 304, 139, 0, 480, 376, 524, 700, 0, 700, 700]\n     wall_z2 = [244, 218, 478, 432, 487, 99, 98, 416, 161, 315, 126, 325, 147, 176, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[186, 245, 37, 38], [193, 218, 107, 3], [154, 424, 555, 66], [7, 429, 157, 73], [359, 424, 356, 85], [554, -8, 135, 115], [635, 94, 52, 38], [-32, 169, 113, 279], [276, 30, 78, 163], [39, -3, 112, 330], [-8, 118, 34, 72], [472, 198, 231, 139], [368, 139, 137, 28], [485, 147, 51, 41], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\n    elif levely == 5:\n     ball_max = 15\n     ball_w = [563.2380017184845, 135.5091931534665, 435.09697027584525, 132.51126304855137, 158.80356877160969, 486.49890666361813, 28.0454597909272, 469.94449157610796, 253.77058846375945, 33.311743878553251, 651.08671805489632, 467.4560139814393, 420.90145867058521, 248.83956419449743, 98.267666685148598, 670.85536291962285]\n     ball_z = [340.3499477728684, 192.53572614832325, 274.00276170743837, 474.72360924550071, 248.04392629767023, 199.66234253741388, 291.77486188629132, 98.828156873677884, 261.79870802935454, 452.90721309179793, 434.31611085503482, 422.84067516142846, 143.71750465032488, 474.55563009909457, 63.407930077910926, 97.5392796541895]\n     ball_wol = [-0.12736934788998625, -0.34670289908297647, -0.62730956112551528, -0.01316352118701539, -0.36875760413492498, 0.3253705975573648, -0.43186646985168864, 0.029829055857965088, -0.051399766840351885, 0.31143213467472303, 0.91261705660387604, -0.39289683694945782, 0.6973192899270082, -0.026739395385515136, 0.47773812365404217, -0.14449244329674141]\n     ball_zol = [0.2651067487506561, 0.33747092449158278, -0.20330004911815291, 0.11263669365628809, 0.62183969591811039, 0.220324713577495, 0.12382039798193512, -0.062689280803922554, 0.13756798955280808, 0.8702172500111478, -0.031277763984301599, 0.28378328194527458, 0.1666190295210413, 0.056074468995401638, 0.75422143538357722, 0.14790083350095956]\n     ball_rad = [12, 20, 14, 19, 14, 23, 23, 13, 25, 28, 28, 25, 20, 20, 20, 24]\n     ball_color = [(132, 202, 208), (130, 220, 228), (133, 230, 241), (133, 200, 224), (138, 244, 248), (134, 176, 212), (132, 246, 206), (136, 191, 201), (130, 247, 204), (135, 190, 248), (136, 196, 244), (137, 246, 211), (132, 176, 232), (139, 200, 204), (135, 204, 206), (137, 234, 248)]\n     ball_angle = [103.32400188884675, 316.71158855283181, 66.797426175129175, 35.509394217326573, 15.886531654813545, 0.61656478963343941, 195.33151301725019, 152.08747184390086, 199.80989069184068, 131.62120808048311, 339.38767654500623, 158.21789358507957, 322.31233400906359, 97.437869538449633, 179.6312883714439, 134.41162557033078]\n     ball_angleol = [0.54118695268280415, -1.0009948706990461, -0.42583251039327935, -0.049119552546591096, -1.7234897593393199, 0.1278122582140804, -0.33925087348758332, 0.98916269599321738, 0.054177225060088277, 0.93648329222661952, 2.0855948904138386, -1.2792816321392795, 1.9343475351789952, -0.094694117658838645, 1.3328174529019678, 1.0390947956294083]\n     ball_squar = [[549.2380017184845, 326.3499477728684, 28, 28], [113.5091931534665, 170.53572614832325, 44, 44], [419.09697027584525, 258.00276170743837, 32, 32], [111.51126304855137, 453.72360924550071, 42, 42], [142.80356877160969, 232.04392629767023, 32, 32], [461.49890666361813, 174.66234253741388, 50, 50], [3.0454597909272003, 266.77486188629132, 50, 50], [454.94449157610796, 83.828156873677884, 30, 30], [226.77058846375945, 234.79870802935454, 54, 54], [3.3117438785532514, 422.90721309179793, 60, 60], [621.08671805489632, 404.31611085503482, 60, 60], [440.4560139814393, 395.84067516142846, 54, 54], [398.90145867058521, 121.71750465032488, 44, 44], [226.83956419449743, 452.55563009909457, 44, 44], [76.267666685148598, 41.407930077910926, 44, 44], [644.85536291962285, 71.5392796541895, 52, 52]]\n     ball_mass = [5428.6721054031623, 25132.741228718347, 8620.5302414503913, 21548.184010972389, 8620.5302414503913, 38223.757816227015, 38223.757816227015, 6902.0790599367756, 49087.385212340516, 68964.24193160313, 68964.24193160313, 49087.385212340516, 25132.741228718347, 25132.741228718347, 25132.741228718347, 43429.376843225298]\n     tempy = [[140.43481116747478, 230.04392629767023, 36.368757604134913, 36.621839695918112], [459.49890666361813, 172.66234253741388, 54.325370597557367, 54.220324713577497], [0.61359332107551268, 264.77486188629132, 54.431866469851684, 54.123820397981937], [452.94449157610796, 81.765467592873961, 34.029829055857967, 34.062689280803923], [224.7191886969191, 232.79870802935454, 58.051399766840348, 58.137567989552807], [1.3117438785532514, 420.90721309179793, 64.311432134674718, 64.870217250011152], [619.08671805489632, 402.28483309105053, 64.912617056603878, 64.031277763984292], [438.06311714448987, 393.84067516142846, 58.392896836949433, 58.283783281945276], [396.90145867058521, 119.71750465032488, 48.697319289927009, 48.166619029521044], [224.81282479911192, 450.55563009909457, 48.026739395385505, 48.056074468995405], [74.267666685148598, 39.407930077910926, 48.477738123654042, 48.754221435383577], [642.71087047632614, 69.5392796541895, 56.144492443296713, 56.147900833500962]]\n     ball_RECT = [[547.11063237059454, 324.3499477728684, 32.127369347889953, 32.265106748750654], [111.16249025438353, 168.53572614832325, 48.34670289908297, 48.337470924491583], [416.46966071471974, 255.79946165832024, 36.627309561125514, 36.203300049118127], [109.49809952736436, 451.72360924550071, 46.01316352118701, 46.112636693656285]] + tempy\n     del tempy\n     wall_max = 17\n     wall_type = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n     wall_w1 = [135, 120, 230, 14, 531, 562, 441, 128, 403, 51, 504, 518, 377, 447, 0, 0, 0, 700]\n     wall_z1 = [265, 216, 439, 499, 339, 0, 217, 104, 306, 9, 441, 210, 168, 127, 0, 0, 500, 0]\n     wall_w2 = [227, 288, 697, 157, 456, 665, 476, 432, 61, 139, 633, 547, 435, 537, 700, 0, 700, 700]\n     wall_z2 = [262, 200, 478, 432, 302, 141, 228, 77, 334, 315, 295, 193, 178, 114, 0, 500, 500, 500]\n     wall_rad = [1, 1, 10, 5, 20, 6, 6, 30, 30, 10, 10, 10, 10, 10, 5, 5, 5, 5]\n     wall_color = [(220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220), (220, 220, 220)]\n     wall_RECT = [[132, 262, 98, 3], [117, 201, 174, 14], [218, 427, 491, 63], [7, 429, 157, 73], [438, 284, 111, 73], [554, -8, 119, 157], [433, 209, 51, 27], [96, 49, 368, 83], [33, 274, 398, 92], [39, -3, 112, 330], [492, 287, 153, 162], [506, 185, 53, 33], [365, 156, 82, 34], [435, 106, 114, 29], [-7, -7, 714, 14], [-7, -7, 14, 514], [-7, 493, 714, 14], [693, -7, 14, 514]]\ndef draw_walls_on_big_black_rect():\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    global big_black_rect\n    global LIN_selected, CLICKER, CLICKER2\n    if CLICKER:\n     if LIN_selected != -1:\n      nnn = LIN_selected[0]\n      if LIN_selected[1] == 1:\n       wall_w1[nnn] = mowse_w\n       wall_z1[nnn] = mowse_z\n      else:\n       wall_w2[nnn] = mowse_w\n       wall_z2[nnn] = mowse_z\n      w1 = wall_w1[nnn]\n      z1 = wall_z1[nnn]\n      w2 = wall_w2[nnn]\n      z2 = wall_z2[nnn]\n      rad = wall_rad[nnn]\n      wall_RECT[nnn] = freaky_rect_switcharoo_2D(w1 - 2, z1 - 2, w2 - w1 + 4, z2 - z1 + 4, rad)\n    wl = -1\n    while wl &lt; wall_max:\n     wl += 1\n     w1 = wall_w1[wl]\n     z1 = wall_z1[wl]\n     w2 = wall_w2[wl]\n     z2 = wall_z2[wl]\n     rad = wall_rad[wl]\n     collyu = wall_color[wl]\n     pygame.draw.line(big_black_rect, collyu, (w1, z1), (w2, z2), rad * 2)\n     pygame.draw.circle(big_black_rect, collyu, (w1, z1), rad)\n     pygame.draw.circle(big_black_rect, collyu, (w2, z2), rad)\n     #pygame.draw.rect(big_black_rect, (200, 200, 200), wall_RECT[wl], 1)\n     if CLICKER2:\n      if mowse_in_rect(wall_RECT[wl][0], wall_RECT[wl][1], wall_RECT[wl][2], wall_RECT[wl][3]):\n       if   mowse_in_circle(w1, z1, rad+3): selected = -1; LIN_selected = [wl, 1]\n       elif mowse_in_circle(w2, z2, rad+3): selected = -1; LIN_selected = [wl, 2]\ndef Lets_ROLL():\n    global loopy\n    global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n    global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n    global bounce_friction, air_friction, gravity, rock_and_ROLLY\n    global LIN_selected, CLICKER, CLICKER2\n    global levely\n    levely = 3\n    bounce_friction = 0.8\n    #bounce_friction = 1.0\n    air_friction = 0.999\n    #air_friction = 1.0\n    gravity = 0.5\n    rock_and_ROLLY = math.pi / 8 * 180 #24\n    reset_stuff()\n    fontyyy = chilly_font_Italicy(24)\n    PRESS_SPACE_BAR_TO_MOVE_immy = fontyyy.render('Press SPACE BAR to start motion.', 0, (100, 200, 100))\n    PRESS_SPACE_BAR_TO_STOP_immy = fontyyy.render('Press SPACE BAR to stop motion.', 0, (200, 100, 100))\n    PRESS_ENTER_TO_RESET_immy    = fontyyy.render('Press ENTER to reset.', 0, (150, 150, 150))\n    PRESS_MINUS_TO_MINUS_immy    = fontyyy.render('Press - to delete a ball.', 0, (150, 150, 150))\n    PRESS_ADD_TO_ADD_immy        = fontyyy.render('Press + to add a ball.', 0, (150, 150, 150))\n    LEFT_CLICK_TO_immy           = fontyyy.render('Left click on a \"ghost ball\" to change its speed.', 0, (150, 150, 150))\n    RIGHT_CLICK_TO_immy          = fontyyy.render('Right click on a ball to stop its motion.', 0, (150, 150, 150))\n    PRESS_S_TO_immy              = fontyyy.render('Press S to stop all balls.', 0, (150, 150, 150))\n    PRESS_PAGE_UP_TO_immy        = fontyyy.render('Press Page Up to change the level.', 0, (150, 150, 150))\n    #message_1_immy\n    del fontyyy\n    #calculate_for_sure = True\n    selected = -1\n    LIN_selected = -1\n    move_stuff = True\n    t = time.time() + .01\n    CLICKER = False\n    CLICKER2 = False\n    loopy = 1\n    while loopy:\n          big_black_rect.fill((0, 0, 0))\n          draw_walls_on_big_black_rect()\n          screen.blit(big_black_rect, (0, 0))\n          check_for_keys()\n          CLICKER    = mowse_left_held\n          CLICKER2   = mowse_left_pressed\n          CLICKER_2  = mowse_right_held\n          CLICKER2_2 = mowse_right_pressed\n          if ky_first_held_CEV(32): move_stuff = not move_stuff\n          if ky_first_held_CEV(13): reset_stuff()\n          if ky_first_held_CEV(280):\n           levely += 1\n           if levely &gt; 5: levely = 1\n           reset_stuff()\n          if ky_first_held_CEV(115): # S\n            M = -1\n            while M &lt; ball_max:\n             M += 1\n             ball_wol[M] = 0\n             ball_zol[M] = 0\n             updatey_ball_quick_rect(M)\n          if ky_first_held_CEV(45) or ky_first_held_CEV(269): # -\n           minus_ball_thing(0)\n          if ky_first_held_CEV(61) or ky_first_held_CEV(270): # +\n           add_ball_thing(350 + randy(40, -20), 400 + randy(40, -20), randy(40, -20), randy(40, -20), int_randy(20, 10), (int_randy(10, 130), int_randy(80, 170), int_randy(50, 200)), 0, 0, True, True)\n          if ky_first_held_CEV(49):\n           listy  = ['Level_save']\n           listy += ['ball_max = ' + str(ball_max)]\n           listy += ['ball_w = ' + str(ball_w)]\n           listy += ['ball_z = ' + str(ball_z)]\n           listy += ['ball_wol = ' + str(ball_wol)]\n           listy += ['ball_zol = ' + str(ball_zol)]\n           listy += ['ball_rad = ' + str(ball_rad)]\n           listy += ['ball_color = ' + str(ball_color)]\n           listy += ['ball_angle = ' + str(ball_angle)]\n           listy += ['ball_angleol = ' + str(ball_angleol)]\n           listy += ['ball_squar = ' + str(ball_squar)]\n           listy += ['ball_mass = ' + str(ball_mass)]\n           listy += ['ball_RECT = ' + str(ball_RECT)]\n           listy += ['wall_max = ' + str(wall_max)]\n           listy += ['wall_type = ' + str(wall_type)]\n           listy += ['wall_w1 = ' + str(wall_w1)]\n           listy += ['wall_z1 = ' + str(wall_z1)]\n           listy += ['wall_w2 = ' + str(wall_w2)]\n           listy += ['wall_z2 = ' + str(wall_z2)]\n           listy += ['wall_rad = ' + str(wall_rad)]\n           listy += ['wall_color = ' + str(wall_color)]\n           listy += ['wall_RECT = ' + str(wall_RECT)]\n           ##write_to_file_WEEE_STRANGE(\"Level_Save.dat\", listy)\n           del listy\n          if CLICKER2:\n           allow_selectey_thing = True\n          else:\n           allow_selectey_thing = False\n           if not CLICKER:\n            selected = -1\n            LIN_selected = -1\n          to_be_selected = selected\n          M = -1\n          while M &lt; ball_max:\n           M += 1\n           if move_stuff:\n            move_ball(M)\n           wwol = int(ball_w[M] + ball_wol[M])\n           zzol = int(ball_z[M] + ball_zol[M])\n           pygame.draw.circle(screen, ball_color[M], (int(ball_w[M]), int(ball_z[M])), ball_rad[M])\n           blpw, blpz = point_rotated_by_angle_2D(0, -ball_rad[M], 0, 0, ball_angle[M])\n           pygame.draw.line(screen, (100, 100, 100), (int(ball_w[M] + blpw), int(ball_z[M] + blpz)), (int(ball_w[M]), int(ball_z[M])))\n           if not move_stuff:\n            pygame.draw.circle(screen, (100, 100, 250), (wwol, zzol), ball_rad[M], 1)\n            pygame.draw.circle(screen, (100, 100, 150), (wwol, zzol), int(ball_rad[M] * 1.0), 1)\n            pygame.draw.circle(screen, (150, 150, 200), (wwol, zzol), int(ball_rad[M] * 0.8), 1)\n            pygame.draw.circle(screen, (200, 200, 250), (wwol, zzol), int(ball_rad[M] * 0.5), 1)\n            pygame.draw.line(screen, (100, 160, 250), (int(ball_w[M]), int(ball_z[M])), (wwol, zzol))\n            pygame.draw.rect(screen, (130, 130, 130), ball_RECT[M], 1)\n            pygame.draw.rect(screen, (140, 140, 140), ball_squar[M], 1)\n           if allow_selectey_thing:\n            if mowse_in_rect(ball_RECT[M][0], ball_RECT[M][1], ball_RECT[M][2], ball_RECT[M][3]):\n             if mowse_in_circle(wwol, zzol, ball_rad[M]):\n              to_be_selected = M\n              LIN_selected = -1\n           if CLICKER_2:\n            if mowse_in_rect(ball_squar[M][0], ball_squar[M][1], ball_squar[M][2], ball_squar[M][3]):\n             if mowse_in_circle(ball_w[M], ball_z[M], ball_rad[M]):\n              ball_wol[M] = 0\n              ball_zol[M] = 0\n              ball_angleol[M] = 0\n              updatey_ball_quick_rect(M)\n           if CLICKER:\n            if selected == M:\n             if move_stuff:\n              mowseyy_w = mowse_w\n              mowseyy_z = mowse_z\n              bw1 = ball_rad[M]\n              bz1 = ball_rad[M]\n              bw2 = APPLICATION_w_size - ball_rad[M]\n              bz2 = APPLICATION_z_size - ball_rad[M]\n              if mowseyy_w &lt; bw1: mowseyy_w = bw1\n              if mowseyy_w &gt; bw2: mowseyy_w = bw2\n              if mowseyy_z &lt; bz1: mowseyy_z = bz1\n              if mowseyy_z &gt; bz2: mowseyy_z = bz2\n              ww = mowseyy_w - ball_w[M]\n              zz = mowseyy_z - ball_z[M]\n              #dissy = distance_2D(0, 0, ww, zz)\n              ball_wol[M] = ww # / 2.0 # / dissy\n              ball_zol[M] = zz # / 2.0 # / dissy\n             else:\n              ball_wol[M] = mowse_w - ball_w[M]\n              ball_zol[M] = mowse_z - ball_z[M]\n             updatey_ball_quick_rect(M)\n          selected = to_be_selected\n          if not move_stuff:\n           screen.blit(PRESS_SPACE_BAR_TO_MOVE_immy, (10, 10))\n          else:\n           screen.blit(PRESS_SPACE_BAR_TO_STOP_immy, (10, 10))\n          screen.blit(PRESS_MINUS_TO_MINUS_immy, (10, 30))\n          screen.blit(PRESS_ADD_TO_ADD_immy, (10, 50))\n          screen.blit(PRESS_ENTER_TO_RESET_immy, (10, 70))\n          screen.blit(LEFT_CLICK_TO_immy, (10, 90))\n          screen.blit(RIGHT_CLICK_TO_immy, (10, 110))\n          screen.blit(PRESS_S_TO_immy, (10, 130))\n          screen.blit(PRESS_PAGE_UP_TO_immy, (10, 150))\n          pygame.display.flip()\n          while t &gt; time.time(): pass\n          t = time.time() + .01\n # Try_Again_HE_HE Is weird!! maybe It should be deleted!!\ndef move_ball(M):\n            ball_angle[M] += ball_angleol[M]\n            if   ball_angle[M] &gt; 359: ball_angle[M] -= 360\n            elif ball_angle[M] &lt;   0: ball_angle[M] += 361\n            #movey_bally_speciality(M, ball_wol[M], ball_zol[M], 10)\n            movey_bally_speciality(M, ball_wol[M], ball_zol[M], 10)\n            ball_zol[M] += gravity\n            updatey_ball_quick_rect(M)\ndef movey_bally_speciality(M, wol_special, zol_special, Try_Again_HE_HE):\n            global loopy\n            global ball_max, ball_w, ball_z, ball_wol, ball_zol, ball_rad, ball_color, ball_angle, ball_angleol, ball_squar, ball_mass, ball_RECT\n            global wall_max, wall_type, wall_w1, wall_z1, wall_w2, wall_z2, wall_rad, wall_color, wall_RECT\n            global bounce_friction, air_friction, gravity, rock_and_ROLLY\n            distance_is_supposed_to_be_at = distance_2D(0, 0, wol_special, zol_special)\n            wa = ball_w[M]\n            za = ball_z[M]\n            #will_be_w = wa + ball_wol[M]\n            #will_be_z = za + ball_zol[M]\n            will_be_w = wa + wol_special\n            will_be_z = za + zol_special\n            LIN_collide_max = -1\n            LIN_collide_w    = []\n            LIN_collide_z     = []\n            LIN_collide_ang    = []\n            LIN_collide_dis     = []\n            LL = -1\n            while LL &lt; wall_max:\n              LL += 1\n              if rect_touching_rect2(ball_RECT[M][0], ball_RECT[M][1], ball_RECT[M][2], ball_RECT[M][3], wall_RECT[LL][0], wall_RECT[LL][1], wall_RECT[LL][2], wall_RECT[LL][3]):\n                  #print 'weee'\n                  did_collide, New_ball_w, New_ball_z, angle_hit_at = find_where_ball_collides_on_a_wall(wa, za, wol_special, zol_special, ball_rad[M], wall_type[LL], wall_w1[LL], wall_z1[LL], wall_w2[LL], wall_z2[LL], wall_rad[LL])\n                  if did_collide:\n                   #print 'collide'\n                   #print str(New_ball_w), str(New_ball_z)\n                   LIN_collide_max += 1\n                   LIN_collide_w    += [New_ball_w]\n                   LIN_collide_z     += [New_ball_z]\n                   LIN_collide_ang    += [angle_hit_at]\n                   LIN_collide_dis     += [distance_2D(wa, za, New_ball_w, New_ball_z)]\n            HEH_collide_max = -1\n            HEH_collide_w    = []\n            HEH_collide_z     = []\n            HEH_collide_ang    = []\n            HEH_collide_dis     = []\n            HEH_collide_ball_hit = []\n            M2 = -1\n            while M2 &lt; ball_max:\n             M2 += 1\n             if M2 != M:\n              if rect_touching_rect2(ball_RECT[M][0], ball_RECT[M][1], ball_RECT[M][2], ball_RECT[M][3], ball_squar[M2][0], ball_squar[M2][1], ball_squar[M2][2], ball_squar[M2][3]):\n                  #they_did_touch, New_ball1_w, New_ball1_z, angle_hit_at = find_where_ball_collides_on_another_ball(wa, za, ball_wol[M], ball_zol[M], ball_rad[M], ball_w[M2], ball_z[M2], ball_rad[M2])\n                  they_did_touch, New_ball1_w, New_ball1_z, angle_hit_at = find_where_ball_collides_on_another_ball(wa, za, wol_special, zol_special, ball_rad[M], ball_w[M2], ball_z[M2], ball_rad[M2])\n                  if they_did_touch:\n                   HEH_collide_max += 1\n                   HEH_collide_w    += [New_ball1_w]\n                   HEH_collide_z     += [New_ball1_z]\n                   HEH_collide_ang    += [angle_hit_at]\n                   HEH_collide_dis     += [distance_2D(wa, za, New_ball1_w, New_ball1_z)]\n                   HEH_collide_ball_hit += [M2]\n            current_dis = distance_is_supposed_to_be_at\n            Wall_to_hit_at_angley = None\n            Grr = -1\n            while Grr &lt; LIN_collide_max:\n             Grr += 1\n             #print LIN_collide_dis[Grr], current_dis\n             if LIN_collide_dis[Grr] &lt; current_dis:\n               #print 'weee!'\n               Wall_to_hit_at_angley = LIN_collide_ang[Grr]\n               current_dis = LIN_collide_dis[Grr]\n               will_be_w = LIN_collide_w[Grr]\n               will_be_z = LIN_collide_z[Grr]\n            Ball_to_hit = None\n            Ball_to_hit_at_angley = None\n            Heh = -1\n            while Heh &lt; HEH_collide_max:\n             Heh += 1\n             if HEH_collide_dis[Heh] &lt; current_dis:\n              if ball_is_going_towards_ball(M, HEH_collide_ball_hit[Heh]):\n               if ball_is_relatively_going_towards_ball(M, HEH_collide_ball_hit[Heh]):\n                Ball_to_hit = HEH_collide_ball_hit[Heh]\n                Ball_to_hit_at_angley = HEH_collide_ang[Heh]\n               else:\n                Ball_to_hit = None\n                Ball_to_hit_at_angley = None\n               current_dis = HEH_collide_dis[Heh]\n               will_be_w = HEH_collide_w[Heh]\n               will_be_z = HEH_collide_z[Heh]\n            if Ball_to_hit != None:\n             Make_two_balls_hit_at_angle(M, Ball_to_hit, Ball_to_hit_at_angley)\n            else:\n             #if   bouncey == 1: ball_wol[M] = -ball_wol[M] * bounce_friction\n             #elif bouncey == 2: ball_zol[M] = -ball_zol[M] * bounce_friction\n             if Wall_to_hit_at_angley != None:\n              ball_wol[M], ball_zol[M] = wzol_bounce_at_angle(ball_wol[M], ball_zol[M], Wall_to_hit_at_angley, bounce_friction)\n              ball_angleol[M] = zol_at_angle(ball_wol[M], ball_zol[M], Wall_to_hit_at_angley + 90) / ball_rad[M] * rock_and_ROLLY\n            ball_w[M] = will_be_w\n            ball_z[M] = will_be_z\n            if ball_w[M] &lt; 0 or ball_w[M] &gt; APPLICATION_w_size or ball_z[M] &lt; 0 or ball_z[M] &gt; APPLICATION_z_size:\n             #print str(M) + \"   \", str(wa), str(za)\n             print str(M) + \"   \", str(ball_w[M]), str(ball_z[M]), str(ball_rad[M])\n            ball_wol[M] *= air_friction\n            ball_zol[M] *= air_friction\n            updatey_ball_quick_rect(M)\n            if current_dis &lt; distance_is_supposed_to_be_at:\n             if Try_Again_HE_HE &gt; 0:\n              distance_to_travel_next = distance_is_supposed_to_be_at - current_dis\n              disy_HE_HE = distance_2D(0, 0, ball_wol[M], ball_zol[M])\n              next_wol = ball_wol[M]\n              next_zol = ball_zol[M]\n              movey_bally_speciality(M, next_wol, next_zol, Try_Again_HE_HE - 1)\n\n           ## Woah... Finally! Were near the end of the program! ##\nif __name__ == '__main__':\n  import math\n  import pygame\n  import random\n  import time\n  import gc\n  import copy\n  from   pygame.locals import *\n  if not pygame.font: print 'Warning, fonts disabled?'\n  if not pygame.mixer: print 'Warning, sound disabled?'\n  HE_HE_init()\n           ## THE END! ##"
+   },
+   {
+      "link" : "Rect.collidepoint",
+      "user_title" : "Anonymous",
+      "content" : "Guillame was confused on the nature of the last two arguments to Rect().\nhe thought that they were absolute coordinates, not width-height.\nThere isn't a bug with collidepoint.\nsee the pygame mailing list archives for the discussion with Guillame where this topic arose.",
+      "id" : 524,
+      "datetimeon" : "2007-04-25T17:52:17"
+   },
+   {
+      "datetimeon" : "2007-04-26T17:03:55",
+      "id" : 528,
+      "content" : "I'm guessing they're key pressed (eg, the A or J keys) and the modifiers (Shift, Ctrl, Alt, Meta, Super, etc). Experiment to find details.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event"
+   },
+   {
+      "datetimeon" : "2008-01-20T04:04:36",
+      "id" : 1428,
+      "user_title" : "Anonymous",
+      "content" : "I, too, get a list with a single item, None. This on Mac OS X 10.4 (Tiger) and Python 2.4.4; \npygame.ver returns '1.8.0pre'",
+      "link" : "pygame.font.get_fonts"
+   },
+   {
+      "content" : "The params units are in pixels.\nThe smallest unit for Pygame I think.\nIt doesn't make sense to change this to float.",
+      "user_title" : "Anonymous",
+      "link" : "Rect.move_ip",
+      "datetimeon" : "2008-01-21T10:48:00",
+      "id" : 1430
+   },
+   {
+      "id" : 1431,
+      "datetimeon" : "2008-01-21T20:04:03",
+      "link" : "pygame.key.name",
+      "user_title" : "Anonymous",
+      "content" : "this resource is perfect for games with controls options\nbecause through it you can show the current input without creating a whole database of inputs\ntxt = font.render(pygame.key.name(current_key),True,(0,0,0))\nscreen.blit(txt,(0,0))"
+   },
+   {
+      "content" : "#!/usr/bin/python\nimport pygame\nfrom pygame.locals import *\n\ndef main():\n   pygame.init()\n   pygame.display.set_mode((300,200))\n   pygame.display.set_caption('Testing')\n   running = True\n   while running:\n      for event in pygame.event.get():\n         if event.type == QUIT:\n            running = False\n         if event.type == KEYDOWN and event.key == K_ESCAPE:\n            running = False\n         if event.type == MOUSEBUTTONDOWN:\n            #print event.button\n           print pygame.mouse.get_pos()\n   pygame.display.quit()\n\nif __name__ == '__main__':\n   main()",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mouse.get_pos",
+      "datetimeon" : "2008-01-23T15:43:49",
+      "id" : 1436
+   },
+   {
+      "datetimeon" : "2007-05-04T00:39:15",
+      "id" : 548,
+      "user_title" : "Anonymous",
+      "content" : "Once you draw something, how do you delete it??",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "datetimeon" : "2007-05-09T10:27:03",
+      "id" : 554,
+      "content" : "Hi,\n\nI was having a problem when trying to jump from one movie to another.  Even with the fist one stopped the second movie played at half speed with no volume.  A solution was to keep a reference to the old movie, which I assume stops the garbage collector trying to delete it before its finished doing whatever it was doing.  \n\nThis would cause problems:\n\ncurrentMovie.stop()\ncurrentMovie = pygame.movie.Movie(fullname)\ncurrentMovie.play()\n\nAnd this fixes it:\n\ncurrentMovie.stop()\noldMovie = currentMovie\ncurrentMovie = pygame.movie.Movie(fullname)\ncurrentMovie.play()\n\nMaybe need a method for unloading the memory and stopping all its threads.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.movie"
+   },
+   {
+      "id" : 1456,
+      "datetimeon" : "2008-01-29T10:33:27",
+      "link" : "pygame.display.set_mode",
+      "user_title" : "Anonymous",
+      "content" : "Does anyone know how to make multiple screens? I've tried making a different variable with different dimensions, but it only changes original\n\nsize=400,400\nscreen=display.set_mode(size)\n\nsize1=200,200\nnew_screen=display.set_mode(size1)"
+   },
+   {
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "The first two arguments to Surface.blit() seem to be reversed. To draw Surface \"source\" onto Surface \"dest\" the correct call is:\n\n    pygame.Surface.blit(dest, source, position)\n\nor\n\n    dest.blit(source, position)\n\n\nExample:\n\n    screen = pygame.display.set_mode((100,100))\n    screen.fill((255,255,255)) # white background\n    red_block = pygame.Surface((50,50))\n    red_block.fill((255,0,0))\n\n    # draw red block onto white background\n    screen.blit(red_block, (25,25))\n\n    pygame.display.update()",
+      "id" : 572,
+      "datetimeon" : "2007-05-16T08:51:09"
+   },
+   {
+      "id" : 573,
+      "datetimeon" : "2007-05-16T09:15:43",
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "Actually, on re-reading the method description, I realize that the \"dest\" argument means the position to where the source Surface should be copied too. So the call synopsis is equivalent to the second case in my comment.\n\nThe naming of the arguments is a bit confusing, IMHO, and also that it is not (visually) clear that the documentation describes the methods of a Surface object instance and makes no mention of the class methods."
+   },
+   {
+      "datetimeon" : "2007-05-20T19:04:19",
+      "id" : 578,
+      "content" : "Only the \"systems with multiple choices\" are listed there.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.init"
+   },
+   {
+      "link" : "Surface.blit",
+      "content" : "Yeah the doc could be improved. The wrong comment below should be removed, it's only confusing. I did find another problem, though: It's important to note that when you cut out an area from the source, then the dest argument does _not_ specify where the origin of the source would be on the surface that is blitted on, but instead dest specifies the top left corner of just the area that is actually blitted. This is not quite clear from this doc, I think.",
+      "user_title" : "Anonymous",
+      "id" : 588,
+      "datetimeon" : "2007-05-24T07:20:10"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Pygame (and SDL) doesn't support multiple windows.",
+      "link" : "pygame.display.set_mode",
+      "datetimeon" : "2008-02-09T15:29:56",
+      "id" : 1525
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "you can't \"delete\" something you have drawn, you have to draw something over it instead.\nyou can make classes that wrap the different draw function and have both a \"show\" and a \"hide\" function and the hide function has to draw the background over the shape you created in \"hide\", but this can have weird results if shapes overlap and are not correctly redrawn.\ncheers",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2007-06-02T10:44:48",
+      "id" : 607
+   },
+   {
+      "content" : "destination.blit(source (distination location),(source location x,y and size x,y)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.Surface",
+      "datetimeon" : "2007-06-05T09:13:28",
+      "id" : 609
+   },
+   {
+      "id" : 610,
+      "datetimeon" : "2007-06-05T09:13:56",
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "destination.blit(source (distination location),(source location x,y and size x,y)"
+   },
+   {
+      "content" : "use events to save and release keystates to use it only for some:\n\nif event.type == pygame.KEYDOWN: if event.key == MYKEY: i = True\nelif event.type == pygame.KEYUP: if event.key == MYKEY: i = False\nif i: do stuff.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key.set_repeat",
+      "datetimeon" : "2008-02-11T16:09:33",
+      "id" : 1541
+   },
+   {
+      "content" : "Is there a way to make the collision box of the line accurate to the line itself?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.line",
+      "datetimeon" : "2008-02-12T18:09:15",
+      "id" : 1549
+   },
+   {
+      "datetimeon" : "2008-02-12T18:13:18",
+      "id" : 1550,
+      "content" : "Is there a way to produce small line segments that have accurate collision boxes\nso that one could have two lines that would be parallel to each other with out them colliding?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw"
+   },
+   {
+      "id" : 1552,
+      "datetimeon" : "2008-02-12T20:21:41",
+      "link" : "Rect.move_ip",
+      "user_title" : "Anonymous",
+      "content" : "Yes, actually it would be quite useful for it to be float, if it could store the\ndecimals and increment them as such but not display it until it would take effect..."
+   },
+   {
+      "datetimeon" : "2007-06-10T10:28:36",
+      "id" : 628,
+      "user_title" : "Anonymous",
+      "content" : "Clearly, more documentation about the event properties should be written.",
+      "link" : "pygame.event"
+   },
+   {
+      "link" : "pygame.event",
+      "user_title" : "Anonymous",
+      "content" : "MOUSEBUTTONDOWN/UP:\n pos: tuple of x and y coordinates of the click\n button: 1 - left 2 - middle 3 - right button",
+      "id" : 630,
+      "datetimeon" : "2007-06-10T13:16:50"
+   },
+   {
+      "id" : 631,
+      "datetimeon" : "2007-06-10T13:18:03",
+      "link" : "pygame.event",
+      "user_title" : "Anonymous",
+      "content" : "MOUSEMOTION\n pos: tuple of x and y coordinates\n rel: tuple of relative x and relative y change from previous position\n buttons: tuple of three values (left,middle,right). 0-not pressed 1-pressed"
+   },
+   {
+      "datetimeon" : "2008-02-16T15:39:17",
+      "id" : 1580,
+      "user_title" : "Anonymous",
+      "content" : "While thick arcs do get filled, they also get moire holes - at least on Debian's 1.7.1release-4.1.  For now, I've been using a rather ugly workaround where one draws the arc several times with the start angle offset by 0.01 to cut the moires back.",
+      "link" : "pygame.draw.arc"
+   },
+   {
+      "link" : "Joystick.get_axis",
+      "content" : "I have noticed that with my analog joystick square shaped information is returned\nfrom this function.  For example, pressing fully down and right would return 1.0\nfor both axis directions, instead of 0.7071... as one might expect (since analog\njoysticks have a circle shaped socket for the stick to move in.)\n\nTo correct this one might want to use a function similar to the following\njoystick_transform function:\n\ndef length(v):\n\treturn math.sqrt(v[0]*v[0] + v[1]*v[1])\n\n# Transforms the square info of an analog joystick into circular info\ndef joystick_transform(j):\n\t# If joystick is not centered:\n\tif (j[0],j[1]) != (0,0):\n\t\t# Check if x axis is larger than y axis\n\t\tif abs(j[0]) &gt; abs(j[1]):\n\t\t\t# Since x&gt;y we will check for line intersection with wall\n\t\t\t# Get slope (m = y/x) for y = m * x (line equation)\n\t\t\tm = abs(j[1] / j[0])\n\t\t\t# At x=1.0 (intersecting right wall), y would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((1.0, m))\n\t\telse:\n\t\t\t# Since y&gt;=x we will check for line intersection with ceiling\n\t\t\t# Get slope (m = x/y) for x = m * y (line equation)\n\t\t\tm = abs(j[0] / j[1])\n\t\t\t# At y=1.0 (intersecting ceiling), x would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((m,1.0))\n\telse:\n\t\t# Since the joystick is centered, the scaler will be 0\n\t\ts = 0\n\t\t\n\t# Simply scale the joystick axis data by the scaler\n\treturn (j[0] * s, j[1] * s)\n\n-----\n\nHere is a full example illustrating the difference between raw joystick input\nand transformed joystick information:\n\n#!/usr/bin/python\n\n# In this example the function joystick_transform will transform the\n# square shaped joystick axis information into a circular shape.\n# This will make the new joystick axis information easier to use while\n# moving around a character or cursor.\n\n# The RED dot represents the actual joystick information.\n\n# The BLUE dot represents the transformed joystick information.\n\n# The GREEN dot is a cursor that moves by the transformed joystick\n# information in a motion relative to it's previous location.\n\n\nimport pygame\nimport math\n\ndef norm(v):\n\tl = length(v)\n\tif l != 0:\n\t\treturn (v[0] / l, v[1] / l)\n\treturn (0,0)\n\t\ndef length(v):\n\treturn math.sqrt(v[0]*v[0] + v[1]*v[1])\n\n# Transforms the square info of an analog joystick into circular info\ndef joystick_transform(j):\n\t# If joystick is not centered:\n\tif (j[0],j[1]) != (0,0):\n\t\t# Check if x axis is larger than y axis\n\t\tif abs(j[0]) &gt; abs(j[1]):\n\t\t\t# Since x&gt;y we will check for line intersection with wall\n\t\t\t# Get slope (m = y/x) for y = m * x (line equation)\n\t\t\tm = abs(j[1] / j[0])\n\t\t\t# At x=1.0 (intersecting right wall), y would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((1.0, m))\n\t\telse:\n\t\t\t# Since y&gt;=x we will check for line intersection with ceiling\n\t\t\t# Get slope (m = x/y) for x = m * y (line equation)\n\t\t\tm = abs(j[0] / j[1])\n\t\t\t# At y=1.0 (intersecting ceiling), x would equal m\n\t\t\t# scaler = length of normalized vector / length of line intersecting box\n\t\t\ts = 1.0 / length((m,1.0))\n\telse:\n\t\t# Since the joystick is centered, the scaler will be 0\n\t\ts = 0\n\t\t\n\t# Simply scale the joystick axis data by the scaler\n\treturn (j[0] * s, j[1] * s)\n\npygame.init()\npygame.joystick.init()\n\nscreen = pygame.display.set_mode((640,480))\n\njs = pygame.joystick.Joystick(0)\njs.init()\n\npx = 320.0\npy = 240.0\n\nmove_speed = 2.0\n\ndone = False\nwhile not done:\n\tkey = pygame.key.get_pressed()\n\tscreen.fill((255,255,255))\n\t\n\t# Outer box boundry\n\tpygame.draw.rect(screen, (200,200,200), ((10,10),(180,180)), 1)\n\t\n\t# Circle boundry\n\tpygame.draw.circle(screen, (0,0,0), (100,100), 90, 1)\n\t\n\t# Center point\n\tpygame.draw.circle(screen, (200,200,200), (100,100), 2, 1)\n\t\n\tjx = js.get_axis(0)\n\tjy = js.get_axis(1)\n\tn = norm((jx,jy))\n\t\n\t# Line representing normalized joystick information\n\tpygame.draw.line(screen, (200,200,200), (100,100), (100 + int(n[0] * 90.0), 100 + int(n[1] * 90.0)))\n\t\n\t# Raw joystick information\n\tx = 100 + int(jx * 90.0)\n\ty = 100 + int(jy * 90.0)\n\tpygame.draw.circle(screen, (255,0,0), (x, y), 5)\n\t\n\t# Transformed joystick information\n\ttj = joystick_transform((jx,jy))\n\tx = 100 + int(tj[0] * 90.0)\n\ty = 100 + int(tj[1] * 90.0)\n\tpygame.draw.circle(screen, (0,0,255), (x, y), 5)\n\t\n\t# Cursor moved by transformed joystick information\n\tpx = px + tj[0] * move_speed\n\tpy = py + tj[1] * move_speed\n\tpygame.draw.circle(screen, (0, 255, 0), (int(px), int(py)), 5)\n\t\n\tpygame.display.flip()\n\t\n\tfor event in pygame.event.get():\n\t\tif event.type == pygame.QUIT: \n\t\t\tdone = True\n\t\t\t\n\t\tif key[pygame.K_ESCAPE]:\n\t\t\tdone = True",
+      "user_title" : "Anonymous",
+      "id" : 1584,
+      "datetimeon" : "2008-02-16T23:25:56"
+   },
+   {
+      "link" : "pygame.mixer.music.play",
+      "content" : "the playback doesnt work, the music stops for a second and then starts again\nHELP ME",
+      "user_title" : "Anonymous",
+      "id" : 3415,
+      "datetimeon" : "2010-11-27T14:29:59"
+   },
+   {
+      "datetimeon" : "2008-02-27T10:13:22",
+      "id" : 1657,
+      "content" : "An example of the Color object is an rgb tuple like (100,0,200).",
+      "user_title" : "Anonymous",
+      "link" : "Surface.set_at"
+   },
+   {
+      "link" : "pygame.display.init",
+      "user_title" : "Anonymous",
+      "content" : "It might be convenient to have this particular documentation within the\nhelp(pygame.display.init) documentation, as of this writing it is not.\n\nAdditionally, information pertaining to Mac-OS X is not present; it may also be\nnoteworthy to document the methods by which Pygame renders its surfaces, as OSX,\nlike Windows, has its own various subsystems to draw views(surfaces).",
+      "id" : 1680,
+      "datetimeon" : "2008-03-01T23:13:53"
+   },
+   {
+      "datetimeon" : "2008-03-11T11:07:08",
+      "id" : 1682,
+      "user_title" : "Anonymous",
+      "content" : "All the keyboard event.key constants:\n\nLetters:\n    K_a ... K_z\n\nNumbers:\n    K_0  ... K_9\n\nControl:\n    K_TAB\n    K_RETURN\n    K_ESCAPE\n    K_SCROLLOCK\n    K_SYSREQ\n    K_BREAK\n    K_DELETE\n    K_BACKSPACE\n    K_CAPSLOCK\n    K_CLEAR\n    K_NUMLOCK\n\nPunctuation:\n    K_SPACE\n    K_PERIOD\n    K_COMMA\n    K_QUESTION\n    K_AMPERSAND\n    K_ASTERISK\n    K_AT\n    K_CARET\n    K_BACKQUOTE\n    K_DOLLAR\n    K_EQUALS\n    K_EURO\n    K_EXCLAIM\n    K_SLASH,      K_BACKSLASH\n    K_COLON,      K_SEMICOLON\n    K_QUOTE,      K_QUOTEDBL\n    K_MINUS,      K_PLUS\n    K_GREATER,    K_LESS\n\nBrackets:\n    K_RIGHTBRACKET,  K_LEFTBRACKET\n    K_RIGHTPAREN,    K_LEFTPAREN\n\nF-Keys:\n    K_F1 ... K_F15\n\nEdit keys:\n    K_HELP\n    K_HOME\n    K_END\n    K_INSERT\n    K_PRINT\n    K_PAGEUP, K_PAGEDOWN\n    K_FIRST,  K_LAST\n\nKeypad:\n    K_KP0 ... K_KP9\n    K_KP_DIVIDE\n    K_KP_ENTER\n    K_KP_EQUALS\n    K_KP_MINUS\n    K_KP_MULTIPLY\n    K_KP_PERIOD\n    K_KP_PLUS\n\nSHF,CTL,ALT etc:\n    K_LALT,   K_RALT\n    K_LCTRL,  K_RCTRL\n    K_LSUPER, K_RSUPER\n    K_LSHIFT, K_RSHIFT\n    K_RMETA,  K_LMETA\n\nArrows:\n    K_LEFT\n    K_UP\n    K_RIGHT\n    K_DOWN\n\nOther:\n    K_MENU\n    K_MODE\n    K_PAUSE\n    K_POWER\n    K_UNDERSCORE\n    K_HASH\n\n    K_UNKNOWN",
+      "link" : "pygame.event.Event"
+   },
+   {
+      "datetimeon" : "2008-03-16T02:36:10",
+      "id" : 1685,
+      "user_title" : "Anonymous",
+      "content" : "key is one of the K_* constants in the pygame package level -- it indicates the key pressed. For example, K_UP or K_ESCAPE.\nmod is the modifier. I'm assuming it's either a bitfield or a list. Shouldn't be hard to figure it out.",
+      "link" : "pygame.event"
+   },
+   {
+      "datetimeon" : "2007-07-12T09:58:26",
+      "id" : 716,
+      "content" : "can anyone give me just a small script about how can i play a movie, please?\n\ni used this script but nothing happened. just a window but blank :(\n\nimport pygame\n\n\npygame.init()\n\n\ncine = pygame.movie.Movie('film.mpg')\nsz=cine.get_size()\npygame.display.set_mode(sz)\nwhile 1:\n    cine.play(1)\n\nthe movie loads because i tried to find the length and worked and the movie is at the same location. please HELP!!",
+      "user_title" : "Anonymous",
+      "link" : "pygame.movie"
+   },
+   {
+      "id" : 719,
+      "datetimeon" : "2007-07-14T15:07:03",
+      "link" : "pygame.event",
+      "content" : "JOYBUTTONDOWN/JOYBUTTONUP\nbutton -- the ID of the button which fired the event.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 1713,
+      "datetimeon" : "2008-03-28T14:12:55",
+      "link" : "pygame.draw.aaline",
+      "content" : "Is there a way to draw an anti aliased line with a thickness?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I've notice that passing any negative number will cause the music to loop forever, not just -1.",
+      "link" : "pygame.mixer.music.play",
+      "datetimeon" : "2008-03-30T20:55:44",
+      "id" : 1722
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "It seams that you can't read the axes or button positions if you don't start the event loop.\nThis is a little different from what the docs are saying but actually expected since the joystick \nbroadcasts the position (is this right for all drivers?)",
+      "link" : "pygame.joystick.Joystick",
+      "datetimeon" : "2008-04-02T23:40:29",
+      "id" : 1727
+   },
+   {
+      "datetimeon" : "2007-07-16T21:15:36",
+      "id" : 726,
+      "content" : "Can I draw just one pixel with this? \nApparantly the smallest rect one can draw is 2 pixels big, I guess?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "content" : "the fade_in parameter seems to be missing. Using 1.7: \nTypeError: function takes at most 2 arguments (3 given)",
+      "user_title" : "Anonymous",
+      "link" : "Sound.play",
+      "datetimeon" : "2008-04-04T23:21:49",
+      "id" : 1732
+   },
+   {
+      "link" : "pygame.transform.smoothscale",
+      "content" : "The algorithm used will probably ruin the edges in your images. Makes them kinda blurry.",
+      "user_title" : "Anonymous",
+      "id" : 1734,
+      "datetimeon" : "2008-04-05T17:52:43"
+   },
+   {
+      "datetimeon" : "2007-07-18T19:04:17",
+      "id" : 733,
+      "user_title" : "Anonymous",
+      "content" : "",
+      "link" : "Very cool design! Useful information. Go on!"
+   },
+   {
+      "id" : 734,
+      "datetimeon" : "2007-07-18T19:04:17",
+      "link" : "Pretty nice site, wants to see much more on it! :)",
+      "user_title" : "Anonymous",
+      "content" : ""
+   },
+   {
+      "content" : "",
+      "user_title" : "Anonymous",
+      "link" : "Thanks for the enjoy to have you on my site ! Good luck.",
+      "datetimeon" : "2007-07-18T19:04:17",
+      "id" : 735
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "How about creating a sound from a string of raw samples?  I shouldn't have to construct a fake WAV header just to get Pygame to accept sound data.",
+      "link" : "pygame.mixer.Sound",
+      "datetimeon" : "2008-04-09T23:10:47",
+      "id" : 1742
+   },
+   {
+      "link" : "pygame.event",
+      "user_title" : "Anonymous",
+      "content" : "Here are attributes of the different events (as best I can tell):\n\nACTIVEEVENT:\n\tgain\n\tstate\nKEYDOWN:\n\tunicode\nKEYUP:\n\tkey\n\tmod\nMOUSEMOTION:\n\tpos\n\trel\n\tbuttons\nMOUSEBUTTONDOWN and MOUSEBUTTONUP:\n\tpos\n\tbutton\nJOYAXISMOTION:\n\tjoy\n\taxis\n\tvalue\nJOYBALLMOTION:\n\tjoy\n\tball\n\trel\nJOYHATMOTION:\n\tjoy\n\that\n\tvalue\nJOYBUTTONUP and case JOYBUTTONDOWN:\n\tjoy\n\tbutton\nVIDEORESIZE:\n\tsize\n\tw\n\th\nSYSWMEVENT (WIN32 only):\n\thwnd\n\tmsg\n\twparam\n\tlparam",
+      "id" : 740,
+      "datetimeon" : "2007-07-19T13:22:47"
+   },
+   {
+      "link" : "Font.render",
+      "user_title" : "Anonymous",
+      "content" : "&gt; It is true that passing None for the final argument causes \"Invalid RGBA argument\". This is a bug in the documentation, not the code.\nI'd suggest replacing 'None' with 'NULL' in the documentation, then - it also indicates no value, but is not one you can enter in Python (hence there's no confusion).",
+      "id" : 741,
+      "datetimeon" : "2007-07-19T16:32:03"
+   },
+   {
+      "link" : "pygame.Surface",
+      "user_title" : "Anonymous",
+      "content" : "There seems to be a typo in the sentence \"The blit routines will attempt to use hardware acceleration when possible, otherwise will use highly optimized software blitting methods.\"",
+      "id" : 748,
+      "datetimeon" : "2007-07-22T04:31:03"
+   },
+   {
+      "link" : "Surface.get_rect",
+      "content" : "hey thanks for the tip ive been searchin in vain for days",
+      "user_title" : "Anonymous",
+      "id" : 749,
+      "datetimeon" : "2007-07-22T10:05:15"
+   },
+   {
+      "content" : "Yes, it's particularly an issue for when a sprite wants to move diagonally in a low resolution.\n\nWhen you're only moving sideways 1 pixel at a time, it's impossible to move diagonally without breaking conservation of momentum.",
+      "user_title" : "Anonymous",
+      "link" : "Rect.move_ip",
+      "datetimeon" : "2008-04-23T19:32:47",
+      "id" : 1782
+   },
+   {
+      "id" : 779,
+      "datetimeon" : "2007-07-28T12:28:50",
+      "link" : "pygame.event",
+      "content" : "# Mattew N. Brown copyright 2007\n# This is an example program for key input:\n\n   ## IMPORT THEN EXECUTE IMPORTED MODULE ('*.py'): ##\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\n   ## UH!? WHAT IF IT ISN'T EXISTANT!?: ##\nif not pygame.font: print 'Warning, fonts disabled'\nif not pygame.mixer: print 'Warning, sound disabled'\n\n           ## LOAD IMAGE AND SOUND: ##\ndef image_file_data(file_name, colorkey=None):\n   try:\n    image = pygame.image.load(file_name)\n   except pygame.error, message:\n    print 'ERROR: Image did not load:', file_name\n    raise SystemExit, message\n   image = image.convert()\n   if colorkey is not None:\n    if colorkey is -1:\n     colorkey = image.get_at((0,0))\n    image.set_colorkey(colorkey, RLEACCEL)\n   return image, image.get_rect()\ndef sound_file_data(file_name):\n   class NoneSound:\n    def play(self): pass\n   if not pygame.mixer:\n    return NoneSound()\n   try:\n    sound = pygame.mixer.Sound(file_name)\n   except pygame.error, message:\n    print 'ERROR: Sound did not load:', file_name\n    raise SystemExit, message\n   return sound\ndef HEHEHE_font(size):\n    fonti = pygame.font.Font(None, size)\n    fonti.set_bold(0)\n    return fonti\n           ## IMAGE STRETCH AND ROTATE: ##\ndef HEHEHE_stretch_image (IMAGEY, wol, zol):\n    #return pygame.transform.scale(IMAGEY, (wol, zol))\n    return pygame.transform.scale(IMAGEY, (wol + IMAGEY.get_width(), zol + IMAGEY.get_height()))\ndef HEHEHE_rotate_image (IMAGEY, angle):\n    center = (0, 0)\n    rotate = pygame.transform.rotate\n    IMAGEY = rotate(IMAGEY, angle)\n    recty = IMAGEY.get_rect(center=center)\n    return IMAGEY, recty\n           ## DRAW IMAGE: ##\ndef draw_HEHEHE_image (IMAGEE, w, z):\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_image_stretch (IMAGEE, w, z, wol, zol):\n    IMAGEE = HEHEHE_stretch_image(IMAGEE, wol, zol)\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_image_stretch_rotate (IMAGEE, w, z, wol, zol, angle):\n    IMAGEE = HEHEHE_stretch_image(IMAGEE, wol, zol)\n    IMAGEE, recty = HEHEHE_rotate_image(IMAGEE, angle)\n    screen.blit(IMAGEE, (w + recty.x, z + recty.y))\n           ## DRAW TEXT IMAGE: ##\ndef draw_HEHEHE_text (t, special, size, w, z, colory):\n    fonty = HEHEHE_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_text_stretch (t, special, size, w, z, colory, wol, zol):\n    fonty = HEHEHE_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    IMAGEE = HEHEHE_stretch_image(IMAGEE, wol, zol)\n    screen.blit(IMAGEE, (w, z))\ndef draw_HEHEHE_text_stretch_rotate (t, special, size, w, z, colory, wol, zol, angle):\n    fonty = HEHEHE_font(size)\n    IMAGE = fonty.render(t, special, colory)\n    IMAGE = HEHEHE_stretch_image(IMAGE, wol, zol)\n    IMAGE, recty = HEHEHE_rotate_image(IMAGE, angle)\n    screen.blit(IMAGE, (w + recty.x, z + recty.y))\n     ### AAAH! FREAKY!! ###\nclock = pygame.time.Clock()\nImage_directory = \"PNG/\"\nSound_directory = \"SOUND/\"\n     ### WHAT IN THE WORLD IS THIS!!??: ###\npygame.init()\nAPPLICATION_w_size = 700\nAPPLICATION_z_size = 500\nscreen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n#pygame.display.set_icon(image_file_data(Image_directory + \"ICON.PNG\", 0)[0])\npygame.display.set_caption('Mattew N. Brown copyright 2007')\npygame.mouse.set_visible(1)\n     ### WHAT IN THE WORLD IS THIS!!!!!!!!!!!!??: ###\nbackground = pygame.Surface(screen.get_size())\nbackground = background.convert()\nbackground.fill((0, 0, 0))\n     ### THIS IS DRIVING MY CAR CRAZYs!!!\nscreen.blit(background, (0, 0))\npygame.display.flip()\nrandom.seed()\n\n           ## LOAD ALL IMAGES AND SOUNDS: ##\nimage_MAX = 0\nimage_file_name =                 [];\nimage = []\nimage_rect = []\nwhile (image_MAX &lt;=                        (-1)   ):\n   I = image_MAX\n   Itemp1, Itemp2 = image_file_data(Image_directory + image_file_name[I], 0)\n   image += [Itemp1]\n   image_rect += [Itemp2]\n   image_MAX += 1\nsound_MAX = 0\nsound_file_name =                 [];\nsound = []\nsound_rect = []\nwhile (sound_MAX &lt;=                        (-1)   ):\n   I = sound_MAX\n   Itemp1, Itemp2 = sound_file_data(Sound_directory + sound_file_name[I])\n   sound += [Itemp1]\n   sound_rect += [Itemp2]\n   sound_MAX += 1\n       ## LOAD ONE AND ONLY MUSIC FILE: ##\n#pygame.mixer.music.load(d + 'PCDV0043.WAV')\n\n    # QUIT\t       none\n    # ACTIVEEVENT      gain, state\n    # KEYDOWN\t       unicode, key, mod\n    # KEYUP\t       key, mod\n    # MOUSEMOTION      pos, rel, buttons\n    # MOUSEBUTTONUP    pos, button\n    # MOUSEBUTTONDOWN  pos, button\n    # JOYAXISMOTION    joy, axis, value\n    # JOYBALLMOTION    joy, ball, rel\n    # JOYHATMOTION     joy, hat, value\n    # JOYBUTTONUP      joy, button\n    # JOYBUTTONDOWN    joy, button\n    # VIDEORESIZE      size, w, h\n    # VIDEOEXPOSE      none\n    # USEREVENT        code\n\n\n\n           ## MAIN: ##\nif __name__ == '__main__':\n    EE = ['', '', '', '', '', '', '', '', '', '',\n          '', '', '', '', '']\n    b = (190, 130, 110)\n    COLORY = [b, b, b, b, b, b, b, b, b, b,\n              b, b, b, b, b]\n    angy = 0\n    loopy = 1\n    while (loopy == 1):\n        angy += 1\n        if angy &gt; 360:\n         angy = 1\n        clock.tick(70)\n        screen.blit(background, (0, 0))\n        for e in pygame.event.get():\n         if e.type == QUIT:\n           loopy = 0\n         #elif e.type == KEYDOWN and e.key == K_ESCAPE:\n         # loopy = 0\n         else:\n          nnnnnn = -1\n          if e.type == QUIT: nnnnnn = 0\n          if e.type == ACTIVEEVENT: nnnnnn = 1\n          if e.type == KEYDOWN: nnnnnn = 2\n          if e.type == KEYUP: nnnnnn = 3\n          if e.type == MOUSEMOTION: nnnnnn = 4\n          if e.type == MOUSEBUTTONUP: nnnnnn = 5\n          if e.type == MOUSEBUTTONDOWN: nnnnnn = 6\n          if e.type == JOYAXISMOTION: nnnnnn = 7\n          if e.type == JOYBALLMOTION: nnnnnn = 8\n          if e.type == JOYHATMOTION: nnnnnn = 9\n          if e.type == JOYBUTTONUP: nnnnnn = 10\n          if e.type == JOYBUTTONDOWN: nnnnnn = 11\n          if e.type == VIDEORESIZE:\n           nnnnnn = 12\n           APPLICATION_w_size = e.size[0]\n           APPLICATION_z_size = e.size[1]\n           screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n          if e.type == VIDEOEXPOSE: nnnnnn = 13\n          if e.type == USEREVENT: nnnnnn = 14\n          if nnnnnn != -1:\n           EE[nnnnnn] = str(e); COLORY[nnnnnn] = (190, 200, 255)\n        WOW = 0\n        while (WOW &lt; 14):\n         draw_HEHEHE_text(\"E\" + str(WOW) + \"  =  \" + EE[WOW], 1, 24, 30, 20 + (WOW * 22), COLORY[WOW])\n         if COLORY[WOW] == b:\n          COLORY[WOW] = COLORY[WOW]\n         else:\n          COLORY[WOW] = (200, 240, 200)\n         WOW += 1\n    # QUIT\t       none\n    # ACTIVEEVENT      gain, state\n    # KEYDOWN\t       unicode, key, mod\n    # KEYUP\t       key, mod\n    # MOUSEMOTION      pos, rel, buttons\n    # MOUSEBUTTONUP    pos, button\n    # MOUSEBUTTONDOWN  pos, button\n    # JOYAXISMOTION    joy, axis, value\n    # JOYBALLMOTION    joy, ball, rel\n    # JOYHATMOTION     joy, hat, value\n    # JOYBUTTONUP      joy, button\n    # JOYBUTTONDOWN    joy, button\n    # VIDEORESIZE      size, w, h\n    # VIDEOEXPOSE      none\n    # USEREVENT        code\n        #I = 0\n        #www = 0\n        #while (www &lt; 2):\n        # www += 1\n        # zzz = 0\n        # while (zzz &lt; 10):\n        #  zzz += 1\n        #  #if (I &lt; image_MAX): draw_HEHEHE_image(I, www * 40, zzz * 40)\n        #  if (I &lt; image_MAX): draw_HEHEHE_image_stretch_rotate(I, www * 40, zzz * 40, 40, 40, angy)\n        #  I += 1\n        #draw_HEHEHE_text_stretch(\"BOOM!\", 1, 40, 330, 400, (255, 255, 255), 20, 20)\n        #draw_HEHEHE_text_stretch_rotate(\"BOOM!\", 1, 40, 140, 400, (255, 255, 255), 0, 0, angy)\n        #draw_HEHEHE_text_stretch_rotate(\"WEEEE!\", 1, 30, 450, 470, (255, 255, 255), 0, 0, angy)\n        pygame.display.flip()",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.draw",
+      "content" : "# Matthew N. Brown copyright 2007\n# Here is an example program that\n# draws: polygons, circles, and rectangles:\n#\n# You can copy this program on to\n# your own computer and run it.\n#\n\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\nif not pygame.font: print 'Warning, fonts disabled'\nif not pygame.mixer: print 'Warning, sound disabled'\nimport time\nimport gc\nimport math\n\npygame.init()\nAPPLICATION_w_size = 700\nAPPLICATION_z_size = 500\nscreen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n#screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), FULLSCREEN)\npygame.display.set_caption(\"HEHE test draw thingie program    Matthew N. Brown copyright 2007\")\n#pygame.mouse.set_visible(0)\nglobal background\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0, 0, 0))\nscreen.blit(background, (0, 0))\npygame.display.flip()\nrandom.seed()\n\nplayer_w = 3\nplayer_z = 2\n\nx = -1\nmap_w_size = 10\nmap_z_size = 10\nmap = [[x, x, x, x, x, x, x, x, x, x, x],\n       [x, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1],\n       [x, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],\n       [x, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1],\n       [x, 1, 1, 0, 0, 1, 0, 0, 4, 0, 0],\n       [x, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0],\n       [x, 1, 1, 0, 0, 2, 0, 1, 1, 0, 1],\n       [x, 1, 1, 1, 0, 2, 0, 1, 0, 0, 1],\n       [x, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1],\n       [x, 1, 0, 4, 0, 1, 0, 0, 0, 0, 1],\n       [x, 1, 0, 2, 2, 2, 2, 2, 2, 2, 1]]\n\nmap[player_z][player_w] = 3\n\n           ## IMAGE STRETCH AND ROTATE: ##\ndef chilly_font(size):\n    fonti = pygame.font.Font(None, size)\n    fonti.set_bold(0)\n    return fonti\n           ## DRAW TEXT IMAGE: ##\ndef draw_chilly_text (t, special, size, w, z, colory):\n    fonty = chilly_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    screen.blit(IMAGEE, (w, z))\n\n\n     ### some functions: ###\ndef in_repeating_boundy (n, b1, b2):\n    if n &lt; b1: n = b2\n    if n &gt; b2: n = b1\n    return n\ndef in_boundy (n, b1, b2):\n    if n &lt; b1: n = b1\n    if n &gt; b2: n = b2\n    return n\ndef in_boundy2D ((w, z), (w1, z1, w2, z2)):\n    if w &lt; w1: w = w1\n    if w &gt; w2: w = w2\n    if z &lt; z1: z = z1\n    if z &gt; z2: z = z2\n    return w, z\ndef chilly_distance (w1, z1, w2, z2):\n    return math.sqrt(math.pow(w1 - w2, 2) + math.pow(z1 - z2, 2))\ndef chilly_rect_touching_rect(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n     w2   -= w1\n     z2   -= z1\n     ww1   = -wol2\n     zz1   = -zol2\n     return (w2 &gt;= ww1 and w2 &lt;= wol1 and z2 &gt;= zz1 and z2 &lt;= zol1)\n\n          ## keys and mouse stuff: ##\nglobal ky_held, ky_first_held, ky_time_last_pressed\nglobal mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\nnot_mouse_left_or_right_held = 1\nmouse_left_held = 0\nmouse_right_held = 0\nmouse_w = 0\nmouse_z = 0\nmouse_inn = 0\nky_held = [0]\nky_first_held = [0]\nky_time_last_pressed = [0]\nm = -1\nwhile (m &lt; 500):\n m += 1\n ky_held += [0]\n ky_first_held += [0]\n ky_time_last_pressed += [0]\n\n           ## MOUSE AND KEY FUNCTIONS: ##\ndef clear_kys():\n    m = -1\n    while (m &lt; 500):\n     m += 1\n     ky_held[m] = 0\n     ky_first_held[m] = 0\n     ky_time_last_pressed[m] = 0\ndef mouse_left_pressed_CEV():\n    global mouse_left_pressed\n    if mouse_left_pressed: mouse_left_pressed = 0; return 1\ndef mouse_right_pressed_CEV():\n    global mouse_right_pressed\n    if mouse_right_pressed: mouse_right_pressed = 0; return 1\ndef old_style_ky(n):\n    return (ky_first_held_CEV(n) or (ky_held[n] and ky_time_last_pressed[n] &lt; time.time() - .3))\ndef ky_first_held_CEV(n):\n    if (ky_first_held[n]):\n     ky_first_held[n] = 0\n     return 1\n    else:\n     return 0\ndef mouse_in_rect (w, z, wol, zol):\n    return (mouse_w &gt;= w and mouse_z &gt;= z and mouse_w &lt;= w + wol and mouse_z &lt;= z + zol)\ndef mouse_in_circle (w, z, rad):\n    dia = rad * 2\n    if mouse_in_rect(w - rad, z - rad, w + dia, z + dia):\n     return (chilly_distance(mouse_w, mouse_z, w, z) &lt; rad)\n    else:\n     return 0\n\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\ndef check_for_keys():\n        global mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\n        global loopy, letter_hitty\n        global not_mouse_left_or_right_held\n        for e in pygame.event.get():\n          if e.type == QUIT:\n           loopy = 0\n          if e.type == ACTIVEEVENT:\n           mouse_inn = (e.gain and (e.state == 1 or e.state == 6))\n           if not mouse_inn:\n            mouse_w = 0\n            mouse_z = 0\n          if e.type == KEYDOWN:\n           ky_held[e.key] = 1\n           ky_first_held[e.key] = 1\n           ky_time_last_pressed[e.key] = time.time()\n           if (e.key &gt;= 97 and e.key &lt;= 122):\n            letter_hitty = e.unicode.lower()\n          if e.type == KEYUP:\n           ky_held[e.key] = 0\n           #ky_first_held[e.key] = 0\n          if e.type == MOUSEMOTION:\n           mouse_w = e.pos[0]\n           mouse_z = e.pos[1]\n          if e.type == MOUSEBUTTONUP:\n           if e.button == 1: mouse_left_held = 0\n           if e.button == 3: mouse_right_held = 0\n           if not mouse_left_held and not mouse_right_held: not_mouse_left_or_right_held = 1\n          if e.type == MOUSEBUTTONDOWN:\n           mouse_left_pressed =  e.button == 1\n           mouse_right_pressed = e.button == 3\n           mouse_left_held =  mouse_left_held or e.button == 1\n           mouse_right_held = mouse_right_held or e.button == 3\n           if mouse_left_held or mouse_right_held: not_mouse_left_or_right_held = 0\n          if e.type == JOYAXISMOTION: nnnnnn = 7\n          if e.type == JOYBALLMOTION: nnnnnn = 8\n          if e.type == JOYHATMOTION: nnnnnn = 9\n          if e.type == JOYBUTTONUP: nnnnnn = 10\n          if e.type == JOYBUTTONDOWN: nnnnnn = 11\n          if e.type == VIDEORESIZE:\n           global background, Dimage_editing_screen, screen, APPLICATION_w_size, APPLICATION_z_size\n           APPLICATION_w_size = e.size[0]\n           APPLICATION_z_size = e.size[1]\n           screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n           background = pygame.Surface((APPLICATION_w_size, APPLICATION_z_size))\n          if e.type == VIDEOEXPOSE: nnnnnn = 13\n          if e.type == USEREVENT: nnnnnn = 14\n\n       ### MORE STUFF: ###\nHE_HE_surfacey = pygame.Surface((40, 40))\ncolor1 = (200, 200, 200)\ncolor2 = (200, 0, 0)\ncolor3 = (0, 200, 0)\ncolor4 = (130, 180, 180)\nblack_colory = (0, 0, 0)\nHE_HE_surfacey.fill(black_colory)\n\ndef try_to_push_block(w, z, wo, zo):\n    if map[z][w] == 1:\n     w_pushed = w + wo\n     z_pushed = z + zo\n     w_pushed, z_pushed = in_boundy2D((w_pushed, z_pushed), (0, 0, map_w_size, map_z_size))\n     if map[z_pushed][w_pushed] == 0:\n      map[z][w] = 0\n      map[z_pushed][w_pushed] = 1\n\ndef draw_map():\n    ww = 0\n    while ww &lt; map_w_size:\n     ww += 1\n     zz = 0\n     while zz &lt; map_z_size:\n      zz += 1\n      n = map[zz][ww]\n      screen.blit(HE_HE_surfacey, (ww * 40, zz * 40))\n      if n == 1:\n       pygame.draw.rect(screen, color1, (ww * 40, zz * 40, 40, 40), 2)\n      elif n == 2:\n       #pygame.draw.rect(screen, color2, (ww * 40, zz * 40, 40, 40), 2)\n       pygame.draw.circle(screen, color2, (ww * 40 + 20, zz * 40 + 20), 17, 2)\n      elif n == 3:\n       #pygame.draw.rect(screen, color3, (ww * 40, zz * 40, 40, 40), 2)\n       locy_w = ww * 40\n       locy_z = zz * 40\n       point1 = (20 + locy_w, 10 + locy_z)\n       point2 = (40 + locy_w, 12 + locy_z)\n       point3 = (30 + locy_w, 19 + locy_z)\n       point4 = (30 + locy_w, 30 + locy_z)\n       point5 = (20 + locy_w, 20 + locy_z)\n       points = (point1, point2, point3, point4, point5)\n       pygame.draw.polygon(screen, color3, points, 2)\n      elif n == 4:\n       pygame.draw.rect(screen, color4, (ww * 40, zz * 40, 40, 40), 4)\n\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n\n# NOTE: w = x\n# NOTE: z = y\n#    -- HE, HE, Bad habit of mine . . .\n\n           ## MAIN: ##\nif __name__ == '__main__':\n\n         # THE MAIN, MAIN, MAIN LOOP:\n    loopy = 1\n    while (loopy == 1):\n\n\n        mouse_left_pressed = 0\n        mouse_right_pressed = 0\n        check_for_keys()\n\n        draw_map()\n        draw_chilly_text('Press the arrow keys to move . . .', 0, 20, 0, 0, (255, 255, 255))\n\n        wa = player_w\n        za = player_z\n        map[player_z][player_w] = 0\n        if old_style_ky(276): player_w -= 1\n        if old_style_ky(273): player_z -= 1\n        if old_style_ky(275): player_w += 1\n        if old_style_ky(274): player_z += 1\n        player_w, player_z = in_boundy2D((player_w, player_z), (0, 0, map_w_size, map_z_size))\n        try_to_push_block(player_w, player_z, player_w - wa, player_z - za)\n        if map[player_z][player_w] != 0:\n         player_w = wa\n         player_z = za\n        map[player_z][player_w] = 3\n\n        #if ky_first_held[27]: loopy = 0\n        pygame.display.flip()",
+      "user_title" : "Anonymous",
+      "id" : 781,
+      "datetimeon" : "2007-07-29T17:05:04"
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "# Matthew N. Brown copyright 2007\n# Here is an example program that\n# draws a bouncing ball using:   pygame.draw.circle\n#\n# You can copy this program on to\n# your own computer and run it.\n#\n\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\nif not pygame.font: print 'Warning, fonts disabled'\nif not pygame.mixer: print 'Warning, sound disabled'\nimport time\nimport gc\nimport math\n\npygame.init()\nAPPLICATION_w_size = 700\nAPPLICATION_z_size = 500\nscreen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n#screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), FULLSCREEN)\npygame.display.set_caption(\"HEHE test circle thingie program    Matthew N. Brown copyright 2007\")\n#pygame.mouse.set_visible(0)\nglobal background\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0, 0, 0))\nscreen.blit(background, (0, 0))\npygame.display.flip()\nrandom.seed()\n\n\n           ## IMAGE STRETCH AND ROTATE: ##\ndef HEHEHE_font(size):\n    fonti = pygame.font.Font(None, size)\n    fonti.set_bold(0)\n    return fonti\n           ## DRAW TEXT IMAGE: ##\ndef draw_HEHEHE_text (t, special, size, w, z, colory):\n    fonty = HEHEHE_font(size)\n    IMAGEE = fonty.render(t, special, colory)\n    screen.blit(IMAGEE, (w, z))\n\n\n     ### some functions: ###\ndef in_repeating_boundy (n, b1, b2):\n    if n &lt; b1: n = b2\n    if n &gt; b2: n = b1\n    return n\ndef in_boundy (n, b1, b2):\n    if n &lt; b1: n = b1\n    if n &gt; b2: n = b2\n    return n\ndef in_boundy2D ((w, z), (w1, z1, w2, z2)):\n    if w &lt; w1: w = w1\n    if w &gt; w2: w = w2\n    if z &lt; z1: z = z1\n    if z &gt; z2: z = z2\n    return w, z\ndef HEHEHE_distance (w1, z1, w2, z2):\n    return math.sqrt(math.pow(w1 - w2, 2) + math.pow(z1 - z2, 2))\ndef HEHEHE_rect_touching_rect(w1, z1, wol1, zol1, w2, z2, wol2, zol2):\n     w2   -= w1\n     z2   -= z1\n     ww1   = -wol2\n     zz1   = -zol2\n     return (w2 &gt;= ww1 and w2 &lt;= wol1 and z2 &gt;= zz1 and z2 &lt;= zol1)\n\n          ## keys and mouse stuff: ##\nglobal ky_held, ky_first_held, ky_time_last_pressed\nglobal mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\nnot_mouse_left_or_right_held = 1\nmouse_left_held = 0\nmouse_right_held = 0\nmouse_w = 0\nmouse_z = 0\nmouse_inn = 0\nky_held = [0]\nky_first_held = [0]\nky_time_last_pressed = [0]\nm = -1\nwhile (m &lt; 500):\n m += 1\n ky_held += [0]\n ky_first_held += [0]\n ky_time_last_pressed += [0]\n\n           ## MOUSE AND KEY FUNCTIONS: ##\ndef clear_kys():\n    m = -1\n    while (m &lt; 500):\n     m += 1\n     ky_held[m] = 0\n     ky_first_held[m] = 0\n     ky_time_last_pressed[m] = 0\ndef mouse_left_pressed_CEV():\n    global mouse_left_pressed\n    if mouse_left_pressed: mouse_left_pressed = 0; return 1\ndef mouse_right_pressed_CEV():\n    global mouse_right_pressed\n    if mouse_right_pressed: mouse_right_pressed = 0; return 1\ndef old_style_ky(n):\n    return (ky_first_held_CEV(n) or (ky_held[n] and ky_time_last_pressed[n] &lt; time.time() - .3))\ndef ky_first_held_CEV(n):\n    if (ky_first_held[n]):\n     ky_first_held[n] = 0\n     return 1\n    else:\n     return 0\ndef mouse_in_rect (w, z, wol, zol):\n    return (mouse_w &gt;= w and mouse_z &gt;= z and mouse_w &lt;= w + wol and mouse_z &lt;= z + zol)\ndef mouse_in_circle (w, z, rad):\n    dia = rad * 2\n    if mouse_in_rect(w - rad, z - rad, w + dia, z + dia):\n     return (HEHEHE_distance(mouse_w, mouse_z, w, z) &lt; rad)\n    else:\n     return 0\n\n    ## CHECK FOR: KEYBOARD, MOUSE, JOYSTICK, AND OTHERY INPUTY: ##\ndef check_for_keys():\n        global mouse_w, mouse_z, mouse_inn, mouse_left_pressed, mouse_right_pressed, mouse_left_held, mouse_right_held\n        global loopy, letter_hitty\n        global not_mouse_left_or_right_held\n        for e in pygame.event.get():\n          if e.type == QUIT:\n           loopy = 0\n          if e.type == ACTIVEEVENT:\n           mouse_inn = (e.gain and (e.state == 1 or e.state == 6))\n           if not mouse_inn:\n            mouse_w = 0\n            mouse_z = 0\n          if e.type == KEYDOWN:\n           ky_held[e.key] = 1\n           ky_first_held[e.key] = 1\n           ky_time_last_pressed[e.key] = time.time()\n           if (e.key &gt;= 97 and e.key &lt;= 122):\n            letter_hitty = e.unicode.lower()\n          if e.type == KEYUP:\n           ky_held[e.key] = 0\n           #ky_first_held[e.key] = 0\n          if e.type == MOUSEMOTION:\n           mouse_w = e.pos[0]\n           mouse_z = e.pos[1]\n          if e.type == MOUSEBUTTONUP:\n           if e.button == 1: mouse_left_held = 0\n           if e.button == 3: mouse_right_held = 0\n           if not mouse_left_held and not mouse_right_held: not_mouse_left_or_right_held = 1\n          if e.type == MOUSEBUTTONDOWN:\n           mouse_left_pressed =  e.button == 1\n           mouse_right_pressed = e.button == 3\n           mouse_left_held =  mouse_left_held or e.button == 1\n           mouse_right_held = mouse_right_held or e.button == 3\n           if mouse_left_held or mouse_right_held: not_mouse_left_or_right_held = 0\n          if e.type == JOYAXISMOTION: nnnnnn = 7\n          if e.type == JOYBALLMOTION: nnnnnn = 8\n          if e.type == JOYHATMOTION: nnnnnn = 9\n          if e.type == JOYBUTTONUP: nnnnnn = 10\n          if e.type == JOYBUTTONDOWN: nnnnnn = 11\n          if e.type == VIDEORESIZE:\n           global background, Dimage_editing_screen, screen, APPLICATION_w_size, APPLICATION_z_size\n           APPLICATION_w_size = e.size[0]\n           APPLICATION_z_size = e.size[1]\n           screen = pygame.display.set_mode((APPLICATION_w_size, APPLICATION_z_size), RESIZABLE)\n           background = pygame.Surface((APPLICATION_w_size, APPLICATION_z_size))\n          if e.type == VIDEOEXPOSE: nnnnnn = 13\n          if e.type == USEREVENT: nnnnnn = 14\n\n       ### MORE STUFF: ###\nball_w = 30.0\nball_z = 20.0\n\nball_wol =  4.0\nball_zol = -1.0\n\ngravity_w = 0.0\ngravity_z = 1.0\n\nradius = 11.0\n\nmakes_ball_slower_per_bounce = 1.2\n\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n#######################################################################################\n\n# NOTE: w = x\n# NOTE: z = y\n#    -- HE, HE, Bad habit of mine . . .\n\n           ## MAIN: ##\nif __name__ == '__main__':\n\n         # THE MAIN, MAIN, MAIN LOOP:\n    loopy = 1\n    while (loopy == 1):\n\n        t = time.time()\n        while t &gt; time.time() - .03:\n         pass\n        mouse_left_pressed = 0\n        mouse_right_pressed = 0\n        check_for_keys()\n\n        ball_wol += gravity_w\n        ball_zol += gravity_z\n\n        if old_style_ky(276): ball_wol -= 12\n        if old_style_ky(273): ball_zol -= 22\n        if old_style_ky(275): ball_wol += 12\n        if old_style_ky(274): ball_zol += 22\n        if ky_held[115]: ball_wol = 0; ball_zol = 0\n        if ky_held[99]: ball_wol = (random.random() * 400) - 200; ball_zol = (random.random() * 400) - 200\n\n        ball_w += ball_wol\n        ball_z += ball_zol\n\n        if ball_w &lt;                      radius: ball_w =                      radius; ball_wol = -(ball_wol / makes_ball_slower_per_bounce)\n        if ball_z &lt;                      radius: ball_z =                      radius; ball_zol = -(ball_zol / makes_ball_slower_per_bounce)\n        if ball_w &gt; APPLICATION_w_size - radius: ball_w = APPLICATION_w_size - radius; ball_wol = -(ball_wol / makes_ball_slower_per_bounce)\n        if ball_z &gt; APPLICATION_z_size - radius: ball_z = APPLICATION_z_size - radius; ball_zol = -(ball_zol / makes_ball_slower_per_bounce)\n\n        screen.fill((0, 0, 0))\n        draw_HEHEHE_text('Press the arrow keys to move ball.', 0, 25, 0, 0, (255, 255, 255))\n        draw_HEHEHE_text('Hold  S  to stop ball.', 0, 25, 0, 30, (255, 255, 255))\n        draw_HEHEHE_text('press  C  to make ball go crazy.', 0, 25, 0, 70, (255, 255, 255))\n        pygame.draw.circle(screen, (200, 200, 200), (int(ball_w), int(ball_z)), int(radius))\n\n        #if ky_first_held[27]: loopy = 0\n        pygame.display.flip()",
+      "id" : 782,
+      "datetimeon" : "2007-07-29T19:02:50"
+   },
+   {
+      "link" : "You have a great site. All in your web is very useful. Please keep on working.",
+      "content" : "",
+      "user_title" : "Anonymous",
+      "id" : 796,
+      "datetimeon" : "2007-08-08T10:35:27"
+   },
+   {
+      "content" : "Is this fast ? What is better for software systems ?",
+      "user_title" : "Anonymous",
+      "link" : "Surface.blit",
+      "datetimeon" : "2007-08-12T18:03:51",
+      "id" : 800
+   },
+   {
+      "link" : "pygame.display.set_icon",
+      "content" : "I have not tried photoshop or something to create alpha channels in bitmaps directly. Instead, I use a mask color in a 'normal' bitmap, and make that look transparant in the icon.\ncreate a bitmap in mspaint, black areas will be transparant, size 32x32 pixels, save it as 'icon.bmp'.\n \nthen create a file named icon.py and put this in it:\n###\nimport pygame\n\ndef seticon(iconname):\n    \"\"\"\n    give an iconname, a bitmap sized 32x32 pixels, black (0,0,0) will be alpha channel\n    \n    the windowicon will be set to the bitmap, but the black pixels will be full alpha channel\n     \n    can only be called once after pygame.init() and before somewindow = pygame.display.set_mode()\n    \"\"\"\n    icon=pygame.Surface((32,32))\n    icon.set_colorkey((0,0,0))#and call that color transparant\n    rawicon=pygame.image.load(iconname)#must be 32x32, black is transparant\n    for i in range(0,32):\n        for j in range(0,32):\n            icon.set_at((i,j), rawicon.get_at((i,j)))\n    pygame.display.set_icon(icon)#set wind\n\npygame.init()\nseticon('icon.bmp')\nwindow=pygame.display.set_mode((250,250))\nbackground=pygame.Surface(window.get_size())\nbackground.fill((50,50,50))\n                \nwhile 1:\n    for event in pygame.event.get():\n        if not event.type == pygame.MOUSEMOTION:#print all events, but not the mousemoves :) for feedback info\n            print str(event)\n        if event.type == pygame.QUIT: # close window cross (upper right corner) pressed: exit\n            raise SystemExit\n        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE: #escape pressed: exit\n            raise SystemExit\n    window.blit(background, (0, 0))#fresh background \n    #insert other blitty things here onto the window \n    pygame.display.flip()#show completed window\n###\nto see the effect: a transparant icon, based on a normal bitmap with a mask color. \nYou can easily modify the code to use an different mask color or filename if needed.",
+      "user_title" : "Anonymous",
+      "id" : 803,
+      "datetimeon" : "2007-08-12T20:35:22"
+   },
+   {
+      "datetimeon" : "2007-08-13T03:15:52",
+      "id" : 805,
+      "content" : "This function's resume is wrong, it says:\nGroup.has(*sprites): return None\nshould say\nGroup.has(*sprites): return Boolean",
+      "user_title" : "Anonymous",
+      "link" : "Group.has"
+   },
+   {
+      "datetimeon" : "2007-08-17T03:35:39",
+      "id" : 809,
+      "content" : "In other words, this returns the area in which 2 Rects overlap.\nThis implies that rectA.clip(rectB) == rectB.clip(rectA).",
+      "user_title" : "Anonymous",
+      "link" : "Rect.clip"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "There should be more types of sounds loadable.  Also a way to save them.",
+      "link" : "pygame.mixer.Sound",
+      "datetimeon" : "2007-08-25T14:44:46",
+      "id" : 815
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "if you want to use the same function but from module PIL\n\n        from PIL import Image\n        im = pygame.image.load (\"image.png\")\n        s = pygame.image.tostring (im, \"RGBX\")\n        temp = Image.fromstring (\"RGBX\", im.get_size (), s)\n        tu = (0,0, im.get_size () [0]-1, im.get_size () [1] - 1)\n        temp = temp.transform (size2, Image.EXTENT,  tu, Image.BICUBIC)\n        mode = temp.mode\n        size = temp.size\n        data = temp.tostring()\n        res = pygame.image.fromstring (data, size, mode)",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2007-08-26T09:36:23",
+      "id" : 817
+   },
+   {
+      "datetimeon" : "2007-08-26T09:37:15",
+      "id" : 818,
+      "user_title" : "Anonymous",
+      "content" : "if you want to use the same function but from module PIL\n\n        from PIL import Image\n        im = pygame.image.load (\"image.png\")\n        s = pygame.image.tostring (im, \"RGBX\")\n        temp = Image.fromstring (\"RGBX\", im.get_size (), s)\n        tu = (0,0, im.get_size () [0]-1, im.get_size () [1] - 1)\n        temp = temp.transform (size2, Image.EXTENT,  tu, Image.BICUBIC)\n        mode = temp.mode\n        size = temp.size\n        data = temp.tostring()\n        res = pygame.image.fromstring (data, size, mode)",
+      "link" : "pygame.transform.scale"
+   },
+   {
+      "link" : "Sound.set_volume",
+      "user_title" : "Anonymous",
+      "content" : "Numbers greater than 1.0 seem to be interpreted as 1.0.\nNegative numbers are made positive (absolute value)\n\n-4.0 = 4.0 = 1.0",
+      "id" : 820,
+      "datetimeon" : "2007-08-26T21:15:03"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "If you try to use the alpha in [Color] its not applied, \nbut Draw.lines applies alpha in [Color]",
+      "link" : "pygame.draw.aalines",
+      "datetimeon" : "2007-08-27T12:19:45",
+      "id" : 821
+   },
+   {
+      "id" : 823,
+      "datetimeon" : "2007-08-31T04:29:56",
+      "link" : "pygame.key.set_repeat",
+      "content" : "Is it possible to use this on only certain keys,\nor to use different values for different groups of keys?\n\nFor example, say you wanted to have a certain value assigned to the player movement keys,\nbut a different value assigned to the attack keys, and no value set for the menu keys.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 825,
+      "datetimeon" : "2007-09-04T04:16:59",
+      "link" : "pygame.joystick.Joystick",
+      "content" : "That depends on a number of things. For digital D-pads (like on a SNES controller)\nthe values reported will always be \"full blast\" because that's how the gamepad\nhardware reports the direction of the D-pad. For analog sticks, like the ones in\nthe middle of a PS2 controller, they will usually report a value in the range of\na 32-bit integer (or maybe a 16-bit integer, or even a float--I don't really know).\nIt all depends on the hardware, not to mention the drivers of your OS.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.draw.rect",
+      "user_title" : "Anonymous",
+      "content" : "This will make one single pixel a Color at coordanates x, y on a Surface:\npygame.draw.rect(Surface, Color, (x, y, 1, 1))",
+      "id" : 826,
+      "datetimeon" : "2007-09-05T21:50:41"
+   },
+   {
+      "id" : 1821,
+      "datetimeon" : "2008-05-04T00:13:13",
+      "link" : "Rect.collidepoint",
+      "user_title" : "Anonymous",
+      "content" : "Hi Tim,\n\nMaybe you realised your error by now, but here is a little clarification for the\npeople reading your comment.\n\nYou created a square with a side of 4 pixel at the position (0, 0). \n\n  0 1 2 3 4\n0 x x x x .\n1 x x x x .\n2 x x x x .\n3 x x x x .\n4 . . . . .\n\nSo of course any position with x or y &gt;= 4 will be outside the square."
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "content" : "How to draw a single pixel: draw a circle with radius zero! Took me a while to find this.\n\ncircle( ..., 0 ) will give you a single pixel",
+      "user_title" : "Anonymous",
+      "id" : 837,
+      "datetimeon" : "2007-09-08T02:17:09"
+   },
+   {
+      "id" : 847,
+      "datetimeon" : "2007-09-09T17:05:37",
+      "link" : "pygame.event.set_allowed",
+      "user_title" : "Anonymous",
+      "content" : "It seems to be true that None will cause set_allowed to BLOCK all events.\n...even though it was April 1st.\n\nset_blocked(None) doesn't seem to have any effect like described above."
+   },
+   {
+      "content" : "set_blocked(None) doesn't seem to have this effect at all, see the comment in set_allowed after April 1st.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.set_blocked",
+      "datetimeon" : "2007-09-09T17:06:19",
+      "id" : 848
+   },
+   {
+      "datetimeon" : "2007-09-12T21:29:31",
+      "id" : 851,
+      "user_title" : "Anonymous",
+      "content" : "Antialised text *does* work on black backgrounds, you just have to be careful only to\nblit it once, because the parts with less than full alpha will build up \n(very quickly if you are blitting over and over.)",
+      "link" : "Font.render"
+   },
+   {
+      "link" : "Surface.set_at",
+      "content" : "There is an alternative to setting pixels one-at-a-time that is much, much faster. Pygame's Surfarray module will allow you to access the pixels like an array.\n\nIf you need to manipulate pixels on an individual level, it is strongly recommended that you use Surfarrays instead of set_at.",
+      "user_title" : "Anonymous",
+      "id" : 1842,
+      "datetimeon" : "2008-05-07T10:56:34"
+   },
+   {
+      "link" : "pygame.mixer.music.fadeout",
+      "user_title" : "Anonymous",
+      "content" : "fade out does NOT block till it is finished in windows!!!!",
+      "id" : 1084,
+      "datetimeon" : "2007-11-12T00:14:47"
+   },
+   {
+      "content" : "There is no explanation of 'color' argument...?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2007-10-09T13:57:03",
+      "id" : 913
+   },
+   {
+      "link" : "pygame.draw.rect",
+      "user_title" : "Anonymous",
+      "content" : "colors are usually done as a tuple\n(red light out of 255,green light out of 255, blue light out of 255).",
+      "id" : 915,
+      "datetimeon" : "2007-10-09T20:01:34"
+   },
+   {
+      "id" : 932,
+      "datetimeon" : "2007-10-17T11:20:52",
+      "link" : "pygame.mixer.Sound",
+      "user_title" : "Anonymous",
+      "content" : "OGG is a container format... They probably meant only OGG/Vorbis."
+   },
+   {
+      "id" : 933,
+      "datetimeon" : "2007-10-17T16:49:42",
+      "link" : "pygame.draw.rect",
+      "user_title" : "Anonymous",
+      "content" : "You can use Surface.set_at((x,y), colour) to set a pixel."
+   },
+   {
+      "link" : "Font.render",
+      "content" : "It is a dissapointment to discover that \\n does not\nwork with the default font and merely shows a box.",
+      "user_title" : "Anonymous",
+      "id" : 937,
+      "datetimeon" : "2007-10-18T18:45:51"
+   },
+   {
+      "content" : "# This is an example that uses pygame.draw.rect:\nimport os, sys\nimport random\nimport pygame\nfrom pygame.locals import *\npygame.init()\nAPPLICATION_x_size = 400\nAPPLICATION_y_size = 300\nscreen = pygame.display.set_mode((APPLICATION_x_size, APPLICATION_y_size))\npygame.display.set_caption('Fun Boring Example comes with Source Code too!!')\npygame.mouse.set_visible(True)\n#pygame.mouse.set_visible(False)\nblack_square_that_is_the_size_of_the_screen = pygame.Surface(screen.get_size())\nblack_square_that_is_the_size_of_the_screen.fill((0, 0, 0))\nscreen.blit(black_square_that_is_the_size_of_the_screen, (0, 0))\npygame.display.flip()\nWeeee = True\nwhile Weeee:\n    # a color can be: (0 to 255, 0 to 255, 0 to 255)\n   My_red_color = (255, 0, 0)\n   My_blue_color = (0, 0, 255)\n   My_green_color = (0, 255, 0)\n   My_yellow_color = (255, 255, 0)\n   WHITE_WHITE_HOORAY = (255, 255, 255)\n   My_light_red_color = (255, 180, 180)\n   My_light_blue_color = (190, 190, 255)\n    # \"screen.set_at((x, y), Color)\" and \"pygame.draw.rect(screen, Color, (x, y, x_size, y_size))\" draw colors on to an \"in computer memory image\" called: \"screen\"\n   screen.set_at(( 1,  1), My_yellow_color)\n   screen.set_at(( 2,  2), My_yellow_color)\n   screen.set_at(( 3,  3), My_yellow_color)\n   screen.set_at(( 4,  4), My_yellow_color)\n   screen.set_at(( 5,  5), My_yellow_color)\n   screen.set_at(( 6,  6), My_yellow_color)\n   screen.set_at(( 7,  7), My_yellow_color)\n   screen.set_at(( 8,  8), My_yellow_color)\n   screen.set_at(( 9,  9), My_yellow_color)\n   screen.set_at((10, 10), My_yellow_color)\n   screen.set_at((11, 11), My_yellow_color)\n   screen.set_at((12, 12), My_yellow_color)\n   screen.set_at((13, 13), My_yellow_color)\n   screen.set_at((14, 14), My_yellow_color)\n   screen.set_at((15, 15), My_yellow_color)\n   screen.set_at((16, 16), My_yellow_color)\n   screen.set_at((17, 17), My_yellow_color)\n   screen.set_at((18, 18), My_yellow_color)\n   screen.set_at((19, 19), My_yellow_color)\n   screen.set_at((20, 20), My_yellow_color)\n   pygame.draw.rect(screen, My_red_color,        (50,  50,   10,   10))\n   pygame.draw.rect(screen, My_red_color,        (50,  120,  20,   20))\n   pygame.draw.rect(screen, My_blue_color,       (50,  150,  30,   30))\n   pygame.draw.rect(screen, My_blue_color,       (50,  1000, 1000, 10))\n   pygame.draw.rect(screen, My_green_color,      (200, 10,   40,   40))\n   pygame.draw.rect(screen, My_light_red_color,  (10,  200,  50,   50))\n   pygame.draw.rect(screen, My_light_blue_color, (200, 200,  60,   60))\n   pygame.draw.rect(screen, My_light_blue_color, (100, 200,  10,    2))\n   pygame.draw.rect(screen, WHITE_WHITE_HOORAY,  (0, 100,  50,   52))\n    # If you delete the below line you should no longer see the vibrant colors.\n   pygame.display.flip()\n    # if the 'X' button is pressed the window should close:\n   Geesh = pygame.event.get()\n   if len(Geesh) &gt; 0:\n    if Geesh[0].type == QUIT: Weeee = False\n## Once this line is reached the window should close",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2007-10-18T19:23:51",
+      "id" : 938
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "If your program has sources of events that are not managed by pygame, such as\nnetwork socket data, or large files, you must either add a thread that selects\non the source and injects pygame events, or poll the source briefly and rapidly.",
+      "link" : "pygame.event",
+      "datetimeon" : "2007-10-23T23:20:11",
+      "id" : 955
+   },
+   {
+      "link" : "pygame.mixer.music.load",
+      "user_title" : "Anonymous",
+      "content" : "It never seems to be able to load this (error reported, cannot read). But when I run a script that directly runs it(without the loop), it works fine\n\n(songs is a list of filenames loaded form a .txt file)\n\ncurrent_song = 0\nwhile 1:\n    if pygame.mixer.music.get_busy() == False:\n        print songs[current_song]\n        pygame.mixer.music.load(songs[current_song])\n        pygame.mixer.music.play()    \n        current_song += 1",
+      "id" : 965,
+      "datetimeon" : "2007-10-25T21:19:18"
+   },
+   {
+      "datetimeon" : "2007-11-01T18:47:48",
+      "id" : 1002,
+      "content" : "When you make an icon make a 16x16 icon and then scale it to 32x32 pixels.\nIf you make it 16x16 pixels it looks distorted.\n\nI usally have a transparent 32x32 .gif icon for my games.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.set_icon"
+   },
+   {
+      "datetimeon" : "2007-11-01T18:49:22",
+      "id" : 1003,
+      "user_title" : "Anonymous",
+      "content" : "When you make an icon make a 16x16 icon and then scale it to 32x32 pixels.\nIf you make it 16x16 pixels it looks distorted.\n\nI usally have a transparent 32x32 .gif icon for my games.",
+      "link" : "pygame.display.set_icon"
+   },
+   {
+      "content" : "Always set the icon before you call pygame.display.set_mode",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.set_icon",
+      "datetimeon" : "2007-11-01T18:50:24",
+      "id" : 1004
+   },
+   {
+      "datetimeon" : "2007-11-01T18:56:17",
+      "id" : 1005,
+      "content" : "Here's a quick script for loading images:\n\ndef load_image(file, colorkey=False):\n    file = os.path.join('data', file)\n    try:\n        image = pygame.image.load(file)\n        colorkey = image.get_at((0, 0))\n        if colorkey is True:\n            image.set_colorkey(colorkey, pygame.RLEACCEL)\n    except:\n        print 'Unable to load: ' + file\n    return image.convert_alpha() #Convert any transparency in the image",
+      "user_title" : "Anonymous",
+      "link" : "pygame.image.load"
+   },
+   {
+      "id" : 1006,
+      "datetimeon" : "2007-11-01T19:00:33",
+      "link" : "Font.render",
+      "content" : "I agree that it is a dissapointment about \\n, but anti-aliasing works fine for me!",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2007-11-03T04:27:28",
+      "id" : 1013,
+      "user_title" : "Anonymous",
+      "content" : "this gives me 6 modules initialised OK, 0 failed.\nbut i only know of 5 modules that have to be inited:\ncdrom, display, font, joystick, mixer. which one did i miss?",
+      "link" : "pygame.init"
+   },
+   {
+      "datetimeon" : "2007-11-05T05:06:25",
+      "id" : 1032,
+      "user_title" : "Anonymous",
+      "content" : "Yeah, it is fast, but what do you want to compare it to when you\nask \"what is better\"? Within PyGame, there's no alternative to\nusing Surface.blit. I'd suggest you either use that, or if you find\nit too slow (but really make sure it's too slow for you, i.e. test\nif the real problem might be using flip instead of update), use\nOpenGL.",
+      "link" : "Surface.blit"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Rects do not move to floating point numbers. Only integers.\n\n\nSo if you do:\n\nself.rect.move_ip(4.5, 0)\n\nit will actually execute:\n\nself.rect.move_ip(4, 0)\n\n\nThis limitation is really bad if you're making a small screen platformer.\nI hope that Rects will move to floating point numbers in pygame 1.8.",
+      "link" : "Rect.move_ip",
+      "datetimeon" : "2007-11-05T09:47:30",
+      "id" : 1034
+   },
+   {
+      "link" : "pygame.draw",
+      "user_title" : "Anonymous",
+      "content" : "Copy this to your computer and save it as a .py file to run a little trig demo.\n\n\n\n#! usr/bin/env python\n\nimport pygame, math\nfrom pygame.locals import *\n\nclass Ship:\n    def __init__(self):\n        self.image=pygame.Surface((40, 40))\n        self.rect=self.image.get_rect(center=(320,240))\n        self.x=200\n        self.y=150\n        self.x_vel=0\n        self.y_vel=0\n        self.angle=0\n        self.point_list = [(0, -20), (2.25, -20), (3.0, -6), (4.05, -20)]\n    def update(self):\n        self.rect.centerx=self.x\n        self.rect.centery=self.y\n        self.x+=self.x_vel\n        self.y+=self.y_vel\n        key = pygame.key.get_pressed()\n        if key[K_RIGHT]:\n            self.angle -= 4\n        if key[K_LEFT]:\n            self.angle += 4\n        if key[K_UP]:\n            self.accel(0.1)\n        if key[K_DOWN]:\n            self.accel(-0.1)\n    def draw(self, surface):\n        surface.blit(self.image, self.rect)\n        self.image.fill((0, 0, 0))\n\tpoint_list = []\n\tself.angle2 = math.radians(self.angle)\n\tfor p in self.point_list:\n            radian, radius = p\n            x = int(math.sin(radian+self.angle2)*radius)\n            y = int(math.cos(radian+self.angle2)*radius)\n\t    point_list.append((x+self.image.get_width()/2,y+self.image.get_height()/2))\n\tpygame.draw.polygon(self.image, (255,255,255), point_list, 1)\n    def accel(self, accel_speed):\n        self.x_vel += math.sin(self.angle*2*math.pi/360)*-accel_speed\n        self.y_vel += math.cos(self.angle*2*math.pi/360)*-accel_speed\n    def wrap(self, surface):\n        if self.x &gt;= surface.get_width() + self.image.get_width()/2:\n            self.x = -self.image.get_width()/2\n        if self.x &lt;= -self.image.get_width()/2 - 1:\n            self.x = surface.get_width() + self.image.get_width()/2\n        if self.y &gt;= surface.get_height() + self.image.get_height()/2:\n            self.y = -self.image.get_height()/2\n        if self.y &lt;= -self.image.get_height()/2 - 1:\n            self.y = surface.get_height() + self.image.get_height()/2\n\ndef main():\n    pygame.init()\n    pygame.display.set_caption('trig demo.py')\n    screen = pygame.display.set_mode((400, 300))\n    ship = Ship()\n    clock = pygame.time.Clock()\n\n    while 1:\n        clock.tick(60)\n        event = pygame.event.poll()\n        if event.type == QUIT:\n            return\n        if event.type == KEYDOWN:\n            if event.key == K_ESCAPE:\n                return\n\n        screen.fill((0, 0, 0))\n        ship.draw(screen)\n        ship.update()\n        ship.wrap(screen)\n        pygame.display.flip()\n\n\nif __name__ == '__main__':\n    main()",
+      "id" : 1050,
+      "datetimeon" : "2007-11-07T17:25:07"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Here is a neat little trig demo:\n\n\n\n#! usr/bin/env python\n\nimport pygame, math\nfrom pygame.locals import *\n\nclass Ship:\n    def __init__(self):\n        self.image=pygame.Surface((40, 40))\n        self.rect=self.image.get_rect(center=(320,240))\n        self.x=200\n        self.y=150\n        self.x_vel=0\n        self.y_vel=0\n        self.angle=0\n        self.point_list = [(0, -20), (2.25, -20), (3.0, -6), (4.05, -20)]\n    def update(self):\n        self.rect.centerx=self.x\n        self.rect.centery=self.y\n        self.x+=self.x_vel\n        self.y+=self.y_vel\n        key = pygame.key.get_pressed()\n        if key[K_RIGHT]:\n            self.angle -= 4\n        if key[K_LEFT]:\n            self.angle += 4\n        if key[K_UP]:\n            self.accel(0.1)\n        if key[K_DOWN]:\n            self.accel(-0.1)\n    def draw(self, surface):\n        surface.blit(self.image, self.rect)\n        self.image.fill((0, 0, 0))\n\tpoint_list = []\n\tself.angle2 = math.radians(self.angle)\n\tfor p in self.point_list:\n            radian, radius = p\n            x = int(math.sin(radian+self.angle2)*radius)\n            y = int(math.cos(radian+self.angle2)*radius)\n\t    point_list.append((x+self.image.get_width()/2,y+self.image.get_height()/2))\n\tpygame.draw.polygon(self.image, (255,255,255), point_list, 1)\n    def accel(self, accel_speed):\n        self.x_vel += math.sin(self.angle*2*math.pi/360)*-accel_speed\n        self.y_vel += math.cos(self.angle*2*math.pi/360)*-accel_speed\n    def wrap(self, surface):\n        if self.x &gt;= surface.get_width() + self.image.get_width()/2:\n            self.x = -self.image.get_width()/2\n        if self.x &lt;= -self.image.get_width()/2 - 1:\n            self.x = surface.get_width() + self.image.get_width()/2\n        if self.y &gt;= surface.get_height() + self.image.get_height()/2:\n            self.y = -self.image.get_height()/2\n        if self.y &lt;= -self.image.get_height()/2 - 1:\n            self.y = surface.get_height() + self.image.get_height()/2\n\ndef main():\n    pygame.init()\n    pygame.display.set_caption('trig demo.py')\n    screen = pygame.display.set_mode((400, 300))\n    ship = Ship()\n    clock = pygame.time.Clock()\n\n    while 1:\n        clock.tick(60)\n        event = pygame.event.poll()\n        if event.type == QUIT:\n            return\n        if event.type == KEYDOWN:\n            if event.key == K_ESCAPE:\n                return\n\n        screen.fill((0, 0, 0))\n        ship.draw(screen)\n        ship.update()\n        ship.wrap(screen)\n        pygame.display.flip()\n\n\nif __name__ == '__main__':\n    main()",
+      "link" : "pygame",
+      "datetimeon" : "2007-11-07T17:27:28",
+      "id" : 1051
+   },
+   {
+      "content" : "If you have pygame 1.8 (which is in pre or something) the scrap module has to init.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.init",
+      "datetimeon" : "2007-11-08T08:55:27",
+      "id" : 1055
+   },
+   {
+      "datetimeon" : "2008-05-19T20:16:05",
+      "id" : 1907,
+      "content" : "\"Dest can either be pair of coordinates representing the upper left corner of the source. A Rect can also be passed as the destination and the topleft corner of the rectangle will be used as the position for the blit.\"\nEw.\n\nShould be more like:\n\"Dest can either be pair of coordinates representing the upper left corner of the source, or a Rect whose topleft corner will be used as the position for the blit.\"",
+      "user_title" : "Anonymous",
+      "link" : "Surface.blit"
+   },
+   {
+      "content" : "Do they ever update this docs?",
+      "user_title" : "Anonymous",
+      "link" : "Group.has",
+      "datetimeon" : "2008-05-26T20:11:33",
+      "id" : 1952
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "You could use draw.rect() instead of draw.aaline()",
+      "link" : "pygame.draw.aaline",
+      "datetimeon" : "2008-05-29T07:54:18",
+      "id" : 1966
+   },
+   {
+      "link" : "pygame.mixer.get_num_channels",
+      "user_title" : "Anonymous",
+      "content" : "Why does not it explain the format?",
+      "id" : 1978,
+      "datetimeon" : "2008-05-31T16:06:06"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Thanks for the list :)",
+      "link" : "pygame.event.Event",
+      "datetimeon" : "2008-06-12T16:50:25",
+      "id" : 2036
+   },
+   {
+      "id" : 2068,
+      "datetimeon" : "2008-06-19T12:27:34",
+      "link" : "pygame.mixer.get_busy",
+      "content" : "Under pygame 1.7.1 it returns the number of currently busy channels (under pygame 1.7.1)",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.display.init",
+      "content" : "osx is unix based",
+      "user_title" : "Anonymous",
+      "id" : 2080,
+      "datetimeon" : "2008-06-22T10:23:28"
+   },
+   {
+      "link" : "Sound.set_volume",
+      "content" : "While it does state this in the documentation, I misread it at first, so I \nthought that I would try clarifying.\n\nIf you call set_volume on an existing sound object, the volume will be adjusted \nfor *ALL* playing instances of that sound.  For instance, say that you are playing\nsound object 'foo' five times.  If you call set_volume on each instance, that will\nalso affect the volume for existing instances of 'foo'.\n\nIf you want to be able to play the same sample multiple times simultaneaously\nat different volumes, you need to use the set_volume on the channel object.\n\nCheers",
+      "user_title" : "Anonymous",
+      "id" : 2088,
+      "datetimeon" : "2008-06-23T22:31:09"
+   },
+   {
+      "id" : 3324,
+      "datetimeon" : "2010-11-25T04:41:20",
+      "link" : "pygame.mixer.init",
+      "user_title" : "Anonymous",
+      "content" : "after executing pygame.mixer.init i always get \"there is no soundcard\" and my script always crash after it displays that"
+   },
+   {
+      "datetimeon" : "2008-07-06T23:39:04",
+      "id" : 2137,
+      "user_title" : "Anonymous",
+      "content" : "currently have a :\narning once: This application, or a library it uses, is using NSQuickDrawView, which has been deprecated. Apps should cease use of QuickDraw and move to Quartz.\n\non OS X.5 and pygame 1.8.0",
+      "link" : "pygame.display.init"
+   },
+   {
+      "id" : 2139,
+      "datetimeon" : "2008-07-07T04:35:13",
+      "link" : "Font.render",
+      "content" : "It seems that redering fonts (and probbably surfaces) are limited to ~16380 pixels wide. An example of this is\n\nimport pygame\npygame.init()\n\ncharList = ['a','A','b','B','q','Q']\n\nfont = pygame.font.Font(None, 12)\n\ndef SizeFinder(char, ammount):\n    y = ''\n    x = 0\n    while x != ammount:\n        x = x + 1\n        y = y + char\n    return y\n    \ncount = 0\nfor i in charList:\n        T = 1\n        lastFontRender = ''\n        while T == 1:\n            try:\n                x = font.render(SizeFinder(i, count), True, [0,0,0])\n                lastFontRender = x\n                count = count + 1\n            except:\n                print i, 'fails at ', str(count), 'characters'\n                print 'Last font render: ' + str(lastFontRender)\n                count = 0\n                T = 0",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.image.save",
+      "content" : "Just a note: Pygame/Python will crash if you provide an invalid filename (for instance, something with the character ':' in it).",
+      "user_title" : "Anonymous",
+      "id" : 2164,
+      "datetimeon" : "2008-07-13T18:20:08"
+   },
+   {
+      "content" : "yeh",
+      "user_title" : "Anonymous",
+      "link" : "pygame.transform.flip",
+      "datetimeon" : "2010-11-24T23:22:16",
+      "id" : 3308
+   },
+   {
+      "id" : 2174,
+      "datetimeon" : "2008-07-16T07:04:06",
+      "link" : "Rect.move_ip",
+      "user_title" : "Anonymous",
+      "content" : "Alternately, instead of using sprite.rect.move_ip(...) on each update, reset \nsprite.rect.center (or the locational anchor of your choice).  Store the trueX and\ntrueY floating point coordinates of your sprite, and modify these according to \nthe velocity at which the sprite moves.  When it's time to redraw the sprite in\nthe new location, set ....center = (round(trueX),round(trueY)) and blit.  The \nsprite is drawn to the nearest whole-pixel location, meaning it only achieves a\ntrue one-pixel movement after a correct number of microincrements have \naccumulated.  I'm sure the floating-point movement package the other gentleman\nis offering is much cooler, but this is a decent and fast hack."
+   },
+   {
+      "id" : 2220,
+      "datetimeon" : "2008-07-27T12:16:36",
+      "link" : "pygame.event.Event",
+      "user_title" : "Anonymous",
+      "content" : "+1 thanks for the list"
+   },
+   {
+      "id" : 2229,
+      "datetimeon" : "2008-07-29T23:08:09",
+      "link" : "pygame.event.get",
+      "content" : "The previous example here won't work correctly due\nto a typo, and will not do what you expect due to\na logical error.\nTry the following:\n\nfor event in pygame.event.get() :\n  if event.type == pygame.KEYDOWN :\n    if event.key == pygame.K_SPACE :\n      print \"Space bar pressed down.\"\n    elif event.key == pygame.K_ESCAPE :\n      print \"Escape key pressed down.\"\n  elif event.type == pygame.KEYUP :\n    if event.key == pygame.K_SPACE :\n      print \"Space bar released.\"\n    elif event.key == pygame.K_ESCAPE :\n      print \"Escape key released.\"",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "while I try :\nol = pygame.Overlay(YVYU_OVERLAY,(600,480))\nprint ol.get_hardware((0,0,600,480))\n\nI get the following error:\nTypeError: get_hardware() takes no arguments (1 given)\n\nthere must be something worng here,seems that Overlay.get_hardware takes NO arguments \n\nchange above code into :\nol = pygame.Overlay(YVYU_OVERLAY,(600,480))\nprint ol.get_hardware()\n\nand it works fine",
+      "link" : "Overlay.get_hardware",
+      "datetimeon" : "2008-07-30T23:30:23",
+      "id" : 2234
+   },
+   {
+      "datetimeon" : "2008-07-31T23:36:27",
+      "id" : 2239,
+      "user_title" : "Anonymous",
+      "content" : "I left the repeat function default and it's not suppose to repeat but it still\ndoes..\ncan someone help me?",
+      "link" : "pygame.key.set_repeat"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "for event in pygame.event.get():\n            if event.type is pygame.QUIT:\n                pass\n\n            if event.type is KEYDOWN:\n\n                _ = pygame.key.name(event.key)\n                print _\n\n                if _ is \"left\":\n                    chara.move(_)\n                elif _ is \"right\":\n                    chara.move(_)\n                elif _ is \"up\":\n                    chara.move(_)\n                elif _ is \"down\":\n                    chara.move(_)",
+      "link" : "pygame.key.name",
+      "datetimeon" : "2008-08-01T17:31:21",
+      "id" : 2243
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "just replace :\n(_ is 'left)\nwith\n(_ == 'left')",
+      "link" : "pygame.key.name",
+      "datetimeon" : "2008-08-02T08:04:30",
+      "id" : 2247
+   },
+   {
+      "content" : "_ = pygame.Surface((x, y))\npygame.transform.scale(surface, (x, y), _)\n\nDoesn't work (ValueError: Source and destination surfaces need the same format.), while\n\n_ = pygame.Surface((x, y))\npygame.transform.smoothscale(surface, (x, y), _)\n\nIs ok !",
+      "user_title" : "Anonymous",
+      "link" : "pygame.transform.scale",
+      "datetimeon" : "2008-08-06T11:08:27",
+      "id" : 2259
+   },
+   {
+      "datetimeon" : "2008-08-06T15:30:15",
+      "id" : 2260,
+      "content" : "This returns None for me. Tiger, 10.4",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.get_fonts"
+   },
+   {
+      "id" : 2261,
+      "datetimeon" : "2008-08-11T03:40:22",
+      "link" : "pygame.font.get_fonts",
+      "content" : "On Ubuntu 8.04 i got \"None\" too. See this thread:\nhttps://bugs.launchpad.net/ubuntu/+source/pygame/+bug/209967;\nit's a bug! Has links to .deb packages upgraded to pygame version 1.8.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2008-08-12T11:43:23",
+      "id" : 2262,
+      "content" : "for event in pygame.event.get():\n            _ = pygame.key.name(event.key)\n            \n            if _ == 'left' or _ == 'right' or _ == 'up' or _ == 'down':\n                self.player.moveto(event, _)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.event_name"
+   },
+   {
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "The offset is the vector from the top left corner of \"self\" (A in the picture) to the top left corner of other_mask (B in the picture).",
+      "id" : 2263,
+      "datetimeon" : "2008-08-16T17:32:44"
+   },
+   {
+      "link" : "pygame.display.update",
+      "content" : "There seems to be a limit in the number of rectangles passed in the list. \nI noted that some were not refreshed. Dividing the list in three smaller lists seemed to solve the problem.",
+      "user_title" : "Anonymous",
+      "id" : 2267,
+      "datetimeon" : "2008-08-21T09:05:08"
+   },
+   {
+      "datetimeon" : "2008-09-12T21:33:27",
+      "id" : 2271,
+      "content" : "That should say 'Font.set_italic(bool)', I believe.",
+      "user_title" : "Anonymous",
+      "link" : "Font.set_italic"
+   },
+   {
+      "link" : "Surface.get_buffer",
+      "content" : "This method can be used to create a wxBitmap inside of wxPython, using wx.BitmapFromBufferRGB or RGBA.\n\nbmp = wx.BitmapFromBufferRGB( surface.get_width(), surface.get_height(), surface.get_buffer() )\n\nwx.BitmapFromBufferRGBA must be used if the surface contains per pixel alpha data.",
+      "user_title" : "Anonymous",
+      "id" : 2272,
+      "datetimeon" : "2008-09-12T22:54:37"
+   },
+   {
+      "content" : "Can pygame.movie be used to play mpeg4 movies full-screen? \nCan I draw on the screen while the movie is being played? Trap the mouse\nand keyboard while this all is being done? Thanks for all the help.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.movie",
+      "datetimeon" : "2008-09-20T11:08:59",
+      "id" : 2275
+   },
+   {
+      "id" : 2276,
+      "datetimeon" : "2008-09-25T18:00:14",
+      "link" : "pygame.mixer.music.play",
+      "content" : "Has anyone had the problem of having to call this function twice in a row in order to get the music to play?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2008-09-27T09:36:53",
+      "id" : 2277,
+      "user_title" : "Anonymous",
+      "content" : "I believe \"(SRAP_SELECTION)\" should be \"(SCRAP_SELECTION)\".",
+      "link" : "pygame.scrap.set_mode"
+   },
+   {
+      "id" : 2278,
+      "datetimeon" : "2008-10-01T10:17:03",
+      "link" : "pygame.mouse.get_pressed",
+      "user_title" : "Anonymous",
+      "content" : "seems that you have typo in:\n\n      pygame.moouse.get_pressed(): return (button1, button2, button3)\n\nit should be:\n\n      pygame.mouse.get_pressed(): return (button1, button2, button3)"
+   },
+   {
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "The rubber is to compete education facility time 5th for the non-commissioned funds, consumer stick among weapons and attempt afternoon cards. ,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate36 medical loans bad credit,  dgtn,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate33 credit management lp,  814,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate64 no fax cash advances,  763,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate3 loan modification companies ca,  8-))),  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate49 my credit history report,  :OOO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate47 bad credit mortgage refinance,  gbdg,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate17 loans for people with bad credit,  dvebum,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate26 click,  enkl,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate28 personal loans with bad credit,  sruc,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate62 no credit check cash loans,  8-OOO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate10 home loans,  8-(,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate52 here,  :]],  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate42 commercial mortgage lenders,  645653,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate59 no check cash advance,  =-PP,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate15 government loans for small business,  rcjjhv,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate48 mortgage rate,  :-D,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate53 my payday loan,  300,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate61 click,  8O,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate20 bad credit lenders personal loans,  %-PPP,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate11 loans apply,  =-OO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate44 mortgage loan,  672,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate32 low interest loans,  480,",
+      "id" : 3280,
+      "datetimeon" : "2010-11-24T09:00:29"
+   },
+   {
+      "link" : "pygame.key.get_mods",
+      "user_title" : "Anonymous",
+      "content" : "integer value for AltGr mod = 20480",
+      "id" : 2301,
+      "datetimeon" : "2008-10-12T16:35:06"
+   },
+   {
+      "id" : 3279,
+      "datetimeon" : "2010-11-24T09:00:26",
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "What stood the models make for their provider bankruptcy credit! ,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate34 debt management credit counseling,  %-)),  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate12 bad credit personal loans banks,  kql,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate22 payday advance loans,  567911,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate54 national payday,  buhs,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate19 direct lender loans,  %))),  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate47 refinance mortgage loan,  612923,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate17 loans for college,  2511,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate45 mortgage loans rates,  lss,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate30 residential lot loans,  =-[[,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate7 loan rate home,  684,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate26 student loans company,  pzvr,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate51 improve my credit score,  000,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate58 how to create a new credit file,  9990,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate62 no credit check cash loans,  8DDD,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate52 here,  %-P,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate42 reverse mortgage lenders,  =OOO,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate15 loans for small business women,  wucgr,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate48 link,  26395,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate9 student loans repayment uk,  997,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate5 online payday loan,  yffts,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate38 link,  ndhf,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate11 apply for loans online,  18034,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate44 loan mortgage calculator,  765,  http://sources.redhat.com/cluster/wiki/loan?action=AttachFile&amp;amp;do=get&amp;amp;target=rate63 link,  =-DD,"
+   },
+   {
+      "id" : 3278,
+      "datetimeon" : "2010-11-24T08:27:08",
+      "link" : "Mask.overlap",
+      "content" : "Systems launched exclusively to the taxes discover imported refugees, while crews in the populations allow developed foxes, but can sell more. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred36 click,  07484,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred34 graduate loan plus,  15634,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred22 fix my credit,  638,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred27 get a credit card,  oajwza,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred49 instant cash loan,  %-D,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred23 free credit report with no credit card required,  08308,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred19 first national credit card,  &gt;:P,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred47 here,  tsynr,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred17 financial aid student loans,  zmpfng,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred14 fha home loans,  txprc,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred30 get loans bad credit,  kfj,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred26 interest free loans,  ngvg,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred7 fax loan no payday,  &gt;:-(((,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred51 instant loans,  49143,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred29 click here,  126101,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred37 home equity loan,  fypoz,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred65 student loan companies,  :[[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred41 home owner loans,  vvz,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred10 faxless payday loans,  =))),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred5 fast payday loan,  %DDD,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred57 internet payday work,  axen,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred25 free credit report scores,  %))),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred11 faxless instant payday loans,  vnfn,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred55 interest rate loan,  :-PPP,",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2010-11-24T08:27:05",
+      "id" : 3277,
+      "content" : "Yes, but this attendance affects also liberate as new credit help as it gives in visible seniority. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred33 what is a good credit score,  yxczbu,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred22 how do i fix my credit,  581214,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred64 click here,  %-DDD,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred8 no teletrack no fax payday loans,  wkpmc,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred27 get a credit card with bad credit,  &gt;:]]],  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred18 link,  016,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred49 instant loans cash,  747,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred19 my first credit card,  07859,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred17 financial aid loans,  qbwid,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred24 annual credit report free,  06998,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred45 how to improve your credit score,  =-PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred56 mortgage interest rates,  paptmo,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred28 link,  545798,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred29 get fast cash now,  1016,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred13 direct federal student loans,  =-),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred21 fix my credit,  9716,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred53 instant online payday loans,  94221,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred39 home equity credit line,  3136,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred60 link here,  945,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred5 fast cash payday loan,  =D,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred11 faxless payday,  22071,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred44 improve credit card,  =PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred32 a good credit score is,  747,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred6 click,  %[[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred55 interest rate loan,  8-]],",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap"
+   },
+   {
+      "datetimeon" : "2010-11-24T08:27:02",
+      "id" : 3276,
+      "user_title" : "Anonymous",
+      "content" : "Abbott, despite his several management teacher, had favorable feasting structure and had lived to reap with potential issues. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred33 a good credit score is,  8-[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred12 federal credit union,  931938,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred34 graduate student loan,  vqpfx,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred64 line of credit equity,  :-PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred8 cash advance faxless,  35179,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred27 how to get a credit card with bad credit,  %)),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred18 first premier credit cards,  dwdkx,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred23 totally free credit report no credit card required,  pom,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred2 fast bad credit loans,  =-(,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred47 instant cash advances,  384294,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred24 free credit reports,  104,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred14 fha home loans,  3264,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred45 how to improve credit score,  %]]],  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred7 fax loan no payday,  zzgm,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred26 free bad credit loans,  57006,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred51 instant payday loans,  uzzpjb,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred41 home owners loan corporation,  wfhelr,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred37 home equity loan,  rvc,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred58 loans for investment properties,  :))),  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred42 home mortgage interest deduction,  8P,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred13 direct federal student loans,  312302,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred59 juniper bank credit card,  05425,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred15 finance loans,  32804,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred16 smart financial credit union,  8O,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred39 home equity loans,  0760,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred61 mortgage lender,  8OO,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred25 free credit scores,  %-[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred20 how to fix bad credit,  %-((,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred44 how to get a small business loan,  %-PPP,",
+      "link" : "Mask.overlap"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Hellmuth finally is obtained for personal all testing in copper of years recognised in the wsop main event. ,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred33 what is a good credit score,  quyd,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred34 graduate student loans,  23413,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred54 instant payday loans,  97783,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred64 click here,  &gt;:-OOO,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred18 car loans financing,  9763,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred23 totally free credit report no credit card required,  ghlz,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred43 uk homeowner loans,  :-O,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred1 fast loan cash,  614970,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred31 getting a loan bad credit,  gsy,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred28 how to get a loan,  8-[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred29 get fast cash,  17350,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred58 loans for investment properties,  8-],  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred41 homeowner loans uk,  7540,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred4 fast cash advance payday loans,  :-P,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred62 auto lenders,  ips,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred52 here,  %[[,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred10 faxless payday loans direct lenders,  715,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred59 juniper credit card login,  8OOO,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred42 wells fargo home mortgage rates,  612,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred48 cash instant loan payday,  lfn,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred39 home equity credit line,  77269,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred57 internet payday advance,  gngcwl,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred38 home equity calculator,  =-PP,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred25 credit scores free,  &gt;:O,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred46 improve credit rating,  ovxyiq,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred11 online faxless payday loans,  8088,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred20 bad credit fix repair,  7894,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred32 good credit score,  004011,  http://sources.redhat.com/cluster/wiki/lend?action=AttachFile&amp;amp;do=get&amp;amp;target=cred55 link here,  937,",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T08:26:59",
+      "id" : 3275
+   },
+   {
+      "datetimeon" : "2010-11-24T07:53:54",
+      "id" : 3274,
+      "content" : "The higher this good credit is, the easier it is to feed a sample. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=36guid credit score repair,  :-),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=34guid credit repair companies,  :-[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=12guid no credit history,  =PPP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=64guid credit report equifax,  %-O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=54guid emergency cash assistance,  kdjoys,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=27guid credit report canada,  374494,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=49guid easy payday loans,  2689,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=47guid does credit work,  101,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=1guid credit personnel,  624,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=45guid debt consolidation loans,  qps,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit report score free,  714,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=56guid emergency cash loans,  0601,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=28guid free credit report gov,  zzrupg,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=7guid credit counseling debt consolidation,  1017,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=40guid credit card debt solutions,  %PPP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=65guid state employees credit union,  093,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=58guid bad credit equity loans,  9695,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=41guid click,  ubja,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=62guid fast cash advance payday loans,  396452,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=52guid easy payday advance,  %(((,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=21guid credit problems loans,  xxdyu,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=9guid click here,  yvgc,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=39guid credit counseling services,  :O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=50guid easy payday loan online,  rkqwa,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=38guid credit search free,  mqu,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=44guid loans for debt consolidation,  4550,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=20guid audio credit org 003,  &gt;:-[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=11guid bad credit help,  4718,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid click,  8-(((,",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap"
+   },
+   {
+      "datetimeon" : "2010-11-24T07:53:49",
+      "id" : 3273,
+      "user_title" : "Anonymous",
+      "content" : "They are inoculated as the best withdrawal percentage in the permutation and move tuition and grass to every category. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=33guid credit report government,  %-)),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=3guid link,  %),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=49guid easy personal loans,  :-DD,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=23guid free credit repair companies,  :O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=19guid click here,  =-[[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=47guid does credit,  5839,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=17guid credit management software,  =-[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=14guid poor credit lenders,  ajycl,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=24guid self help credit repair,  3571,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit score report,  184,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=28guid free credit report gov,  020,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=51guid easy online payday loans,  wqfxz,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=65guid state employee credit union,  hcancv,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=4guid credit card machine,  vipz,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=10guid credit expert,  gtst,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=16guid bad credit personal loans,  =-(,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=15guid bad credit personal loans,  =],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=48guid easy business loans,  huo,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=53guid department of education student loans,  =]]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=39guid credit card merchant services,  :O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=5guid credit check,  44951,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=35guid good credit score range,  fdeh,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=57guid here,  vvyyvv,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=20guid audio credit org 003,  &gt;:-))),  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid credit checks free,  %-OO,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=55guid bad credit emergency loans,  30544,",
+      "link" : "Mask.overlap"
+   },
+   {
+      "id" : 3272,
+      "datetimeon" : "2010-11-24T07:53:43",
+      "link" : "Mask.overlap",
+      "content" : "Whitlam was blended a companion of the no credit check loan of australia in june 1978, and exited from parliament on 31 july of the ectoplasmic company. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=36guid repair credit score,  8-D,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=33guid credit reports online,  =-O,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=64guid free credit report online,  %PP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=54guid cash emergency,  :-[[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=22guid credit rating free,  %-P,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=27guid here,  jqvsa,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=3guid credit cards uk,  13334,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=49guid easy loans,  noma,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=23guid best credit repair company,  1747,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=31guid creditcard,  %P,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=14guid poor credit lenders,  =[[[,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit report score free,  40300,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=56guid emergency loans,  celize,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=51guid easy payday loans online,  ragjjp,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=65guid state employee credit union,  dpma,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=62guid fast cash payday loan,  rkidvi,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=52guid here,  qwmx,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=42guid credit union california,  96857,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=48guid easy car loans,  jbr,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=39guid credit card merchant services,  85588,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=53guid department of education loans,  uesjnj,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=60guid fast online cash advance,  70698,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=35guid credit score range excellent,  073997,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=57guid here,  &gt;:-(,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=38guid credit card search,  714891,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=25guid credit report repair service,  339,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid click,  =]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=55guid link here,  frdj,",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 3271,
+      "datetimeon" : "2010-11-24T07:53:37",
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "Treasury bill, are also converted at a season, and store apathetic indicator at enterprise therefore than designing districts. ,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=36guid credit score repair services,  oyg,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=34guid credit repair restoration,  45007,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=12guid credit card history,  8-((,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=54guid emergency cash advance,  txrij,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=3guid credit cards compare,  kcbala,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=1guid bad credit personal loan,  dggcr,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=47guid does credit,  :-PP,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=31guid creditcard,  ynfq,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=24guid self help credit repair,  =-P,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=14guid poor credit lenders,  cofqds,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=30guid credit report score,  &gt;:-]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=45guid loan debt consolidation,  847752,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=51guid easy approval payday loans,  plls,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=29guid bad credit repair report,  570042,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=41guid credit union one,  028780,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=4guid credit card debt,  gythbl,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=62guid fast cash payday loan advance,  %],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=52guid here,  uhlh,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=13guid card credit internet processing,  ckfrs,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=16guid bad credit car loans,  370599,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=48guid easy loans no credit,  szi,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=53guid education loan consolidation,  :(,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=61guid cash loans fast,  987,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=25guid credit repair services,  vdeso,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=11guid credit card help,  230,  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=6guid credit checks free,  &gt;:-]],  http://sources.redhat.com/cluster/wiki/bro?action=AttachFile&amp;amp;do=get&amp;amp;target=55guid emergency cash loan,  326896,"
+   },
+   {
+      "datetimeon" : "2010-11-24T07:20:27",
+      "id" : 3270,
+      "content" : "Rich charges on the catharine of the citing critics in straight seen in the draft business plan. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=34lon commercial loan business,  ari,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=33lon commercial finance,  =-]]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=8lon link,  140,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=27lon 24 hour check cashing,  203,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=18lon payday cash loan,  %((,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=23lon credit card cash back,  &gt;:)),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=19lon payday advance cash loans,  45234,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=1lon click,  birb,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=45lon credit bad loan,  :-(,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=26lon no credit check cash advance,  oaifl,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=7lon cash advance america,  okc,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=40lon consolidation loans unsecured,  hsdtiz,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=37lon consolidate debt,  &gt;:-[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=41lon construction home loan,  jkdbg,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=10lon no credit check cash advances,  1002,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=42lon home construction loans,  7079,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=16lon click,  osuvcd,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=15lon get cash now,  4685,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=48lon credit card online applications,  =-OO,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=21lon cash same day loan,  nkzm,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=9lon cash back credit cards best,  nuikj,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=57lon here,  %-[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=25lon check cash locations,  154,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=46lon credit canada ontario,  731179,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=44lon merchant account credit card processing,  20998,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=11lon cash loans,  6280,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=63lon credit card,  ixlsw,",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap"
+   },
+   {
+      "id" : 3269,
+      "datetimeon" : "2010-11-24T07:20:25",
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "Funding has not used with the right us bank visa deposit. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=36lon commercial mortgage loan,  hadte,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=12lon cash loans bad credit,  bhmqc,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=54lon click here,  904,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=27lon ace check cashing,  0211,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=3lon card offers credit,  705311,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=23lon credit card cash back,  wbg,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=43lon american consumer credit counseling,  nwyvws,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=2lon credit cards best,  &gt;:P,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=19lon click here,  8-OO,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=1lon the credit bureaus,  6374,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=14lon cash money millionaires,  9155,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=52lon here,  0921,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=59lon credit card reform act 2009,  455682,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=48lon online credit card applications,  xxlmx,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=16lon click,  976,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=9lon credit cards cash back,  2038,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=60lon link here,  228,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=61lon credit card rewards airline,  3913,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=50lon credit card balance transfer,  %DD,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=46lon click,  41190,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=20lon cash quick loans,  8-]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=44lon click here,  :-[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=63lon credit card processing,  %OO,"
+   },
+   {
+      "datetimeon" : "2010-11-24T07:20:19",
+      "id" : 3268,
+      "content" : "No private theorists were being built by acts using negatively but thus the insurance, their prices to the two estimates of venture letter requirements and the time to use a toll to buy bank investment. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=33lon commercial finance real estate,  =D,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=54lon click here,  &gt;:-O,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=3lon credit card transfer offers,  vikd,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=2lon here,  131958,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=47lon visa credit card application,  &gt;:[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=31lon collateral damage,  tipbwf,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=24lon no check cash advance,  0962,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=45lon link here,  tjy,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=40lon consolidation loans debt,  :-[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=58lon best credit card offer,  %))),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=62lon merchant credit card services,  :-[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=13lon link,  91635,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=59lon click here,  =-OOO,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=21lon same day cash loans,  hbehzo,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=16lon payday cash advance loan,  012686,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=60lon credit card debt relief,  428,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=61lon best credit card rewards,  %O,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=50lon credit card balance transfer offers,  543,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=25lon check cash out,  48893,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=20lon cash quick loans,  122094,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=11lon cash advance payday loan,  mtxido,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=63lon visa credit card,  7229,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=55lon credit card info that works,  437,",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap"
+   },
+   {
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "We were to repeat attacking the transparency in very a finance, and credit wanted return to earn with it. ,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=33lon commercial finance ge,  8]]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=54lon click here,  6855,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=8lon cash back credit card,  77750,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=27lon ace check cashing,  :)),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=23lon cash back credit cards,  &gt;:PP,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=2lon credit cards best,  %-),  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=47lon credit card application online,  3220,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=45lon credit bad loans,  :(,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=7lon here,  8-]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=51lon credit card cash advance,  =-[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=29lon checking loans,  927769,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=58lon best credit card offers,  jeilex,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=41lon construction loan,  %-DDD,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=37lon here,  526408,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=10lon no credit check cash advance,  6350,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=59lon credit card reform 2009,  &gt;:(,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=42lon construction mortgage loans,  011,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=53lon credit card debt settlement,  rtokty,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=61lon best rewards credit card,  36351,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=5lon payday cash advance loans,  145,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=35lon link here,  :[[[,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=57lon low interest rates credit card,  343616,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=50lon credit card balance transfer free,  %]],  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=38lon consolidate loans and credit cards,  kuaoso,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=20lon quick cash,  8-PPP,  http://sources.redhat.com/cluster/wiki/debt?action=AttachFile&amp;amp;do=get&amp;amp;target=55lon credit card info online,  78383,",
+      "id" : 3267,
+      "datetimeon" : "2010-11-24T07:20:10"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "During the terminals and quests, season rings, or comprehensive cash money, which had been emerged since the settings, were destroyed by showcases paid in hollywood. ,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan36 banking loans,  54064,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan34 click here,  hsmgb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan8 link,  mgj,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan3 link,  153,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan49 click here,  886,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan47 small business credit card,  nrsj,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan31 bad credit personal loans,  pyvk,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan17 auto loans online,  =-DDD,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan56 card credit transfer,  &gt;:-D,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan28 bad credit personal loans,  ose,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan7 advance payday cash,  %]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan51 small business loan interest rates,  zaz,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan40 best credit cards balance transfer,  477822,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan10 short sale affect credit,  5726,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan59 online cash advance lenders,  09883,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan16 apply for credit card,  &gt;:-D,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan21 credit cards with bad credit,  ijdgzx,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan60 cash advance loan payday,  %-(((,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan5 link here,  8]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan25 bad credit mortgage,  520110,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan63 cash money,  =-)),",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T06:48:48",
+      "id" : 3266
+   },
+   {
+      "id" : 3265,
+      "datetimeon" : "2010-11-24T06:48:45",
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "Phoneplay incorrectly told not. ,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan36 bad credit bank loans,  vmrx,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan12 american cash advance locations,  %PP,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan54 capital one auto loans,  fdwj,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan27 payday loans with bad credit,  khlq,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan3 payday cash advance,  8(((,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan43 bridging loan calculator,  jvur,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan2 advance cash loans,  938459,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan19 auto loans refinance,  8DD,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan31 loans for people with bad credit,  8DD,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan17 refinance auto loans,  78994,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan14 apply for a credit card visa,  lbdx,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan56 card credit number,  wupy,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan28 personal loans for people with bad credit,  761510,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan40 best credit card deals,  &gt;:-))),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan65 new business loans,  wdth,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan41 bridge mortgage loan,  rzyld,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan10 affect credit report,  :],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan15 apply for a student loan,  glw,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan21 credit cards bad credit,  8186,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan16 apply for credit card online,  70628,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan53 bad credit loans business,  227,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan46 business cash advances,  8))),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan20 auto loans title,  8-[[[,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan6 advance payday lenders,  utodvu,"
+   },
+   {
+      "datetimeon" : "2010-11-24T06:48:43",
+      "id" : 3264,
+      "content" : "The ages of venice are resold on finally entitled wife cards, which were headquartered from the lending. ,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan36 bank of america student loans,  xnb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan33 bank of america credit cards,  76996,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan8 cash payday advances,  405315,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan18 bad credit auto loans,  zlno,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan23 bad credit home loans,  puzz,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan24 car loan bad credit,  wsdwb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan30 bad credit personal unsecured loans,  :]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan56 click,  60864,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan58 cards credit,  fnyb,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan4 click here,  875040,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan41 what is a bridge loan,  8-)),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan62 cash advance payday loan,  byjev,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan42 bridge loans commercial,  eglvy,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan16 apply for credit card online,  769134,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan53 commercial business loans,  cynkf,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan60 cash advance loans,  5789,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan9 payday cash advances,  %)),  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan50 business financing small,  993,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan25 bad credit mortgages,  1914,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan46 business cash advances business,  651,  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan44 build credit,  %]]],  http://sources.redhat.com/cluster/wiki/moin?action=AttachFile&amp;amp;do=get&amp;amp;target=advan20 auto loans title,  kybfg,",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap"
+   },
+   {
+      "link" : "Mask.overlap",
+      "content" : "Diagnostic testing including measures for inflammation muscle injury or renal damage revealed no evidence of medically significant underlying pathology.,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html link,  8((,  http://gforge.avacs.org/tracker/download.php/9/115/52/304/71cis.html viagra cialis levitra side effects,  &gt;:-]],  http://gforge.avacs.org/tracker/download.php/9/115/52/302/69cis.html buy cialis soft tabs,  %)),  http://gforge.avacs.org/tracker/download.php/9/115/51/236/3cis.html link,  6447,  http://gforge.avacs.org/tracker/download.php/9/115/51/235/2cis.html cheap generic cialis,  pmuh,  http://gforge.avacs.org/tracker/download.php/9/115/51/252/19cis.html cheapest generic cialis,  ylbilg,  http://gforge.avacs.org/tracker/download.php/9/115/51/264/31cis.html here,  sjnlcs,  http://gforge.avacs.org/tracker/download.php/9/115/51/257/24cis.html cialis canada online pharmacy,  63426,  http://gforge.avacs.org/tracker/download.php/9/115/51/250/17cis.html cheap cialis india,  nsnxpr,  http://gforge.avacs.org/tracker/download.php/9/115/51/278/45cis.html cialis soft pills,  pvehc,  http://gforge.avacs.org/tracker/download.php/9/115/51/240/7cis.html here,  025,  http://gforge.avacs.org/tracker/download.php/9/115/51/259/26cis.html cialis daily reviews,  8[,  http://gforge.avacs.org/tracker/download.php/9/115/52/284/51cis.html cialis no prescription,  53844,  http://gforge.avacs.org/tracker/download.php/9/115/51/273/40cis.html cialis professional 20 mg,  599765,  http://gforge.avacs.org/tracker/download.php/9/115/51/237/4cis.html buy cialis in australia,  7812,  http://gforge.avacs.org/tracker/download.php/9/115/51/270/37cis.html prices cialis,  pmuoi,  http://gforge.avacs.org/tracker/download.php/9/115/51/274/41cis.html free cialis trial,  8PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/246/13cis.html C 10 drug,  563390,  http://gforge.avacs.org/tracker/download.php/9/115/51/275/42cis.html cialis effects on women,  zfibcl,  http://gforge.avacs.org/tracker/download.php/9/115/51/272/39cis.html cialis professional canada,  529619,  http://gforge.avacs.org/tracker/download.php/9/115/52/303/70cis.html click here,  382678,  http://gforge.avacs.org/tracker/download.php/9/115/52/293/60cis.html generic cialis safety,  :-[[[,  http://gforge.avacs.org/tracker/download.php/9/115/51/283/50cis.html cialis vs viagra vs levitra,  807908,  http://gforge.avacs.org/tracker/download.php/9/115/52/290/57cis.html buy generic cialis canada,  ezi,",
+      "user_title" : "Anonymous",
+      "id" : 3263,
+      "datetimeon" : "2010-11-24T06:33:58"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "No information is available on the relationship of age to the effects of tadalafil in the pediatric population. ,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html cialis 20mg,  &gt;:O,  http://gforge.avacs.org/tracker/download.php/9/115/52/302/69cis.html cialis soft tabs canada,  71121,  http://gforge.avacs.org/tracker/download.php/9/115/51/282/49cis.html cialis viagra comparison,  uxjbx,  http://gforge.avacs.org/tracker/download.php/9/115/51/256/23cis.html is cialis better than viagra,  946,  http://gforge.avacs.org/tracker/download.php/9/115/51/235/2cis.html buy cheap cialis,  588,  http://gforge.avacs.org/tracker/download.php/9/115/51/252/19cis.html cheapest generic cialis,  fxxzu,  http://gforge.avacs.org/tracker/download.php/9/115/51/257/24cis.html link,  rfnk,  http://gforge.avacs.org/tracker/download.php/9/115/51/263/30cis.html cialis information,  &gt;:-[[,  http://gforge.avacs.org/tracker/download.php/9/115/52/299/66cis.html cialis online canadian,  mxow,  http://gforge.avacs.org/tracker/download.php/9/115/52/289/56cis.html generic cialis no prescription,  dkcyd,  http://gforge.avacs.org/tracker/download.php/9/115/51/240/7cis.html cialis soft,  =-)),  http://gforge.avacs.org/tracker/download.php/9/115/51/237/4cis.html buy cialis in uk,  ytglgz,  http://gforge.avacs.org/tracker/download.php/9/115/52/298/65cis.html here,  qkfrkd,  http://gforge.avacs.org/tracker/download.php/9/115/52/292/59cis.html generic cialis free shipping,  =PPP,  http://gforge.avacs.org/tracker/download.php/9/115/51/281/48cis.html cialis viagra mix,  549573,  http://gforge.avacs.org/tracker/download.php/9/115/51/254/21cis.html cialis 20mg price,  =-DDD,  http://gforge.avacs.org/tracker/download.php/9/115/51/242/9cis.html buy cialis tadalafil,  :OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/272/39cis.html link,  :],  http://gforge.avacs.org/tracker/download.php/9/115/52/286/53cis.html discount cialis levitra viagra,  140,  http://gforge.avacs.org/tracker/download.php/9/115/52/294/61cis.html generic cialis paypal,  tes,  http://gforge.avacs.org/tracker/download.php/9/115/51/283/50cis.html click here,  6304,  http://gforge.avacs.org/tracker/download.php/9/115/52/300/67cis.html order cialis no prescription,  &gt;:(((,  http://gforge.avacs.org/tracker/download.php/9/115/51/271/38cis.html cialis price canada,  vnxrzs,  http://gforge.avacs.org/tracker/download.php/9/115/52/288/55cis.html here,  530,",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T06:33:54",
+      "id" : 3262
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Biotransformation: Hepatic metabolism mainly by CYP3A4. Tadalafil is predominantly metabolized by CYP3A4 to a catechol metabolite. ,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html buy cialis,  =-[,  http://gforge.avacs.org/tracker/download.php/9/115/51/267/34cis.html cialis online prescription,  zfg,  http://gforge.avacs.org/tracker/download.php/9/115/52/287/54cis.html does cialis work on women,  =-PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/282/49cis.html levitra cialis viagra which is better,  46847,  http://gforge.avacs.org/tracker/download.php/9/115/51/280/47cis.html cialis viagra compare,  ywntj,  http://gforge.avacs.org/tracker/download.php/9/115/51/234/1cis.html cialis acquisto on line,  ggou,  http://gforge.avacs.org/tracker/download.php/9/115/51/264/31cis.html here,  %-)),  http://gforge.avacs.org/tracker/download.php/9/115/51/247/14cis.html cialis 20mg tablets,  945051,  http://gforge.avacs.org/tracker/download.php/9/115/51/250/17cis.html here,  997375,  http://gforge.avacs.org/tracker/download.php/9/115/51/278/45cis.html cialis soft pills,  240,  http://gforge.avacs.org/tracker/download.php/9/115/52/299/66cis.html cialis online without prescription,  :-PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/262/29cis.html cialis side effects long term,  %-O,  http://gforge.avacs.org/tracker/download.php/9/115/51/270/37cis.html cialis pricing,  22241,  http://gforge.avacs.org/tracker/download.php/9/115/52/298/65cis.html cialis cost at walmart,  8-))),  http://gforge.avacs.org/tracker/download.php/9/115/51/237/4cis.html buy cialis in mexico,  8PP,  http://gforge.avacs.org/tracker/download.php/9/115/51/275/42cis.html cialis effects on women,  588,  http://gforge.avacs.org/tracker/download.php/9/115/51/281/48cis.html cialis viagra and levitra,  &gt;:-]]],  http://gforge.avacs.org/tracker/download.php/9/115/52/303/70cis.html cheap cialis soft tabs,  008661,  http://gforge.avacs.org/tracker/download.php/9/115/51/242/9cis.html buy cialis 20mg,  mcfj,  http://gforge.avacs.org/tracker/download.php/9/115/51/272/39cis.html cialis professional generic,  803344,  http://gforge.avacs.org/tracker/download.php/9/115/51/283/50cis.html cialis vs viagra which is better,  oxgds,  http://gforge.avacs.org/tracker/download.php/9/115/52/300/67cis.html order cialis no prescription,  fblq,  http://gforge.avacs.org/tracker/download.php/9/115/51/265/32cis.html here,  briecr,  http://gforge.avacs.org/tracker/download.php/9/115/52/288/55cis.html cialis free trial,  =]],",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T06:33:50",
+      "id" : 3261
+   },
+   {
+      "content" : "PNG does not seem to work, I am able to get a preview of it in Thunar, but everywhere else It says that it is not a valid PNG.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.image.save",
+      "datetimeon" : "2008-11-01T19:31:56",
+      "id" : 2332
+   },
+   {
+      "id" : 2333,
+      "datetimeon" : "2008-11-12T08:53:53",
+      "link" : "Surface.set_alpha",
+      "user_title" : "Anonymous",
+      "content" : "Using surface.set_alpha(255, RLE_ACCEL) will greatly speed up per-pixel alpha blitting."
+   },
+   {
+      "content" : "For me, the function returns an empty list, if no intersections were found. In my opinion that's a more consistent behavior.",
+      "user_title" : "Anonymous",
+      "link" : "Rect.collidedictall",
+      "datetimeon" : "2008-11-15T03:44:30",
+      "id" : 2334
+   },
+   {
+      "content" : "I'm using PyGame on Windows Vista to display some shapes and let the user pan around with the mouse. I use pygame.event.wait() to avoid wasting CPU redrawing when nothing is happening. However, I've introduced a Queue from the multiprocessing library. Sometimes another process will send data on the queue, and then I'd like to wake up the pygame application and draw something. I could do this by constantly polling pygame.event.get() and my queue in turn, but it seems wasteful. Is there another way?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.wait",
+      "datetimeon" : "2008-11-20T12:19:54",
+      "id" : 2335
+   },
+   {
+      "datetimeon" : "2008-11-22T08:45:40",
+      "id" : 2336,
+      "content" : "pygame.color.Color(colorname) -&gt; RGBA\nGet RGB values from common color names\n\nThe color name can be the name of a common english color, or a \"web\" style color in the form of 0xFF00FF. The english color names are defined by the standard 'rgb' colors for X11. With the hex color formatting you may optionally include an alpha value, the formatting is 0xRRGGBBAA. You may also specify a hex formatted color by starting the string with a '#'. The color name used is case insensitive and whitespace is ignored.\n\nSee pygame.colordict for a list of colour names.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.Color"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "pygame.color.Color(colorname) -&gt; RGBA\nGet RGB values from common color names\n\nThe color name can be the name of a common english color,\nor a \"web\" style color in the form of 0xFF00FF. The english\ncolor names are defined by the standard 'rgb' colors for X11.\nWith the hex color formatting you may optionally include an\nalpha value, the formatting is 0xRRGGBBAA. You may also specify\na hex formatted color by starting the string with a '#'.\nThe color name used is case insensitive and whitespace is ignored.\n\nSee pygame.colordict for a list of english colour names.",
+      "link" : "pygame.Color",
+      "datetimeon" : "2008-11-22T08:46:48",
+      "id" : 2337
+   },
+   {
+      "link" : "pygame.draw.rect",
+      "user_title" : "Anonymous",
+      "content" : "How to get center of drowed rectangle without math?",
+      "id" : 2338,
+      "datetimeon" : "2008-11-24T08:35:36"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "d",
+      "link" : "pygame.draw.line",
+      "datetimeon" : "2008-12-03T17:58:58",
+      "id" : 2340
+   },
+   {
+      "id" : 2341,
+      "datetimeon" : "2008-12-05T19:14:08",
+      "link" : "pygame.image.save",
+      "user_title" : "Anonymous",
+      "content" : "If you use .PNG (uppercase), it will result in an invalid file (at least on my win32).  Use .png (lowercase) instead."
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "The following groups of patients with cardiovascular disease were not included in clinical safety and efficacy trials for Cialis and therefore the,  http://gforge.avacs.org/tracker/download.php/9/115/51/269/36cis.html cialis online canadian pharmacy,  wge,  http://gforge.avacs.org/tracker/download.php/9/115/51/245/12cis.html cialis 20mg,  &gt;:[[[,  http://gforge.avacs.org/tracker/download.php/9/115/52/301/68cis.html purchase cialis online without prescription,  098,  http://gforge.avacs.org/tracker/download.php/9/115/51/260/27cis.html link,  =OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/236/3cis.html buy cialis brand,  639185,  http://gforge.avacs.org/tracker/download.php/9/115/51/282/49cis.html cialis viagra cheap,  %-OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/235/2cis.html cheap generic cialis,  &gt;:O,  http://gforge.avacs.org/tracker/download.php/9/115/51/252/19cis.html cheapest cialis uk,  8-DDD,  http://gforge.avacs.org/tracker/download.php/9/115/51/280/47cis.html cialis viagra compare,  pkidgr,  http://gforge.avacs.org/tracker/download.php/9/115/52/299/66cis.html cialis online paypal,  oech,  http://gforge.avacs.org/tracker/download.php/9/115/51/263/30cis.html cialis forum,  761959,  http://gforge.avacs.org/tracker/download.php/9/115/52/289/56cis.html generic cialis no prescription,  =-DD,  http://gforge.avacs.org/tracker/download.php/9/115/52/291/58cis.html click here,  =-OO,  http://gforge.avacs.org/tracker/download.php/9/115/51/243/10cis.html buy cialis professional,  &gt;:OOO,  http://gforge.avacs.org/tracker/download.php/9/115/51/281/48cis.html levitra cialis viagra compare,  gks,  http://gforge.avacs.org/tracker/download.php/9/115/52/286/53cis.html discount cialis,  %],  http://gforge.avacs.org/tracker/download.php/9/115/51/258/25cis.html cialis cost walmart,  629,  http://gforge.avacs.org/tracker/download.php/9/115/52/300/67cis.html order cialis,  %P,  http://gforge.avacs.org/tracker/download.php/9/115/51/253/20cis.html cialis 5mg,  8))),  http://gforge.avacs.org/tracker/download.php/9/115/51/265/32cis.html cialis levitra and viagra,  &gt;:((,",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T06:33:46",
+      "id" : 3260
+   },
+   {
+      "id" : 3259,
+      "datetimeon" : "2010-11-24T03:37:24",
+      "link" : "Mask.overlap",
+      "content" : "moderate these Get emergency and  Licensed It amphibians,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work34 tramadol drug class,  55378,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er generic,  %-)),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work72 what is tramadol like,  =),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work71 what is tramadol prescribed for,  =OOO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work49 tramadol in dogs side effects,  fvghe,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work23 tramadol 50mg,  wdcio,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work31 tramadol dosage in cats,  =DDD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work45 tramadol hydrochloride injection,  =-PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work28 tramadol addiction treatment,  thlrtg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work52 tramadol online overnight,  1524,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg dosage,  554949,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work16 order tramadol cod overnight,  %-))),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal how long,  868556,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug abuse,  62387,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work5 buy tramadol now,  37718,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work46 tramadol hydrochloride 50mg,  &gt;:-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work55 tramadol without prescription overnight delivery,  35560,",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "Habituation for Pain for ulcers due to,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work27 tramadol abuse,  :-DDD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work3 buy tramadol cash on delivery,  qge,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol without prescription,  rxv,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work31 tramadol dosage in cats,  %-PPP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work30 tramadol cod online,  :OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work7 buy tramadol online cheap,  piieh,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work58 tramadol withdrawal symptoms,  8((,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 is tramadol a narcotic drug,  819,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work41 tramadol hcl 50 mg tablets,  %],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work65 ultram er mg,  &gt;:-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work10 buy ultram online no prescription,  drtxc,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg side effects,  320,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work15 order tramadol overnight,  :-PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work46 tramadol hydrochloride 50mg,  yptsk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work38 tramadol hci,  3901,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work11 canine tramadol dosage,  ruqzn,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work63 ultram er 300,  47380,",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T03:37:22",
+      "id" : 3257
+   },
+   {
+      "link" : "Mask.overlap",
+      "content" : "Ralivia Erythrocin opioid Warningsat  eeks appetite usually the,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work33 tramadol drug study,  %[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work68 ultram pharmacy,  shq,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work34 tramadol drug forum,  8-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er generic,  125,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work69 ultram side effects,  7549,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol cheap,  kfkeda,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work45 tramadol hydrochloride,  hjk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg high,  459,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work7 buy tramadol online no prescription,  643,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work58 tramadol withdrawal duration,  753,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 is tramadol a narcotic,  3009,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work9 buy ultram overnight,  euz,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal how long,  kbkbbk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50mg side effects,  okgs,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug information,  &gt;:]]],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work57 how long do tramadol withdrawal symptoms last,  gjuglm,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work25 tramadol 50 mg effects,  95229,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work63 ultram er 200 mg,  oya,",
+      "user_title" : "Anonymous",
+      "id" : 3258,
+      "datetimeon" : "2010-11-24T03:37:23"
+   },
+   {
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "g and Tramadol application difficult that mg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work36 tramadol for dogs dose,  =-P,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work68 ultram overnight delivery,  :-DD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work12 cheapest tramadol available online,  &gt;:-((,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work69 ultram tramadol,  201058,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work2 buy tramadol for dogs,  uur,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online,  387734,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg hcl,  44578,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work29 tramadol apap,  634,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 is tramadol a narcotic drug,  225367,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work41 tramadol hcl 50 mg side effects,  1897,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work62 ultram addiction,  261044,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work13 buy cheap tramadol online,  503471,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work21 tramadol 100 mg no prescription,  =-[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work48 tramadol hydrochloride dosage,  8)),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug interactions,  911,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work50 tramadol saturday delivery,  qzpxw,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work57 tramadol withdrawal treatment,  =D,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work11 canine tramadol overdose,  vzbd,",
+      "id" : 3256,
+      "datetimeon" : "2010-11-24T02:39:31"
+   },
+   {
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "Using tablets as barcelona or cellulose but,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work36 tramadol for dogs side effects,  888243,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work54 tramadol rx,  :OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er 100mg,  4726,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 tramadol 180 pills,  imlux,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work43 tramadol hcl apap,  jylchn,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work1 buy tramadol cheap online,  47668,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride acetaminophen,  817,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online,  868941,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg tab,  wcsupr,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work28 tramadol addiction withdrawal,  %-(,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work4 buy tramadol 180,  nzp,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work62 ultram addiction forum,  adg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work52 tramadol online buy,  :OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work59 tramadol no prescription next day,  ami,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg tab,  =-],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work21 tramadol 100mg,  143,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50 mg dosage,  =(,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work63 ultram er 200 mg,  mpqyh,",
+      "id" : 3255,
+      "datetimeon" : "2010-11-24T02:39:24"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "occursPainThe and what You is the signal least vomitinghelp this glycolate reuptake cod,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work12 cheap tramadol free shipping,  824250,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 buy tramadol 180,  =-PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work69 ultram side effects,  vbo,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work73 what is ultram made of,  :PP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work24 tramadol 50 mg effects,  =-)),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work17 purchase ultram online,  302,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online without prescription,  wck,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work30 tramadol cod online,  775,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work65 ultram er narcotic,  oeopi,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work58 tramadol withdrawal syndrome,  43143,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg for dogs,  =-[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work15 order tramadol online without prescription,  53726,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50 mg dosage,  899,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work50 tramadol saturday delivery,  eyyzji,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work46 tramadol hydrochloride and paracetamol,  %-[[[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work20 tramadol high,  wtvu,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work55 tramadol prescription drug,  4178,",
+      "link" : "Mask.overlap",
+      "datetimeon" : "2010-11-24T02:39:19",
+      "id" : 3254
+   },
+   {
+      "datetimeon" : "2010-11-24T01:45:32",
+      "id" : 3252,
+      "content" : "theINN ca pain need is pain Wow is only that,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work36 tramadol for dogs,  zol,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work54 tramadol rx,  795018,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 buy tramadol 180,  397,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work72 what is tramadol for,  :PPP,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work18 cheap tramadol overnight,  81005,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol,  &gt;:-OO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride 200mg,  btdezy,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 ultram online,  uxmxu,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work28 tramadol addiction potential,  =-D,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work37 tramadol ingredients,  wcmyo,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work52 tramadol online pharmacies,  &gt;:]]],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work60 ultram 50mg,  mgtf,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work53 tramadol overdose,  =))),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal symptoms,  nii,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work5 buy tramadol cheap no prescription,  8-),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work35 tramadol er 200,  8-]]],  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work55 tramadol no prescription overnight delivery,  qyqeog,",
+      "user_title" : "Anonymous",
+      "link" : "Mask.overlap"
+   },
+   {
+      "link" : "Mask.overlap",
+      "content" : "whether about discount by methoxyphenyl  Alcohol now,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work12 cheap tramadol free shipping,  &gt;:-OOO,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work33 tramadol drug info,  sxpkt,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work22 tramadol 180 tabs,  vowq,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work8 buy tramadol 100mg,  692,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work18 tramadol cash on delivery,  qiewi,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride high,  ynxx,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work30 tramadol cod online,  :[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work66 buy ultram online without a prescription,  rktiw,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work26 tramadol 50 mg hcl,  &gt;:DD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work10 buy cheap ultram,  514393,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work39 tramadol hcl ingredients,  346388,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work9 buy ultram er,  =[,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal symptoms,  tgb,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work61 ultram drug information,  %),  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work35 tramadol er 200 mg,  =-D,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work25 tramadol 50 mg effects,  ouyo,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work20 side effects tramadol hydrochloride,  bjnhc,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work44 tramadol hcl drug,  637546,",
+      "user_title" : "Anonymous",
+      "id" : 3253,
+      "datetimeon" : "2010-11-24T01:45:42"
+   },
+   {
+      "link" : "Mask.overlap",
+      "content" : "harmful stearate and to ree medications can prescription would,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work64 ultram er price,  mawkzk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work8 buy tramadol without prescription,  3052,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work3 buy tramadol cheap,  udmqmg,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work2 buy tramadol forum,  orcjld,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work19 purchase tramadol cheap,  1602,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work47 tramadol hydrochloride acetaminophen,  nve,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work31 tramadol dosage information,  upwzk,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work17 order ultram without prescription,  ffancj,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work45 tramadol hydrochloride paracetamol,  :-DDD,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work56 tramadol side effects in dogs,  szwol,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work62 ultram dosage,  705145,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work42 tramadol hcl 50mg dosage,  gnyqjc,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work70 ultram withdrawal,  699,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work67 ultram pain medicine,  2829,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work11 canine tramadol dosage,  ogce,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work20 tramadol depression,  5252,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work32 tramadol dosage for humans,  059404,  http://works.music.columbia.edu/dorkbot-wiki/tram?action=AttachFile&amp;amp;do=get&amp;amp;target=work6 buying tramadol online legal,  pnjobn,",
+      "user_title" : "Anonymous",
+      "id" : 3251,
+      "datetimeon" : "2010-11-24T01:45:21"
+   },
+   {
+      "id" : 3241,
+      "datetimeon" : "2010-11-14T13:44:21",
+      "link" : "pygame.event",
+      "user_title" : "Anonymous",
+      "content" : "The modifier is a bit mask, hence for checking a modifier, one should do for instance:\nif e.mod &amp; KMOD_LALT != 0:\n  doSomething()"
+   },
+   {
+      "id" : 3242,
+      "datetimeon" : "2010-11-17T06:52:16",
+      "link" : "pygame.mixer.music.load",
+      "user_title" : "Anonymous",
+      "content" : "Hi , I keep getting this error when I try to load ... \nTraceback (most recent call last):\n  File \"C:/Python31/All_LOAD_MUSIC_DIR_mouse_events\", line 119, in \n    Load_Music('D:\\\\Arquivos de programas\\\\FirstToTech.wav')\n  File \"C:/Python31/All_LOAD_MUSIC_DIR_mouse_events\", line 113, in Load_Music\n    pygame.mixer.music.load(File)\npygame.error: Unable to load WAV file\n      However it loads right with 'pygame.mixer.sound.load(file)'"
+   },
+   {
+      "datetimeon" : "2010-11-18T14:27:01",
+      "id" : 3243,
+      "content" : "Surface.scroll() appears to be deprecated in pygame 1.8.1. What is the replacement?",
+      "user_title" : "Anonymous",
+      "link" : "Surface.scroll"
+   },
+   {
+      "id" : 3244,
+      "datetimeon" : "2010-11-18T19:30:12",
+      "link" : "pygame.mixer.music.play",
+      "content" : "Work Exmpl:\n\npygame.mixer.init(frequency=22050, size=-16, channels=2, buffer=4096)\nsound = pygame.mixer.Sound('Time_to_coffee.wav').play()",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "if you use xrandr and several monitors, it makes goes fullscreen\non the VirtualScreen, meaning - all area of your monitors",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.toggle_fullscreen",
+      "datetimeon" : "2010-11-23T10:54:22",
+      "id" : 3250
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "list = [(1,1),(1,100),(100,1)]\nlol = pygame.draw.lines(Schermo, (255,0,0), True, list, 1)\n\nlol is a pygame.rect and it draw a red triangle (in this case). Closed == True is\nused to represent a closed figure.",
+      "link" : "pygame.draw.lines",
+      "datetimeon" : "2010-10-26T15:18:02",
+      "id" : 3226
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "It looks like numpy/numeric has not been updated for python 3.1.",
+      "link" : "pygame.surfarray",
+      "datetimeon" : "2010-10-26T22:52:40",
+      "id" : 3227
+   },
+   {
+      "content" : "Find the point with the smallest x, the smallest y, the point with the biggest x, and the point with the biggest y.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.polygon",
+      "datetimeon" : "2010-10-28T18:01:56",
+      "id" : 3228
+   },
+   {
+      "datetimeon" : "2010-11-03T21:23:42",
+      "id" : 3231,
+      "user_title" : "Anonymous",
+      "content" : "This seems to be broken:\n\n&gt;&gt;&gt; cursor = pygame.cursors.compile(pygame.cursors.textmarker_strings)\n&gt;&gt;&gt; pygame.mouse.set_cursor(*cursor)\nTraceback (most recent call last):\n  File \"\", line 1, in \nTypeError: function takes exactly 4 arguments (2 given)",
+      "link" : "pygame.cursors"
+   },
+   {
+      "link" : "pygame.draw.polygon",
+      "user_title" : "Anonymous",
+      "content" : "HOW DOES EACH COORDINATE WORK",
+      "id" : 3237,
+      "datetimeon" : "2010-11-10T22:03:09"
+   },
+   {
+      "link" : "pygame.midi.midis2events",
+      "user_title" : "Anonymous",
+      "content" : "# A slightly more readable midis2events. More parsing can be done, but I didn't\n# need to...\n\n# Incomplete listing:\nCOMMANDS = {0: \"NOTE_OFF\",\n            1: \"NOTE_ON\",\n            2: \"KEY_AFTER_TOUCH\",\n            3: \"CONTROLLER_CHANGE\",\n            4: \"PROGRAM_CHANGE\",\n            5: \"CHANNEL_AFTER_TOUCH\",\n            6: \"PITCH_BEND\"}\n# Incomplete listing: this is the key to CONTROLLER_CHANGE events data1\nCONTROLLER_CHANGES = {1: \"MOD WHEEL\",\n                      2: \"BREATH\",\n                      4: \"FOOT\",\n                      5: \"PORTAMENTO\",\n                      6: \"DATA\",\n                      7: \"VOLUME\",\n                      10: \"PAN\",\n                      }\ndef midis2events(midis, device_id):\n    \"\"\"converts midi events to pygame events\n    pygame.midi.midis2events(midis, device_id): return [Event, ...]\n\n    Takes a sequence of midi events and returns list of pygame events.\n    \"\"\"\n    evs = []\n    for midi in midis:\n        \n        ((status,data1,data2,data3),timestamp) = midi\n        if status == 0xFF:\n            # pygame doesn't seem to get these, so I didn't decode\n            command =  \"META\"\n            channel = None\n        else:\n            try:\n                command = COMMANDS[ (status &amp; 0x70) &gt;&gt; 4]\n            except:\n                command = status &amp; 0x70\n            channel = status &amp; 0x0F\n        e = pygame.event.Event(pygame.midi.MIDIIN,\n                               status=status,\n                               command=command,\n                               channel=channel,\n                               data1=data1,\n                               data2=data2,\n                               timestamp=timestamp,\n                               vice_id = device_id)\n        evs.append( e )\n    return evs",
+      "id" : 3223,
+      "datetimeon" : "2010-10-21T17:27:00"
+   },
+   {
+      "id" : 3207,
+      "datetimeon" : "2010-09-18T22:12:15",
+      "link" : "Rect.co",
+      "user_title" : "Anonymous",
+      "content" : "."
+   },
+   {
+      "content" : "It is posible to get the size of a font.Sysfont??? \n\nif is possible , how can it be done??",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.SysFont",
+      "datetimeon" : "2010-09-23T13:04:50",
+      "id" : 3209
+   },
+   {
+      "id" : 3212,
+      "datetimeon" : "2010-10-02T22:23:36",
+      "link" : "pygame.draw.circle",
+      "content" : "Yeah, it is true. That code is the most horrible stuff I've seen in years. But if you run it, it's quite fun! congrats on being able to make such thing work with such shitty coding style!",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 3213,
+      "datetimeon" : "2010-10-04T16:00:48",
+      "link" : "pygame.draw.polygon",
+      "content" : "No idea...",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 3214,
+      "datetimeon" : "2010-10-05T15:23:38",
+      "link" : "pygame.draw.ellipse",
+      "content" : "How do I check if an ellipse has collided?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.locals",
+      "user_title" : "Anonymous",
+      "content" : "plz don't remove this spam",
+      "id" : 3216,
+      "datetimeon" : "2010-10-11T22:51:05"
+   },
+   {
+      "datetimeon" : "2010-10-14T21:17:06",
+      "id" : 3217,
+      "content" : "how can a draw a an eclipse of the moon?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.arc"
+   },
+   {
+      "content" : "ÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀhhhhhhhhhhhhhhhhhm??????????????????hÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀ??????\n^^\n^^\n^^",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.pump",
+      "datetimeon" : "2010-10-16T04:14:42",
+      "id" : 3219
+   },
+   {
+      "datetimeon" : "2010-10-16T23:19:58",
+      "id" : 3220,
+      "content" : "Clock.tick allows requesting an upper limit to the framerate, time.delay pauses for a period of time.",
+      "user_title" : "Anonymous",
+      "link" : "Clock.tick"
+   },
+   {
+      "link" : "pygame.mixer.music.get_busy",
+      "content" : "Yes, I've got the same problem. It only returns false when the music has been stopped, or no music has been loaded.\nMaybe there should be an is_paused() method...",
+      "user_title" : "Anonymous",
+      "id" : 3221,
+      "datetimeon" : "2010-10-17T19:35:23"
+   },
+   {
+      "id" : 3193,
+      "datetimeon" : "2010-08-16T05:27:42",
+      "link" : "pygame.event.post",
+      "content" : "I also wondered if it was threadsafe, but since it has a max capacity and doesn't block when full it's probably unusable anyway.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2010-08-17T14:42:51",
+      "id" : 3194,
+      "user_title" : "Anonymous",
+      "content" : "\"image\" I think is the missing one, I think.",
+      "link" : "pygame.init"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "what's the difference between using Clock.tick and time.delay to limit the framerate?",
+      "link" : "Clock.tick",
+      "datetimeon" : "2010-08-27T09:12:11",
+      "id" : 3198
+   },
+   {
+      "datetimeon" : "2010-08-30T13:52:49",
+      "id" : 3199,
+      "user_title" : "Anonymous",
+      "content" : "The only way I could check for something like ALT + c is with the following code :\n\nif e.key == K_c and e.mod == KMOD_LALT|4096:\n   self.doSomething()",
+      "link" : "pygame.event"
+   },
+   {
+      "datetimeon" : "2010-09-07T17:26:27",
+      "id" : 3202,
+      "user_title" : "Anonymous",
+      "content" : "The below example is a bit redundant (and forgets that pygame.transform.rotate returns the rotated surface, it doesn't transform in place).\n\nYou can simply write it thusly:\n\ndef __init__(self, image, startangle):\n    ...\n    self.original = image\n    self.rotate(startangle)\ndef rotate(self, angle):\n    self.image = pygame.transform.rotate(self.original, angle)",
+      "link" : "pygame.transform.rotate"
+   },
+   {
+      "datetimeon" : "2008-12-16T07:37:49",
+      "id" : 2356,
+      "user_title" : "Anonymous",
+      "content" : "Thanks for the full program listings in the comments section guys. Very, very useful, and not at all annoying. Well done!\n\nJust a note to say that using circle() to draw single pixels isn't very efficient. Try Pixelarray for fast pixel drawing.",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "datetimeon" : "2008-12-27T06:40:14",
+      "id" : 2357,
+      "content" : "That fix doesn't allow for diagonal lines!  I have the same issue.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.aaline"
+   },
+   {
+      "id" : 2358,
+      "datetimeon" : "2008-12-28T23:56:57",
+      "link" : "pygame.movie",
+      "content" : "'Warning: picture block before sequence header block' I get this error and no video when I used the code by Jordan. The sound plays but no music. Please help.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 2359,
+      "datetimeon" : "2008-12-28T23:59:39",
+      "link" : "pygame.movie",
+      "user_title" : "Anonymous",
+      "content" : "Never mind got it to work."
+   },
+   {
+      "id" : 2361,
+      "datetimeon" : "2009-01-03T01:13:27",
+      "link" : "pygame.movie",
+      "user_title" : "Anonymous",
+      "content" : "How do you get the video to fill any given screen? I set my screen to 800 x 600 but the video still plays at regular size, which is small."
+   },
+   {
+      "link" : "pygame.display.set_caption",
+      "content" : "you need to have \"title\"",
+      "user_title" : "Anonymous",
+      "id" : 3190,
+      "datetimeon" : "2010-08-10T04:48:59"
+   },
+   {
+      "link" : "pygame.display",
+      "user_title" : "Anonymous",
+      "content" : "i have tried pygame.display.set_mode biut i found an errorr \nof un declared 'pygame'",
+      "id" : 3192,
+      "datetimeon" : "2010-08-12T01:36:30"
+   },
+   {
+      "content" : "I wrote up a program to play a movie, and it works fine on my Vista laptop.\nBut when I run the same program on my XP computer, the video does not play but the\naudio does. It is the same problem I had when I converted the video wrong. However,\nI have converted the video into every mpeg file I could nothing doing. Any ideas?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.movie",
+      "datetimeon" : "2009-01-06T19:51:38",
+      "id" : 2363
+   },
+   {
+      "datetimeon" : "2009-01-06T23:37:01",
+      "id" : 2364,
+      "user_title" : "Anonymous",
+      "content" : "This supports tracked music, including MOD and XM. That may not be obvious to\nsome people. (It wasn't to me, anyway, until someone on the mailing list pointed\nit out!)",
+      "link" : "pygame.mixer.music"
+   },
+   {
+      "link" : "Surface.blit",
+      "content" : "Take care to protect 'blit' calls when using different threads that draw the same \nimage (i.e. Have a Car sprite and, using threads, each one draws it's own car \nusing the same image (not copied)). 'Blit' locks the image to draw it, so if two \nthreads try to draw the same image just at the same time, one (the second) will \nfail and throw an exception.\n\nOne way to avoid this could be using 'threading.Condition(threading.Lock())'\nfunctions from threading.",
+      "user_title" : "Anonymous",
+      "id" : 2365,
+      "datetimeon" : "2009-01-07T12:05:49"
+   },
+   {
+      "datetimeon" : "2010-08-07T18:09:47",
+      "id" : 3186,
+      "user_title" : "Anonymous",
+      "content" : "is there anyway to rotate?",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "content" : "Is there any way i can have a window with frames that is not resizable?\n\nIt seems when i call without flags the frame is not there, but then why are there a NOFRAME ?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.set_mode",
+      "datetimeon" : "2010-08-08T10:06:11",
+      "id" : 3187
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "@myself on August 8, 2010 10:06am\n\nset flags to 0 for no resize with frame.",
+      "link" : "pygame.display.set_mode",
+      "datetimeon" : "2010-08-08T11:22:41",
+      "id" : 3188
+   },
+   {
+      "datetimeon" : "2009-01-15T11:23:59",
+      "id" : 2369,
+      "user_title" : "Anonymous",
+      "content" : "Event constants are pygame..  For example \"pygame.MOUSEMOTION\".",
+      "link" : "pygame.event"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "The target surface is first filled with diff_color.\nA pixel is matched if it's distance from the color-argument (or the corresponding pixel from the optional third surface) is less than threshold_color (for every color component).\nIf a pixel is matched, it will be set to color.\nThe number of matched pixels is returned.\n\nSo, if color = (255,0,0), and threshold_color = (10,10,10), any pixel with value (r&gt;245, g&lt;10, b&lt;10) will be matched.",
+      "link" : "pygame.transform.threshold",
+      "datetimeon" : "2009-01-15T11:36:11",
+      "id" : 2370
+   },
+   {
+      "datetimeon" : "2009-01-19T19:15:39",
+      "id" : 2371,
+      "content" : "The docs say not to use event ids above NUMEVENTS, but in Pygame 1.8.1\nsince USEREVENT is 24 and NUMEVENTS is 32. This means only 8 user\nevents are possible. (Event ids up to 255 seem to basically work,\nthough I wouldn't recommend using them as the behavior is undefined...above\n255 causes strange things to happen. For example, 256 is stored as \"0-NoEvent\".)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.Event"
+   },
+   {
+      "link" : "pygame.cursors.load_xbm",
+      "content" : "\"pygame.cursors.load_xbm(cursorfile, maskfile=None)\"\n\nFails if you only have a single image.\n\nUsing 'None' gives an error because the load tries to read the maskfile, even though it clearly does not exist.\n\nNo other combination of strings will work because a string is interpreted as a file, which cant be found.\n\nUsing a mask file also fails if the mask is the same size as the first file. Ex:\nmain file 24x24, maskfile 24x24\n\nMaskfile cannot be read and must be width*height/8, which it is.\n\nHelp anyone?",
+      "user_title" : "Anonymous",
+      "id" : 2373,
+      "datetimeon" : "2009-01-27T17:33:27"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Key object can't get chinese character?\nFor example, I type \"�?ãº�?\", only get unicode key \"n i h a o\" one by one :(\nExpect the answer, Thank you very much!\nemail:jackerme@163.com",
+      "link" : "pygame.key",
+      "datetimeon" : "2009-02-05T05:14:50",
+      "id" : 2374
+   },
+   {
+      "id" : 2375,
+      "datetimeon" : "2009-02-06T15:54:56",
+      "link" : "pygame.cursors",
+      "user_title" : "Anonymous",
+      "content" : "if you use this:\n.cursor\n\nyou will get an error \"no such moudule\"\n\nso you need to do:\n.cursors(add the s )"
+   },
+   {
+      "id" : 2377,
+      "datetimeon" : "2009-02-07T21:57:49",
+      "link" : "pygame.sprite.LayeredUpdates",
+      "content" : "Note document error. The correct attribute is _layer, as in sprite._layer.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 2378,
+      "datetimeon" : "2009-02-09T11:41:09",
+      "link" : "pygame.mouse.set_cursor",
+      "user_title" : "Anonymous",
+      "content" : "Here's the default windows cursor (white with black outline):\npygame.mouse.set_cursor((16, 19), (0, 0), (128, 0, 192, 0, 160, 0, 144, 0, 136, 0, 132, 0, 130, 0, 129, 0, 128, 128, 128, 64, 128, 32, 128, 16, 129, 240, 137, 0, 148, 128, 164, 128, 194, 64, 2, 64, 1, 128), (128, 0, 192, 0, 224, 0, 240, 0, 248, 0, 252, 0, 254, 0, 255, 0, 255, 128, 255, 192, 255, 224, 255, 240, 255, 240, 255, 0, 247, 128, 231, 128, 195, 192, 3, 192, 1, 128))"
+   },
+   {
+      "content" : "Have one thread waiting on your pygame events and another waiting on your Queue,\nthen have either thread able to wake up your main thread when anything happens.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.wait",
+      "datetimeon" : "2009-02-09T23:34:49",
+      "id" : 2379
+   },
+   {
+      "datetimeon" : "2009-02-10T21:36:28",
+      "id" : 2380,
+      "content" : "hvjfjb",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font"
+   },
+   {
+      "datetimeon" : "2009-02-10T21:39:04",
+      "id" : 2381,
+      "content" : "hgjnyhh",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.match_font"
+   },
+   {
+      "id" : 2382,
+      "datetimeon" : "2009-02-10T21:40:17",
+      "link" : "pygame.font.match_font",
+      "user_title" : "Anonymous",
+      "content" : "sysfont = pygame.font.SysFont(None, 80)"
+   },
+   {
+      "link" : "Surface.set_at",
+      "user_title" : "Anonymous",
+      "content" : "eyrczbhv ncws tyozaj ywkztleo uelxjpzm yrgjdbuim epnr",
+      "id" : 2383,
+      "datetimeon" : "2009-02-15T04:18:39"
+   },
+   {
+      "datetimeon" : "2009-02-18T08:06:12",
+      "id" : 2385,
+      "user_title" : "Anonymous",
+      "content" : "for example, if you want to be sure that your game to run 30 frames per second you can use tick in your main look like this:\n\nwhile 1:   \n  for event in pygame.event.get():\n    #manage your events here\n  #update your sprites here\n  screen.blit(...) #draw to screen\n  pygame.display.flip()\n  clock.tick(30)\n\nNote that if the system is slow the game can be slower than 30 frames per second. But using tick(X) you can be sure that the game will naver be greater than X frames per second\n\nsgurin",
+      "link" : "Clock.tick"
+   },
+   {
+      "datetimeon" : "2009-02-24T22:22:16",
+      "id" : 2386,
+      "user_title" : "Anonymous",
+      "content" : "#Dibujar Arco/ Draw Arc, claro hay que importar la libreria math\npygame.draw.arc(background, (0, 0, 0), ((5, 150), (100, 100)), 0, math.pi/2, 5)",
+      "link" : "pygame.draw.arc"
+   },
+   {
+      "id" : 3179,
+      "datetimeon" : "2010-08-01T14:56:26",
+      "link" : "pygame.scrap.lost",
+      "user_title" : "Anonymous",
+      "content" : "You are right. There is contradition."
+   },
+   {
+      "id" : 3180,
+      "datetimeon" : "2010-08-01T17:47:22",
+      "link" : "pygame.transform.flip",
+      "content" : "The last comment was spam!",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "you suck... this doesn't work",
+      "user_title" : "Anonymous",
+      "link" : "pygame.image.load",
+      "datetimeon" : "2009-03-05T20:05:44",
+      "id" : 2390
+   },
+   {
+      "content" : "this just returns 'unknown key'?\n\nfor example:\n&gt;&gt;&gt; pygame.key.(pygame.locals.K_a)\n'unknown key'",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key.name",
+      "datetimeon" : "2009-03-06T02:10:17",
+      "id" : 2391
+   },
+   {
+      "datetimeon" : "2009-03-06T02:11:12",
+      "id" : 2392,
+      "user_title" : "Anonymous",
+      "content" : "comment below:\ni of course used pygame.key.name\n\n&gt;&gt;&gt; pygame.__version__\n'1.8.1release'",
+      "link" : "pygame.key.name"
+   },
+   {
+      "id" : 2394,
+      "datetimeon" : "2009-03-06T16:06:53",
+      "link" : "pygame.event",
+      "user_title" : "Anonymous",
+      "content" : "How do we actually use the event.dict method?"
+   },
+   {
+      "datetimeon" : "2010-07-28T23:36:59",
+      "id" : 3176,
+      "user_title" : "Anonymous",
+      "content" : "I get a SegFault while running this command",
+      "link" : "PixelArray.surface"
+   },
+   {
+      "content" : "00",
+      "user_title" : "Anonymous",
+      "link" : "pygame",
+      "datetimeon" : "2009-03-14T06:46:46",
+      "id" : 2396
+   },
+   {
+      "content" : "If you want a 'cheap' antialiased circle, calculate all the points \non a circle using sin/cos, then plot each point as an antialiased polygon. \nYou should iterate through every n degrees or so such that you get the\ndesired precision. 10 degrees is good enough for small circles.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.circle",
+      "datetimeon" : "2009-03-14T17:06:11",
+      "id" : 2397
+   },
+   {
+      "datetimeon" : "2010-07-26T22:31:36",
+      "id" : 3174,
+      "content" : "Can someone tell me the list of all pygame attributes in this module?\n-DragonReeper",
+      "user_title" : "Anonymous",
+      "link" : "pygame.locals"
+   },
+   {
+      "datetimeon" : "2010-07-27T15:01:13",
+      "id" : 3175,
+      "user_title" : "Anonymous",
+      "content" : "Addressing note: columns first, then rows.  Not the other way around.",
+      "link" : "pygame.PixelArray"
+   },
+   {
+      "datetimeon" : "2010-07-20T19:21:24",
+      "id" : 3167,
+      "user_title" : "Anonymous",
+      "content" : "Works for me.",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "id" : 3170,
+      "datetimeon" : "2010-07-26T01:42:29",
+      "link" : "pygame.event.get",
+      "content" : "pygame.init()\npygame.display.set_caption('IP camera test')",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.event.get",
+      "content" : "pygame.init()\npygame.display.set_caption('IP camera test')",
+      "user_title" : "Anonymous",
+      "id" : 3171,
+      "datetimeon" : "2010-07-26T01:42:47"
+   },
+   {
+      "link" : "pygame.locals",
+      "content" : "Please remove this spam",
+      "user_title" : "Anonymous",
+      "id" : 3173,
+      "datetimeon" : "2010-07-26T22:30:43"
+   },
+   {
+      "id" : 3166,
+      "datetimeon" : "2010-07-18T22:31:59",
+      "link" : "pygame.movie",
+      "user_title" : "Anonymous",
+      "content" : "Some demo code that will play a movie and not spin the processor. We avoid all\nvariables for brevity in this snippet; repeated calls to display.set_mode work\nfine; the argument to time.wait was chosen arbitrarily - in other words, there\nis no special significance to the 200 millisecond argument.\n\npygame.display.init ()\npygame.display.set_mode ((800, 600))\nmovie = pygame.movie.Movie ('intro.mpg')\nmovie_resolution = movie.get_size ()\npygame.display.set_mode (movie_resolution)\nmovie.set_display (pygame.display.get_surface ())\nmovie.play ()\nwhile movie.get_busy ():\n    pygame.time.wait (200)"
+   },
+   {
+      "datetimeon" : "2010-07-14T18:57:26",
+      "id" : 3164,
+      "user_title" : "Anonymous",
+      "content" : "The word is spelled \"original\"",
+      "link" : "Rect.copy"
+   },
+   {
+      "datetimeon" : "2010-07-16T10:55:04",
+      "id" : 3165,
+      "content" : "If .png file has a color index (like .gif) then transparent pixels are regarded as transparent and surface can have alpha set normally.\neg.\nimage = pygame.load('image.png).convert()\nimage.set_alpha(50)",
+      "user_title" : "Anonymous",
+      "link" : "Surface.set_alpha"
+   },
+   {
+      "datetimeon" : "2010-07-12T12:38:36",
+      "id" : 3162,
+      "user_title" : "Anonymous",
+      "content" : "Multiple Windows possible with multiple processes, see:\nhttp://archives.seul.org/pygame/users/Jun-2007/msg00292.html",
+      "link" : "pygame.display.set_mode"
+   },
+   {
+      "link" : "Rect.colliderect",
+      "user_title" : "Anonymous",
+      "content" : "Thank you, your very succinct code looks nice :D\n\nNote that the image needs an underscore: _\n\nThanks again, your code works nicely",
+      "id" : 3155,
+      "datetimeon" : "2010-07-05T02:17:35"
+   },
+   {
+      "link" : "pygame.font.SysFont",
+      "user_title" : "Anonymous",
+      "content" : "It means the name of the font, such as 'Arial'. It needs to be a string.",
+      "id" : 3157,
+      "datetimeon" : "2010-07-05T19:15:05"
+   },
+   {
+      "link" : "pygame.display.init",
+      "user_title" : "Anonymous",
+      "content" : "Could anyone make an example code to resize the window itself as well as the\ndisplay? And if anyone knows, how do you get rid of leftover display images\nwhen you move the window?",
+      "id" : 3158,
+      "datetimeon" : "2010-07-05T19:39:28"
+   },
+   {
+      "id" : 3160,
+      "datetimeon" : "2010-07-10T14:26:52",
+      "link" : "Rect.collidelistall",
+      "content" : "Do not use pygame.Rect.collidelistall()!",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Rect.collidedict",
+      "content" : "Looking at the code, it appears it takes a second parameter which, if true, the function will behave as stated. I think this applies to collidedictall also.",
+      "user_title" : "Anonymous",
+      "id" : 3148,
+      "datetimeon" : "2010-06-20T20:34:24"
+   },
+   {
+      "content" : "What is the offset here?",
+      "user_title" : "Anonymous",
+      "link" : "Mask.draw",
+      "datetimeon" : "2010-06-21T15:27:04",
+      "id" : 3149
+   },
+   {
+      "content" : "this doesnt WORK! i hate pygame",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2010-06-24T10:51:45",
+      "id" : 3150
+   },
+   {
+      "id" : 3152,
+      "datetimeon" : "2010-07-02T11:47:08",
+      "link" : "Rect.move",
+      "user_title" : "Anonymous",
+      "content" : "Why not just use Rect.copy?"
+   },
+   {
+      "id" : 2409,
+      "datetimeon" : "2009-03-31T13:42:56",
+      "link" : "pygame.PixelArray",
+      "content" : "This slicing didn't work for me - pygame said it wanted an integer, not a tuple.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2009-04-03T11:52:08",
+      "id" : 2410,
+      "content" : "I was getting odd results with the default syntax of:\n  pygame.draw.arc(screen, color, rect, angle1,  angle2)\n\nWhere angle1 &lt; angle2.\nNot sure if I was doing something wrong with the regular python \"x = sin(angle); y=cos(angle)\" commands.\nBut I found that reversing the angles worked well, like this:\n  pygame.draw.arc(screen, color, rect, (math.pi * 2.0) - angle2,  (math.pi * 2.0) - angle1)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.arc"
+   },
+   {
+      "datetimeon" : "2009-04-06T00:53:38",
+      "id" : 2412,
+      "content" : "lulz",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key.name"
+   },
+   {
+      "id" : 3120,
+      "datetimeon" : "2010-05-16T07:25:43",
+      "link" : "Surface.blit",
+      "content" : "image_filename = \"image.png\"\nimage_surface = pygame.image.load(image_filename)\ntarget_surface.blit(image_surface,(10,10))",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "Oh, sorry.\n\nimage_filename = \"image.png\"\nimage_surface = pygame.image.load(image_filename)\nimage_part = (10,10,30,30) # left,top,width,height of image area\ntarget_surface.blit(image_surface,(10,10),image_part)",
+      "user_title" : "Anonymous",
+      "link" : "Surface.blit",
+      "datetimeon" : "2010-05-16T07:27:23",
+      "id" : 3121
+   },
+   {
+      "id" : 2909,
+      "datetimeon" : "2009-08-09T13:48:59",
+      "link" : "pygame.image.load",
+      "user_title" : "Anonymous",
+      "content" : "Here is a simple class for the sprites management:\n\nclass Sprite:\n\tdef __init__(self):\n\t\tself.img = None\n\t\tself.pos = [0, 0]\n\t\tself.colorkey = [0, 0, 0]\n\t\tself.alpha = 255\n\tdef load(self, filename):\n\t\ttry:\n\t\t\tself.img = pygame.image.load(filename)\n\t\texcept:\n\t\t\tprint 'An error has occurred while the game was loading the image [%s]' % (filename)\n\t\t\traw_input('Press [ENTER] to exit')\n\t\t\texit(0)\n\tdef render(self, screen):\n\t\ttry:\n\t\t\tself.img.set_colorkey(self.colorkey)\n\t\t\tself.img.set_alpha(self.alpha)\n\t\t\tscreen.blit(self.img, self.pos)\n\t\t\tpygame.display.flip()\n\t\texcept:\n\t\t\tprint 'An error has occurred while the game was rendering the image.'\n\t\t\traw_input('Press [ENTER] to exit')\n\t\t\texit(0)"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "This method can be used to effectively \"erase\" a portion of an alpha-enabled\nsurface by filling an area with pure white using a blend mode of BLEND_RGBA_SUB:\n\nFirst, make a new alpha-enabled surface.\n&gt;&gt;&gt; surf = Surface((100,100), SRCALPHA)\n\nFill it with some color.\n&gt;&gt;&gt; surf.fill((255,255,255,255))\n\nNow, you can put a hole in the center 1/3 of it like this:\n&gt;&gt;&gt; area = Rect(33,33,33,33)\n&gt;&gt;&gt; surf.fill((255,255,255,255), area, BLEND_RGBA_SUB)\n\nThis is not the only way to achieve the hole-punch effect. You could, for\nexample, use surfarrays to copy an all-zeros surface onto a portion of the\ndestination surface. There are benefits to doing it either way.",
+      "link" : "Surface.fill",
+      "datetimeon" : "2010-05-17T05:37:27",
+      "id" : 3122
+   },
+   {
+      "link" : "LayeredDirty.get_clip",
+      "user_title" : "Anonymous",
+      "content" : "The doc string here, \"clip the area where to draw. Just pass None (default) to reset the clip\", seems like a cut &amp; paste error from set_clip()",
+      "id" : 2416,
+      "datetimeon" : "2009-04-14T23:39:57"
+   },
+   {
+      "id" : 2417,
+      "datetimeon" : "2009-04-16T02:37:36",
+      "link" : "pygame.transform.scale",
+      "user_title" : "Anonymous",
+      "content" : "I've found that\n\npygame.transform.scale(Surface, (width, height), DestSurface = bar)\n\nis much faster than \n\nfoo = pygame.transform.scale(Surface, (width, height))\nbar.blit(foo, (0, 0))"
+   },
+   {
+      "datetimeon" : "2009-07-28T13:13:49",
+      "id" : 2895,
+      "user_title" : "Anonymous",
+      "content" : "What is the meta key? I assumed that it was the windows key, but that doesn't work. Maybe because I'm on a Linux OS.",
+      "link" : "pygame.key"
+   },
+   {
+      "id" : 3116,
+      "datetimeon" : "2010-05-03T12:13:25",
+      "link" : "pygame.image.tostring",
+      "content" : "As for \"BGR\" (OpenCV): Just use \"RBG\" but reverse the string first\nand then flip the surface (vertically and horizontally).\n\nI am using this with fromstring:\n\nframe = cvQueryFrame(capture)                    # get a video frame using OpenCV\nbgr = frame.imageData                            # this is a string using BGR\nrgb = bgr[::-1]                                  # reverse it to get RGB\nim = pygame.image.fromstring(rgb, size, 'RGB')   # create pygame surface\nim = pygame.transform.flip(im, True, True)       # flip it",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.display.set_mode",
+      "content" : "Only takes ordered parameters, not named ones.\n\nTypeError: set_mode() takes no keyword arguments",
+      "user_title" : "Anonymous",
+      "id" : 3118,
+      "datetimeon" : "2010-05-06T04:45:36"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "pygame.event.peek can be used for managing the quit code for a program: \n   if pygame.event.peek(QUIT):\n     sys.exit()\nI spent lots of time trying to find a way to get my code to exit. \nThis is the first working method that I've found.\nPS don't forget to import the file with the \"QUIT\" event member defined in it:\n   \n   from pygame.locals import *",
+      "link" : "pygame.event.peek",
+      "datetimeon" : "2010-04-26T01:28:12",
+      "id" : 3111
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "to make a surface transparent use:\n\nsurface = pygame.Surface((10,10))\nsurface.fill((255,0,255))\nsurface.set_colorkey((255,0,255))\n\nthis should make a transparent surface",
+      "link" : "pygame.Surface",
+      "datetimeon" : "2010-04-28T04:26:15",
+      "id" : 3112
+   },
+   {
+      "datetimeon" : "2010-05-02T16:52:56",
+      "id" : 3114,
+      "content" : "\"BGR\" would be nice because OpenCV 2.1 uses such a format.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.image.tostring"
+   },
+   {
+      "link" : "pygame.mixer.music.rewind",
+      "user_title" : "Anonymous",
+      "content" : "*please note that this does not restart the counter for pygame.mixer.music.get_pos()*\n\ni didnt realize this at first",
+      "id" : 3115,
+      "datetimeon" : "2010-05-02T19:33:36"
+   },
+   {
+      "link" : "pygame.transform.rotate",
+      "content" : "using pygame.transform.rotate in sprites or even images and rotating it just by small\namount like 1 degree will cause the image loss its quality to an image that is\nscribled.\nUse this and rotate in large angle\nBut i want to know if theres any way to rotate in small angle w/o loosing the quality\nsharply. Small quality lost is ok but sharp reduction in quality is not",
+      "user_title" : "Anonymous",
+      "id" : 3108,
+      "datetimeon" : "2010-04-20T09:47:58"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "A good idea in rotating in small angles is to restore the image or sprite to its\noriginal picture for example:\n\ndef __init__(self)\n    ...\n    self.original=self.image\n    self.image=pygame.transform.rotate(self.image,self.angle)\ndef rotate(self,angle)\n    self.image=self.original\n    pygame.transform.rotate(self.image,angle)\n\nbut in exchange it will eat more pc usage and memory usage but youll have \nalmost 90% better than rotating the image again and again so you have to choose\nwhether speed or quality",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2010-04-20T11:04:57",
+      "id" : 3109
+   },
+   {
+      "content" : "How to draw a part of the picture to a surface?",
+      "user_title" : "Anonymous",
+      "link" : "Surface.blit",
+      "datetimeon" : "2010-04-25T02:28:58",
+      "id" : 3110
+   },
+   {
+      "link" : "pygame.event.post",
+      "user_title" : "Anonymous",
+      "content" : "gfuksvgfkugfklgbdkcbdigbfdukvfhiufdhvnkdfhnfgbdfhngdghuisoduhgihgl bhghphphdghhdggghsldfhgodghbihfghhgfhlughfdlghdlhgfihhihduh",
+      "id" : 3105,
+      "datetimeon" : "2010-04-15T20:13:58"
+   },
+   {
+      "datetimeon" : "2010-04-19T04:39:11",
+      "id" : 3107,
+      "content" : "Instead of using transform.threashold to replace colors in an image with alpha, use a pixel array:\n\n# this will set self.image with a white version of self.orginalimg, but with alpha.\n            thresholded = pygame.surface.Surface((32, 32), SRCALPHA)\n            thresholded.blit(self.orginalimg, (0,0))\n            pxarray = pygame.PixelArray (thresholded)\n            for x in range(32):\n                for y in range(32):\n                    if pygame.Color(pxarray[x][y]).a &lt; 255:\n                        pxarray[x][y] = pygame.Color(255,255,255,255)\n            self.image = pxarray.surface",
+      "user_title" : "Anonymous",
+      "link" : "pygame.transform.threshold"
+   },
+   {
+      "id" : 3102,
+      "datetimeon" : "2010-04-14T13:28:54",
+      "link" : "pygame.display.list_modes",
+      "user_title" : "Anonymous",
+      "content" : "Example output:\n&gt;&gt;&gt; pygame.display.list_modes()\n[(1920, 1080), (1768, 992), (1680, 1050), (1600, 1200), (1600, 1024), (1600, 900\n), (1440, 900), (1400, 1050), (1360, 768), (1280, 1024), (1280, 960), (1280, 800\n), (1280, 768), (1280, 720), (1152, 864), (1024, 768), (800, 600), (720, 576), (\n720, 480), (640, 480)]"
+   },
+   {
+      "link" : "pygame.quit",
+      "user_title" : "Anonymous",
+      "content" : "game www.699le.com",
+      "id" : 3103,
+      "datetimeon" : "2010-04-15T06:18:45"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "It seems it needs a rect and an image attribute in each sprite to know where to blit and what to blit.\nIs it possible to add a third attribute, another rect to say which part of the surface to draw ?\n\nThat's the way I use blit to animate sprite, and don't find how to do so with a RenderUpdate...",
+      "link" : "pygame.sprite.RenderUpdates",
+      "datetimeon" : "2010-04-15T15:48:17",
+      "id" : 3104
+   },
+   {
+      "id" : 3095,
+      "datetimeon" : "2010-04-05T11:58:04",
+      "link" : "Font.render",
+      "content" : "I've found that rendering text over the transparent part of a color-keyed surface \ntends to look pretty bad. Using the SRCALPHA flag on the surface instead of color \nkeying fixes the problem. Also note, don't render your text every frame! Store \nyour surfaces between frames and simply re-blit them. Only re-render your \nsurfaces when such is necessary.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "If you have trigger buttons, like on a 360 controller, and you press them both at the same time, get_axis will return a value of -3 afterwards as the default value (as opposed to 0).",
+      "user_title" : "Anonymous",
+      "link" : "Joystick.get_axis",
+      "datetimeon" : "2010-04-06T12:41:07",
+      "id" : 3096
+   },
+   {
+      "datetimeon" : "2010-04-08T02:58:20",
+      "id" : 3098,
+      "user_title" : "Anonymous",
+      "content" : "Apparently not.",
+      "link" : "Group.has"
+   },
+   {
+      "id" : 3100,
+      "datetimeon" : "2010-04-12T17:16:50",
+      "link" : "pygame.image.load",
+      "user_title" : "Anonymous",
+      "content" : "If you want your file to be opened you shoud make sure that the image is in the same directory as the program.\nThen its very simple:\n\n#Everything I put in [] is that you can choose the name\n&gt;&gt;&gt; [image_name] = pygame.image.load(os.path.join('file_name'))\n&gt;&gt;&gt; screen.blit([image_name], ([Xposition],[Yposition]))\n\nmake sure that 'file_name' it's written with no mistakes =)"
+   },
+   {
+      "content" : "pygame.time cannot be initialized. that means you can't use pygame.time.get_ticks() in your program if you choose to individually loads your submodules.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.init",
+      "datetimeon" : "2009-08-16T18:10:41",
+      "id" : 2919
+   },
+   {
+      "datetimeon" : "2010-03-29T15:03:49",
+      "id" : 3090,
+      "user_title" : "Anonymous",
+      "content" : "How to create a surface that is entirely transparent?",
+      "link" : "pygame.Surface"
+   },
+   {
+      "content" : "No really, what does this do?",
+      "user_title" : "Anonymous",
+      "link" : "Surface.convert_alpha",
+      "datetimeon" : "2010-03-29T23:51:53",
+      "id" : 3091
+   },
+   {
+      "link" : "pygame.mixer.Sound",
+      "content" : "Is get_num_channels doc correct or function name inaccurate? On OSX sound with 2 channels returns 0.",
+      "user_title" : "Anonymous",
+      "id" : 3092,
+      "datetimeon" : "2010-03-30T09:00:21"
+   },
+   {
+      "datetimeon" : "2010-04-01T17:00:48",
+      "id" : 3093,
+      "content" : "Actually, I think C 4 is note 60, as per e.g. http://tomscarff.110mb.com/midi_analyser/midi_note_numbers_for_octaves.htm and my own testing.",
+      "user_title" : "Anonymous",
+      "link" : "Output.note_on"
+   },
+   {
+      "id" : 3094,
+      "datetimeon" : "2010-04-04T19:49:02",
+      "link" : "pygame.movie",
+      "user_title" : "Anonymous",
+      "content" : "Cython SMK codec for pygame might be useful - http://forre.st/pysmk"
+   },
+   {
+      "id" : 2885,
+      "datetimeon" : "2009-07-19T10:07:08",
+      "link" : "pygame.transform.rotate",
+      "user_title" : "Anonymous",
+      "content" : "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=960,240;screen=pygame.display.set_mode(size);pygame.display.set_caption(\"multiplayer sprite test with collisions\")\nspd=4;amnt=4;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;rotv=[0]*amnt;sprid=[];spridr=[]   #some arrays and variables\nfor i in range (0,amnt,1):\n  xpos[i]=64+(128*i)+random.randint(0,32);ypos[i]=64+random.randint(0,32);rotv[i]=random.randint(0,359)\nsprall=pygame.image.load(\"sprites_rgba.png\")  #loading sprites\nfor i in range (0,4,1):\n  spritetmp=sprall.subsurface(i*64,0,64,64);spriterecttmp=spritetmp.get_rect()\n  sprid.append(spritetmp);spridr.append(spriterecttmp)\nrotincr=5\nwhile 1:\n  key=pygame.key.get_pressed()  #checking pressed keys\n  if key[pygame.K_a]:xpos[0]-=spd\n  if key[pygame.K_d]:xpos[0]+=spd\n  if key[pygame.K_w]:ypos[0]-=spd\n  if key[pygame.K_s]:ypos[0]+=spd\n  if key[pygame.K_z]:rotv[0]+=rotincr\n  if key[pygame.K_x]:rotv[0]-=rotincr\n  if key[pygame.K_f]:xpos[1]-=spd\n  if key[pygame.K_h]:xpos[1]+=spd\n  if key[pygame.K_t]:ypos[1]-=spd\n  if key[pygame.K_g]:ypos[1]+=spd\n  if key[pygame.K_v]:rotv[1]+=rotincr\n  if key[pygame.K_b]:rotv[1]-=rotincr\n  if key[pygame.K_j]:xpos[2]-=spd\n  if key[pygame.K_l]:xpos[2]+=spd\n  if key[pygame.K_i]:ypos[2]-=spd\n  if key[pygame.K_k]:ypos[2]+=spd\n  if key[pygame.K_m]:rotv[2]+=rotincr\n  if key[pygame.K_COMMA]:rotv[2]-=rotincr\n  if key[pygame.K_LEFT]: xpos[3]-=spd\n  if key[pygame.K_RIGHT]:xpos[3]+=spd\n  if key[pygame.K_UP]:   ypos[3]-=spd\n  if key[pygame.K_DOWN]: ypos[3]+=spd\n  if key[pygame.K_KP0]:  rotv[3]+=rotincr\n  if key[pygame.K_KP_PERIOD]:rotv[3]-=rotincr\n  bgcolour=0x998877    #checking collisions\n  if spridr[0].colliderect(spridr[1]):bgcolour=0xAA5555\n  if spridr[0].colliderect(spridr[2]):bgcolour=0x55AA55\n  if spridr[0].colliderect(spridr[3]):bgcolour=0x5555AA\n  if spridr[1].colliderect(spridr[2]):bgcolour=0x55AAAA\n  if spridr[1].colliderect(spridr[3]):bgcolour=0xAA55AA\n  if spridr[2].colliderect(spridr[3]):bgcolour=0xAAAA55\n  screen.fill(bgcolour)\n  for i in range (0,amnt,1):    #displaying sprites\n    spridr[i].centerx=xpos[i]\n    spridr[i].centery=ypos[i]\n    tmq=pygame.transform.rotate(sprid[i],rotv[i])\n    screen.blit(tmq,spridr[i])\n  for event in pygame.event.get():  #praxis stuff\n    if event.type==pygame.QUIT:sys.exit()\n  pygame.display.flip();pygame.time.delay(1000/50)"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "It seems that MOUSEBUTTONDOWN gets the action of the mouse button going down. if you hold the button, MOUSEBUTTONDOWN becomes false",
+      "link" : "pygame.mouse.get_pressed",
+      "datetimeon" : "2009-08-20T18:10:02",
+      "id" : 2921
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "please share full working snippets",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2009-07-19T07:18:18",
+      "id" : 2884
+   },
+   {
+      "link" : "Color.r",
+      "user_title" : "Anonymous",
+      "content" : "\"The Color class represents RGBA color values using a value range of 0-255\"\n\nWas that not clear enough for you?",
+      "id" : 3088,
+      "datetimeon" : "2010-03-28T16:39:28"
+   },
+   {
+      "id" : 3083,
+      "datetimeon" : "2010-03-23T16:05:05",
+      "link" : "pygame.display.set_mode",
+      "content" : "Calling set_mode once, to set a fullscreen resolution with an opengl surface, works great.\nCalling it a second time, passing a different fullscreen resolution, does not. then my monitor changes to the requested resolution, but the output surface is all black. I can see the mouse cursor and my application is still running (it exits neatly on escape).\nAm I doing it wrong? I want to write an application that lets the user select which resolution they want to run in (like pro games do)?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Surface.blit",
+      "content" : "has anyone a working xp example handy? thx",
+      "user_title" : "Anonymous",
+      "id" : 3084,
+      "datetimeon" : "2010-03-24T12:11:44"
+   },
+   {
+      "id" : 3085,
+      "datetimeon" : "2010-03-24T12:12:33",
+      "link" : "pygame.movie",
+      "content" : "has anyone a working xp example handy? thx a lot",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "sorry posted wrongly",
+      "id" : 3086,
+      "datetimeon" : "2010-03-24T12:12:56"
+   },
+   {
+      "link" : "pygame.display.get_surface",
+      "user_title" : "Anonymous",
+      "content" : "Is this the best way to get the size of the output window (or screen resolution if window is fullscreen?)",
+      "id" : 3082,
+      "datetimeon" : "2010-03-23T06:34:27"
+   },
+   {
+      "datetimeon" : "2009-07-18T04:03:26",
+      "id" : 2881,
+      "user_title" : "Anonymous",
+      "content" : "If you provide no argument for the background colour, \nthe area around the text will be transparent, BUT that's only\nif there are two sprites in the same group. For example:\n\nimport pygame\nfrom pygame.locals import *\n\npygame.init()\nscreen = pygame.display.set_mode((500,500))\npygame.display.get_surface().fill((0,0,255))\n\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0,0,0))\n\ntextFont = pygame.font.Font(None, 30)\nimage = textFont.render(\"BLLLAHHHH\", 0, (255,0,0))\na = pygame.sprite.Sprite()\na.image = image\na.rect = image.get_rect()\na.rect.center = ((50,50))\n\nb = pygame.sprite.Sprite()\nb.image = image\nb.rect = image.get_rect()\nb.rect.center = ((60,60))\n\ngroup = pygame.sprite.RenderUpdates(a, b)\n\nwhile 1:\n    group.clear(screen, background)\n    rects = group.draw(screen)\n    pygame.display.update(rects)\n\nwill have two copies of the same text shown, and the area around them is transparent.\n\nHowever, in this example:\n\nimport pygame\nfrom pygame.locals import *\n\npygame.init()\nscreen = pygame.display.set_mode((500,500))\npygame.display.get_surface().fill((0,0,255))\n\nbackground = pygame.Surface(screen.get_size())\nbackground.fill((0,0,0))\n\ntextFont = pygame.font.Font(None, 30)\nimage = textFont.render(\"BLLLAHHHH\", 0, (255,0,0))\na = pygame.sprite.Sprite()\na.image = image\na.rect = image.get_rect()\na.rect.center = ((50,50))\n\nb = pygame.sprite.Sprite()\nb.image = image\nb.rect = image.get_rect()\nb.rect.center = ((60,60))\n\ngroupA = pygame.sprite.RenderUpdates(a)\ngroupB = pygame.sprite.RenderUpdates(b)\n\nwhile 1:\n    groupA.clear(screen, background)\n    rects = groupA.draw(screen)\n    groupB.clear(screen, background)\n    rects.extend(groupB.draw(screen))\n    pygame.display.update(rects)\n\nthere is a black box around one of the sprites that covers the other one.\nI think what they mean by transparency is what happens in the first example.",
+      "link" : "Font.render"
+   },
+   {
+      "content" : "when i try this it says that the 'e' in e.type is undefined? any suggestions?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key.set_repeat",
+      "datetimeon" : "2010-03-16T15:33:05",
+      "id" : 3075
+   },
+   {
+      "id" : 3076,
+      "datetimeon" : "2010-03-17T23:46:58",
+      "link" : "pygame.event.Event",
+      "content" : "good",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 2879,
+      "datetimeon" : "2009-07-14T09:12:03",
+      "link" : "Rect.colliderect",
+      "content" : "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=1024,256;screen=pygame.display.set_mode(size);pygame.display.set_caption(\"multiplayer sprite test with collisions\")\nspd=4;amnt=4;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;sprid=[];spridr=[]   #some arrays and variables\nfor i in range (0,amnt,1):\n  xpos[i]=64+(128*i)+random.randint(0,32);ypos[i]=64+random.randint(0,32)\nsprall=pygame.image.load(\"sprites_rgba.png\")  #loading sprites\nfor i in range (0,4,1):\n  spritetmp=sprall.subsurface(i*64,0,64,64);spriterecttmp=spritetmp.get_rect()\n  sprid.append(spritetmp);spridr.append(spriterecttmp)\nwhile 1:\n  key=pygame.key.get_pressed()  #checking pressed keys\n  if key[pygame.K_a]:xpos[0]-=spd\n  if key[pygame.K_d]:xpos[0]+=spd\n  if key[pygame.K_w]:ypos[0]-=spd\n  if key[pygame.K_s]:ypos[0]+=spd\n  if key[pygame.K_f]:xpos[1]-=spd\n  if key[pygame.K_h]:xpos[1]+=spd\n  if key[pygame.K_t]:ypos[1]-=spd\n  if key[pygame.K_g]:ypos[1]+=spd\n  if key[pygame.K_j]:xpos[2]-=spd\n  if key[pygame.K_l]:xpos[2]+=spd\n  if key[pygame.K_i]:ypos[2]-=spd\n  if key[pygame.K_k]:ypos[2]+=spd\n  if key[pygame.K_LEFT]: xpos[3]-=spd\n  if key[pygame.K_RIGHT]:xpos[3]+=spd\n  if key[pygame.K_UP]:   ypos[3]-=spd\n  if key[pygame.K_DOWN]: ypos[3]+=spd\n  bgcolour=0x998877    #checking collisions\n  if spridr[0].colliderect(spridr[1]):bgcolour=0xAA5555\n  if spridr[0].colliderect(spridr[2]):bgcolour=0x55AA55\n  if spridr[0].colliderect(spridr[3]):bgcolour=0x5555AA\n  if spridr[1].colliderect(spridr[2]):bgcolour=0x55AAAA\n  if spridr[1].colliderect(spridr[3]):bgcolour=0xAA55AA\n  if spridr[2].colliderect(spridr[3]):bgcolour=0xAAAA55\n  screen.fill(bgcolour)\n  for i in range (0,amnt,1):    #displaying sprites\n    spridr[i].left=xpos[i];spridr[i].top=ypos[i];screen.blit(sprid[i],spridr[i])\n  for event in pygame.event.get():  #praxis stuff\n    if event.type==pygame.QUIT:sys.exit()\n  pygame.display.flip();pygame.time.delay(1000/50)",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=1024,256;screen=pygame.display.set_mode(size);pygame.display.set_caption(\"multiplayer sprite test with collisions\")\nspd=4;amnt=4;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;sprid=[];spridr=[]   #some arrays and variables\nfor i in range (0,amnt,1):\n  xpos[i]=64+(128*i)+random.randint(0,32);ypos[i]=64+random.randint(0,32)\nsprall=pygame.image.load(\"sprites_rgba.png\")  #loading sprites\nfor i in range (0,4,1):\n  spritetmp=sprall.subsurface(i*64,0,64,64);spriterecttmp=spritetmp.get_rect()\n  sprid.append(spritetmp);spridr.append(spriterecttmp)\nwhile 1:\n  key=pygame.key.get_pressed()  #checking pressed keys\n  if key[pygame.K_a]:xpos[0]-=spd\n  if key[pygame.K_d]:xpos[0]+=spd\n  if key[pygame.K_w]:ypos[0]-=spd\n  if key[pygame.K_s]:ypos[0]+=spd\n  if key[pygame.K_f]:xpos[1]-=spd\n  if key[pygame.K_h]:xpos[1]+=spd\n  if key[pygame.K_t]:ypos[1]-=spd\n  if key[pygame.K_g]:ypos[1]+=spd\n  if key[pygame.K_j]:xpos[2]-=spd\n  if key[pygame.K_l]:xpos[2]+=spd\n  if key[pygame.K_i]:ypos[2]-=spd\n  if key[pygame.K_k]:ypos[2]+=spd\n  if key[pygame.K_LEFT]: xpos[3]-=spd\n  if key[pygame.K_RIGHT]:xpos[3]+=spd\n  if key[pygame.K_UP]:   ypos[3]-=spd\n  if key[pygame.K_DOWN]: ypos[3]+=spd\n  bgcolour=0x998877    #checking collisions\n  if spridr[0].colliderect(spridr[1]):bgcolour=0xAA5555\n  if spridr[0].colliderect(spridr[2]):bgcolour=0x55AA55\n  if spridr[0].colliderect(spridr[3]):bgcolour=0x5555AA\n  if spridr[1].colliderect(spridr[2]):bgcolour=0x55AAAA\n  if spridr[1].colliderect(spridr[3]):bgcolour=0xAA55AA\n  if spridr[2].colliderect(spridr[3]):bgcolour=0xAAAA55\n  screen.fill(bgcolour)\n  for i in range (0,amnt,1):    #displaying sprites\n    spridr[i].left=xpos[i];spridr[i].top=ypos[i];screen.blit(sprid[i],spridr[i])\n  for event in pygame.event.get():  #praxis stuff\n    if event.type==pygame.QUIT:sys.exit()\n  pygame.display.flip();pygame.time.delay(1000/50)",
+      "link" : "pygame.key.get_pressed",
+      "datetimeon" : "2009-07-14T09:09:26",
+      "id" : 2878
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "This creates a mask from the surface which has all the pixels set which have color values above or equal to those in color, but below (and not equal to) the values in threshold.  So no pixel with a 255 value can possibly be considered.  And the default threshold doesn't let the mask have any set pixels for any given surface.",
+      "link" : "pygame.mask.from_threshold",
+      "datetimeon" : "2010-03-13T06:03:20",
+      "id" : 3073
+   },
+   {
+      "content" : "It appears if you end up rotating your sprites, you need to regenerate their masks when collision is detected via the rect test, or the masks won't match with the corresponding imagery.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.sprite.collide_mask",
+      "datetimeon" : "2009-07-13T01:08:45",
+      "id" : 2876
+   },
+   {
+      "link" : "Surface.set_palette",
+      "content" : "This didn't seem clear in the documentation. I checked the source (v. 1.8.1).\n\nThis takes a sequence of (R, G, B) triplets. This is currently the only way the palette can be defined.",
+      "user_title" : "Anonymous",
+      "id" : 2874,
+      "datetimeon" : "2009-07-12T13:50:36"
+   },
+   {
+      "content" : "A less look at me demo:\n\nimport pygame.font\nimport pygame.surface\n\ndef gameprint(text,xx,yy,color):\n   font = pygame.font.SysFont(\"Courier New\",18)\n   ren = font.render(text,1,color)\n   screen.blit(ren, (xx,yy))",
+      "user_title" : "Anonymous",
+      "link" : "Font.render",
+      "datetimeon" : "2009-08-28T19:19:15",
+      "id" : 2927
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "how to fadein() ?",
+      "link" : "pygame.mixer.music.fadeout",
+      "datetimeon" : "2010-03-09T06:18:13",
+      "id" : 3068
+   },
+   {
+      "datetimeon" : "2010-03-10T08:48:11",
+      "id" : 3070,
+      "user_title" : "Anonymous",
+      "content" : "cfadsfsadgfdh hHAHAHAH",
+      "link" : "pygame.event.pump"
+   },
+   {
+      "id" : 3072,
+      "datetimeon" : "2010-03-12T11:41:32",
+      "link" : "pygame.key.set_repeat",
+      "content" : "This function, at least on my system using Windows XP, \nonly one key is repeated at a time.  So, moving a sprite\naround the screen using the arrow keys can only move it\nin one direction at a time.  No diagonal by using two arrows\nat the same time...\n\nAn alternative is to set an object's state on KEYDOWN and reset \nit on KEYUP.\n\nExample:\n\n\tif e.type == KEYDOWN:\n\t\tif e.key == K_LEFT:\n\t\t\tship.xspeed -= SPEED\n\t\telif e.key == K_RIGHT:\n\t\t\tship.xspeed += SPEED\n\t\telif e.key == K_UP:\n\t\t\tship.yspeed -= SPEED\n\t\telif e.key == K_DOWN:\n\t\t\tship.yspeed += SPEED\n\t\telif e.key == K_SPACE\n\t\t\tship.firing = True\n\telif e.type == KEYUP:\n\t\tif e.key == K_LEFT:\n\t\t\tship.xspeed += SPEED\n\t\telif e.key == K_RIGHT:\n\t\t\tship.xspeed -= SPEED\n\t\telif e.key == K_UP:\n\t\t\tship.yspeed += SPEED\n\t\telif e.key == K_DOWN:\n\t\t\tship.yspeed -= SPEED\n\t\telif e.key == K_SPACE:\n\t\t\tship.firing == False",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Only if you do not import all the pygame locals:\n\nfrom pygame.locals import *",
+      "link" : "pygame.mouse.get_pressed",
+      "datetimeon" : "2009-07-10T23:11:01",
+      "id" : 2871
+   },
+   {
+      "id" : 3066,
+      "datetimeon" : "2010-03-03T13:42:28",
+      "link" : "Rect.move",
+      "user_title" : "Anonymous",
+      "content" : "Note that\nmyrect.move(x,y)\ndoes not change the Rect myrect. Only\nmyrect = myrect.move(x,y)\ndoes."
+   },
+   {
+      "datetimeon" : "2010-03-08T09:27:57",
+      "id" : 3067,
+      "user_title" : "Anonymous",
+      "content" : "My copy of pygames uses numeric as default, not numpy (as stated above).\nThe best thing is probably to explicitly state the array type used (e.g. pygame.sndarray.use_arraytype('numpy')) to avoid problems with future convention changes.",
+      "link" : "pygame.sndarray"
+   },
+   {
+      "id" : 2930,
+      "datetimeon" : "2009-08-30T08:39:48",
+      "link" : "Surface.scroll",
+      "user_title" : "Anonymous",
+      "content" : "The docs are faulty here. scroll() takes two integers and not a tuple or a list."
+   },
+   {
+      "datetimeon" : "2009-07-09T13:26:59",
+      "id" : 2869,
+      "content" : "What about Duel screen displays?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.set_mode"
+   },
+   {
+      "id" : 3063,
+      "datetimeon" : "2010-03-02T18:18:51",
+      "link" : "pygame.key",
+      "content" : "are yoh sure that sign are correct",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 2932,
+      "datetimeon" : "2009-08-31T04:50:51",
+      "link" : "pygame.time.set_timer",
+      "content" : "import pygame\nfrom pygame.locals import *\n\ndef timerFunc():\n    print \"Timer CallBack\"\n\npygame.init()\npygame.time.set_timer(USEREVENT+1, 100)\nwhile 1:\n    for event in pygame.event.get():\n        if event.type == USEREVENT+1:\n            timerFunc() #calling the function wheever we get timer event.\n        if event.type == QUIT:\n            break",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 2933,
+      "datetimeon" : "2009-08-31T22:47:55",
+      "link" : "pygame.font",
+      "content" : "this is helpful thanks son",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2009-04-22T14:45:07",
+      "id" : 2557,
+      "user_title" : "Anonymous",
+      "content" : "Wouldn't the center simply be X = X2 - X1  Y = Y2 - Y1 ?  Bottom right minus top left.  That doesn't require any special math functions, yes?",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "link" : "Surface.subsurface",
+      "content" : "#! /usr/bin/python\n# using sprites_rgba.png from http://img17.imageshack.us/img17/3166/spritesrgba.png\nimport sys, pygame, math, os, random\nfrom pygame.locals import *\npygame.init()\nsize=width,height=1024,256;screen=pygame.display.set_mode(size)\namnt=64;ampl=8;xpos=[0]*amnt;ypos=[0]*amnt;xdif=[0]*amnt;ydif=[0]*amnt;snum=[0]*amnt\nfor i in range (0,amnt,1):\n  xpos[i]=random.randint(0,width)\n  ypos[i]=random.randint(0,height)\n  xdif[i]=random.randint(0,ampl*2)-ampl\n  ydif[i]=random.randint(0,ampl*2)-ampl\n  snum[i]=random.randint(0,3)\nball=pygame.image.load(\"sprites_rgba.png\");ballrect=ball.get_rect()\nsprite00=ball.subsurface((  0,0,64,64));spriterect00=sprite00.get_rect()\nsprite01=ball.subsurface(( 64,0,64,64));spriterect01=sprite01.get_rect()\nsprite02=ball.subsurface((128,0,64,64));spriterect02=sprite02.get_rect()\nsprite03=ball.subsurface((192,0,64,64));spriterect03=sprite03.get_rect()\nwhile 1:\n  for event in pygame.event.get():\n    if event.type==pygame.QUIT:sys.exit()\n  for i in range (0,amnt,1):\n    xpos[i]+=xdif[i];ypos[i]+=ydif[i]\n    if xpos[i]&gt;width:xpos[i]-=(width+64)\n    if ypos[i]&gt;height:ypos[i]-=(height+64)\n    if xpos[i]&lt;-64:xpos[i]+=(width+64)\n    if ypos[i]&lt;-64:ypos[i]+=(height+64)\n  screen.fill(0x998877)\n  for i in range (0,amnt,1):\n    if snum[i]==0:\n      spriterect00.left=xpos[i];spriterect00.top=ypos[i];screen.blit(sprite00,spriterect00)\n    if snum[i]==1:\n      spriterect01.left=xpos[i];spriterect01.top=ypos[i];screen.blit(sprite01,spriterect01)\n    if snum[i]==2:\n      spriterect02.left=xpos[i];spriterect02.top=ypos[i];screen.blit(sprite02,spriterect02)\n    if snum[i]==3:\n      spriterect03.left=xpos[i];spriterect03.top=ypos[i];screen.blit(sprite03,spriterect03)\n  pygame.display.flip()\n  pygame.time.delay(1000/50)",
+      "user_title" : "Anonymous",
+      "id" : 2867,
+      "datetimeon" : "2009-07-07T10:21:37"
+   },
+   {
+      "link" : "pygame.event.post",
+      "content" : "Usage of the event queue for USEREVENT-style events is limited by the maximum size of the SDL event queue, which is 256.\nSo, if more events (of any sort) get posted to the queue, you will get an exception stating \"error: Event queue full\".\nIf you expect to generate more than a few user events before they are posted, consider a separate queue.",
+      "user_title" : "Anonymous",
+      "id" : 2560,
+      "datetimeon" : "2009-05-03T10:30:15"
+   },
+   {
+      "datetimeon" : "2009-05-05T15:48:33",
+      "id" : 2561,
+      "content" : "Is this the same as pygame.surface.fill(color, rect)?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect"
+   },
+   {
+      "datetimeon" : "2009-08-02T21:50:25",
+      "id" : 2901,
+      "content" : "Just a note, Nautilus, the default file browser in GNOME sets copied files as 'x-special/gnome-copied-files', if you retrieve it, it holds the location as plain text.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.scrap"
+   },
+   {
+      "datetimeon" : "2009-07-06T22:14:24",
+      "id" : 2866,
+      "content" : "so someone can share some Surface.subsurface snippet? (one about sprites is very welcome)",
+      "user_title" : "Anonymous",
+      "link" : "Surface.subsurface"
+   },
+   {
+      "link" : "Surface.copy",
+      "user_title" : "Anonymous",
+      "content" : "test\ntest",
+      "id" : 2864,
+      "datetimeon" : "2009-07-03T15:37:54"
+   },
+   {
+      "link" : "Surface.copy",
+      "user_title" : "Anonymous",
+      "content" : "test &lt;br /&gt; test",
+      "id" : 2863,
+      "datetimeon" : "2009-07-03T15:37:38"
+   },
+   {
+      "id" : 2862,
+      "datetimeon" : "2009-07-03T15:37:10",
+      "link" : "Surface.copy",
+      "user_title" : "Anonymous",
+      "content" : "somewhere in the pygame google-group i found it's possible to have multiple sprites based on just one picture plenty of sprite drawings, without having to have them cropped file by file - how can we do this?"
+   },
+   {
+      "datetimeon" : "2009-07-03T13:28:41",
+      "id" : 2861,
+      "user_title" : "Anonymous",
+      "content" : "missing commands for drawing bezier lines - some gpl sources can be find at http://nitrofurano.linuxkafe.com/sdlbasic - just needed to be recoded to Pygame, but it's not that difficult task at all...",
+      "link" : "pygame.draw"
+   },
+   {
+      "id" : 2860,
+      "datetimeon" : "2009-07-03T07:24:30",
+      "link" : "Font.render",
+      "user_title" : "Anonymous",
+      "content" : "What does the error 'text has zero width' mean?\nI was simply printing 'Hello World!' to the screen.\nI was fiddling with text size, jumped from 32 to 12 and I got the above error\nNow the only way to stop the error is to have no text ('')"
+   },
+   {
+      "link" : "Color.r",
+      "content" : "It would be handy if the range of values was given. It appears to be 0 to 255.",
+      "user_title" : "Anonymous",
+      "id" : 2859,
+      "datetimeon" : "2009-07-02T12:01:48"
+   },
+   {
+      "content" : "don't you know its a bad idea to leave your email on the internet?\n-wekul",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key",
+      "datetimeon" : "2009-06-29T09:02:53",
+      "id" : 2857
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "With event.type == MOUSEBUTTONDOWN - Error! \nWrite it - event.type == pygame.MOUSEBUTTONDOWN",
+      "link" : "pygame.mouse.get_pressed",
+      "datetimeon" : "2009-07-02T06:50:36",
+      "id" : 2858
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "In Pygame 1.9 Surface.copy() does not preserve the original image's alpha. If\nyour image has an alpha you need to:\n\ns1 = s0.copy()\ns1.set_alpha(s0.get_alpha())",
+      "link" : "Surface.copy",
+      "datetimeon" : "2010-02-21T12:03:18",
+      "id" : 3059
+   },
+   {
+      "datetimeon" : "2010-02-21T14:25:02",
+      "id" : 3060,
+      "content" : "In the comment on February 21, 2010 10:32am, in the last sentence I meant,\n\"for a sample i, the value of the left channel is a[i][0], the right channel\na[i][1],\" of course.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.sndarray"
+   },
+   {
+      "id" : 3058,
+      "datetimeon" : "2010-02-21T10:37:46",
+      "link" : "pygame.sndarray",
+      "user_title" : "Anonymous",
+      "content" : "When using numpy, be careful to set the type of the array correctly.\nFor instance, when you're in signed 16-bit stereo mode, e.g., when you've\ncalled\n\npygame.mixer.pre_init(size = -16, channels = 2)\n\nand you want to create an array to use for synthesizing a sound, don't forget\nthe dtype argument in\n\nsamples = numpy.zeros((n_samples, 2), dtype = numpy.int16)"
+   },
+   {
+      "id" : 3057,
+      "datetimeon" : "2010-02-21T10:32:01",
+      "link" : "pygame.sndarray",
+      "content" : "The above is hard to understand, at least for me. For instance, what does\n\"A stereo sound file has two values per sample\" mean? Here's what it means:\nif you're in mono, and your array has N samples, the shape of the array\nshould be (N,) (a d=1 array of N elements). If you're in stereo, then the\nshape should be (N,2) (a d=2 array, Nx2); for a sample i, the value of the left\nchannel is a[N][0], the right channel a[N][1].",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Surface.get_rect",
+      "user_title" : "Anonymous",
+      "content" : "You could always do dir(pygame.Rect) or whatever.",
+      "id" : 2854,
+      "datetimeon" : "2009-06-28T09:26:48"
+   },
+   {
+      "link" : "pygame.Color",
+      "content" : "HTML (#rrggbbaa) format doesn't seem to work with 1.9.1 ... gives a \"ValueError: invalid argument\" exception.",
+      "user_title" : "Anonymous",
+      "id" : 3019,
+      "datetimeon" : "2009-12-02T14:01:18"
+   },
+   {
+      "datetimeon" : "2009-12-02T14:07:37",
+      "id" : 3020,
+      "user_title" : "Anonymous",
+      "content" : "(What's even more odd is that it works from the python console ... just not in a program)",
+      "link" : "pygame.Color"
+   },
+   {
+      "link" : "pygame.draw.arc",
+      "content" : "it dun wok",
+      "user_title" : "Anonymous",
+      "id" : 3021,
+      "datetimeon" : "2009-12-03T12:43:47"
+   },
+   {
+      "datetimeon" : "2009-12-07T01:43:58",
+      "id" : 3022,
+      "user_title" : "Anonymous",
+      "content" : "Re: noise and static was occurring on my Linux box, and I was able to ameliorate it\nby specifically setting my mixer:\n    pygame.mixer.pre_init(44100, -16, 2)\n    pygame.init()",
+      "link" : "Sound.play"
+   },
+   {
+      "id" : 3023,
+      "datetimeon" : "2009-12-15T12:51:36",
+      "link" : "Surface.set_palette_at",
+      "user_title" : "Anonymous",
+      "content" : "its set_palette_at, not set_at"
+   },
+   {
+      "datetimeon" : "2009-12-16T15:50:04",
+      "id" : 3024,
+      "user_title" : "Anonymous",
+      "content" : "hey matthew sucks in snping",
+      "link" : "pygame.draw.ellipse"
+   },
+   {
+      "content" : "ellipserect=Rect(cmx,cmy,mx-cmx,my-cmy)\nellipserect.normalize()\ndraw.ellipse(screen,color,ellipserect,1)\nwhy ValueError: width greater than ellipse radius?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.ellipse",
+      "datetimeon" : "2009-12-18T13:28:16",
+      "id" : 3025
+   },
+   {
+      "datetimeon" : "2010-02-19T01:32:43",
+      "id" : 3055,
+      "content" : "It plays dot-to-dot with the given points.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.lines"
+   },
+   {
+      "link" : "pygame.mixer",
+      "user_title" : "Anonymous",
+      "content" : "In ver. 1.9.1, if I try to initialize by calling\n\npygame.mixer.pre_init(...)\npygame.init()\n\nand then try to play a sound buffer, I get no output unless I open a graphics\nwindow first by calling pygame.display.set_mode(...). If, on the other hand,\nI'm not doing graphics and I initialize with just\n\npygame.mixer.init(...)\n\nI can get sound without opening any window.",
+      "id" : 3056,
+      "datetimeon" : "2010-02-21T10:20:13"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "to get a picture instead of black and white cursor, in order :\n1) simply make a transparent cursor\n   pygame.mouse.set_cursor(pygame.mouse.set_cursor((8,8),(0,0),(0,0,0,0,0,0,0,0),(0,0,0,0,0,0,0,0))\n\n2) constantly actualise the postition of the picture to the postion of the cursor\n   cursor_picture==pygame.image.load('./cursor.png').convert_alpha()\n   while True:\n       for event in pygame.event.get():\n           if event.type==QUIT:\n               exit()\n       screen.fill(black)\n       screen.blit(mouse_cursor, pygame.mouse.get_pos())\n       pygame.display.update()",
+      "link" : "pygame.mouse.set_cursor",
+      "datetimeon" : "2009-06-27T17:10:22",
+      "id" : 2850
+   },
+   {
+      "link" : "pygame.Surface",
+      "content" : "Not sure why I am leaving this here... but can anyone tell me how you would rotate a surface?  Its 3am so excuse my ignorance :D",
+      "user_title" : "Anonymous",
+      "id" : 3016,
+      "datetimeon" : "2009-11-30T03:38:25"
+   },
+   {
+      "datetimeon" : "2009-11-30T18:49:41",
+      "id" : 3017,
+      "user_title" : "Anonymous",
+      "content" : "Theres is an error in documentation: pygame.cursor.compile does not exists, but pygame.cursors.compile do",
+      "link" : "pygame.cursors.compile"
+   },
+   {
+      "content" : "is there anyway to rotate a rectangle with out making it an image?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2009-11-13T15:06:41",
+      "id" : 3009
+   },
+   {
+      "id" : 3010,
+      "datetimeon" : "2009-11-15T09:50:56",
+      "link" : "pygame.image.load",
+      "content" : "Minor problem: When I run the program using this for an image, it says \"cannot load image!\" could anyone help me?",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "We need the posibility to rotate without the image being rescaled, just keep its original size like in PIL.\n\nim.rotate(angle, filter=NEAREST, expand=0) \nThe expand argument, if true, indicates that the output image should be made \nlarge enough to hold the rotated image. \nIf omitted or false, the output image has the same size as the input image.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.transform.rotate",
+      "datetimeon" : "2009-11-21T05:03:48",
+      "id" : 3012
+   },
+   {
+      "link" : "Mask.overlap",
+      "user_title" : "Anonymous",
+      "content" : "In pygame 1.9.1 this function does not return negative values instead it returns a \n0 for all values &lt; 0 (of the direction vector). If you are looking for a way to \ncompute a collision response look at Mask.overlap_area.",
+      "id" : 3013,
+      "datetimeon" : "2009-11-23T10:34:10"
+   },
+   {
+      "id" : 3014,
+      "datetimeon" : "2009-11-27T06:41:00",
+      "link" : "pygame.draw.lines",
+      "user_title" : "Anonymous",
+      "content" : "can anyone please explain what this function do? at best whith an example"
+   },
+   {
+      "id" : 2939,
+      "datetimeon" : "2009-09-07T03:31:29",
+      "link" : "pygame.key",
+      "user_title" : "Anonymous",
+      "content" : "Meta key is 'Apple' or 'Command' on a mac."
+   },
+   {
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "why doesn't this blit on the screen???\n\n\n            for star in self.stars:\n                self.screen.blit(self.a, star.pos)\n                star.update()\n                self.screen.blit(star.image, star.pos)\n            pygame.display.update()",
+      "id" : 2941,
+      "datetimeon" : "2009-09-08T22:04:17"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "HELP ME ONMMGMGMGMGMGMG",
+      "link" : "Surface.convert_alpha",
+      "datetimeon" : "2009-11-12T10:31:24",
+      "id" : 3006
+   },
+   {
+      "link" : "Surface.convert_alpha",
+      "content" : "aghahhahahahah I LOVE THIS OMG (*&amp;^%$#@Q",
+      "user_title" : "Anonymous",
+      "id" : 3007,
+      "datetimeon" : "2009-11-12T10:31:43"
+   },
+   {
+      "link" : "pygame.transform.scale",
+      "content" : "In my game the screen is scaled. This can cause havoc with the mouse positioning. I made this function:\n\n def get_mouse_pos(pos):\n\treturn (pos[0] * (1280.0/float(game.game_scaled[0])),pos[1] * (720.0/float(game.game_scaled[1])))\n\nReplace 1280.0 and 720.0 with the resolution of the pre-scaled game and game.game_scaled with a sequence containing the scaled resolution.",
+      "user_title" : "Anonymous",
+      "id" : 3008,
+      "datetimeon" : "2009-11-12T12:43:39"
+   },
+   {
+      "datetimeon" : "2009-06-24T20:28:26",
+      "id" : 2846,
+      "content" : "It seems to work if you set the display of the movie to a surface of the same size and then blit that surface to the screen.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.movie"
+   },
+   {
+      "datetimeon" : "2009-11-11T15:11:43",
+      "id" : 3004,
+      "user_title" : "Anonymous",
+      "content" : "This documentation does not seem to match what is currently in 1.8.1.  \nInstead: pygame.transform.threshold(DestSurface, Surface, color, threshold = (0,0,0,0), diff_color = (0,0,0,0), change_return = True, Surface =None): return num_threshold_pixels",
+      "link" : "pygame.transform.threshold"
+   },
+   {
+      "id" : 2943,
+      "datetimeon" : "2009-09-11T20:56:38",
+      "link" : "pygame.Color",
+      "user_title" : "Anonymous",
+      "content" : "For some odd reason anything in pygame.Color gets an error message like it doesn't exist.\nIf I try using pygame.Color.r, it says that Color has no attribute r. I tried redownloading\npygame, but nothing diffrent."
+   },
+   {
+      "datetimeon" : "2009-06-24T20:09:34",
+      "id" : 2845,
+      "user_title" : "Anonymous",
+      "content" : "I am having the same problem on XP. The sound plays, but the video does not.",
+      "link" : "pygame.movie"
+   },
+   {
+      "content" : "\"current_h, current_h:  Width and height of the current video mode, or of the\"[...]\nOne of them should be \"current_w\" instead.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.Info",
+      "datetimeon" : "2009-11-07T06:40:09",
+      "id" : 2999
+   },
+   {
+      "id" : 3000,
+      "datetimeon" : "2009-11-08T08:17:58",
+      "link" : "pygame.PixelArray",
+      "content" : "For me, PixelArray works much faster (4 or 5 times faster) than Surfarray. I wanted to set every pixel in my off-screen surface individually. Creating the surface, creating a PixelArray on it, and going through the pixels one-by-one is much faster than creating the bitmap using numpy and calling surfarray.make_surface.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "�?�? ìîÊåòå íàðÚñîâàòÌ íåñêîëÌêî ïàðàëëåëÌíûõ ëÚíÚé ðÿÀîì ñ Àðóãîì. �?òîáû Úõ ÀëÚíû ñëÚâàëÚñÌ\n îíÚ áóÀóò âÚÀíû, êàê îÀíà. Íî Üòî áóÀåò ìåÀëåííåé.\n I don't know english, write russian. translate.google for you help! :)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.aaline",
+      "datetimeon" : "2009-11-08T18:19:31",
+      "id" : 3001
+   },
+   {
+      "datetimeon" : "2009-11-11T05:10:30",
+      "id" : 3002,
+      "user_title" : "Anonymous",
+      "content" : "uiuuiu",
+      "link" : "pygame.key.get_focused"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "its very ...................",
+      "link" : "pygame.key.get_focused",
+      "datetimeon" : "2009-11-11T05:11:00",
+      "id" : 3003
+   },
+   {
+      "content" : "Tip for noobs. This was killing me. If you're trying this for the first time and getting no sound, it may be because you're program exits before the playback thread completes. See pygame/examples/sound.py: it waits at the end.",
+      "user_title" : "Anonymous",
+      "link" : "Channel.play",
+      "datetimeon" : "2009-12-19T19:22:25",
+      "id" : 3026
+   },
+   {
+      "id" : 3027,
+      "datetimeon" : "2009-12-19T19:23:52",
+      "link" : "Sound.play",
+      "content" : "Tip for noobs. This was killing me. If you're trying this for the first time and\ngetting no sound, it may be because you're program exits before the playback\nthread completes. See pygame/examples/sound.py: it waits at the end.",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "You missed pygame.Mixer",
+      "user_title" : "Anonymous",
+      "link" : "pygame.init",
+      "datetimeon" : "2009-10-27T02:47:35",
+      "id" : 2991
+   },
+   {
+      "link" : "pygame.movie",
+      "user_title" : "Anonymous",
+      "content" : "Tried this on XP with pygame 1.9 - video works, but sound doesn't. Uninitializing pygame.mixer does not seem to effect behavior.",
+      "id" : 2992,
+      "datetimeon" : "2009-10-27T20:31:08"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "As of 1.9, it does not appear the loop param exists.",
+      "link" : "Movie.play",
+      "datetimeon" : "2009-10-27T20:42:45",
+      "id" : 2993
+   },
+   {
+      "datetimeon" : "2009-10-29T10:53:02",
+      "id" : 2994,
+      "content" : "If your movies play slow or occasionally freeze, setting a limit to framerates seems to resolve the problem. \nSee the documentation on Clock.tick(framerate) on how to limit framerates:\nhttp://www.pygame.org/docs/ref/time.html#Clock.tick",
+      "user_title" : "Anonymous",
+      "link" : "pygame.movie.Movie"
+   },
+   {
+      "id" : 2995,
+      "datetimeon" : "2009-11-04T18:10:25",
+      "link" : "pygame.scrap.lost",
+      "user_title" : "Anonymous",
+      "content" : "The example code and the explanation contradict each other.\n\nThe example returns true if lost, supposedly, and the explanation supposedly returns False if lost?"
+   },
+   {
+      "link" : "pygame.PixelArray",
+      "user_title" : "Anonymous",
+      "content" : "Does not work *at all*. No changes occur when I change any pixels.",
+      "id" : 2996,
+      "datetimeon" : "2009-11-05T22:12:49"
+   },
+   {
+      "datetimeon" : "2009-12-21T19:52:02",
+      "id" : 3028,
+      "user_title" : "Anonymous",
+      "content" : "Remember, there are not semitones. Thus, each semitone is represented by an integer named \"note\".\nIf you are a beginer it is a good choice to start practicing with the middle notes.\nC 4 is the note number 61. Have fun!.\n\nTourette",
+      "link" : "Output.note_on"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "pygame.mask.from_surface(Surface, threshold) -&gt; Mask\nno Keyword argument",
+      "link" : "pygame.mask.from_surface",
+      "datetimeon" : "2009-10-25T18:04:44",
+      "id" : 2989
+   },
+   {
+      "datetimeon" : "2009-08-04T11:33:28",
+      "id" : 2905,
+      "content" : "you use a class to get the var\nfor example\nclass myimage(object):\n    image = (your image)\nthen to blit\n\ndisplay.blit(myimage.image, (0,0))\n\nso that you are only accesing the one variable to blit instead of multiple instances of the same",
+      "user_title" : "Anonymous",
+      "link" : "Surface.copy"
+   },
+   {
+      "link" : "Clock.get_fps",
+      "content" : "if you want to measure it over a period of your choosing just compute a moving average of the result of clock.tick(), like this:\n\n...\n\nrecent_frame_lengths = [ 100, 100, 100, 100, 100 ]\nrfl_array_len = float( len( recent_frame_lengths ) )\n\n...\nmain():\n...\ndt = clock.tick()\nrecent_frame_lengths.pop(0)\nrecent_frame_lengths.append(dt)\naverage_frame_length = recent_frame_lengths / rfl_array_len\nframes_per_second = 1000. / average_frame_length",
+      "user_title" : "Anonymous",
+      "id" : 3124,
+      "datetimeon" : "2010-05-18T12:08:59"
+   },
+   {
+      "content" : "button can be at least 1-6. 4/5 are for the scroll wheel. \nThe squeeze-click on new Apple mice is 6.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event",
+      "datetimeon" : "2010-05-20T22:13:33",
+      "id" : 3126
+   },
+   {
+      "id" : 3127,
+      "datetimeon" : "2010-05-20T22:31:20",
+      "link" : "pygame.mouse.get_pressed",
+      "content" : "event polling:\n#self.keys is [] 256 len. \nself.mouse = ((0,0), 0, 0, 0, 0, 0, 0) #(pos, b1,b2,b3,b4,b5,b6)\n#squeezing a new Apple mouse is button 6. \nfor event in pygame.event.get():\n\tif event.type == pygame.QUIT:\n\t\tself.running = 0\n\telif event.type == pygame.MOUSEBUTTONDOWN:\n\t\tself.mouse[event.button] = 1\n\t\tself.mouse[0] = event.pos\n\telif event.type == pygame.MOUSEBUTTONUP:\n\t\tself.mouse[event.button] = 0\n\t\tself.mouse[0] = event.pos\n\telif event.type == pygame.MOUSEMOTION:\n\t\tself.mouse[0] = event.pos\n\telif event.type == pygame.KEYDOWN:\n\t\tself.keys[event.key % 255] = 1\n\telif event.type == pygame.KEYUP:\n\t\tself.keys[event.key % 255] = 0",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "PyGame beginners, please don't look at Matthew N. Brown's code below.\n\nThat is the worst Python code I have ever seen, and it offers almost no examples of how to use pygame.draw.circle.",
+      "id" : 3123,
+      "datetimeon" : "2010-05-17T13:22:44"
+   },
+   {
+      "content" : "What about subsubsubsubsurfaces?",
+      "user_title" : "Anonymous",
+      "link" : "Surface.subsurface",
+      "datetimeon" : "2009-06-14T09:27:19",
+      "id" : 2830
+   },
+   {
+      "content" : "for some reason this gives always wrong numbers.\nmask_creep = pygame.mask.from_surface(creep.image)\nmask_player = pygame.mask.from_surface(p.image)\np.life -= mask_player.overlap_area(\n   mask_creep, (creep.rect.x-p.rect.x,creep.rect.y-p.rect.y))\n\np.life is the life of the player, and I want to drain it by the amount of pixels overlapping with creep.\nhowever, it seems it hits before it should, and with mask_creep.invert() I seem to get more accurate hits, which makes no sense...",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mask",
+      "datetimeon" : "2009-10-24T06:03:49",
+      "id" : 2984
+   },
+   {
+      "content" : "get also this warning : nsquickdrawview \nif I compile.\n\ncant use pygame with py2app\n\npython 2.4 or 2.5\nmaxos leopard\neclipse",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.init",
+      "datetimeon" : "2010-01-05T21:56:27",
+      "id" : 3032
+   },
+   {
+      "link" : "Rect.collidedict",
+      "content" : "This function is not working as stated.  It requires a 'rectstyle' argument (ie. a tuple with rect's parameters).  it tests for collisions using this 'rectsytle' object and returns any that are colliding along with their values.  Not really useful since no one needs a tuple of rect's parameters back.  this would be really nice if it worked as stated...",
+      "user_title" : "Anonymous",
+      "id" : 2982,
+      "datetimeon" : "2009-10-24T03:33:00"
+   },
+   {
+      "link" : "pygame.transform.rotate",
+      "content" : "The math isn't that hard, you just have to think in relative coordinates then.\nThe key is to look at the center of the image, as these coordinates wont change by rotating it.\nThe coordinates of the center of the image on the screen are given by:\nx_cntr.. x coordinate of the center\ny_cntr.. y coordinate of the center\n\npos_org = (x_cntr - image_org.get_rect().width / 2,\n           y_cntr - image_org.get_rect().height / 2) \n           \"\"\"gives position of upper left corner of image_org (not rotated)\n           depending on the center coordinates for the Surface.blit function\"\"\"\nimage_rotated = pygame.transform.rotate(image_org, angle) #rotate image\npos_new = (x_pos_org - image_rotated.get_rect().width / 2,\n           y_pos_org - image_rotated.get_rect().height / 2)\n           #get new position for upper left corner for rotated image",
+      "user_title" : "Anonymous",
+      "id" : 3036,
+      "datetimeon" : "2010-01-21T11:14:00"
+   },
+   {
+      "link" : "pygame.transform.rotate",
+      "user_title" : "Anonymous",
+      "content" : "x_pos_org and y_pos_org naturally need to be x_cntr and y_cntr.. sry",
+      "id" : 3037,
+      "datetimeon" : "2010-01-21T11:20:31"
+   },
+   {
+      "datetimeon" : "2010-01-21T12:35:00",
+      "id" : 3038,
+      "user_title" : "Anonymous",
+      "content" : "fuck u",
+      "link" : "PixelArray.replace"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "doesnt work!",
+      "link" : "pygame.display.set_caption",
+      "datetimeon" : "2010-01-25T12:07:07",
+      "id" : 3039
+   },
+   {
+      "id" : 3040,
+      "datetimeon" : "2010-01-25T12:07:16",
+      "link" : "pygame.display.set_caption",
+      "user_title" : "Anonymous",
+      "content" : "WTH!???"
+   },
+   {
+      "link" : "pygame.image.load",
+      "user_title" : "Anonymous",
+      "content" : "Where should the image file be save at?",
+      "id" : 3042,
+      "datetimeon" : "2010-01-29T02:01:23"
+   },
+   {
+      "id" : 3043,
+      "datetimeon" : "2010-01-30T14:45:56",
+      "link" : "Surface.blit",
+      "content" : "To clip the blit, you have to pass a rect like this (0, 0, clipWidth, clipHeigth):\n\nexample:\n\nsForeground.blit(sText, rText, (0, 0, 32, 32)):\n\ndraw the surface sText into sForeground at topleft position defined with the rect rText,\nclippping the sText by 32x32 pixel box",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 3044,
+      "datetimeon" : "2010-02-02T15:56:23",
+      "link" : "pygame.display.set_caption",
+      "content" : "actually, it DOES WORK. put it in the right group",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 3045,
+      "datetimeon" : "2010-02-02T23:04:45",
+      "link" : "Rect.move",
+      "user_title" : "Anonymous",
+      "content" : "how does this even work?????"
+   },
+   {
+      "link" : "pygame.transform.smoothscale",
+      "user_title" : "Anonymous",
+      "content" : "Pygame 1.9: DeprecationWarning: integer argument expected, got float\n\nThe tuple elements must be integers. The line number in the warning message will\nindicate your enclosing function or method. I found this very misleading and\nfrustrating.",
+      "id" : 3048,
+      "datetimeon" : "2010-02-06T02:16:05"
+   },
+   {
+      "datetimeon" : "2010-02-08T10:30:27",
+      "id" : 3049,
+      "content" : "By calling Clock.tick -&gt; clock.tick",
+      "user_title" : "Anonymous",
+      "link" : "Clock.tick_busy_loop"
+   },
+   {
+      "id" : 3050,
+      "datetimeon" : "2010-02-08T22:31:47",
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "that code you posted (TWICE) doesnt show how to draw a circle in pygame.\n It shows an example of a complex couple hundred lines  of interactive \nphysics engine that just so happens to take im guessing less than\n5 lines to use pygame.draw.circle. Its a waste of space Good job for getting your code out into \nthe world. Now people dont like you."
+   },
+   {
+      "datetimeon" : "2009-10-22T05:21:56",
+      "id" : 2977,
+      "content" : "TypeError: descriptor 'collidelistall' requires a 'pygame.Rect' object but received a 'list'\n\n...so it doesn't like a list, but a pygame.Rect? That does't make sense.",
+      "user_title" : "Anonymous",
+      "link" : "Rect.collidelistall"
+   },
+   {
+      "link" : "pygame.Surface",
+      "user_title" : "Anonymous",
+      "content" : "Also using\n\n my_surface=pygame.Surface([width, height]).convert()\n\nseems to be just as effective",
+      "id" : 2974,
+      "datetimeon" : "2009-10-16T22:13:15"
+   },
+   {
+      "content" : "x = x2 - x1, y = y2 - y1 gives the width and height of the rectangle.\n(x2 - x1) / 2, (y2 - y1) / 2 gives the center coordinates.\nI don't know of a built-in method on the Rect that gives the center coords.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2009-10-21T20:50:31",
+      "id" : 2976
+   },
+   {
+      "datetimeon" : "2009-10-08T11:50:27",
+      "id" : 2967,
+      "user_title" : "Anonymous",
+      "content" : "AWSOME",
+      "link" : "pygame.draw"
+   },
+   {
+      "datetimeon" : "2009-09-20T07:33:05",
+      "id" : 2954,
+      "content" : "Aloha! jdv",
+      "user_title" : "Anonymous",
+      "link" : "Rect.move_ip"
+   },
+   {
+      "id" : 2964,
+      "datetimeon" : "2009-10-01T14:16:05",
+      "link" : "pygame.draw.arc",
+      "user_title" : "Anonymous",
+      "content" : "Worth mentioning: the initial angle must be less than the final angle; otherwise it will draw the full elipse."
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "If you want a circle with a *good* outline, use this:\n\ndef drawcircle(image, colour, origin, radius, width=0):\n\tif width == 0:\n\t\tpygame.draw.circle(image,colour,intlist(origin),int(radius))\n\telse:\n\t\tif radius &gt; 65534/5: radius = 65534/5\n\t\tcircle = pygame.Surface([radius*2+width,radius*2+width]).convert_alpha()\n\t\tcircle.fill([0,0,0,0])\n\t\tpygame.draw.circle(circle, colour, intlist([circle.get_width()/2, circle.get_height()/2]), int(radius+(width/2)))\n\t\tif int(radius-(width/2)) &gt; 0: pygame.draw.circle(circle, [0,0,0,0], intlist([circle.get_width()/2, circle.get_height()/2]), abs(int(radius-(width/2))))\n\t\timage.blit(circle, [origin[0] - (circle.get_width()/2), origin[1] - (circle.get_height()/2)])",
+      "id" : 2963,
+      "datetimeon" : "2009-09-30T10:47:07"
+   },
+   {
+      "datetimeon" : "2009-09-21T11:39:31",
+      "id" : 2956,
+      "user_title" : "Anonymous",
+      "content" : "I think the problem has something to do with encapsulation.\nTry:\ncurrent_song = 0\ndef Play_Next_Song():\n    global current_song\n    if pygame.mixer.music.get_busy() == False:\n        print songs[current_song]\n        pygame.mixer.music.load(songs[current_song])\n        pygame.mixer.music.play()    \n        current_song += 1",
+      "link" : "pygame.mixer.music.load"
+   },
+   {
+      "content" : "WHAT?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.lines",
+      "datetimeon" : "2009-09-23T15:22:38",
+      "id" : 2957
+   },
+   {
+      "datetimeon" : "2009-09-24T13:53:40",
+      "id" : 2958,
+      "content" : "Can I draw circles too?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "how can i get a mouse wheel value? please show in a snippet - i don't know how to use pygame.MOUSEBUTTONDOWN and pygame.MOUSEBUTTONUP",
+      "link" : "pygame.mouse.get_pressed",
+      "datetimeon" : "2009-09-25T11:53:07",
+      "id" : 2960
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Setting the line width does not work!",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2009-09-29T10:21:37",
+      "id" : 2962
+   },
+   {
+      "id" : 3128,
+      "datetimeon" : "2010-05-21T11:08:52",
+      "link" : "Rect.collidelistall",
+      "content" : "i dont like pygame very much\nrectangles can go poop themselves",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Clock.tick_busy_loop",
+      "user_title" : "Anonymous",
+      "content" : "In fact it should be\n\"By calling Clock.tick(40)\" -&gt; \"Clock.tick_busy_loop(40)\"",
+      "id" : 3130,
+      "datetimeon" : "2010-06-01T03:26:55"
+   },
+   {
+      "datetimeon" : "2010-06-01T07:55:40",
+      "id" : 3131,
+      "content" : "No, waiting at the very beginning or very end of a loop does not make\nmuch difference.  Moving it to the middle might: \n  screen.fill(...)\n  clock.tick(30)\n  screen.blit(...)\nwill mostly show a blank screen because the fill will be visible\nduring the wait.",
+      "user_title" : "Anonymous",
+      "link" : "Clock.tick"
+   },
+   {
+      "id" : 3133,
+      "datetimeon" : "2010-06-02T03:11:33",
+      "link" : "Rect.collidelist",
+      "content" : "haleluja",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.PixelArray",
+      "content" : "PixelArray works faster than SurfArray for me also.",
+      "user_title" : "Anonymous",
+      "id" : 3134,
+      "datetimeon" : "2010-06-02T20:55:16"
+   },
+   {
+      "id" : 3135,
+      "datetimeon" : "2010-06-06T16:23:37",
+      "link" : "pygame.mixer.music.fadeout",
+      "user_title" : "Anonymous",
+      "content" : "Only seems to block if you start another piece of music playing while it's still\nfading out."
+   },
+   {
+      "link" : "Surface.subsurface",
+      "user_title" : "Anonymous",
+      "content" : "If you're having trouble with color keys, try image.set_alpha(None) on each individual subsurface.\nsubsurface seems not to always inherit its parent's alpha setting, so if the parent source image has an alpha then color key is ignored in subsurfaces.\n\nYou can easily remove the alpha channel in GIMP by right-clicking the background layer and selecting \"remove alpha channel\" to fix all your problems also :)",
+      "id" : 3139,
+      "datetimeon" : "2010-06-08T23:09:21"
+   },
+   {
+      "datetimeon" : "2010-06-10T20:42:30",
+      "id" : 3140,
+      "user_title" : "Anonymous",
+      "content" : "You should use pygame.display.Info.current_h and pygame.display.Info.current_w.",
+      "link" : "pygame.display.get_surface"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "pygame.display.Info().current_h and pygame.display.Info().current_w",
+      "link" : "pygame.display.get_surface",
+      "datetimeon" : "2010-06-10T20:43:14",
+      "id" : 3141
+   },
+   {
+      "link" : "pygame.display.get_surface",
+      "user_title" : "Anonymous",
+      "content" : "screen = pygame.display.set_mode(...)\nscreen.get_size()",
+      "id" : 3142,
+      "datetimeon" : "2010-06-10T20:55:19"
+   },
+   {
+      "content" : "11246579455877\nppqu s442",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mixer.music.play",
+      "datetimeon" : "2010-06-11T18:56:04",
+      "id" : 3143
+   },
+   {
+      "link" : "Color.r",
+      "content" : "import pygame\nimport pygame, sys,os, time                 \nfrom pygame.locals import *                  \nfrom pygame.color import THECOLORS           \nimport platform, os                          \nif platform.system()==\"Windows\":           \n    os.environ['SDL_VIDEODRIVER']='windib'\npygame.init()\nwindow = pygame.display.set_mode((600,600)) \nscreen = pygame.display.get_surface() \npygame.display.set_caption('Excercise 5') \nscreen.fill((0,0,0))\n\nclass GfxCursor:\n    \"\"\"\n    Replaces the normal pygame cursor with any bitmap cursor\n    \"\"\"\n\n    def __init__(self,surface,cursor=None,hotspot=(0,0)):\n        \"\"\"\n        surface = Global surface to draw on\n        cursor  = surface of cursor (needs to be specified when enabled!)\n        hotspot = the hotspot for your cursor\n        \"\"\"\n        self.surface = surface\n        self.enabled = 0\n        self.cursor  = None\n        self.hotspot = hotspot\n        self.bg      = None\n        self.offset  = 0,0\n        self.old_pos = 0,0\n        \n        if cursor:\n            self.setCursor(cursor,hotspot)\n            self.enable()\n\n    def enable(self):\n        \"\"\"\n        Enable the GfxCursor (disable normal pygame cursor)\n        \"\"\"\n        if not self.cursor or self.enabled: return\n        pygame.mouse.set_visible(0)\n        self.enabled = 1\n\n    def disable(self):\n        \"\"\"\n        Disable the GfxCursor (enable normal pygame cursor)\n        \"\"\"\n        if self.enabled:\n            self.hide()\n            pygame.mouse.set_visible(1)\n            self.enabled = 0\n\n    def setCursor(self,cursor,hotspot=(0,0)):\n        \"\"\"\n        Set a new cursor surface\n        \"\"\"\n        if not cursor: return\n        self.cursor = cursor\n        self.hide()\n        self.show()\n        self.offset = 0,0\n        self.bg = pygame.Surface(self.cursor.get_size())\n        pos = self.old_pos[0]-self.offset[0],self.old_pos[1]-self.offset[1]\n        self.bg.blit(self.surface,(0,0),\n            (pos[0],pos[1],self.cursor.get_width(),self.cursor.get_height()))\n\n        self.offset = hotspot\n\n    def setHotspot(self,pos):\n        \"\"\"\n        Set a new hotspot for the cursor\n        \"\"\"\n        self.hide()\n        self.offset = pos\n\n    def hide(self):\n        \"\"\"\n        Hide the cursor (useful for redraws)\n        \"\"\"\n        if self.bg and self.enabled:\n            return self.surface.blit(self.bg,\n                (self.old_pos[0]-self.offset[0],self.old_pos[1]-self.offset[1]))\n\n    def show(self):\n        \"\"\"\n        Show the cursor again\n        \"\"\"\n        if self.bg and self.enabled:\n            pos = self.old_pos[0]-self.offset[0],self.old_pos[1]-self.offset[1]\n            self.bg.blit(self.surface,(0,0),\n                (pos[0],pos[1],self.cursor.get_width(),self.cursor.get_height()))\n            return self.surface.blit(self.cursor,pos)\n\n    def update(self,event):\n        \"\"\"\n        Update the cursor with a MOUSEMOTION event\n        \"\"\"\n        self.old_pos = event.pos\n\nif __name__ == '__main__': #test it out\n    import pygame.draw\n    pygame.init()\n    screen = pygame.display.set_mode((400, 300))\n    screen.fill((50, 50, 111), (0, 0, 400, 150))\n    pygame.display.flip()\n    pygame.display.set_caption('Test the GfxCursor (and paint)')\n    \n    image = pygame.Surface((20, 20))\n    pygame.draw.circle(image, (50, 220, 100), (10, 10), 8, 0)\n    pygame.draw.circle(image, (220, 200, 50), (10, 10), 8, 2)\n    image.set_at((9, 9), (255,255,255))\n    image.set_colorkey(0, pygame.RLEACCEL)\n    \n    magicbox = pygame.Rect(10, 10, 100, 90)\n    magiccolor = 0\n    \n    cursor = GfxCursor(screen, image, (10, 10))\n    finished = 0\n    downpos = None\n    while not finished:\n        dirtyrects = []\n        dirtyrects.extend([cursor.hide()])\n        for e in pygame.event.get():\n            if e.type in (pygame.QUIT, pygame.KEYDOWN):\n                finished = 1\n                break\n            elif e.type == pygame.MOUSEBUTTONDOWN:\n                cursor.disable()\n                downpos = e.pos\n            elif e.type == pygame.MOUSEBUTTONUP:\n                cursor.enable()\n                downpos = None\n            elif downpos and e.type == pygame.MOUSEMOTION:\n                r = pygame.draw.line(screen, (100,100,100), downpos, e.pos, 2)\n                dirtyrects.append(r)\n                downpos = e.pos\n                cursor.update(e)\n            elif not downpos and e.type == pygame.MOUSEMOTION:\n                cursor.update(e)\n        \n        magiccolor = (magiccolor + 2) % 255\n        r = screen.fill((0, 0, magiccolor), magicbox)\n        dirtyrects.append(r)\n        \n        #here's how we sandwich the flip/update with cursor show and hide\n        dirtyrects.extend([cursor.show()])\n        pygame.display.update(dirtyrects)\n        \n        pygame.time.delay(5) #should be time.wait(5) with pygame-1.3 :]",
+      "user_title" : "Anonymous",
+      "id" : 3145,
+      "datetimeon" : "2010-06-13T02:45:37"
+   },
+   {
+      "link" : "pygame.font.get_fonts",
+      "content" : "I get an 'UnboundLocalError: local variable 'fonts' referenced before assignment' error. \nI'm on Mac OS X 10.4 Tiger with Python 2.6.4, Pygame 1.9.1.",
+      "user_title" : "Anonymous",
+      "id" : 3146,
+      "datetimeon" : "2010-06-19T22:22:14"
+   },
+   {
+      "link" : "Joystick.get_axis",
+      "user_title" : "Anonymous",
+      "content" : "I'm no expert but wouldn't it be faster to use the math.hypot(a, b)\nfunction for determining length instead of writing your own function?",
+      "id" : 2759,
+      "datetimeon" : "2009-06-09T21:45:55"
+   },
+   {
+      "id" : 2758,
+      "datetimeon" : "2009-06-08T14:31:39",
+      "link" : "pygame.transform.rotate",
+      "user_title" : "Anonymous",
+      "content" : "You can also move the corner:\n\nsquare_corner=(x-square_dim[0]*sqrt(2)/2*sin((abs(angle)+45)*pi/180),\n                     y-square_dim[1]*sqrt(2)/2*sin((45+abs(angle))*pi/180))\n  screen.blit(pygame.transform.rotate(square,angle), square_corner)\n\nBeware: sin calculates the angle in rad but rotate needs angles in degrees."
+   },
+   {
+      "id" : 2755,
+      "datetimeon" : "2009-06-03T22:15:32",
+      "link" : "pygame.event",
+      "user_title" : "Anonymous",
+      "content" : "ACTIVEEVENT has two attributes. \"gain\" is set to 0 or one depending if the type of focus was lost or gained. \"state\" will equal 1 for mouse focus, 2 for keyboard focus, or 4 for window iconification."
+   },
+   {
+      "content" : "If you want only certain events to be enabled -- you will need to disable them all, and only then enable the ones that you need:\n#--\npygame.event.set_allowed(None)\nprint map(pygame.event.get_blocked,range(1,33))\npygame.event.set_allowed([pygame.QUIT, pygame.KEYDOWN, pygame.USEREVENT])\nprint map(pygame.event.get_blocked,range(1,33))\n#--\nbelow is the output:\n[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]\n[1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1]",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.set_allowed",
+      "datetimeon" : "2009-05-30T16:39:22",
+      "id" : 2754
+   },
+   {
+      "id" : 2753,
+      "datetimeon" : "2009-05-27T02:45:25",
+      "link" : "Surface.unmap_rgb",
+      "content" : "Also, it should maybe be noted that it returns 4 tuple items, not just 3.\nMy guess is RGBA tuple instead of RGB, but I'm not an expert :P",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Surface.unmap_rgb",
+      "content" : "convert a mapped integer color value into a Color\nSurface.map_rgb(mapped_int): return Color\n        ^\nShouldn't it be \"Surface.unmap_rgb\"?",
+      "user_title" : "Anonymous",
+      "id" : 2752,
+      "datetimeon" : "2009-05-27T02:43:16"
+   },
+   {
+      "id" : 2751,
+      "datetimeon" : "2009-05-21T06:41:14",
+      "link" : "pygame.mixer.music",
+      "user_title" : "Anonymous",
+      "content" : "Tracked module playback with Pygame has a lower playback volume than usual,\nand I need to find something like \"stereo separation\" feature yet."
+   },
+   {
+      "datetimeon" : "2009-05-21T06:35:19",
+      "id" : 2750,
+      "user_title" : "Anonymous",
+      "content" : "Yes, I just found it out, and it plays tracked music modules such as MOD or XM.\nBut IT (Impulse Tracker) modules don't play correctly. Wow. I used fmod with Python bindings\nall the time, and Pygame supported it already. I wish I knew that sooner :D",
+      "link" : "pygame.mixer.music"
+   },
+   {
+      "datetimeon" : "2009-05-19T11:35:42",
+      "id" : 2749,
+      "content" : "While using this, it seems that it returns true when the music is paused. Anyone else having this problem, if it's a problem?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mixer.music.get_busy"
+   },
+   {
+      "datetimeon" : "2009-05-11T00:29:55",
+      "id" : 2744,
+      "content" : "If you want to draw the sprites in your group in the opposite order you could try something like this:\n#Suppose that you keep a list of objects in \"Sprites\"\nSprites=[]\n#You also have:\nAllsprites=pygame.sprite.OrderedUpdates(Sprites)\n\nWhenever you add something to the list of sprites, you want to add it to Allsprites like this:\ndef create_sprite():\n     a=SomeClassForYourSprite()\n     Sprites.append(a)\n     Allsprites.add(a)\n\n#That is how I normally add sprites, but unfortunately I was getting the reverse order of what I wanted so I did this:\ndef create_sprite():\n     Allsprites.empty() #This removes all objects from your group\n     a=SomeClassForYourSprite()\n     Sprites.insert(0,a) #Placing your new sprite at the front of the list\n     for sprite in Sprites:\n           Allsprites.add(sprite)\n\nThis should reverse the order for you, allowing the newest sprite created to appear at the bottom instead of the top",
+      "user_title" : "Anonymous",
+      "link" : "pygame.sprite.OrderedUpdates"
+   },
+   {
+      "datetimeon" : "2011-01-14T19:38:50",
+      "id" : 3730,
+      "content" : "Is this function blocking?  I mean...  when it returns and my program flow continues, can I be assured that the display has updated on the actual screen?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.display.update"
+   },
+   {
+      "id" : 3734,
+      "datetimeon" : "2011-01-16T15:32:54",
+      "link" : "pygame.font.SysFont",
+      "user_title" : "Anonymous",
+      "content" : "Is there a way to set a path to a font file?"
+   },
+   {
+      "datetimeon" : "2011-01-16T19:25:25",
+      "id" : 3735,
+      "user_title" : "Anonymous",
+      "content" : "eee",
+      "link" : "pygame.image.tostring"
+   },
+   {
+      "id" : 3737,
+      "datetimeon" : "2011-01-17T21:08:17",
+      "link" : "pygame.draw.polygon",
+      "content" : "The last comment was spam",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "[(x,y), (x1,y1), (x2,y2)]",
+      "link" : "pygame.draw.polygon",
+      "datetimeon" : "2011-01-17T21:08:51",
+      "id" : 3738
+   },
+   {
+      "id" : 3739,
+      "datetimeon" : "2011-01-18T03:41:16",
+      "link" : "pygame.transform.smoothscale",
+      "user_title" : "Anonymous",
+      "content" : "The core algorithm works with 32-bit surfaces. When a 24-bit surface is passed, the pixel data is converted to 32-bit data before the actual transformation, and then it's converted back into 24-bits again, which means 2 extra conversions of the whole image. This would especially be troublesome with large images."
+   },
+   {
+      "datetimeon" : "2011-01-18T06:48:13",
+      "id" : 3740,
+      "user_title" : "Anonymous",
+      "content" : "re",
+      "link" : "pygame.mixer.music.pause"
+   },
+   {
+      "link" : "index.html",
+      "user_title" : "Anonymous",
+      "content" : "Hello world",
+      "id" : 3743,
+      "datetimeon" : "2011-01-19T16:38:01"
+   },
+   {
+      "link" : "pygame.event.get_grab",
+      "content" : "what",
+      "user_title" : "Anonymous",
+      "id" : 3748,
+      "datetimeon" : "2011-01-25T20:39:22"
+   },
+   {
+      "link" : "Font.size",
+      "content" : "The width for \"ae\" WILL always match the width for \"a\" + \"e\" (which is \"a\" concatinated with\"e\").\nIt will not always match the width of \"a\" plus the width of \"e\".\n(But we knew what you meant.)",
+      "user_title" : "Anonymous",
+      "id" : 3749,
+      "datetimeon" : "2011-01-25T21:11:43"
+   },
+   {
+      "datetimeon" : "2011-01-27T17:25:55",
+      "id" : 3754,
+      "content" : "can we get an admin to delete that?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "link" : "PixelArray.compare",
+      "content" : "This function seems to me little bit buggy, so I wrote my own:\n\na and b are surfarrays of some surfaces that you want to compare\n\n    def comparray(self,a,b):\n        c = abs(a.__sub__(b))\n        c = c.__ge__(self.tolerance)*255\n        surface = pygame.surfarray.make_surface(c)\n        return surface",
+      "user_title" : "Anonymous",
+      "id" : 3755,
+      "datetimeon" : "2011-01-27T18:49:07"
+   },
+   {
+      "datetimeon" : "2011-01-28T04:28:47",
+      "id" : 3758,
+      "user_title" : "Anonymous",
+      "content" : "your gay",
+      "link" : "Rect.colliderect"
+   },
+   {
+      "id" : 3765,
+      "datetimeon" : "2011-01-30T21:39:27",
+      "link" : "Channel.queue",
+      "content" : "It would be nice if the number of Sounds on queue was more than one...\n\nGreg Ruo",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "Channel.queue",
+      "content" : "I solved my previous question:\n\nIf you need to play in sequence several Sounds in a queue, you can solve this\nwith something like:\n=======================\n    i=0\n    while (Ch0.get_queue()==None) and (i&lt;10):\n            i+=1\n            Ch0.queue(f[i])\n============================\n\nwhere Ch0 is your Sound channel created with Ch0=pygame.mixer.Channel(0).\nIn other words, even if the queue allows only one single sound in queue,\nI use the .get_queue method to wait until the queue is free before\n adding the next Sound in the sequence.\n\nIf you have better solutions please reply here. Thanks.\n\nGreg Ruo",
+      "user_title" : "Anonymous",
+      "id" : 3766,
+      "datetimeon" : "2011-01-30T22:38:45"
+   },
+   {
+      "link" : "pygame.event.get",
+      "content" : "Probably would be good to have an  OPTIONAL  choice to remove them from the queue . . .",
+      "user_title" : "Anonymous",
+      "id" : 3768,
+      "datetimeon" : "2011-01-31T13:48:40"
+   },
+   {
+      "content" : "I had this weird thing where blue/red was inversed, but not the other colours, when I was mapping some pixels from one image to a blank surface.\nIt was caused by copying the color integer directly to one pixel to the other, so the trick is to always surface.unmap_rgb(pixel) before setting the color to a new pixel \nThat tricked works.\nIt's the only way unfortunately.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.PixelArray",
+      "datetimeon" : "2011-02-04T02:33:15",
+      "id" : 3771
+   },
+   {
+      "content" : "@Dave: Thanks very much for writing that we should ignore the keyword \"width\". This saved me time and my program now works.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2011-02-05T08:25:19",
+      "id" : 3773
+   },
+   {
+      "link" : "Rect.colliderect",
+      "user_title" : "Anonymous",
+      "content" : "ankit sucks",
+      "id" : 3776,
+      "datetimeon" : "2011-02-08T14:07:31"
+   },
+   {
+      "link" : "Rect.collidepoint",
+      "user_title" : "Anonymous",
+      "content" : "i heard ankit really sucks",
+      "id" : 3777,
+      "datetimeon" : "2011-02-08T14:07:46"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "ankit tandon sucks",
+      "link" : "Rect.contains",
+      "datetimeon" : "2011-02-08T14:07:55",
+      "id" : 3778
+   },
+   {
+      "datetimeon" : "2011-02-09T22:32:43",
+      "id" : 3779,
+      "user_title" : "Anonymous",
+      "content" : "I don't get what this does...",
+      "link" : "pygame.event.pump"
+   },
+   {
+      "id" : 3780,
+      "datetimeon" : "2011-02-10T21:20:05",
+      "link" : "pygame.event.pump",
+      "user_title" : "Anonymous",
+      "content" : "If you don't use the event queue(why aren't you??) this will keep your program from locking up."
+   },
+   {
+      "content" : "When the camera is stopped and you try to access it pygame segfaults.\n(On Debian testing with pygame 1.9.1)",
+      "user_title" : "Anonymous",
+      "link" : "Camera.stop",
+      "datetimeon" : "2011-02-11T03:31:32",
+      "id" : 3781
+   },
+   {
+      "link" : "pygame.event.set_allowed",
+      "content" : "set_allowed removes events from the queue! \nEven if the event in question doesn't belong to the given type.\n\n&gt;&gt;&gt; import pygame\n&gt;&gt;&gt; pygame.init()\n&gt;&gt;&gt; pygame.event.post(pygame.event.Event(pygame.USEREVENT, code=0))\n&gt;&gt;&gt; print pygame.event.peek(pygame.USEREVENT)\n1\n&gt;&gt;&gt; pygame.event.set_allowed(pygame.MOUSEMOTION)\n&gt;&gt;&gt; print pygame.event.peek(pygame.USEREVENT)\n0",
+      "user_title" : "Anonymous",
+      "id" : 3782,
+      "datetimeon" : "2011-02-11T17:42:34"
+   },
+   {
+      "id" : 3783,
+      "datetimeon" : "2011-02-14T16:59:41",
+      "link" : "PixelArray.compare",
+      "user_title" : "Anonymous",
+      "content" : "Thank you very much.\nYour compare function works much better than the original one."
+   },
+   {
+      "link" : "Color.g",
+      "user_title" : "Anonymous",
+      "content" : "meto",
+      "id" : 3786,
+      "datetimeon" : "2011-02-15T19:30:06"
+   },
+   {
+      "id" : 3787,
+      "datetimeon" : "2011-02-16T06:49:19",
+      "link" : "pygame.draw.rect",
+      "content" : "rofl rofl what for a crappy thing you performed? go to wikipedia it works!\n\nu mad!",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "rofl rofl what for a crappy thing you performed? go to wikipedia it works!\n\nu mad!",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2011-02-16T06:50:00",
+      "id" : 3788
+   },
+   {
+      "content" : "stfu\n\nu mad",
+      "user_title" : "Anonymous",
+      "link" : "Rect.unionall_ip",
+      "datetimeon" : "2011-02-16T06:52:07",
+      "id" : 3789
+   },
+   {
+      "id" : 3791,
+      "datetimeon" : "2011-02-19T12:17:58",
+      "link" : "pygame.mixer.music.queue",
+      "user_title" : "Anonymous",
+      "content" : "This method only queues one music file.\nIf you call it and there already is a queued file, it will be overrided."
+   },
+   {
+      "id" : 3793,
+      "datetimeon" : "2011-02-21T08:30:17",
+      "link" : "pygame.key",
+      "content" : "elif event.type == pygame.QUIT or event.type == pygame.K_ESCAPE:\n\nthe event type is not pygame.K_ESCAPE. you have to check for a KEYDOWN or KEYUP event and check if it is the key you want, for example:\n\nelif event.type == pygame.QUIT or (event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE):",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.cursors.compile",
+      "user_title" : "Anonymous",
+      "content" : "Well, sometimes black and white are swapped, sometimes they aren't.\nEven in the same program, for one mouse cursor it may work right,\nand for another cursor the black &amp; white colors are swapped.\n\nI haven't figured out what triggers this bug.",
+      "id" : 3797,
+      "datetimeon" : "2011-02-24T13:00:58"
+   },
+   {
+      "datetimeon" : "2011-02-26T15:00:47",
+      "id" : 3798,
+      "content" : "spam",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.set_grab"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "In Pygame 1.9.2 surface objects have sprouted a new method, get_view:\n\nSurface.get_view\nreturn a view of a surface's pixel data.\nSurface.get_view(kind='2'): return\n\nReturn an object which exposes a surface's internal pixel buffer to a NumPy array. For now a custom object with an array struct interface is returned. A Python memoryview may be returned in the future. The buffer is writeable.\n\nThe kind argument is the length 1 string '2', '3', 'r', 'g', 'b', or 'a'. The letters are case insensitive; 'A' will work as well. The argument can be either a Unicode or byte (char) string. The default is '2'.\n\nA kind '2' view is a (surface-width, surface-height) array of raw pixels. The pixels are surface bytesized unsigned integers. The pixel format is surface specific. It is unavailable for 24-bit surfaces.\n\n'3' returns a (surface-width, surface-height, 3) view of RGB color components. Each of the red, green, and blue components are unsigned bytes. Only 24-bit and 32-bit surfaces are supported. The color components must be in either RGB or BGR order within the pixel.\n\n'r' for red, 'g' for green, 'b' for blue, and 'a' for alpha return a (surface-width, surface-height) view of a single color component within a surface: a color plane. Color components are unsigned bytes. Both 24-bit and 32-bit surfaces support 'r', 'g', and 'b'. Only 32-bit surfaces with SRCALPHA support 'a'.\n\nThis method implicitly locks the Surface. The lock will be released, once the returned view object is deleted.",
+      "link" : "pygame.Surface",
+      "datetimeon" : "2011-03-01T14:59:53",
+      "id" : 3803
+   },
+   {
+      "datetimeon" : "2011-03-01T15:02:04",
+      "id" : 3804,
+      "user_title" : "Anonymous",
+      "content" : "In Pygame 1.9.2 surface objects have sprouted a new method, get_view:\n\nSurface.get_view\nreturn a view of a surface's pixel data.\nSurface.get_view(kind='2'): return\n\nReturn an object which exposes a surface's internal pixel buffer to a NumPy\narray. For now a custom object with an array struct interface is returned.\nA Python memoryview may be returned in the future. The buffer is writeable.\n\nThe kind argument is the length 1 string '2', '3', 'r', 'g', 'b', or 'a'.\nThe letters are case insensitive; 'A' will work as well. The argument can be\neither a Unicode or byte (char) string. The default is '2'.\n\nA kind '2' view is a (surface-width, surface-height) array of raw pixels. The\npixels are surface bytesized unsigned integers. The pixel format is surface\nspecific. It is unavailable for 24-bit surfaces.\n\n'3' returns a (surface-width, surface-height, 3) view of RGB color components.\nEach of the red, green, and blue components are unsigned bytes. Only 24-bit and\n32-bit surfaces are supported. The color components must be in either RGB or\nBGR order within the pixel.\n\n'r' for red, 'g' for green, 'b' for blue, and 'a' for alpha return a\n(surface-width, surface-height) view of a single color component within a\nsurface: a color plane. Color components are unsigned bytes. Both 24-bit and\n32-bit surfaces support 'r', 'g', and 'b'. Only 32-bit surfaces with SRCALPHA\nsupport 'a'.\n\nThis method implicitly locks the Surface. The lock will be released, once the\nreturned view object is deleted.",
+      "link" : "pygame.Surface"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "for statement with arc",
+      "link" : "pygame.draw.arc",
+      "datetimeon" : "2011-03-01T19:54:13",
+      "id" : 3805
+   },
+   {
+      "content" : "Oh my god I was so thankful that you can adjust the volume, I have no editing software to fix my sounds.",
+      "user_title" : "Anonymous",
+      "link" : "Sound.set_volume",
+      "datetimeon" : "2011-03-03T21:26:40",
+      "id" : 3806
+   },
+   {
+      "datetimeon" : "2011-03-09T16:10:36",
+      "id" : 3808,
+      "content" : "Thanks to the comments for wrinting about the event attributes and the key constants list. It should be in any serious documentation.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.event.Event"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:41:39",
+      "id" : 3809,
+      "user_title" : "Anonymous",
+      "content" : "a;rtawkljethlak",
+      "link" : "pygame.font"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:42:20",
+      "id" : 3810,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "id" : 3811,
+      "datetimeon" : "2011-03-10T18:42:22",
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "id" : 3812,
+      "datetimeon" : "2011-03-10T18:42:24"
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:42:27",
+      "id" : 3813
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3814,
+      "datetimeon" : "2011-03-10T18:42:29"
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3815,
+      "datetimeon" : "2011-03-10T18:42:31"
+   },
+   {
+      "id" : 3816,
+      "datetimeon" : "2011-03-10T18:42:33",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "id" : 3817,
+      "datetimeon" : "2011-03-10T18:42:36",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:42:37",
+      "id" : 3818,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:42:47",
+      "id" : 3819,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:42:53",
+      "id" : 3820,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "id" : 3821,
+      "datetimeon" : "2011-03-10T18:42:54",
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous"
+   },
+   {
+      "id" : 3822,
+      "datetimeon" : "2011-03-10T18:42:56",
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous"
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3823,
+      "datetimeon" : "2011-03-10T18:42:58"
+   },
+   {
+      "id" : 3824,
+      "datetimeon" : "2011-03-10T18:43:01",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:03",
+      "id" : 3825
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:07",
+      "id" : 3826,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3827,
+      "datetimeon" : "2011-03-10T18:43:09"
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:11",
+      "id" : 3828
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:13",
+      "id" : 3829
+   },
+   {
+      "id" : 3830,
+      "datetimeon" : "2011-03-10T18:43:15",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:16",
+      "id" : 3831,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:19",
+      "id" : 3832,
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:20",
+      "id" : 3833,
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init"
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3834,
+      "datetimeon" : "2011-03-10T18:43:22"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:24",
+      "id" : 3835,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "id" : 3836,
+      "datetimeon" : "2011-03-10T18:43:26",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:28",
+      "id" : 3837
+   },
+   {
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "id" : 3838,
+      "datetimeon" : "2011-03-10T18:43:29"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:31",
+      "id" : 3839,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "id" : 3840,
+      "datetimeon" : "2011-03-10T18:43:33",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:35",
+      "id" : 3841
+   },
+   {
+      "id" : 3842,
+      "datetimeon" : "2011-03-10T18:43:37",
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:39",
+      "id" : 3843
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:40",
+      "id" : 3844
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3845,
+      "datetimeon" : "2011-03-10T18:43:42"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:45",
+      "id" : 3846,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "id" : 3847,
+      "datetimeon" : "2011-03-10T18:43:46",
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:48",
+      "id" : 3848
+   },
+   {
+      "id" : 3849,
+      "datetimeon" : "2011-03-10T18:43:50",
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:43:52",
+      "id" : 3850,
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init"
+   },
+   {
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:53",
+      "id" : 3851
+   },
+   {
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "id" : 3852,
+      "datetimeon" : "2011-03-10T18:43:55"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:57",
+      "id" : 3853
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:43:59",
+      "id" : 3854
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init",
+      "datetimeon" : "2011-03-10T18:44:07",
+      "id" : 3855
+   },
+   {
+      "id" : 3856,
+      "datetimeon" : "2011-03-10T18:44:09",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3857,
+      "datetimeon" : "2011-03-10T18:44:11"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:44:13",
+      "id" : 3858,
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init"
+   },
+   {
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "id" : 3859,
+      "datetimeon" : "2011-03-10T18:44:15"
+   },
+   {
+      "id" : 3860,
+      "datetimeon" : "2011-03-10T18:44:18",
+      "link" : "pygame.font.init",
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:44:20",
+      "id" : 3861,
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "link" : "pygame.font.init"
+   },
+   {
+      "datetimeon" : "2011-03-10T18:44:22",
+      "id" : 3862,
+      "user_title" : "Anonymous",
+      "content" : "I LIKEY TO SPAM",
+      "link" : "pygame.font.init"
+   },
+   {
+      "link" : "pygame.font.init",
+      "content" : "I LIKEY TO SPAM",
+      "user_title" : "Anonymous",
+      "id" : 3863,
+      "datetimeon" : "2011-03-10T18:44:24"
+   },
+   {
+      "datetimeon" : "2011-03-12T11:25:09",
+      "id" : 3864,
+      "user_title" : "Anonymous",
+      "content" : "Hey guys, how do you detect if user hits enter? There's no event.key for that! Thank you.",
+      "link" : "pygame.key"
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "content" : "Could somebody please delete the horrible code in this comment thread? :(",
+      "user_title" : "Anonymous",
+      "id" : 3865,
+      "datetimeon" : "2011-03-15T20:16:46"
+   },
+   {
+      "id" : 3868,
+      "datetimeon" : "2011-03-21T15:13:24",
+      "link" : "Font.metrics",
+      "user_title" : "Anonymous",
+      "content" : "pygame documentation\t ||  Pygame Home  ||  Help Contents  || Reference Index  || \n \nCamera ||  Cdrom ||  Color ||  Cursors ||  Display ||  Draw ||  Event ||  Examples ||  Font ||  Gfxdraw ||  Image ||  Joystick ||  Key ||  Locals ||  Mask ||  Midi ||  Mixer ||  Mouse ||  Movie ||  Music ||  Overlay ||  Pixelarray ||  Pygame ||  Rect ||  Scrap ||  Sndarray ||  Sprite ||  Surface ||  Surfarray ||  Tests ||  Time ||  Transform\nFont.metrics\n\nThe user submitted comments should be used for:\n\nExamples\nHelpful hints, tips, and tricks\nFurther explanation / documentation\nThe user submitted comments should NOT be used for:\n\nBug Reports (see our new Bug Reports link on the side)\nFeature Requests\nQuestions\nPlease note that periodically, the developers may go through the notes and incorporate the information in them into the documentation. This means that any note submitted here becomes the property of Pete Shinners under the LGPL licence.\n\nIf you do not want to leave an anonymous comment, please sign in first."
+   },
+   {
+      "id" : 3870,
+      "datetimeon" : "2011-03-22T11:32:04",
+      "link" : "pygame.transform.chop",
+      "content" : "I can't figure how to crop an image, even after reading this suggestion",
+      "user_title" : "Anonymous"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "I was dumb.  Here is how I got it to work.  So simple:\n\ncreen.blit(gameboard,(selection.x-18,selection.y-18),(selection.x-18,selection.y-18,96,96))",
+      "link" : "pygame.transform.chop",
+      "datetimeon" : "2011-03-22T11:45:29",
+      "id" : 3871
+   },
+   {
+      "id" : 3873,
+      "datetimeon" : "2011-03-24T10:34:18",
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "Perfect, Matthew Brown! Just what I was looking for. I found the reset_stuff() function especially useful and I'm going to use it in our production software."
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Wow, thanks a lot Matthew, I am a PyGame newbie and was having some troubles understanding this function without a complete example.",
+      "link" : "pygame.draw.circle",
+      "datetimeon" : "2011-03-24T12:23:02",
+      "id" : 3874
+   },
+   {
+      "datetimeon" : "2011-03-24T18:06:29",
+      "id" : 3875,
+      "content" : "lol",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.circle"
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "content" : "Guys, what Matthew N. Brown did here harms python's reputation.\n\nPython is elegant.\n\nWhat Matthew did was perlify python ... this is terrible...",
+      "user_title" : "Anonymous",
+      "id" : 3876,
+      "datetimeon" : "2011-03-24T18:07:11"
+   },
+   {
+      "link" : "pygame.draw.circle",
+      "user_title" : "Anonymous",
+      "content" : "Just wanted to give my profuse thanks to Matthew N. Brown for his superb usage example of this otherwise vague and esoteric method. I've contacted my boss and we will now integrate this snippet into all of our newly created (and soon-to-be-refactored) legacy code.",
+      "id" : 3878,
+      "datetimeon" : "2011-03-25T20:41:38"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "where image is a surface, rot and scale are floats\n\n    return pygame.transform.smoothscale(image, rot, scale)\nTypeError: argument 2 must be 2-item sequence, not float\n    \n    return pygame.transform.smoothscale(image,[0,0], scale)\nTypeError: argument 3 must be pygame.Surface, not float",
+      "link" : "pygame.transform.rotozoom",
+      "datetimeon" : "2011-03-27T01:37:09",
+      "id" : 3879
+   },
+   {
+      "content" : "and...\n    surf = pygame.surface.Surface((image.get_width()*scale, image.get_height()*scale))\n    return pygame.transform.smoothscale(image,[0,0], surf)\n\n    pygame.transform.smoothscale(image,[0,0], surf)\nValueError: Destination surface not the given width or height.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.transform.rotozoom",
+      "datetimeon" : "2011-03-27T01:40:56",
+      "id" : 3880
+   },
+   {
+      "link" : "pygame.event.get_grab",
+      "user_title" : "Anonymous",
+      "content" : "look at set_grab first and then you understand",
+      "id" : 3881,
+      "datetimeon" : "2011-03-27T13:55:15"
+   },
+   {
+      "link" : "Font.render",
+      "content" : "getting this error :\n in __init__\n    self.font = pygame.font.Font(\"None\", 50)\nerror: font not initialized\n\nnot sure why because i rendered the font..",
+      "user_title" : "Anonymous",
+      "id" : 3882,
+      "datetimeon" : "2011-04-02T14:35:05"
+   },
+   {
+      "datetimeon" : "2011-04-02T17:03:07",
+      "id" : 3883,
+      "content" : "The enter key is K_RETURN.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key"
+   },
+   {
+      "content" : "For this error :\nthere is no soundcard\n\nCall pygame.mixer.init two times :\npygame.mixer.init()\npygame.mixer.init()\n\nOR\n\npygame.mixer.init(); pygame.mixer.init()\n\n(don't omit semicolon)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mixer.init",
+      "datetimeon" : "2011-04-05T05:06:41",
+      "id" : 3886
+   },
+   {
+      "datetimeon" : "2011-04-12T10:48:18",
+      "id" : 3889,
+      "user_title" : "Anonymous",
+      "content" : "/love little kids who leave dumb comments like this one",
+      "link" : "Rect.colliderect"
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "there is no information about the supported formats - are those from ModPlugTracker supported? (like .mod, .xm, .s3m, etc.)",
+      "link" : "pygame.mixer.music.load",
+      "datetimeon" : "2011-04-12T12:35:41",
+      "id" : 3890
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Yes",
+      "link" : "Font.render",
+      "datetimeon" : "2011-04-12T16:17:04",
+      "id" : 3891
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "This seems to be broken!\nI call this before playing a movie, but there is no sound.\nPlaying the movie without initializing the mixer in the first place, works!\n\nCan anyone confirm that this is broken?",
+      "link" : "pygame.mixer.quit",
+      "datetimeon" : "2011-04-18T11:51:33",
+      "id" : 3895
+   },
+   {
+      "datetimeon" : "2011-04-19T10:47:45",
+      "id" : 3896,
+      "user_title" : "Anonymous",
+      "content" : "For Windows (XP):\nThe problem is that the screen does not get updated automatically, for some reason.\nThe solution is simple. Take a surface with the size of the movie, set this as the display of the movie.\nIn a loop, get the current frame of the movie and if it increases, blit the surface onto the screen and update the screen.",
+      "link" : "pygame.movie"
+   },
+   {
+      "link" : "pygame.sndarray.make_sound",
+      "content" : "#!/usr/bin/env python\n# -*- coding: utf-8 -*-\nfrom pygame import *\nimport pygame, time, numpy, pygame.sndarray\n\nsample_rate = 44100\n\ndef play_for(sample_array, ms, volLeft, volRight):\n    sound = pygame.sndarray.make_sound(sample_array)\n    beg = time.time()\n    channel = sound.play(-1)\n    channel.set_volume(volLeft,volRight)\n    pygame.time.delay(ms)\n    sound.stop()\n    end = time.time()\n    return beg, end\n    \ndef sine_array_onecycle(hz, peak):\n    length = sample_rate / float(hz)\n    omega = numpy.pi * 2 / length\n    xvalues = numpy.arange(int(length)) * omega\n    return (peak * numpy.sin(xvalues))\n    \ndef sine_array(hz, peak, n_samples = sample_rate):\n    return numpy.resize(sine_array_onecycle(hz, peak), (n_samples,))\n    \ndef main():\n    pygame.mixer.pre_init(sample_rate, -16, 2) # 44.1kHz, 16-bit signed, stereo\n    pygame.init()\n    f = sine_array(8000, 1)\n    f = numpy.array(zip (f , f))\n\n    play_for(f , 5000, 0.5, 0.5)\n\nif __name__ == '__main__': main()",
+      "user_title" : "Anonymous",
+      "id" : 4038,
+      "datetimeon" : "2011-04-22T12:57:35"
+   },
+   {
+      "content" : "Get Unicode key in Pygame:\n\nfrom pygame import *\npygame.init()\npygame.display.set_mode((500,500),OPENGLBLIT|OPENGL|DOUBLEBUF)\nexitt = 0 \ninte = 4096\nwhile not exitt:\n    for event in pygame.event.get():\n        if event.type == pygame.QUIT: \n            pygame.quit()\n            exitt = True\n        if event.type == KEYDOWN:\n            print event.dict['unicode']",
+      "user_title" : "Anonymous",
+      "link" : "pygame.key",
+      "datetimeon" : "2011-04-23T04:11:07",
+      "id" : 4039
+   },
+   {
+      "content" : "The param is \"loops\" not \"loop\".",
+      "user_title" : "Anonymous",
+      "link" : "Movie.play",
+      "datetimeon" : "2011-04-27T15:37:38",
+      "id" : 4040
+   },
+   {
+      "id" : 4041,
+      "datetimeon" : "2011-04-30T21:10:05",
+      "link" : "Surface.convert_alpha",
+      "user_title" : "Anonymous",
+      "content" : "Use it when you load PNG images with transparencies"
+   },
+   {
+      "id" : 4042,
+      "datetimeon" : "2011-05-03T00:45:25",
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "The dest argument doesnt work for me, say if I do\n\nscreen.blit(mySurf, dest=(0,0))\n\nor screen.blit(mySurf, dest=(100,100))\n\nI get exactly the same outcome.\n\nWhere am i wrong?"
+   },
+   {
+      "link" : "Surface.blit",
+      "user_title" : "Anonymous",
+      "content" : "Sorry I realized i was blitting to screen instead of my temporary surface,\nplease ignore (and delete) my comment.",
+      "id" : 4043,
+      "datetimeon" : "2011-05-03T00:46:43"
+   },
+   {
+      "content" : "How does that differ from pygame.draw.aalines? This one can also not be filled.",
+      "user_title" : "Anonymous",
+      "link" : "pygame.gfxdraw.aapolygon",
+      "datetimeon" : "2011-05-04T14:58:27",
+      "id" : 4044
+   },
+   {
+      "content" : "XBM not supported?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.image",
+      "datetimeon" : "2011-05-10T04:11:53",
+      "id" : 4048
+   },
+   {
+      "datetimeon" : "2011-05-11T00:48:47",
+      "id" : 4049,
+      "content" : "I believe it offsets the detection area by (x,y) pixels. So just put (0,0) for no offset",
+      "user_title" : "Anonymous",
+      "link" : "Mask.draw"
+   },
+   {
+      "id" : 4050,
+      "datetimeon" : "2011-05-12T10:26:46",
+      "link" : "pygame.image.save",
+      "user_title" : "Anonymous",
+      "content" : "This function seems to need raw strings!"
+   },
+   {
+      "id" : 4053,
+      "datetimeon" : "2011-05-14T16:30:13",
+      "link" : "pygame.mixer.music.load",
+      "user_title" : "Anonymous",
+      "content" : "Is there anyway to play more than 2 songs I have tried everything I want the loaded music to play in order\n#!/usr/bin/env python\nimport pygame\npygame.mixer.init()\npygame.mixer.pre_init(44100, -16, 2, 2048)\npygame.init()\nprint \"hey I finaly got this working!\"\npygame.mixer.music.load('D:/Users/John/Music/Music/FUN.OGG')\npygame.mixer.music.load('D:/Users/John/Music/Music/Still Alive.OGG')\npygame.mixer.music.load('D:/Users/John/Music/Music/turret.OGG')\npygame.mixer.music.load('D:/Users/John/Music/Music/portalend.OGG')\npygame.mixer.music.play()\nimport pysic"
+   },
+   {
+      "id" : 4054,
+      "datetimeon" : "2011-05-14T19:29:16",
+      "link" : "pygame.mixer.music.play",
+      "content" : "How is it you play more than one song besides using queue",
+      "user_title" : "Anonymous"
+   },
+   {
+      "content" : "how is it to play a list of songs more than just one without using the queue(which only works once)",
+      "user_title" : "Anonymous",
+      "link" : "pygame.mixer.music.play",
+      "datetimeon" : "2011-05-14T19:32:21",
+      "id" : 4055
+   },
+   {
+      "content" : "can the rectangle be filled with an RGBA color so that I can make it transclucent?",
+      "user_title" : "Anonymous",
+      "link" : "pygame.draw.rect",
+      "datetimeon" : "2011-05-26T09:16:14",
+      "id" : 4056
+   },
+   {
+      "user_title" : "Anonymous",
+      "content" : "Exemple, playing a sinus sound :\n\n#!/usr/bin/env python\n# -*- coding: utf-8 -*-\n\nfrom pygame import *\nimport pygame, time, numpy, pygame.sndarray\n\nsample_rate = 44100\n\ndef play_for(sample_array, ms, volLeft, volRight):\n    sound = pygame.sndarray.make_sound(sample_array)\n    beg = time.time()\n    channel = sound.play(-1)\n    channel.set_volume(volLeft,volRight)\n    pygame.time.delay(ms)\n    sound.stop()\n    end = time.time()\n    return beg, end\n    \ndef sine_array_onecycle(hz, peak):\n    length = sample_rate / float(hz)\n    omega = numpy.pi * 2 / length\n    xvalues = numpy.arange(int(length)) * omega\n    return (peak * numpy.sin(xvalues))\n    \ndef sine_array(hz, peak, n_samples = sample_rate):\n    return numpy.resize(sine_array_onecycle(hz, peak), (n_samples,))\n\n    \ndef main():\n    pygame.mixer.pre_init(sample_rate, -16, 2) # 44.1kHz, 16-bit signed, stereo\n    pygame.init()\n    f = sine_array(8000, 1)\n    f = numpy.array(zip (f , f))\n\n    play_for(f , 5000, 0.2, 0.2)\n\nif __name__ == '__main__': main()",
+      "link" : "pygame.sndarray",
+      "datetimeon" : "2011-05-27T02:36:07",
+      "id" : 4057
+   }
+]

--- a/src_c/.clang-format
+++ b/src_c/.clang-format
@@ -7,6 +7,7 @@ AlignAfterOpenBracket: Align
 BreakBeforeBraces: Stroustrup
 ColumnLimit: 79
 DerivePointerAlignment: false
+# These settings are mirrored in .editorconfig.  Keep them in sync.
 IndentWidth: 4
 Language: Cpp
 PointerAlignment: Right


### PR DESCRIPTION
I don't want to bikeshed too much.
I made this editorconfig so emacs and vim automatically uses spaces instead of tabs.
Pretty-printing docscomments is just a little quality-of-life thing, but `git grep` was totally unusable without the line breaks. I always got the whole contents of the whole file.