### PR TITLE
Fixed pygame.draw.circle size

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1753,24 +1753,31 @@ draw_arc(SDL_Surface *dst, int x, int y, int radius1, int radius2,
     }
 }
 
-
+/* This function is used just for circle drawing because Bresenham Circle Algorithm
+ * draws the circle with the odd diameter and in the original pygame it had even diameter
+ * It does scaling by that one pixel (direction based on relative quadrant to the center
+ * to keep symmetry). In any other drawing function use normal set_at function
+ */
 static void
 draw_circle_pixel(SDL_Surface *dst, int x0, int y0, int x1, int y1, Uint32 color)
 {
+    // (x0, y0) -> center of the circle, (x1, y1) -> pixel to bve drawn
+    // leading_bit -> used for fast quadrant calculation, 1 for negative and 0 for positive
+    // number (number is "vector" from center to the pixel)
     int x_leading_bit = ((x1-x0) > 0) - ((x1-x0) < 0) == 1 ? 0 : 1;
     int y_leading_bit = ((y1-y0) > 0) - ((y1-y0) < 0) == 1 ? 0 : 1;
     int quadrant = (x_leading_bit != y_leading_bit) + y_leading_bit + y_leading_bit + 1;
     if (quadrant == 1) {
-        set_at(dst, x1 - 1, y1 - 1, color);
+        set_at(dst, x1 - 1, y1 - 1, color);  // Move one to the left and up
     }
     else if (quadrant == 2) {
-        set_at(dst, x1, y1 - 1, color);
+        set_at(dst, x1, y1 - 1, color);      // Move one to the up
     }
     else if (quadrant == 3) {
         set_at(dst, x1, y1, color);
     }
     else {
-        set_at(dst, x1 - 1, y1, color);
+        set_at(dst, x1 - 1, y1, color);      // Move one to the left
     }
 }
 
@@ -1856,8 +1863,8 @@ draw_circle_filled(SDL_Surface *dst, int x0, int y0, int radius, Uint32 color)
     int y = radius;
     int y1;
 
