### PR TITLE
Fix LGTM alerts for possible multiplication overflow

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -361,7 +361,7 @@ image_tostring(PyObject *self, PyObject *arg)
             return RAISE(
                 PyExc_ValueError,
                 "Can only create \"P\" format data with 8bit Surfaces");
-        string = Bytes_FromStringAndSize(NULL, surf->w * surf->h);
+        string = Bytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h);
         if (!string)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
@@ -374,7 +374,7 @@ image_tostring(PyObject *self, PyObject *arg)
         pgSurface_Unlock(surfobj);
     }
     else if (!strcmp(format, "RGB")) {
-        string = Bytes_FromStringAndSize(NULL, surf->w * surf->h * 3);
+        string = Bytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 3);
         if (!string)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
@@ -448,7 +448,7 @@ image_tostring(PyObject *self, PyObject *arg)
         if (strcmp(format, "RGBA"))
             hascolorkey = 0;
 
-        string = Bytes_FromStringAndSize(NULL, surf->w * surf->h * 4);
+        string = Bytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 4);
         if (!string)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
@@ -539,7 +539,7 @@ image_tostring(PyObject *self, PyObject *arg)
     else if (!strcmp(format, "ARGB")) {
         hascolorkey = 0;
 
-        string = Bytes_FromStringAndSize(NULL, surf->w * surf->h * 4);
+        string = Bytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 4);
         if (!string)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
@@ -635,7 +635,7 @@ image_tostring(PyObject *self, PyObject *arg)
 
         hascolorkey = 0;
 
-        string = Bytes_FromStringAndSize(NULL, surf->w * surf->h * 4);
+        string = Bytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 4);
         if (!string)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
@@ -727,7 +727,7 @@ image_tostring(PyObject *self, PyObject *arg)
 
         hascolorkey = 0;
 
-        string = Bytes_FromStringAndSize(NULL, surf->w * surf->h * 4);
+        string = Bytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 4);
         if (!string)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
