### PR TITLE
Add prebuilt_downloads to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Windows prebuilt external libraries
 /prebuilt-x??
+/prebuilt_downloads
 
 # Sphinx generated files: makeref.py
 /docs/\.buildinfo


### PR DESCRIPTION
Added `prebuilt_downloads` to gitignore. It is created when building pygame from source on Windows.