### PR TITLE
Verbose mode arg passing added to our test runner.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -137,7 +137,7 @@ skip_branch_with_pr: true
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
-  - "%PYTHON% -m pygame.tests --exclude opengl"
+  - "%PYTHON% -m pygame.tests -v --exclude opengl"
 
   # Move back to the project folder
   - "cd .."

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,7 @@ env:
     - secure: "EGrZt/2EGOAzwcI69la5RgJ1Fr8uXM0TYarCheBrDVwcESNXccH9myyflN97m/jDrdyJB2fmVgI2WDpFdvnpEXNC7+lTEhApgFx6L1TwE/s5Fj6Kd72cERcPmDwLwzQFChXl2kjPTgu/Qr2u2X3EYCfEd0jRf+TcdHasvOLeGuQu7l0cnyW6WK+xMhF1wV8O9F1IdggyeysYIpP/v8rCtmjd268AqploBJ3cM3qau1F9NYBCSUPhu9eZfB0JRhHzeFDbNxRJtG+WZjk2CuGi1W8BGM/CeJkM/3b7iHMEwCYd8JW4k8ZYLSrPUiHkKxSeL9R12+p9u6AHMlXfEfO96Nt8pQkhVP9BxH374RRvQsIl5OxACTAW9XEiqTP7aRXIBSOxX6p3DxUXl6Ogn0d9U5rIu4SUAiaWW9e0k+Oeo/H3OGuerFlBIh6rW4kzVZ7ftcqzVRz9QgnrSy2r93BYzTWwM3eifkFQwtgnBSvXxM151leHOJ9r3PAiRup7V90WZBD4zytQSMaOc+fcdIWscP88sPcLXZEb6n6y7Ja3t5ASO58dXLw9EvqS4CsRYI08ltH85L/cq37dKgpvu33lsx1ZDksiMKtZW7tXhV1DZ9thl1JH/3f9QLRFz+02mJ6FD4PCJRYQvDDs5J4j7rf76FUlcBr+9bAN0sRnPL6UOms="
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $(set | grep PYPI_ | python -c "import sys;print('\n'.join(['unset %s' % l.split('=')[0] for l in sys.stdin.readlines() if l.startswith('PYPI')]))"); fi
-  - $PYTHON_EXE -m pygame.tests.__main__ --exclude opengl --time_out 300
+  - $PYTHON_EXE -m pygame.tests.__main__ -v --exclude opengl --time_out 300
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx_after_success.sh; fi

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -107,7 +107,6 @@ opt_parser.add_option("-S", "--seed", type="int", help="Randomisation seed")
 # args will be the test module list, passed as positional argumemts.
 
 options, args = opt_parser.parse_args()
-
 kwds = {}
 if options.incomplete:
     kwds["incomplete"] = True
@@ -137,6 +136,8 @@ if options.python:
     kwds["python"] = options.python
 if options.interactive:
     kwds["interactive"] = True
+kwds["verbosity"] = options.verbosity if options.verbosity is not None else 1
+
 
 ###########################################################################
 # Run the test suite.

--- a/test/test_utils/run_tests.py
+++ b/test/test_utils/run_tests.py
@@ -239,7 +239,7 @@ def run(*args, **kwds):
             from test.test_utils.async_sub import proc_in_time_or_kill
 
         pass_on_args = ["--exclude", ",".join(option_exclude)]
-        for field in ["randomize", "incomplete", "unbuffered"]:
+        for field in ["randomize", "incomplete", "unbuffered", "verbosity"]:
             if kwds.get(field, False):
                 pass_on_args.append("--" + field)
 

