### PR TITLE
Fix exceptions from freetype kerning being enabled

### DIFF
--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -196,11 +196,15 @@ _PGFT_BuildRenderMode(FreeTypeInstance *ft,
 
     if (mode->render_flags & FT_RFLAG_KERNING) {
         font = _PGFT_GetFontSized(ft, fontobj, mode->face_size);
+
+        if (!font) {
             PyErr_SetString(pgExc_SDLError, _PGFT_GetError(ft));
             return -1;
-            if (!FT_HAS_KERNING(font)) {
-                mode->render_flags &= ~FT_RFLAG_KERNING;
-            }
+        }
+
+        if (!FT_HAS_KERNING(font)) {
+            mode->render_flags &= ~FT_RFLAG_KERNING;
+        }
     }
     return 0;
 }

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -174,6 +174,59 @@ class FreeTypeFontTest(unittest.TestCase):
             # Ensures file is closed even if test fails.
             handle.close()
 
+    def test_freetype_Font_kerning(self):
+        """Ensures get/set works with the kerning property."""
+        ft_font = self._TEST_FONTS['sans']
+
+        # Test default is disabled.
+        self.assertFalse(ft_font.kerning)
+
+        # Test setting to True.
+        ft_font.kerning = True
+
+        self.assertTrue(ft_font.kerning)
+
+        # Test setting to False.
+        ft_font.kerning = False
+
+        self.assertFalse(ft_font.kerning)
+
+    def test_freetype_Font_kerning__enabled(self):
+        """Ensures exceptions are not raised when calling freetype methods
+        while kerning is enabled.
+
+        Note: This does not test what changes occur to a rendered font by
+              having kerning enabled.
+
+        Related to issue #367.
+        """
+        surface = pygame.Surface((10, 10), 0, 32)
+        TEST_TEXT = "Freetype Font"
+        ft_font = self._TEST_FONTS['bmp-8-75dpi']
+
+        ft_font.kerning = True
+
+        # Call different methods to ensure they don't raise an exception.
+        metrics = ft_font.get_metrics(TEST_TEXT)
+        self.assertIsInstance(metrics, list)
+
+        rect = ft_font.get_rect(TEST_TEXT)
+        self.assertIsInstance(rect, pygame.Rect)
+
+        font_surf, rect = ft_font.render(TEST_TEXT)
+        self.assertIsInstance(font_surf, pygame.Surface)
+        self.assertIsInstance(rect, pygame.Rect)
+
+        rect = ft_font.render_to(surface, (0, 0), TEST_TEXT)
+        self.assertIsInstance(rect, pygame.Rect)
+
+        buf, size = ft_font.render_raw(TEST_TEXT)
+        self.assertIsInstance(buf, bytes_)
+        self.assertIsInstance(size, tuple)
+
+        rect = ft_font.render_raw_to(surface.get_view('2'), TEST_TEXT)
+        self.assertIsInstance(rect, pygame.Rect)
+
     def test_freetype_Font_scalable(self):
 
         f = self._TEST_FONTS['sans']


### PR DESCRIPTION
Overview of changes:
- Fixed exceptions being raised due to the kerning property being enabled
- Added some related tests

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 8a937fcdcf47f09b828f7f3363e8468577697005

Resolves #367. Note: The root cause of this problem was found via a Coverity issue.
Resolves ft_render.c's "Structurally dead code" issue from the Coverity static analysis link in #1325.