@@ -842,7 +842,7 @@ image_fromstring(PyObject *self, PyObject *arg)
     Bytes_AsStringAndSize(string, &data, &len);
 
     if (!strcmp(format, "P")) {
-        if (len != w * h)
+        if (len != (Py_ssize_t)w * h)
             return RAISE(
                 PyExc_ValueError,
                 "String length does not equal format and resolution size");
@@ -857,7 +857,7 @@ image_fromstring(PyObject *self, PyObject *arg)
         SDL_UnlockSurface(surf);
     }
     else if (!strcmp(format, "RGB")) {
-        if (len != w * h * 3)
+        if (len != (Py_ssize_t)w * h * 3)
             return RAISE(
                 PyExc_ValueError,
                 "String length does not equal format and resolution size");
@@ -887,7 +887,7 @@ image_fromstring(PyObject *self, PyObject *arg)
     }
     else if (!strcmp(format, "RGBA") || !strcmp(format, "RGBX")) {
         int alphamult = !strcmp(format, "RGBA");
-        if (len != w * h * 4)
+        if (len != (Py_ssize_t)w * h * 4)
             return RAISE(
                 PyExc_ValueError,
                 "String length does not equal format and resolution size");
@@ -913,7 +913,7 @@ image_fromstring(PyObject *self, PyObject *arg)
         SDL_UnlockSurface(surf);
     }
     else if (!strcmp(format, "ARGB")) {
-        if (len != w * h * 4)
+        if (len != (Py_ssize_t)w * h * 4)
             return RAISE(
                 PyExc_ValueError,
                 "String length does not equal format and resolution size");
@@ -965,7 +965,7 @@ image_frombuffer(PyObject *self, PyObject *arg)
         return NULL;
 
     if (!strcmp(format, "P")) {
-        if (len != w * h)
+        if (len != (Py_ssize_t)w * h)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
@@ -973,7 +973,7 @@ image_frombuffer(PyObject *self, PyObject *arg)
         surf = SDL_CreateRGBSurfaceFrom(data, w, h, 8, w, 0, 0, 0, 0);
     }
     else if (!strcmp(format, "RGB")) {
-        if (len != w * h * 3)
+        if (len != (Py_ssize_t)w * h * 3)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
@@ -989,7 +989,7 @@ image_frombuffer(PyObject *self, PyObject *arg)
     }
     else if (!strcmp(format, "RGBA") || !strcmp(format, "RGBX")) {
         int alphamult = !strcmp(format, "RGBA");
-        if (len != w * h * 4)
+        if (len != (Py_ssize_t)w * h * 4)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
@@ -1005,7 +1005,7 @@ image_frombuffer(PyObject *self, PyObject *arg)
             surf->flags |= SDL_SRCALPHA;
     }
     else if (!strcmp(format, "ARGB")) {
-        if (len != w * h * 4)
+        if (len != (Py_ssize_t)w * h * 4)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
@@ -1099,7 +1099,7 @@ rle_line(Uint8 *src, Uint8 *dst, int w, int bpp)
             while (raw < x0) {
                 int n = MIN(TGA_RLE_MAX, x0 - raw);
                 dst[out++] = n - 1;
-                memcpy(dst + out, src + raw * bpp, n * bpp);
+                memcpy(dst + out, src + raw * bpp, (size_t)n * bpp);
                 out += n * bpp;
                 raw += n;
             }

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -387,9 +387,9 @@ mask_angle(PyObject *self, PyObject *args)
         for (y = 0; y < mask->h; y++) {
             if (bitmask_getbit(mask, x, y)) {
                 m10 += x;
-                m20 += x * x;
-                m11 += x * y;
-                m02 += y * y;
+                m20 += (long)x * x;
+                m11 += (long)x * y;
+                m02 += (long)y * y;
                 m01 += y;
                 m00++;
             }
@@ -400,8 +400,8 @@ mask_angle(PyObject *self, PyObject *args)
         xc = m10 / m00;
         yc = m01 / m00;
         theta = -90.0 *
-                atan2(2 * (m11 / m00 - xc * yc),
-                      (m20 / m00 - xc * xc) - (m02 / m00 - yc * yc)) /
+                atan2(2 * (m11 / m00 - (long)xc * yc),
+                      (m20 / m00 - (long)xc * xc) - (m02 / m00 - (long)yc * yc)) /
                 M_PI;
         return PyFloat_FromDouble(theta);
     }

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1577,7 +1577,7 @@ _chunk_from_array(void *buf, PG_sample_format_t view_format, int ndim,
         return -1;
     }
     length = shape[0];
-    step1 = strides ? strides[0] : view_itemsize * channels;
+    step1 = strides ? strides[0] : (Py_ssize_t)view_itemsize * channels;
     length2 = ndim;
     if (ndim == 2) {
         step2 = strides ? strides[1] : view_itemsize;
@@ -1611,7 +1611,7 @@ _chunk_from_array(void *buf, PG_sample_format_t view_format, int ndim,
     */
     /* Copy samples.
      */
-    if (step1 == itemsize * channels && step2 == itemsize) {
+    if (step1 == (Py_ssize_t)itemsize * channels && step2 == itemsize) {
         /*OPTIMIZATION: in these cases, we don't need to loop through
          *the samples individually, because the bytes are already layed
          *out correctly*/

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1026,7 +1026,7 @@ _array_assign_array(pgPixelArrayObject *array, Py_ssize_t low, Py_ssize_t high,
      * first. */
     if (SURFACE_EQUALS(array, val)) {
         /* We assign a different view or so. Copy the source buffer. */
-        size_t size = val_surf->h * val_surf->pitch;
+        size_t size = (size_t)val_surf->h * val_surf->pitch;
         int val_offset = val_pixels - (Uint8 *)val_surf->pixels;
 
         copied_pixels = (Uint8 *)malloc(size);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3272,7 +3272,7 @@ _get_buffer_0D(PyObject *obj, Py_buffer *view_p, int flags)
     }
     view_p->buf = surface->pixels;
     view_p->itemsize = 1;
-    view_p->len = surface->pitch * surface->h;
+    view_p->len = (Py_ssize_t)surface->pitch * surface->h;
     view_p->readonly = 0;
     if (PyBUF_HAS_FLAG(flags, PyBUF_FORMAT)) {
         view_p->format = FormatUint8;
@@ -3333,10 +3333,10 @@ _get_buffer_1D(PyObject *obj, Py_buffer *view_p, int flags)
     view_p->buf = surface->pixels;
     view_p->itemsize = itemsize;
     view_p->readonly = 0;
-    view_p->len = surface->pitch * surface->h;
+    view_p->len = (Py_ssize_t)surface->pitch * surface->h;
     if (PyBUF_HAS_FLAG(flags, PyBUF_ND)) {
         view_p->ndim = 1;
-        view_p->shape[0] = surface->w * surface->h;
+        view_p->shape[0] = (Py_ssize_t)surface->w * surface->h;
         if (PyBUF_HAS_FLAG(flags, PyBUF_STRIDES)) {
             view_p->strides[0] = itemsize;
         }
@@ -3422,7 +3422,7 @@ _get_buffer_2D(PyObject *obj, Py_buffer *view_p, int flags)
     view_p->itemsize = itemsize;
     view_p->ndim = 2;
     view_p->readonly = 0;
-    view_p->len = surface->w * surface->h * itemsize;
+    view_p->len = (Py_ssize_t)surface->w * surface->h * itemsize;
     view_p->shape[0] = surface->w;
     view_p->shape[1] = surface->h;
     view_p->strides[0] = itemsize;
@@ -3463,7 +3463,7 @@ _get_buffer_3D(PyObject *obj, Py_buffer *view_p, int flags)
     view_p->itemsize = 1;
     view_p->ndim = 3;
     view_p->readonly = 0;
-    view_p->len = surface->w * surface->h * 3;
+    view_p->len = (Py_ssize_t)surface->w * surface->h * 3;
     view_p->shape[0] = surface->w;
     view_p->shape[1] = surface->h;
     view_p->shape[2] = 3;
@@ -3583,7 +3583,7 @@ _get_buffer_colorplane(PyObject *obj, Py_buffer *view_p, int flags, char *name,
     view_p->itemsize = 1;
     view_p->ndim = 2;
     view_p->readonly = 0;
-    view_p->len = surface->w * surface->h;
+    view_p->len = (Py_ssize_t)surface->w * surface->h;
     view_p->shape[0] = surface->w;
     view_p->shape[1] = surface->h;
     view_p->strides[0] = pixelsize;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1325,7 +1325,7 @@ scalesmooth(SDL_Surface *src, SDL_Surface *dst, struct _module_state *st)
     /* convert to 32-bit if necessary */
     if (bpp == 3) {
         int newpitch = srcwidth * 4;
-        Uint8 *newsrc = (Uint8 *)malloc(newpitch * srcheight);
+        Uint8 *newsrc = (Uint8 *)malloc((size_t)newpitch * srcheight);
         if (!newsrc)
             return;
         convert_24_32(srcpix, srcpitch, newsrc, newpitch, srcwidth, srcheight);
@@ -1333,7 +1333,7 @@ scalesmooth(SDL_Surface *src, SDL_Surface *dst, struct _module_state *st)
         srcpitch = newpitch;
         /* create a destination buffer for the 32-bit result */
         dstpitch = dstwidth << 2;
-        dst32 = (Uint8 *)malloc(dstpitch * dstheight);
+        dst32 = (Uint8 *)malloc((size_t)dstpitch * dstheight);
         if (dst32 == NULL) {
             free(srcpix);
             return;
@@ -1347,7 +1347,7 @@ scalesmooth(SDL_Surface *src, SDL_Surface *dst, struct _module_state *st)
         tempwidth = dstwidth;
         temppitch = tempwidth << 2;
         tempheight = srcheight;
-        temppix = (Uint8 *)malloc(temppitch * tempheight);
+        temppix = (Uint8 *)malloc((size_t)temppitch * tempheight);
         if (temppix == NULL) {
             if (bpp == 3) {
                 free(srcpix);


### PR DESCRIPTION
Overview of changes:
- Fixed the “Multiplication result may overflow 'int' before it is converted to ....” LGTM alerts
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 8fc97232dc4e679ce8ae5aa6f9ab904b0a2768fd

Resolves some of the c issues from the LGTM link in #1133.