### PR TITLE
Fix the LGTM alerts in config_darwin.py

### DIFF
--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -1,13 +1,12 @@
 """Config on Darwin w/ frameworks"""
 
-import os, sys, string
-from glob import glob
+import os
 from distutils.sysconfig import get_python_inc
 
 
 try:
     from config_unix import DependencyProg
-except:
+except ImportError:
     from buildconfig.config_unix import DependencyProg
 
 


### PR DESCRIPTION
Overview of changes:
- Fixed the LGTM alerts in config_darwin.py
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 1556f34474a6f70f2165968eebf9fd95e9737aa3

Note:
- Unable to properly test these changes on my Windows system.

Resolves the config_darwin.py alerts from the LGTM link in #1133.