### PR TITLE
Fix some Coverity issues

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1089,7 +1089,7 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
         item = PySequence_GetItem(value, 3);
         if (!item || !_get_double(item, &(hsva[3])) || hsva[3] < 0 ||
             hsva[3] > 100) {
-            Py_DECREF(item);
+            Py_XDECREF(item);
             PyErr_SetString(PyExc_ValueError, "invalid HSVA value");
             return -1;
         }
@@ -1252,7 +1252,7 @@ _color_set_hsla(pgColorObject *color, PyObject *value, void *closure)
         item = PySequence_GetItem(value, 3);
         if (!item || !_get_double(item, &(hsla[3])) || hsla[3] < 0 ||
             hsla[3] > 100) {
-            Py_DECREF(item);
+            Py_XDECREF(item);
             PyErr_SetString(PyExc_ValueError, "invalid HSLA value");
             return -1;
         }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -3660,8 +3660,8 @@ vector_elementwiseproxy_pow(PyObject *baseObj, PyObject *expoObj,
 {
     Py_ssize_t i, dim;
     double *tmp;
-    PyObject *bases[VECTOR_MAX_SIZE];
-    PyObject *expos[VECTOR_MAX_SIZE];
+    PyObject *bases[VECTOR_MAX_SIZE] = {NULL};
+    PyObject *expos[VECTOR_MAX_SIZE] = {NULL};
     PyObject *ret, *result;
     if (mod != Py_None) {
         PyErr_SetString(PyExc_TypeError,

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -288,7 +288,6 @@ transformSurfaceRGBA(SDL_Surface *src, SDL_Surface *dst, int cx, int cy,
                         c11 = *sp;
                     }
                     else if ((dx == -1) && (dy == sh)) {
-                        sp = (tColorRGBA *)(src->pixels);
                         sp = (tColorRGBA *)((Uint8 *)src->pixels +
                                             src->pitch * dy);
                         c00 = *sp;

--- a/src_c/scale_mmx32.c
+++ b/src_c/scale_mmx32.c
@@ -395,6 +395,7 @@ filter_expand_X_MMX(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int 
         free(xidx0);
         if (xmult0) free(xmult0);
         if (xmult1) free(xmult1);
+        return;
     }
 
     /* Create multiplier factors and starting indices and put them in arrays */
@@ -471,6 +472,7 @@ filter_expand_X_SSE(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int 
         free(xidx0);
         if (xmult0) free(xmult0);
         if (xmult1) free(xmult1);
+        return;
     }
 
     /* Create multiplier factors and starting indices and put them in arrays */

--- a/src_c/scale_mmx64.c
+++ b/src_c/scale_mmx64.c
@@ -401,6 +401,7 @@ filter_expand_X_MMX(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int 
         free(xidx0);
         if (xmult0) free(xmult0);
         if (xmult1) free(xmult1);
+        return;
     }
 
     /* Create multiplier factors and starting indices and put them in arrays */
@@ -476,6 +477,7 @@ filter_expand_X_SSE(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int 
         free(xidx0);
         if (xmult0) free(xmult0);
         if (xmult1) free(xmult1);
+        return;
     }
 
     /* Create multiplier factors and starting indices and put them in arrays */

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1177,6 +1177,8 @@ filter_expand_X_ONLYC(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
             free(xmult0);
         if (xmult1)
             free(xmult1);
+
+        return;
     }
 
     /* Create multiplier factors and starting indices and put them in arrays */
@@ -1834,6 +1836,11 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     }
 
     surf = pgSurface_AsSurface(surf_obj);
+
+    if (NULL == surf) {
+        return RAISE(PyExc_TypeError, "invalid surf argument");
+    }
+
     if (search_surf_obj && pgSurface_Check(search_surf_obj))
         search_surf = pgSurface_AsSurface(search_surf_obj);
 
@@ -1862,11 +1869,11 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
             return RAISE(PyExc_TypeError, "invalid set_color argument");
     }
 
-    if (dest_surf && surf &&
-        (surf->h != dest_surf->h || surf->w != dest_surf->w)) {
+    if (dest_surf && (surf->h != dest_surf->h || surf->w != dest_surf->w)) {
         return RAISE(PyExc_TypeError, "surf and dest_surf not the same size");
     }
-    if (search_surf && surf &&
+
+    if (search_surf &&
         (surf->h != search_surf->h || surf->w != search_surf->w)) {
         return RAISE(PyExc_TypeError,
                      "surf and search_surf not the same size");


### PR DESCRIPTION
Overview of changes:
- Fixed some issues found by Coverity
  (Coverity info for pygame: https://scan.coverity.com/projects/pygame)
- Also fixed issues with scale_mmx32.c (not detected) which mirrored the scale_mmx64.c issues detected by Coverity

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 119c84e8c6d02701911513c272ede62617ce2617

Resolves some of the issues from the Coverity static analysis link in #1325.