### PR TITLE
Fix image.c and imageext.c Coverity issues

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -189,8 +189,10 @@ image_save(PyObject *self, PyObject *arg)
     PyObject *oencoded;
     PyObject *imgext = NULL;
     SDL_Surface *surf;
-    SDL_Surface *temp = NULL;
     int result = 1;
+#if IS_SDLv1
+    SDL_Surface *temp = NULL;
+#endif /* IS_SDLv1 */
 
     if (!PyArg_ParseTuple(arg, "O!O", &pgSurface_Type, &surfobj, &obj)) {
         return NULL;
@@ -278,12 +280,16 @@ image_save(PyObject *self, PyObject *arg)
     }
     Py_XDECREF(oencoded);
 
+#if IS_SDLv1
     if (temp) {
         SDL_FreeSurface(temp);
     }
     else {
         pgSurface_Unprep(surfobj);
     }
+#else  /* IS_SDLv2 */
+    pgSurface_Unprep(surfobj);
+#endif /* IS_SDLv2 */
 
     if (result == -2) {
         /* Python error raised elsewhere */
@@ -312,13 +318,14 @@ image_tostring(PyObject *self, PyObject *arg)
 {
     PyObject *surfobj, *string = NULL;
     char *format, *data, *pixels;
-    SDL_Surface *surf, *temp = NULL;
+    SDL_Surface *surf;
     int w, h, color, flipped = 0;
     Py_ssize_t len;
     Uint32 Rmask, Gmask, Bmask, Amask, Rshift, Gshift, Bshift, Ashift, Rloss,
         Gloss, Bloss, Aloss;
     int hascolorkey;
 #if IS_SDLv1
+    SDL_Surface *temp = NULL;
     int colorkey;
 #else  /* IS_SDLv2 */
     Uint32 colorkey;
@@ -379,8 +386,13 @@ image_tostring(PyObject *self, PyObject *arg)
             return NULL;
         Bytes_AsStringAndSize(string, &data, &len);
 
+#if IS_SDLv1
         if (!temp)
             pgSurface_Lock(surfobj);
+#else  /* IS_SDLv2 */
+        pgSurface_Lock(surfobj);
+#endif /* IS_SDLv2 */
+
         pixels = (char *)surf->pixels;
         switch (surf->format->BytesPerPixel) {
             case 1:
@@ -441,8 +453,13 @@ image_tostring(PyObject *self, PyObject *arg)
                 }
                 break;
         }
+
+#if IS_SDLv1
         if (!temp)
             pgSurface_Unlock(surfobj);
+#else  /* IS_SDLv2 */
+        pgSurface_Unlock(surfobj);
+#endif /* IS_SDLv2 */
     }
     else if (!strcmp(format, "RGBX") || !strcmp(format, "RGBA")) {
         if (strcmp(format, "RGBA"))
@@ -556,8 +573,7 @@ image_tostring(PyObject *self, PyObject *arg)
                         data[1] = (char)surf->format->palette->colors[color].r;
                         data[2] = (char)surf->format->palette->colors[color].g;
                         data[3] = (char)surf->format->palette->colors[color].b;
-                        data[0] = hascolorkey ? (char)(color != colorkey) * 255
-                                              : (char)255;
+                        data[0] = (char)255;
                         data += 4;
                     }
                 }
@@ -571,10 +587,7 @@ image_tostring(PyObject *self, PyObject *arg)
                         data[1] = (char)(((color & Rmask) >> Rshift) << Rloss);
                         data[2] = (char)(((color & Gmask) >> Gshift) << Gloss);
                         data[3] = (char)(((color & Bmask) >> Bshift) << Bloss);
