### PR TITLE
Initialize freetype.get_error() data

### DIFF
--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -66,9 +66,10 @@ loaded. This module must be imported explicitly to be used. ::
 
    | :sl:`Return the latest FreeType error`
    | :sg:`get_error() -> str`
+   | :sg:`get_error() -> None`
 
    Return a description of the last error which occurred in the FreeType2
-   library, or None if no errors have occurred.
+   library, or ``None`` if no errors have occurred.
 
 .. function:: get_version
 

--- a/src_c/doc/freetype_doc.h
+++ b/src_c/doc/freetype_doc.h
@@ -1,6 +1,6 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEFREETYPE "Enhanced pygame module for loading and rendering computer fonts"
-#define DOC_PYGAMEFREETYPEGETERROR "get_error() -> str\nReturn the latest FreeType error"
+#define DOC_PYGAMEFREETYPEGETERROR "get_error() -> str\nget_error() -> None\nReturn the latest FreeType error"
 #define DOC_PYGAMEFREETYPEGETVERSION "get_version() -> (int, int, int)\nReturn the FreeType version"
 #define DOC_PYGAMEFREETYPEINIT "init(cache_size=64, resolution=72)\nInitialize the underlying FreeType library."
 #define DOC_PYGAMEFREETYPEQUIT "quit()\nShut down the underlying FreeType library."
@@ -60,6 +60,7 @@ Enhanced pygame module for loading and rendering computer fonts
 
 pygame.freetype.get_error
  get_error() -> str
+ get_error() -> None
 Return the latest FreeType error
 
 pygame.freetype.get_version

--- a/src_c/freetype/ft_wrap.c
+++ b/src_c/freetype/ft_wrap.c
@@ -576,6 +576,8 @@ _PGFT_Init(FreeTypeInstance **_instance, int cache_size)
         goto error_cleanup;
     }
 
+    _PGFT_SetError(inst, "", 0); /* Initialize error data. */
+
     *_instance = inst;
     return 0;
 

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1612,6 +1612,12 @@ class FreeTypeTest(unittest.TestCase):
         ft.init(cache_size=new_cache_size)
         self.assertEqual(ft.get_cache_size(), new_cache_size)
 
+    def test_get_error(self):
+        """Ensures get_error() is initially empty (None)."""
+        error_msg = ft.get_error()
+
+        self.assertIsNone(error_msg)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Overview of changes:
- Initialized the error data for `freetype.get_error()`
- Added a `freetype.get_error()` test
- Updated the `freetype.get_error()` documentation

System details:
- os: windows 10 (64bit)
- sphinx: 1.8.5
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 027374a11770de5f5bb773dcc17e5fe1257af6a4

Resolves #1356.