### PR TITLE
Fix a display.c compiler warning

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -461,7 +461,8 @@ pg_GetVideoInfo(pg_VideoInfo *info)
             SDL_FreeFormat(tempformat);
         }
         else {
-            return RAISE(pgExc_SDLError, SDL_GetError());
+            PyErr_SetString(pgExc_SDLError, SDL_GetError());
+            return (pg_VideoInfo *)NULL;
         }
     }
 


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 8a937fcdcf47f09b828f7f3363e8468577697005

Related to #1316.