### PR TITLE
Use newer xcode8.3 image on travis CI mac builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     # Should only need one OSX build because older builds can work on newer machines ok.
     #https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
       language: generic
       env:
         - PY_VERSION=3
@@ -64,7 +64,7 @@ matrix:
         - GITHUB_UPLOAD=yes
         - UPLOAD_WHL_PYPI=yes
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
       language: generic
       env:
         - PY_VERSION=2
@@ -72,7 +72,7 @@ matrix:
         - GITHUB_UPLOAD=yes
         - UPLOAD_WHL_PYPI=yes
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
       language: generic
       env:
         - PY_VERSION=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     # Should only need one OSX build because older builds can work on newer machines ok.
     #https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode7.3
       language: generic
       env:
         - PY_VERSION=3
@@ -64,7 +64,7 @@ matrix:
         - GITHUB_UPLOAD=yes
         - UPLOAD_WHL_PYPI=yes
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode7.3
       language: generic
       env:
         - PY_VERSION=2
@@ -72,7 +72,7 @@ matrix:
         - GITHUB_UPLOAD=yes
         - UPLOAD_WHL_PYPI=yes
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode7.3
       language: generic
       env:
         - PY_VERSION=3

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -49,11 +49,11 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ -n "$TRAVIS_TAG" ] || [ "$TRAVIS_B
 	# brew uninstall --force --ignore-dependencies sdl_mixer
 	# brew uninstall --force --ignore-dependencies sdl_ttf
 	# brew uninstall --force --ignore-dependencies smpeg
-  brew uninstall --force --ignore-dependencies sdl2
-  brew uninstall --force --ignore-dependencies sdl2_image
-  brew uninstall --force --ignore-dependencies sdl2_mixer
-  brew uninstall --force --ignore-dependencies sdl2_ttf
-  brew uninstall --force --ignore-dependencies smpeg2
+	brew uninstall --force --ignore-dependencies sdl2
+	brew uninstall --force --ignore-dependencies sdl2_image
+	brew uninstall --force --ignore-dependencies sdl2_mixer
+	brew uninstall --force --ignore-dependencies sdl2_ttf
+	#brew uninstall --force --ignore-dependencies smpeg2
 
 	brew uninstall --force --ignore-dependencies jpeg
 	brew uninstall --force --ignore-dependencies libpng
@@ -103,6 +103,8 @@ fi
 
 set +e
 
+# TODO: tap-pin deprecated. Need `brew install pygame/portmidi/sdl2`
+#       https://github.com/pygame/pygame/issues/1272
 brew tap pygame/portmidi
 brew tap-pin pygame/portmidi
 
@@ -120,7 +122,7 @@ install_or_upgrade flac ${UNIVERSAL_FLAG}
 install_or_upgrade fluid-synth
 install_or_upgrade libmikmod ${UNIVERSAL_FLAG}
 # install_or_upgrade smpeg
-install_or_upgrade smpeg2
+# install_or_upgrade smpeg2
 
 
 # Because portmidi hates us... and installs python2, which messes homebrew up.


### PR DESCRIPTION
https://docs.travis-ci.com/user/reference/osx/

Because of sdl2 compilation failure.
```
==> ./configure --prefix=/usr/local/Cellar/sdl2/2.0.10 --without-x
==> make install
Last 15 lines from /Users/travis/Library/Logs/Homebrew/sdl2/02.make:
  CC     build/SDL_cocoaopengles.lo
  CC     build/SDL_cocoashape.lo
  CC     build/SDL_cocoavideo.lo
  CC     build/SDL_cocoavulkan.lo
  CC     build/SDL_cocoawindow.lo
  CC     build/SDL_render_metal.lo
/private/tmp/sdl2-20190829-31479-1nmyf53/SDL2-2.0.10/src/video/cocoa/SDL_cocoawindow.m:1119:52: error: use of undeclared identifier 'NSEventSubtypeMouseEvent'
    const BOOL istrackpad = ([theEvent subtype] == NSEventSubtypeMouseEvent);
                                                   ^
/private/tmp/sdl2-20190829-31479-1nmyf53/SDL2-2.0.10/src/video/cocoa/SDL_cocoawindow.m:1164:52: error: use of undeclared identifier 'NSEventSubtypeMouseEvent'
    const BOOL istrackpad = ([theEvent subtype] == NSEventSubtypeMouseEvent);

2 errors generated.
make: *** [build/SDL_cocoawindow.lo] Error 1
make: *** Waiting for unfinished jobs....
```

