### PR TITLE
Fix doc build error with newer versions of Sphinx

### DIFF
--- a/docs/reST/ext/customversion.py
+++ b/docs/reST/ext/customversion.py
@@ -1,6 +1,14 @@
 from sphinx.domains.changeset import versionlabels, VersionChange
 from sphinx.locale import _ # just to suppress warnings
 
+try:
+    from sphinx.domains.changeset import versionlabel_classes
+except ImportError:
+    # versionlabel_classes doesn't exist in old Sphinx versions.
+    UPDATE_VERIONLABEL_CLASSES = False
+else:
+    UPDATE_VERIONLABEL_CLASSES = True
+
 
 labels = ('versionadded', 'versionchanged', 'deprecated', 'versionextended')
 
@@ -14,6 +22,9 @@ def set_version_formats(app, config):
 def setup(app):
     app.add_directive('versionextended', VersionChange)
     versionlabels['versionextended'] = 'Extended in pygame %s'
+
+    if UPDATE_VERIONLABEL_CLASSES:
+        versionlabel_classes['versionextended'] = 'extended'
 
     for label in ('versionadded', 'versionchanged', 'deprecated', 'versionextended'):
         app.add_config_value('{}_format'.format(label), str(versionlabels[label]), 'env')


### PR DESCRIPTION
Tested with Sphinx versions 1.8.5 and 2.2.0.

There are still a few issues when building the pygame docs using Sphinx v2.2.0 (latest version). Issue #1298 has been opened to track them.

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at c256992573554c137a9770d7d8c3e099172bc8c6

Resolves #1278.