### PR TITLE
Update freetype render_raw_to() documentation

### DIFF
--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -476,13 +476,16 @@ loaded. This module must be imported explicitly to be used. ::
    .. method:: render_raw_to
 
       | :sl:`Render text into an array of ints`
-      | :sg:`render_raw_to(array, text, dest=None, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> (int, int)`
+      | :sg:`render_raw_to(array, text, dest=None, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> Rect`
 
       Render to an array object exposing an array struct interface. The array
       must be two dimensional with integer items. The default *dest* value,
       ``None``, is equivalent to position (0, 0). See :meth:`render_to`.
       As with the other render methods, *text* can be ``None`` to
       render a text string passed previously to another method.
+
+      The return value is a :func:`pygame.Rect` giving the size and position of
+      the rendered text.
 
    .. attribute:: style
 

--- a/src_c/doc/freetype_doc.h
+++ b/src_c/doc/freetype_doc.h
@@ -28,7 +28,7 @@
 #define DOC_FONTRENDER "render(text, fgcolor=None, bgcolor=None, style=STYLE_DEFAULT, rotation=0, size=0) -> (Surface, Rect)\nReturn rendered text as a surface"
 #define DOC_FONTRENDERTO "render_to(surf, dest, text, fgcolor=None, bgcolor=None, style=STYLE_DEFAULT, rotation=0, size=0) -> Rect\nRender text onto an existing surface"
 #define DOC_FONTRENDERRAW "render_raw(text, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> (bytes, (int, int))\nReturn rendered text as a string of bytes"
-#define DOC_FONTRENDERRAWTO "render_raw_to(array, text, dest=None, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> (int, int)\nRender text into an array of ints"
+#define DOC_FONTRENDERRAWTO "render_raw_to(array, text, dest=None, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> Rect\nRender text into an array of ints"
 #define DOC_FONTSTYLE "style -> int\nThe font's style flags"
 #define DOC_FONTUNDERLINE "underline -> bool\nThe state of the font's underline style flag"
 #define DOC_FONTSTRONG "strong -> bool\nThe state of the font's strong style flag"
@@ -174,7 +174,7 @@ pygame.freetype.Font.render_raw
 Return rendered text as a string of bytes
 
 pygame.freetype.Font.render_raw_to
- render_raw_to(array, text, dest=None, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> (int, int)
+ render_raw_to(array, text, dest=None, style=STYLE_DEFAULT, rotation=0, size=0, invert=False) -> Rect
 Render text into an array of ints
 
 pygame.freetype.Font.style


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- sphinx: 1.8.5
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 41692d7e1e5ffea3b7f18569ca7703c262bdb447