### PR TITLE
WIP: Trying arm64 support on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: c
 
 cache:
   directories:
@@ -44,6 +44,11 @@ matrix:
       python: 3.7
       env:
         - PPC=yes
+
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      dist: xenial
 
     - os: linux
       sudo: required


### PR DESCRIPTION
https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support

Seems `language: python` doesn't have support yet. `language: c` does, but our builds need to be changed on there for this to work.