-    for (y1=y0 - y; y1 <= y0 + y; y1++){
-	draw_circle_pixel(dst, x0, y0, x0, y1, color);
+    for (y1=y0 - y; y1 <= y0 + y; y1++) {
+	    draw_circle_pixel(dst, x0, y0, x0, y1, color);
     }
     draw_circle_pixel(dst, x0, y0, x0 + radius, y0, color);
     draw_circle_pixel(dst, x0, y0, x0 - radius, y0, color);

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -741,8 +741,8 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 
     l = MAX(posx - radius, surf->clip_rect.x);
     t = MAX(posy - radius, surf->clip_rect.y);
-    r = MIN(posx + radius + 1, surf->clip_rect.x + surf->clip_rect.w);
-    b = MIN(posy + radius + 1, surf->clip_rect.y + surf->clip_rect.h);
+    r = MIN(posx + radius, surf->clip_rect.x + surf->clip_rect.w);
+    b = MIN(posy + radius, surf->clip_rect.y + surf->clip_rect.h);
     return pgRect_New4(l, t, MAX(r - l, 0), MAX(b - t, 0));
 }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1763,13 +1763,13 @@ draw_circle_pixel(SDL_Surface *dst, int x0, int y0, int x1, int y1, Uint32 color
     if (quadrant == 1) {
         set_at(dst, x1 - 1, y1 - 1, color);
     }
-    if (quadrant == 2) {
+    else if (quadrant == 2) {
         set_at(dst, x1, y1 - 1, color);
     }
-    if (quadrant == 3) {
+    else if (quadrant == 3) {
         set_at(dst, x1, y1, color);
     }
-    if (quadrant == 4) {
+    else (quadrant == 4) {
         set_at(dst, x1 - 1, y1, color);
     }
 }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1769,7 +1769,7 @@ draw_circle_pixel(SDL_Surface *dst, int x0, int y0, int x1, int y1, Uint32 color
     else if (quadrant == 3) {
         set_at(dst, x1, y1, color);
     }
-    else (quadrant == 4) {
+    else {
         set_at(dst, x1 - 1, y1, color);
     }
 }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1754,6 +1754,27 @@ draw_arc(SDL_Surface *dst, int x, int y, int radius1, int radius2,
 }
 
 
+static void
+draw_circle_pixel(SDL_Surface *dst, int x0, int y0, int x1, int y1, Uint32 color)
+{
+    int x_leading_bit = ((x1-x0) > 0) - ((x1-x0) < 0) == 1 ? 0 : 1;
+    int y_leading_bit = ((y1-y0) > 0) - ((y1-y0) < 0) == 1 ? 0 : 1;
+    int quadrant = (x_leading_bit != y_leading_bit) + y_leading_bit + y_leading_bit + 1;
+    if (quadrant == 1) {
+        set_at(dst, x1 - 1, y1 - 1, color);
+    }
+    if (quadrant == 2) {
+        set_at(dst, x1, y1 - 1, color);
+    }
+    if (quadrant == 3) {
+        set_at(dst, x1, y1, color);
+    }
+    if (quadrant == 4) {
+        set_at(dst, x1 - 1, y1, color);
+    }
+}
+
+
 /* Bresenham Circle Algorithm
  * adapted from: https://de.wikipedia.org/wiki/Bresenham-Algorithmus
  * with additional line width parameter
@@ -1777,10 +1798,10 @@ draw_circle_bresenham(SDL_Surface *dst, int x0, int y0, int radius, int thicknes
      * instead of concentric circles in outer loop */
     for (i=0; i<thickness; i++){
         radius1=radius - i;
-        set_at(dst, x0, y0 + radius1, color);
-        set_at(dst, x0, y0 - radius1, color);
-        set_at(dst, x0 + radius1, y0, color);
-        set_at(dst, x0 - radius1, y0, color);
+        draw_circle_pixel(dst, x0, y0, x0, y0 + radius1, color);
+        draw_circle_pixel(dst, x0, y0, x0, y0 - radius1, color);
+        draw_circle_pixel(dst, x0, y0, x0 + radius1, y0, color);
+        draw_circle_pixel(dst, x0, y0, x0 - radius1, y0, color);
     }
 
     while(x < y)
@@ -1813,14 +1834,14 @@ draw_circle_bresenham(SDL_Surface *dst, int x0, int y0, int radius, int thicknes
       for (i=0; i<thickness; i++){
           y1=y-i;
 
-          set_at(dst, x0 + x, y0 + y1, color);
-          set_at(dst, x0 - x, y0 + y1, color);
-          set_at(dst, x0 + x, y0 - y1 , color);
-          set_at(dst, x0 - x, y0 - y1, color);
-          set_at(dst, x0 + y1 , y0 + x, color);
-          set_at(dst, x0 - y1, y0 + x, color);
-          set_at(dst, x0 + y1, y0 - x, color);
-          set_at(dst, x0 - y1, y0 - x, color);
+          draw_circle_pixel(dst, x0, y0, x0 + x, y0 + y1, color);
+          draw_circle_pixel(dst, x0, y0, x0 - x, y0 + y1, color);
+          draw_circle_pixel(dst, x0, y0, x0 + x, y0 - y1, color);
+          draw_circle_pixel(dst, x0, y0, x0 - x, y0 - y1, color);
+          draw_circle_pixel(dst, x0, y0, x0 + y1, y0 + x, color);
+          draw_circle_pixel(dst, x0, y0, x0 - y1, y0 + x, color);
+          draw_circle_pixel(dst, x0, y0, x0 + y1, y0 - x, color);
+          draw_circle_pixel(dst, x0, y0, x0 - y1, y0 - x, color);
       }
     }
 }
@@ -1836,10 +1857,10 @@ draw_circle_filled(SDL_Surface *dst, int x0, int y0, int radius, Uint32 color)
     int y1;
 
     for (y1=y0 - y; y1 <= y0 + y; y1++){
-        set_at(dst, x0, y1, color);
+	draw_circle_pixel(dst, x0, y0, x0, y1, color);
     }
-    set_at(dst, x0 + radius, y0, color);
-    set_at(dst, x0 - radius, y0, color);
+    draw_circle_pixel(dst, x0, y0, x0 + radius, y0, color);
+    draw_circle_pixel(dst, x0, y0, x0 - radius, y0, color);
 
     while(x < y)
     {
@@ -1854,12 +1875,12 @@ draw_circle_filled(SDL_Surface *dst, int x0, int y0, int radius, Uint32 color)
       f += ddF_x + 1;
 
       for (y1=y0 - y; y1 <= y0 + y; y1++){
-        set_at(dst, x0+x, y1, color);
-        set_at(dst, x0-x, y1, color);
+        draw_circle_pixel(dst, x0, y0, x0+x, y1, color);
+        draw_circle_pixel(dst, x0, y0, x0-x, y1, color);
       }
       for (y1=y0 - x; y1 <= y0 + x; y1++){
-        set_at(dst, x0+y, y1, color);
-        set_at(dst, x0-y, y1, color);
+        draw_circle_pixel(dst, x0, y0, x0+y, y1, color);
+        draw_circle_pixel(dst, x0, y0, x0-y, y1, color);
       }
     }
 }

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4804,6 +4804,17 @@ class DrawCircleMixin(object):
             if sqr_distance <(radius-width-1)**2 or sqr_distance > (radius+1)**2:
                 self.assertEqual(surface.get_at(pt), surface_color)
 
+    def test_circle__diameter(self):
+        """Ensures draw circle is twice size of radius high and wide."""
+        surf = pygame.Surface((100, 100))
+        color = (0, 0, 0, 50)
+        center = surf.get_height() // 2, surf.get_height() // 2
+        width = 1
+        radius = 6
+        bounding_rect = self.draw_circle(surf, color, center, radius, width)
+        self.assertEqual(bounding_rect.width, radius * 2)
+        self.assertEqual(bounding_rect.height, radius * 2)
+
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):
     """Test draw module function circle.
 


### PR DESCRIPTION
This should resolve issue #1384, if you need me to write the comments in code for this commit I will gladly do it. The problem was with the new algorithm we use to draw the circle we can only draw odd number of pixels (midpoint algorithm has the range of [-radius, radius] so that means it draws 2 * radius + 1 pixels). Algorithm we used before had the range of [-radius, radius - 1] so that means it used to draw 2 * radius pixels (one less). This had the effect if you run any code that called pygame.draw.circle() function. With this fix I still use the same algorithm, just move pixels based on the quadrant which makes circle have the diameter of 2 * radius (just like it used to be pre 2.0.0dev4).

illume said that eventually we should do sub pixel rendering, but until than something like this should work