### PR TITLE
Fix imageext.c compiler warning

### DIFF
--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -549,8 +549,7 @@ write_jpeg(const char *file_name, unsigned char **image_buffer,
     struct jpeg_error_mgr jerr;
     SDL_RWops *outfile;
     JSAMPROW row_pointer[NUM_LINES_TO_WRITE];
-    int num_lines_to_write;
-    int i;
+    JDIMENSION i, num_lines_to_write;
 
     num_lines_to_write = NUM_LINES_TO_WRITE;
 


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 3dc30228458e024b1df03ea869899b785a8f4fb1