### PR TITLE
Fix the LGTM alerts in setup_win_common.py

### DIFF
--- a/buildconfig/setup_win_common.py
+++ b/buildconfig/setup_win_common.py
@@ -15,14 +15,12 @@ class Definition(object):
         self.name = name
         self.value = value
 
+
 def read():
     """Return the contents of the Windows Common Setup as a string"""
-
-    setup_in = open(PATH)
-    try:
+    with open(PATH) as setup_in:
         return setup_in.read()
-    finally:
-        setup_in.close()
+
 
 def get_definitions():
     """Return a list of definitions in the Windows Common Setup
@@ -31,16 +29,17 @@ def get_definitions():
     """
     import re
 
-    setup_in = open(PATH)
-    try:
-        deps = []
-        match = re.compile(r'([a-zA-Z0-9_]+) += +(.+)$').match
+    deps = []
+    match = re.compile(r'([a-zA-Z0-9_]+) += +(.+)$').match
+
+    with open(PATH) as setup_in:
         for line in setup_in:
             m = match(line)
+
             if m is not None:
                 deps.append(Definition(m.group(1), m.group(2)))
-        return deps
-    finally:
-        setup_in.close()
+
+    return deps
+
 
 __all__= ['read', 'get_definitions']


### PR DESCRIPTION
Overview of changes:
- Fixed the LGTM alerts in setup_win_common.py
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 1556f34474a6f70f2165968eebf9fd95e9737aa3

Resolves the setup_win_common.py alerts from the LGTM link in #1133.