### PR TITLE
Fix an LGTM alert in download_win_prebuilt.py

### DIFF
--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -1,4 +1,6 @@
 import os
+import stat
+
 
 try:
     raw_input
@@ -142,7 +144,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
                 st = os.lstat(s)
                 mode = stat.S_IMODE(st.st_mode)
                 os.lchmod(d, mode)
-            except:
+            except OSError:
                 pass # lchmod not available
         elif os.path.isdir(s):
             copytree(s, d, symlinks, ignore)


### PR DESCRIPTION
Overview of changes:
- Fixed the “Except block directly handles BaseException” LGTM alert in download_win_prebuilt.py
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)
- Added missing stat module import

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 8a937fcdcf47f09b828f7f3363e8468577697005

Resolves a download_win_prebuilt.py alert from the LGTM link in #1133.