### PR TITLE
Add kwargs to Sprite and sprite Group `update`

### DIFF
--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -165,7 +165,7 @@ class Sprite(object):
     def remove_internal(self, group):
         del self.__g[group]
 
-    def update(self, *args):
+    def update(self, *args, **kwargs):
         """method to control sprite behavior
 
         Sprite.update(*args):
@@ -450,7 +450,7 @@ class AbstractGroup(object):
 
         return return_value
 
-    def update(self, *args):
+    def update(self, *args, **kwargs):
         """call the update method of every member sprite
 
         Group.update(*args): return None
@@ -460,7 +460,7 @@ class AbstractGroup(object):
 
         """
         for s in self.sprites():
-            s.update(*args)
+            s.update(*args, **kwargs)
 
     def draw(self, surface):
         """draw all sprites onto the surface

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -168,7 +168,7 @@ class Sprite(object):
     def update(self, *args, **kwargs):
         """method to control sprite behavior
 
-        Sprite.update(*args):
+        Sprite.update(*args, **kwargs):
 
         The default implementation of this method does nothing; it's just a
         convenient "hook" that you can override. This method is called by
@@ -453,7 +453,7 @@ class AbstractGroup(object):
     def update(self, *args, **kwargs):
         """call the update method of every member sprite
 
-        Group.update(*args): return None
+        Group.update(*args, **kwargs): return None
 
         Calls the update method of every member sprite. All arguments that
         were passed to this method are passed to the Sprite update function.

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -583,6 +583,23 @@ class AbstractGroupTypeTest( unittest.TestCase ):
 
         self.assertEqual(test_sprite.sink, [1, 2, 3])
 
+    def test_update_with_kwargs(self):
+
+        class test_sprite(pygame.sprite.Sprite):
+            sink = []
+            sink_kwargs = {}
+            def __init__(self, *groups):
+                pygame.sprite.Sprite.__init__(self, *groups)
+            def update(self, *args, **kwargs):
+                self.sink += args
+                self.sink_kwargs.update(kwargs)
+
+        s = test_sprite(self.ag)
+        self.ag.update(1, 2, 3, foo=4, bar=5)
+
+        self.assertEqual(test_sprite.sink, [1, 2, 3])
+        self.assertEqual(test_sprite.sink_kwargs, {'foo': 4, 'bar': 5})
+
 
 ################################################################################
 
@@ -1141,6 +1158,23 @@ class SpriteBase:
         s.update(1, 2, 3)
 
         self.assertEqual(test_sprite.sink, [1, 2, 3])
+
+    def test_update_with_kwargs(self):
+
+        class test_sprite(pygame.sprite.Sprite):
+            sink = []
+            sink_dict = {}
+            def __init__(self, *groups):
+                pygame.sprite.Sprite.__init__(self, *groups)
+            def update(self, *args, **kwargs):
+                self.sink += args
+                self.sink_dict.update(kwargs)
+
+        s = test_sprite()
+        s.update(1, 2, 3, foo=4, bar=5)
+
+        self.assertEqual(test_sprite.sink, [1, 2, 3])
+        self.assertEqual(test_sprite.sink_dict, {'foo': 4, 'bar': 5})
 
     def test___init____added_to_groups_passed(self):
         expected_groups = sorted(self.groups, key=id)


### PR DESCRIPTION
A simple change to add support to keyword arguments in `Sprite.update` and sprite `Group.update` method.

Prior to this, calling `Group.update` with a keyword arg would raise `TypeError`.

Related to #808.
