### PR TITLE
Fix math.c compiler warning

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3256,7 +3256,8 @@ vector_elementwiseproxy_dealloc(vector_elementwiseproxy *it)
 static PyObject *
 vector_elementwiseproxy_richcompare(PyObject *o1, PyObject *o2, int op)
 {
-    Py_ssize_t i, dim, ret;
+    Py_ssize_t i, dim;
+    int ret = 1;
     double diff, value;
     double *other_coords;
     pgVector *vec;
@@ -3283,7 +3284,6 @@ vector_elementwiseproxy_richcompare(PyObject *o1, PyObject *o2, int op)
         other = (PyObject *)((vector_elementwiseproxy *)other)->vec;
     dim = vec->dim;
 
-    ret = 1;
     if (pgVectorCompatible_Check(other, dim)) {
         other_coords = PyMem_New(double, dim);
         if (other_coords == NULL) {


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 7eabb6ff3273a927ae544916ccf25004e5077b12