--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -273,9 +273,11 @@ def run_test(
     """
     suite = unittest.TestSuite()
 
-    print("loading %s" % module)
     if verbosity is None:
         verbosity = 1
+
+    if verbosity:
+        print("loading %s" % module)
 
     loader = PygameTestLoader(
         randomize_tests=randomize, include_incomplete=incomplete, exclude=exclude
@@ -286,8 +288,7 @@ def run_test(
     runner = unittest.TextTestRunner(stream=output, buffer=buffer, verbosity=verbosity)
     results = runner.run(suite)
 
-    # TODO: unbuffered is maybe 'buffer' arg?
-    if unbuffered is not None:
+    if verbosity == 2:
         output.seek(0)
         print(output.read())
         output.seek(0)

--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -74,10 +74,27 @@ opt_parser.add_option(
 )
 
 opt_parser.add_option(
-    "-v",
+    "-u",
     "--unbuffered",
     action="store_true",
     help="Show stdout/stderr as tests run, rather than storing it and showing on failures",
+)
+
+opt_parser.add_option(
+    '-v',
+    '--verbose',
+    dest='verbosity',
+    action='store_const',
+    const=2,
+    help='Verbose output'
+)
+opt_parser.add_option(
+    '-q',
+    '--quiet',
+    dest='verbosity',
+    action='store_const',
+    const=0,
+    help='Quiet output'
 )
 
 opt_parser.add_option(
@@ -200,12 +217,16 @@ def run_test(
     randomize=False,
     exclude=("interactive",),
     buffer=True,
+    unbuffered=None,
+    verbosity=1,
 ):
     """Run a unit test module
     """
     suite = unittest.TestSuite()
 
     print("loading %s" % module)
+    if verbosity is None:
+        verbosity = 1
 
     loader = PygameTestLoader(
         randomize_tests=randomize, include_incomplete=incomplete, exclude=exclude
@@ -213,8 +234,18 @@ def run_test(
     suite.addTest(loader.loadTestsFromName(module))
 
     output = StringIO.StringIO()
-    runner = unittest.TextTestRunner(stream=output, buffer=buffer)
+    runner = unittest.TextTestRunner(
+        stream=output,
+        buffer=buffer,
+        verbosity=verbosity,
+    )
     results = runner.run(suite)
+
+    #TODO: unbuffered is maybe 'buffer' arg?
+    if unbuffered is not None:
+        output.seek(0)
+        print(output.read())
+        output.seek(0)
 
     results = {
         module: {

--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -81,20 +81,20 @@ opt_parser.add_option(
 )
 
 opt_parser.add_option(
-    '-v',
-    '--verbose',
-    dest='verbosity',
-    action='store_const',
+    "-v",
+    "--verbose",
+    dest="verbosity",
+    action="store_const",
     const=2,
-    help='Verbose output'
+    help="Verbose output",
 )
 opt_parser.add_option(
-    '-q',
-    '--quiet',
-    dest='verbosity',
-    action='store_const',
+    "-q",
+    "--quiet",
+    dest="verbosity",
+    action="store_const",
     const=0,
-    help='Quiet output'
+    help="Quiet output",
 )
 
 opt_parser.add_option(
@@ -134,6 +134,7 @@ RAN_TESTS_DIV = (70 * "-") + "\nRan"
 
 DOTS = re.compile("^([FE.sux]*)$", re.MULTILINE)
 
+
 def extract_tracebacks(output):
     """ from test runner output return the tracebacks.
     """
@@ -158,15 +159,15 @@ def output_into_dots(output):
     if verbose_mode:
         # a map from the verbose output to the dots output.
         reasons = {
-            "... ERROR": 'E',
-            "... unexpected success": 'u',
+            "... ERROR": "E",
+            "... unexpected success": "u",
             "... skipped": "s",
-            "... expected failure": 'x',
+            "... expected failure": "x",
             "... ok": ".",
             "... FAIL": "F",
         }
         results = output.split("\n\n==")[0]
-        lines = [l for l in results.split("\n") if l and '...' in l]
+        lines = [l for l in results.split("\n") if l and "..." in l]
         dotlist = []
         for l in lines:
             found = False
@@ -176,12 +177,11 @@ def output_into_dots(output):
                     found = True
                     break
             if not found:
-                raise ValueError('Not sure what this is. Add to reasons. :%s' % l)
+                raise ValueError("Not sure what this is. Add to reasons. :%s" % l)
 
         return "".join(dotlist)
     dots = DOTS.search(output).group(1)
     return dots
-
 
 
 def combine_results(all_results, t):
@@ -218,7 +218,6 @@ def combine_results(all_results, t):
         tracebacks = extract_tracebacks(output)
         if tracebacks:
             failures.append(tracebacks)
-
 
     total_fails, total_errors = map(all_dots.count, "FE")
     total_tests = len(all_dots)
@@ -284,14 +283,10 @@ def run_test(
     suite.addTest(loader.loadTestsFromName(module))
 
     output = StringIO.StringIO()
-    runner = unittest.TextTestRunner(
-        stream=output,
-        buffer=buffer,
-        verbosity=verbosity,
-    )
+    runner = unittest.TextTestRunner(stream=output, buffer=buffer, verbosity=verbosity)
     results = runner.run(suite)
 
-    #TODO: unbuffered is maybe 'buffer' arg?
+    # TODO: unbuffered is maybe 'buffer' arg?
     if unbuffered is not None:
         output.seek(0)
         print(output.read())


### PR DESCRIPTION
- Our test runner has a verbose mode. ```python3 -m pygame.tests -v```
- Travis, and Appveyor run the tests in verbose mode.

The "unbuffered" mode is moved to `-u`. (Not really sure what that is... but hey! it's not -v anymore).

Fixes https://github.com/pygame/pygame/pull/1404