### PR TITLE
WIP: linux-ppc64le and linux-ppc64be builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,18 @@ matrix:
       python: 3.7
       dist: xenial
 
+    - os: linux-ppc64le
+      compiler: gcc
+      sudo: required
+      python: 3.7
+      dist: xenial
+
+    - os: linux-ppc64be
+      compiler: gcc
+      sudo: required
+      python: 3.7
+      dist: xenial
+
     - os: linux
       sudo: required
       python: 3.7


### PR DESCRIPTION
I don't know where these are documented... but I saw haproxy uses linux-ppc64le. So... I'll give it a go.