### PR TITLE
Add header guard to scrap.h

### DIFF
--- a/src_c/scrap.h
+++ b/src_c/scrap.h
@@ -19,6 +19,9 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#ifndef SCRAP_H
+#define SCRAP_H
+
 /* This is unconditionally defined in Python.h */
 #if defined(_POSIX_C_SOURCE)
 #undef _POSIX_C_SOURCE
@@ -141,3 +144,5 @@ pygame_scrap_get_types (void);
  */
 extern int
 pygame_scrap_contains (char *type);
+
+#endif /* SCRAP_H */


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 9a24a10db6407e5e3a2997645a5c7c3b6fc595d0