### PR TITLE
Fix freetype.Font dest parameter check

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -289,7 +289,7 @@ parse_dest(PyObject *dest, int *x, int *y)
     int i, j;
 
     if (!PySequence_Check(dest) || /* conditional and */
-        !PySequence_Size(dest) > 1) {
+        !(PySequence_Size(dest) > 1)) {
         PyErr_Format(PyExc_TypeError,
                      "Expected length 2 sequence for dest argument:"
                      " got type %.1024s",

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -627,7 +627,7 @@ class FreeTypeFontTest(unittest.TestCase):
         for dest in [None, 0, 'a', 'ab',
                      (), (1,), ('a', 2), (1, 'a'), (1+2j, 2), (1, 1+2j),
                      (1, int), (int, 1)]:
-            self.assertRaises(TypeError, font.render,
+            self.assertRaises(TypeError, font.render_to,
                               surf, dest, 'foobar', color, size=24)
 
         # misc parameter test
@@ -980,6 +980,16 @@ class FreeTypeFontTest(unittest.TestCase):
                 self.assertEqual(rrect, srect)
         finally:
             font.antialiased = True
+
+        # Invalid dest parameter test.
+        srect = font.get_rect(text, size=24)
+        surf_buf = pygame.Surface(srect.size, 0, 32).get_view('2')
+
+        for dest in [0, 'a', 'ab',
+                     (), (1,), ('a', 2), (1, 'a'), (1 + 2j, 2), (1, 1 + 2j),
+                     (1, int), (int, 1)]:
+            self.assertRaises(TypeError, font.render_raw_to, surf_buf, text,
+                              dest, size=24)
 
     def test_freetype_Font_text_is_None(self):
         f = ft.Font(self._sans_path, 36)


### PR DESCRIPTION
Overview of changes:
- Fixed the dest parameter check for `freetype.Font`
  (used by `render_to()` and `render_raw_to()`)
- Fixed the `render_to()` test to correctly test `render_to()` for invalid dest parameters
- Updated the `render_raw_to()` test to test invalid dest parameters

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 6922b19a623b09d4bb6ab0c093b034ad3a6ed8dc