### PR TITLE
Fix encode_string()/encode_file_path() segfaults

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -68,6 +68,11 @@ static int
 _pg_rw_close(SDL_RWops *);
 #endif /* IS_SDLv2 */
 
+/* Converter function used by PyArg_ParseTupleAndKeywords with the "O&" format.
+ *
+ * Returns: 1 on success
+ *          0 on fail (with exception set)
+ */
 static int
 _pg_is_exception_class(PyObject *obj, void **optr)
 {
@@ -81,14 +86,20 @@ _pg_is_exception_class(PyObject *obj, void **optr)
         !PyObject_IsSubclass(obj, PyExc_BaseException)) {
         oname = PyObject_Str(obj);
         if (oname == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                            "invalid exception class argument");
             return 0;
         }
 #if PY3
         tmp = PyUnicode_AsEncodedString(oname, "ascii", "replace");
-        Py_DECREF(tmp);
+        Py_DECREF(oname);
+
         if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                            "invalid exception class argument");
             return 0;
         }
+
         oname = tmp;
 #endif
         PyErr_Format(PyExc_TypeError,

--- a/test/rwobject_test.py
+++ b/test/rwobject_test.py
@@ -57,6 +57,12 @@ class RWopsEncodeStringTest(unittest.TestCase):
         self.assertRaises(SyntaxError, encode_string,
                           u, 'ascii', 'strict', SyntaxError)
 
+    def test_etype__invalid(self):
+        """Ensures invalid etypes are properly handled."""
+
+        for etype in ("SyntaxError", self):
+            self.assertRaises(TypeError, encode_string, "test", etype=etype)
+
     def test_string_with_null_bytes(self):
         b = as_bytes("a\x00b\x00c")
         encoded_string = encode_string(b, etype=SyntaxError)
@@ -112,6 +118,13 @@ class RWopsEncodeFilePathTest(unittest.TestCase):
     def test_etype(self):
         b = as_bytes("a\x00b\x00c")
         self.assertRaises(TypeError, encode_file_path, b, TypeError)
+
+    def test_etype__invalid(self):
+        """Ensures invalid etypes are properly handled."""
+
+        for etype in ("SyntaxError", self):
+            self.assertRaises(TypeError, encode_file_path, "test", etype)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Overview of changes:
- Fixed the segmentation faults caused by invalid etype parameters passed to `encode_string()`/`encode_file_path()`
- Added setting exceptions on fail paths in `_pg_is_exception_class()`
- Added related tests

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 41692d7e1e5ffea3b7f18569ca7703c262bdb447

Resolves #1373.
Resolves rwobject.c's "Dereference before null check" issue from the Coverity static analysis link in #1325.