### PR TITLE
Fix SDL1 compile issues

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -132,7 +132,14 @@ typedef enum {
     PGS_PREALLOC = 0x01000000
 } PygameSurfaceFlags;
 #else /* ~SDL_VERSION_ATLEAST(2, 0, 0) */
+/* To maintain SDL 1.2 build support. */
+#define PGE_USEREVENT SDL_USEREVENT
 #define PG_NUMEVENTS SDL_NUMEVENTS
+/* These midi events were originally defined in midi.py.
+ * Note: They are outside the SDL_USEREVENT/SDL_NUMEVENTS event range for
+ * SDL 1.2. */
+#define PGE_MIDIIN PGE_USEREVENT + 10
+#define PGE_MIDIOUT PGE_USEREVENT + 11
 #endif /* ~SDL_VERSION_ATLEAST(2, 0, 0) */
 
 #define RAISE(x, y) (PyErr_SetString((x), (y)), (PyObject *)NULL)


### PR DESCRIPTION
Fixed the code so SDL1 will compile, but running the full slate of tests is not working due to a
JPEG library version issue. This happens with both python 2 and 3.

Since SDL1 isn't officially being supported anymore, no issue has been raise for this.

```
>py -3 -m pygame.tests
pygame 2.0.0.dev3 (SDL 1.2.15, python 3.7.4)
Hello from the pygame community. https://www.pygame.org/contribute.html
skipping pygame.tests.cdrom_test (tag 'interactive')
skipping pygame.tests.touch_test (tag 'SDL1_ignore')
loading pygame.tests.base_test
loading pygame.tests.blit_test
loading pygame.tests.bufferproxy_test
loading pygame.tests.camera_test
loading pygame.tests.color_test
loading pygame.tests.compat_test
loading pygame.tests.constants_test
loading pygame.tests.cursors_test
loading pygame.tests.display_test
loading pygame.tests.draw_test
loading pygame.tests.event_test
loading pygame.tests.fastevent_test
loading pygame.tests.font_test
loading pygame.tests.freetype_test
loading pygame.tests.ftfont_test
loading pygame.tests.gfxdraw_test
loading pygame.tests.image__save_gl_surface_test
loading pygame.tests.image_test
Wrong JPEG library version: library is 80, caller expects 90
```

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10 and SDL 1.2.15) at c256992573554c137a9770d7d8c3e099172bc8c6