### PR TITLE
Fix some Coverity issues: fastevents, math, mixer, mouse

### DIFF
--- a/src_c/fastevents.c
+++ b/src_c/fastevents.c
@@ -152,8 +152,12 @@ timerCallback(Uint32 interval, void *param)
 int
 FE_Init()
 {
-    if (0 == (SDL_INIT_TIMER & SDL_WasInit(SDL_INIT_TIMER)))
-        SDL_InitSubSystem(SDL_INIT_TIMER);
+    if (0 == (SDL_INIT_TIMER & SDL_WasInit(SDL_INIT_TIMER))) {
+        if (SDL_InitSubSystem(SDL_INIT_TIMER) < 0) {
+            setError("FE: unable to initialize required timer subsystem");
+            return -1;
+        }
+    }
 
     eventLock = SDL_CreateMutex();
     if (NULL == eventLock) {

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1881,17 +1881,13 @@ _vector2_set(pgVector *self, PyObject *xOrSequence, PyObject *y)
         }
     }
 
-    if (y) {
-        if (RealNumber_Check(y)) {
-            self->coords[1] = PyFloat_AsDouble(y);
-        }
-        else {
-            goto error;
-        }
+    if (RealNumber_Check(y)) {
+        self->coords[1] = PyFloat_AsDouble(y);
     }
     else {
         goto error;
     }
+
     /* success initialization */
     return 0;
 error:

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1872,8 +1872,13 @@ LOAD_BUFFER:
     }
 
     if (chunk == NULL) {
-        PyErr_Format(PyExc_TypeError, "Unrecognized argument (type %s)",
-                     Py_TYPE(obj)->tp_name);
+        if (obj == NULL) {
+            PyErr_SetString(PyExc_TypeError, "Unrecognized argument");
+        }
+        else {
+            PyErr_Format(PyExc_TypeError, "Unrecognized argument (type %s)",
+                         Py_TYPE(obj)->tp_name);
+        }
         return -1;
     }
 

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -224,6 +224,12 @@ mouse_set_cursor(PyObject *self, PyObject *args)
     xordata = (Uint8 *)malloc(xorsize);
     anddata = (Uint8 *)malloc(andsize);
 
+    if ((NULL == xordata) || (NULL == anddata)) {
+        free(xordata);
+        free(anddata);
+        return PyErr_NoMemory();
+    }
+
     for (loop = 0; loop < xorsize; ++loop) {
         if (!pg_IntFromObjIndex(xormask, loop, &val))
             goto interror;


### PR DESCRIPTION
Overview of changes:
- Fixed the following issues found by Coverity
  (Coverity info for pygame: https://scan.coverity.com/projects/pygame)
  - fastevents.c: Unchecked return value
  - math.c: Logically dead code
  - mixer.c: Explicit null dereferenced
  - mouse.c: Dereference null return value

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 8a937fcdcf47f09b828f7f3363e8468577697005

Resolves some of the issues from the Coverity static analysis link in #1325.