-                        data[0] =
-                            hascolorkey
-                                ? (char)(color != colorkey) * 255
-                                : (char)(Amask ? (((color & Amask) >> Ashift)
+                        data[0] = (char)(Amask ? (((color & Amask) >> Ashift)
                                                   << Aloss)
                                                : 255);
                         data += 4;
@@ -595,10 +608,7 @@ image_tostring(PyObject *self, PyObject *arg)
                         data[1] = (char)(((color & Rmask) >> Rshift) << Rloss);
                         data[2] = (char)(((color & Gmask) >> Gshift) << Gloss);
                         data[3] = (char)(((color & Bmask) >> Bshift) << Bloss);
-                        data[0] =
-                            hascolorkey
-                                ? (char)(color != colorkey) * 255
-                                : (char)(Amask ? (((color & Amask) >> Ashift)
+                        data[0] = (char)(Amask ? (((color & Amask) >> Ashift)
                                                   << Aloss)
                                                : 255);
                         data += 4;
@@ -614,10 +624,7 @@ image_tostring(PyObject *self, PyObject *arg)
                         data[1] = (char)(((color & Rmask) >> Rshift) << Rloss);
                         data[2] = (char)(((color & Gmask) >> Gshift) << Gloss);
                         data[3] = (char)(((color & Bmask) >> Bshift) << Bloss);
-                        data[0] =
-                            hascolorkey
-                                ? (char)(color != colorkey) * 255
-                                : (char)(Amask ? (((color & Amask) >> Ashift)
+                        data[0] = (char)(Amask ? (((color & Amask) >> Ashift)
                                                   << Aloss)
                                                : 255);
                         data += 4;
@@ -812,13 +819,19 @@ image_tostring(PyObject *self, PyObject *arg)
         pgSurface_Unlock(surfobj);
     }
     else {
+#if IS_SDLv1
         if (temp)
             SDL_FreeSurface(temp);
+#endif /* IS_SDLv1 */
+
         return RAISE(PyExc_ValueError, "Unrecognized type of format");
     }
 
+#if IS_SDLv1
     if (temp)
         SDL_FreeSurface(temp);
+#endif /* IS_SDLv1 */
+
     return string;
 }
 
@@ -939,8 +952,6 @@ image_fromstring(PyObject *self, PyObject *arg)
     else
         return RAISE(PyExc_ValueError, "Unrecognized type of format");
 
-    if (!surf)
-        return NULL;
     return pgSurface_New(surf);
 }
 
@@ -1242,15 +1253,21 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
                                    rmask, gmask, bmask, amask);
     if (!linebuf)
         return -1;
-    if (h.has_cmap)
+
+    if (h.has_cmap) {
 #if IS_SDLv1
         SDL_SetColors(linebuf, surface->format->palette->colors, 0,
                       surface->format->palette->ncolors);
 #else  /* IS_SDLv2 */
-        SDL_SetPaletteColors(linebuf->format->palette,
-                             surface->format->palette->colors, 0,
-                             surface->format->palette->ncolors);
+        if (0 != SDL_SetPaletteColors(linebuf->format->palette,
+                                      surface->format->palette->colors, 0,
+                                      surface->format->palette->ncolors)) {
+            /* SDL error already set. */
+            goto error;
+        }
 #endif /* IS_SDLv2 */
+    }
+
     if (rle) {
         rlebuf = malloc(bpp * surface->w + 1 + surface->w / TGA_RLE_MAX);
         if (!rlebuf) {
@@ -1306,10 +1323,14 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
         SDL_SetColorKey(surface, SDL_TRUE, surf_colorkey);
 #endif /* IS_SDLv2 */
 
-error:
     free(rlebuf);
     SDL_FreeSurface(linebuf);
     return 0;
+
+error:
+    free(rlebuf);
+    SDL_FreeSurface(linebuf);
+    return -1;
 }
 
 static int
@@ -1391,29 +1412,34 @@ MODINIT_DEFINE(image)
         extload = PyObject_GetAttrString(extmodule, "load_extended");
         if (!extload) {
             Py_DECREF(extmodule);
+            DECREF_MOD(module);
             MODINIT_ERROR;
         }
         extsave = PyObject_GetAttrString(extmodule, "save_extended");
         if (!extsave) {
             Py_DECREF(extload);
             Py_DECREF(extmodule);
+            DECREF_MOD(module);
             MODINIT_ERROR;
         }
         if (PyModule_AddObject(module, "load_extended", extload)) {
             Py_DECREF(extload);
             Py_DECREF(extsave);
             Py_DECREF(extmodule);
+            DECREF_MOD(module);
             MODINIT_ERROR;
         }
         if (PyModule_AddObject(module, "save_extended", extsave)) {
             Py_DECREF(extsave);
             Py_DECREF(extmodule);
+            DECREF_MOD(module);
             MODINIT_ERROR;
         }
         Py_INCREF(extload);
         if (PyModule_AddObject(module, "load", extload)) {
             Py_DECREF(extload);
             Py_DECREF(extmodule);
+            DECREF_MOD(module);
             MODINIT_ERROR;
         }
         Py_DECREF(extmodule);
@@ -1423,10 +1449,27 @@ MODINIT_DEFINE(image)
         PyObject *basicload = PyObject_GetAttrString(module, "load_basic");
         PyErr_Clear();
         Py_INCREF(Py_None);
-        PyModule_AddObject(module, "load_extended", Py_None);
+        if (PyModule_AddObject(module, "load_extended", Py_None)) {
+            Py_DECREF(Py_None);
+            Py_DECREF(basicload);
+            DECREF_MOD(module);
+            MODINIT_ERROR;
+        }
+
         Py_INCREF(Py_None);
-        PyModule_AddObject(module, "save_extended", Py_None);
-        PyModule_AddObject(module, "load", basicload);
+        if (PyModule_AddObject(module, "save_extended", Py_None)){
+            Py_DECREF(Py_None);
+            Py_DECREF(basicload);
+            DECREF_MOD(module);
+            MODINIT_ERROR;
+        }
+
+        if (PyModule_AddObject(module, "load", basicload)) {
+            Py_DECREF(basicload);
+            DECREF_MOD(module);
+            MODINIT_ERROR;
+        }
+
         st->is_extended = 0;
     }
     MODINIT_RETURN(module);

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -617,6 +617,10 @@ SaveJPEG(SDL_Surface *surface, const char *file)
     int pixel_bits = 32;
     int free_ss_surface = 1;
 
+    if (!surface) {
+        return -1;
+    }
+
     ss_rows = 0;
     ss_size = 0;
     ss_surface = NULL;
@@ -625,10 +629,6 @@ SaveJPEG(SDL_Surface *surface, const char *file)
     ss_h = surface->h;
 
     pixel_bits = 24;
-
-    if (!surface) {
-        return -1;
-    }
 
     /* See if the Surface is suitable for using directly.
        So no conversion is needed.  24bit, RGB
@@ -790,8 +790,10 @@ image_save_ext(PyObject *self, PyObject *arg)
     PyObject *obj;
     PyObject *oencoded = NULL;
     SDL_Surface *surf;
-    SDL_Surface *temp = NULL;
     int result = 1;
+#if IS_SDLv1
+    SDL_Surface *temp = NULL;
+#endif /* IS_SDLv1 */
 
     if (!PyArg_ParseTuple(arg, "O!O", &pgSurface_Type, &surfobj, &obj)) {
         return NULL;
@@ -864,12 +866,16 @@ image_save_ext(PyObject *self, PyObject *arg)
         result = -2;
     }
 
+#if IS_SDLv1
     if (temp != NULL) {
         SDL_FreeSurface(temp);
     }
     else {
         pgSurface_Unprep(surfobj);
     }
+#else  /* IS_SDLv2 */
+    pgSurface_Unprep(surfobj);
+#endif /* IS_SDLv2 */
 
     Py_XDECREF(oencoded);
     if (result == -2) {


### PR DESCRIPTION
Overview of changes:
- Fixed the image.c and imageext.c issues found by Coverity
  (Coverity info for pygame: https://scan.coverity.com/projects/pygame)
- Fixed an error path (`goto error`) in image.c returning a success value
- Added `DECREF_MOD()` calls to existing module initialization fail paths in image.c

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 19ccbd4bf9bf2ad39ee4dd41f7e3c3c767f2573b

Resolves the image.c and imageext.c issues from the Coverity static analysis link in #1325.