### PR TITLE
Fix some surface compiler warnings

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -517,27 +517,20 @@ surface_dealloc(PyObject *self)
 static PyObject *
 surface_str(PyObject *self)
 {
-    char str[1024];
     SDL_Surface *surf = pgSurface_AsSurface(self);
-#if IS_SDLv1
-    const char *type;
-#endif /* IS_SDLv1 */
 
-    if (surf) {
+    if (!surf) {
+        return Text_FromUTF8("<Surface(Dead Display)>");
+    }
+
 #if IS_SDLv1
-        type = (surf->flags & SDL_HWSURFACE) ? "HW" : "SW";
-        sprintf(str, "<Surface(%dx%dx%d %s)>", surf->w, surf->h,
-                surf->format->BitsPerPixel, type);
+    return Text_FromFormat("<Surface(%dx%dx%d %s)>", surf->w, surf->h,
+                           surf->format->BitsPerPixel,
+                           (surf->flags & SDL_HWSURFACE) ? "HW" : "SW");
 #else  /* IS_SDLv2 */
-        sprintf(str, "<Surface(%dx%dx%d SW)>", surf->w, surf->h,
-                surf->format->BitsPerPixel);
+    return Text_FromFormat("<Surface(%dx%dx%d SW)>", surf->w, surf->h,
+                           surf->format->BitsPerPixel);
 #endif /* IS_SDLv2 */
-    }
-    else {
-        strcpy(str, "<Surface(Dead Display)>");
-    }
-
-    return Text_FromUTF8(str);
 }
 
 static intptr_t
@@ -559,18 +552,19 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     if (PySequence_Check(size) && PySequence_Length(size) == 2) {
         if ((!pg_IntFromObjIndex(size, 0, &width)) ||
             (!pg_IntFromObjIndex(size, 1, &height))) {
-            RAISE(PyExc_ValueError,
-                  "size needs to be (int width, int height)");
+            PyErr_SetString(PyExc_ValueError,
+                            "size needs to be (int width, int height)");
             return -1;
         }
     }
     else {
-        RAISE(PyExc_ValueError, "size needs to be (int width, int height)");
+        PyErr_SetString(PyExc_ValueError,
+                        "size needs to be (int width, int height)");
         return -1;
     }
 
     if (width < 0 || height < 0) {
-        RAISE(pgExc_SDLError, "Invalid resolution for Surface");
+        PyErr_SetString(pgExc_SDLError, "Invalid resolution for Surface");
         return -1;
     }
 
@@ -583,30 +577,33 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     if (depth && masks) { /* all info supplied, most errorchecking
                            * needed */
         if (pgSurface_Check(depth)) {
-            RAISE(PyExc_ValueError,
-                  "cannot pass surface for depth and color masks");
+            PyErr_SetString(PyExc_ValueError,
+                            "cannot pass surface for depth and color masks");
             return -1;
         }
         if (!pg_IntFromObj(depth, &bpp)) {
-            RAISE(PyExc_ValueError, "invalid bits per pixel depth argument");
+            PyErr_SetString(PyExc_ValueError,
+                            "invalid bits per pixel depth argument");
             return -1;
         }
         if (!PySequence_Check(masks) || PySequence_Length(masks) != 4) {
-            RAISE(PyExc_ValueError,
-                  "masks argument must be sequence of four numbers");
+            PyErr_SetString(PyExc_ValueError,
+                            "masks argument must be sequence of four numbers");
             return -1;
         }
         if (!pg_UintFromObjIndex(masks, 0, &Rmask) ||
             !pg_UintFromObjIndex(masks, 1, &Gmask) ||
             !pg_UintFromObjIndex(masks, 2, &Bmask) ||
             !pg_UintFromObjIndex(masks, 3, &Amask)) {
-            RAISE(PyExc_ValueError, "invalid mask values in masks sequence");
+            PyErr_SetString(PyExc_ValueError,
+                            "invalid mask values in masks sequence");
             return -1;
         }
     }
     else if (depth && PyNumber_Check(depth)) { /* use default masks */
         if (!pg_IntFromObj(depth, &bpp)) {
-            RAISE(PyExc_ValueError, "invalid bits per pixel depth argument");
+            PyErr_SetString(PyExc_ValueError,
+                            "invalid bits per pixel depth argument");
             return -1;
         }
 #if IS_SDLv1
@@ -628,9 +625,10 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
                     Amask = 0xFF << 24;
                     break;
                 default:
-                    RAISE(PyExc_ValueError,
-                          "no standard masks exist for given bitdepth with "
-                          "alpha");
+                    PyErr_SetString(
+                        PyExc_ValueError,
+                        "no standard masks exist for given bitdepth with "
+                        "alpha");
                     return -1;
             }
         }
@@ -670,7 +668,8 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
                     Bmask = 0xFF;
                     break;
                 default:
-                    RAISE(PyExc_ValueError, "nonstandard bit depth given");
+                    PyErr_SetString(PyExc_ValueError,
+                                    "nonstandard bit depth given");
                     return -1;
             }
         }
@@ -721,9 +720,10 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
                     Amask = 0xFF << 24;
                     break;
                 default:
-                    RAISE(PyExc_ValueError,
-                          "no standard masks exist for given bitdepth with "
-                          "alpha");
+                    PyErr_SetString(
+                        PyExc_ValueError,
+                        "no standard masks exist for given bitdepth with "
+                        "alpha");
                     return -1;
             }
         }
@@ -739,7 +739,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
     surface = SDL_CreateRGBSurface(flags, width, height, bpp, Rmask, Gmask,
                                    Bmask, Amask);
     if (!surface) {
-        RAISE(pgExc_SDLError, SDL_GetError());
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return -1;
     }
 
@@ -760,7 +760,7 @@ surface_init(pgSurfaceObject *self, PyObject *args, PyObject *kwds)
               (surface->flags & SDL_SRCALPHA ? format->Aloss
                                              : format->Aloss != 8)))) {
             SDL_FreeSurface(surface);
-            RAISE(PyExc_ValueError, "Invalid mask values");
+            PyErr_SetString(PyExc_ValueError, "Invalid mask values");
             return -1;
         }
     }
@@ -1860,7 +1860,7 @@ surf_convert(PyObject *self, PyObject *args)
 static SDL_Surface *
 pg_DisplayFormat(SDL_Surface *surface)
 {
-    SDL_Surface *newsurf = NULL, *displaysurf;
+    SDL_Surface *displaysurf;
     if (!pg_GetDefaultWindowSurface()) {
         SDL_SetError("No video mode has been set");
         return NULL;
@@ -2485,7 +2485,7 @@ _PgSurface_SrcAlpha(SDL_Surface *surf)
 {
     SDL_BlendMode mode;
     if (SDL_GetSurfaceBlendMode(surf, &mode) < 0) {
-        RAISE(pgExc_SDLError, SDL_GetError());
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return -1;
     }
     return (mode != SDL_BLENDMODE_NONE);
@@ -4060,9 +4060,9 @@ pgSurface_Blit(PyObject *dstobj, PyObject *srcobj, SDL_Rect *dstrect,
     pgSurface_Unprep(srcobj);
 
     if (result == -1)
-        RAISE(pgExc_SDLError, SDL_GetError());
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
     if (result == -2)
-        RAISE(pgExc_SDLError, "Surface was lost");
+        PyErr_SetString(pgExc_SDLError, "Surface was lost");
 
     return result != 0;
 }


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 19ccbd4bf9bf2ad39ee4dd41f7e3c3c767f2573b

Related to #1316.