### PR TITLE
Fix draw.lines bounding rect

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -1942,8 +1942,6 @@ class LinesMixin(BaseLineMixin):
         """Ensures thick lines are drawn without any gaps."""
         self.fail()
 
-    # This decorator can be removed when issue #1117 is resolved.
-    @unittest.expectedFailure
     def test_lines__bounding_rect(self):
         """Ensures draw lines returns the correct bounding rect.
 


### PR DESCRIPTION
Overview of changes:
- Fixed the bounding rect returned from `pygame.draw.lines` so it encloses the changed area
- Removed the expected failure decorator from the now passing test


System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 7eabb6ff3273a927ae544916ccf25004e5077b12


Resolves #1117.