### PR TITLE
V2.0.0.dev4

### DIFF
--- a/docs/reST/conf.py
+++ b/docs/reST/conf.py
@@ -48,9 +48,9 @@ copyright = u'2011-2019, pygame developers'
 # built documents.
 #
 # The short X.Y version.
-version = '2.0.0.dev4'
+version = '2.0.0.dev5'
 # The full version, including alpha/beta/rc tags.
-release = '2.0.0.dev4'
+release = '2.0.0.dev5'
 
 # Format strings for the version directives
 versionadded_format = 'New in pygame %s'

--- a/docs/reST/conf.py
+++ b/docs/reST/conf.py
@@ -48,9 +48,9 @@ copyright = u'2011-2019, pygame developers'
 # built documents.
 #
 # The short X.Y version.
-version = '2.0.0.dev3'
+version = '2.0.0.dev4'
 # The full version, including alpha/beta/rc tags.
-release = '2.0.0.dev3'
+release = '2.0.0.dev4'
 
 # Format strings for the version directives
 versionadded_format = 'New in pygame %s'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ EXTRAS = {}
 
 METADATA = {
     "name":             "pygame",
-    "version":          "2.0.0.dev3",
+    "version":          "2.0.0.dev4",
     "license":          "LGPL",
     "url":              "https://www.pygame.org",
     "author":           "A community project.",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ EXTRAS = {}
 
 METADATA = {
     "name":             "pygame",
-    "version":          "2.0.0.dev4",
+    "version":          "2.0.0.dev5",
     "license":          "LGPL",
     "url":              "https://www.pygame.org",
     "author":           "A community project.",


### PR DESCRIPTION
SDL is doing a thing where the odd number in the repo is kept until the release.
So even numbered things are released. Let's try that this time?

So it's marked as V2.0.0.dev5 in the repo now.
When we release we can mark it as V2.0.0.dev6.

The small benefit is; if we see an issue with "2.0.0.dev5" we know that it was somewhere in the time between 2.0.0.dev5 and 2.0.0.dev6. When we release 2.0.0.dev6 it will mean it's that released version, and the in-repo code will be the odd numbered 2.0.0.dev7.

I guess that makes sense?