### PR TITLE
Zero and negative sized circles do not draw anything or raise.

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -710,11 +710,7 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 
     CHECK_LOAD_COLOR(colorobj)
 
-    if (radius < 0) {
-        return RAISE(PyExc_ValueError, "negative radius");
-    }
-
-    if (width < 0) {
+    if (radius < 1 || width < 0) {
         return pgRect_New4(posx, posy, 0, 0);
     }
 
@@ -743,6 +739,13 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     t = MAX(posy - radius, surf->clip_rect.y);
     r = MIN(posx + radius, surf->clip_rect.x + surf->clip_rect.w);
     b = MIN(posy + radius, surf->clip_rect.y + surf->clip_rect.h);
+
+    /*
+    printf("posx=%i, posy=%i, radius=%i, l=%i, t=%i, r=%i, b=%i, clip_rect_x=%i, \
+            clip_rect_y=%i, clip_rect_w=%i, clip_rect_h=%i\n", posx, posy, \
+            radius, l, t, r, b,surf->clip_rect.x, surf->clip_rect.y, \
+            surf->clip_rect.w, surf->clip_rect.h);
+    */
     return pgRect_New4(l, t, MAX(r - l, 0), MAX(b - t, 0));
 }
 


### PR DESCRIPTION
Added some commented out debugging printf for failing test.

For issue https://github.com/pygame/pygame/issues/1122 "Incorrect bounding rects returned from pygame.draw.circle"