### PR TITLE
Fix some display.c Coverity issues

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -822,7 +822,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
     }
 
     if (!state->title) {
-        state->title = malloc((strlen(DefaultTitle) + 1) * sizeof(char *));
+        state->title = malloc((strlen(DefaultTitle) + 1) * sizeof(char));
         if (!state->title)
             return PyErr_NoMemory();
         strcpy(state->title, DefaultTitle);
@@ -2008,7 +2008,7 @@ pg_set_caption(PyObject *self, PyObject *arg)
 
     if (state->title)
         free(state->title);
-    state->title = (char *)malloc((strlen(title) + 1) * sizeof(char *));
+    state->title = (char *)malloc((strlen(title) + 1) * sizeof(char));
     if (!state->title) {
         PyErr_NoMemory();
         goto error;


### PR DESCRIPTION
Overview of changes:
- Fixed the following Coverity issues in display.c
  (Coverity info for pygame: https://scan.coverity.com/projects/pygame)
  - 2 issues of type: Wrong sizeof argument

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev5 (SDL: 2.0.10) at 65395160f90c02ae52df27306204852ca93869af

Resolves 2 of the display.c issues from the Coverity static analysis link in #1325.