### PR TITLE
Fix some font related warnings/issues

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -669,7 +669,7 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (!font_initialized) {
-        RAISE(pgExc_SDLError, "font not initialized");
+        PyErr_SetString(pgExc_SDLError, "font not initialized");
         return -1;
     }
 
@@ -765,14 +765,14 @@ fileobject:
         font = TTF_OpenFontIndexRW(rw, 1, fontsize, 0);
         Py_END_ALLOW_THREADS;
 #else
-        RAISE(PyExc_NotImplementedError,
-              "nonstring fonts require SDL_ttf-2.0.6");
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "nonstring fonts require SDL_ttf-2.0.6");
         goto error;
 #endif
     }
 
     if (font == NULL) {
-        RAISE(PyExc_RuntimeError, SDL_GetError());
+        PyErr_SetString(PyExc_RuntimeError, SDL_GetError());
         goto error;
     }
 
@@ -783,7 +783,7 @@ fileobject:
 
 error:
     Py_XDECREF(oencoded);
-    Py_DECREF(obj);
+    Py_XDECREF(obj);
     return -1;
 }
 

--- a/src_c/include/pygame_font.h
+++ b/src_c/include/pygame_font.h
@@ -23,7 +23,7 @@
 #include <Python.h>
 #include "pgplatform.h"
 
-typedef struct TTF_Font;
+struct TTF_Font;
 
 typedef struct {
   PyObject_HEAD


### PR DESCRIPTION
Overview of changes:
- Fixed some font related compiler warnings
- Fixed a font.c issue found by Coverity
  (Coverity info for pygame: https://scan.coverity.com/projects/pygame)

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 6922b19a623b09d4bb6ab0c093b034ad3a6ed8dc

Resolves the font.c issue from the Coverity static analysis link in #1325.