### PR TITLE
Fix incorrect return in pygame_scrap_init

### DIFF
--- a/src_c/scrap_sdl2.c
+++ b/src_c/scrap_sdl2.c
@@ -52,8 +52,9 @@ pygame_scrap_init(void)
     SDL_Init(SDL_INIT_VIDEO);
 
     pygame_scrap_types = malloc(sizeof(char *) * 2);
-    if (!pygame_scrap_types)
-        return NULL;
+    if (!pygame_scrap_types) {
+        return 0;
+    }
 
     pygame_scrap_types[0] = pygame_scrap_plaintext_type;
     pygame_scrap_types[1] = NULL;


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 98c4164c227e6015703d70b03aa9253e1f2df403