### PR TITLE
Fix some event, surface, gfxdraw compiler warnings

### DIFF
--- a/docs/reST/ref/gfxdraw.rst
+++ b/docs/reST/ref/gfxdraw.rst
@@ -599,7 +599,7 @@ For example:
 
 .. function:: bezier
 
-   | :sl:`draw a Bézier curve`
+   | :sl:`draw a Bezier curve`
    | :sg:`bezier(surface, points, steps, color) -> None`
 
    Draws a Bézier curve on the given surface.

--- a/src_c/doc/gfxdraw_doc.h
+++ b/src_c/doc/gfxdraw_doc.h
@@ -21,7 +21,7 @@
 #define DOC_PYGAMEGFXDRAWAAPOLYGON "aapolygon(surface, points, color) -> None\ndraw an antialiased polygon"
 #define DOC_PYGAMEGFXDRAWFILLEDPOLYGON "filled_polygon(surface, points, color) -> None\ndraw a filled polygon"
 #define DOC_PYGAMEGFXDRAWTEXTUREDPOLYGON "textured_polygon(surface, points, texture, tx, ty) -> None\ndraw a textured polygon"
-#define DOC_PYGAMEGFXDRAWBEZIER "bezier(surface, points, steps, color) -> None\ndraw a Bézier curve"
+#define DOC_PYGAMEGFXDRAWBEZIER "bezier(surface, points, steps, color) -> None\ndraw a Bezier curve"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -117,6 +117,6 @@ draw a textured polygon
 
 pygame.gfxdraw.bezier
  bezier(surface, points, steps, color) -> None
-draw a Bézier curve
+draw a Bezier curve
 
 */

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -137,7 +137,6 @@ pg_event_filter(void *_, SDL_Event *event)
 #pragma PG_WARN(Add event blocking here.)
 
     else if (type == SDL_KEYDOWN) {
-        SDL_Event inputEvent[2];
         if (event->key.repeat) {
             return 0;
         }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -431,7 +431,7 @@ pgSurface_SetSurface(pgSurfaceObject *self, SDL_Surface *s, int owner)
 #endif /* IS_SDLv2 */
 {
     if (!s) {
-        RAISE(pgExc_SDLError, SDL_GetError());
+        PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return -1;
     }
     if (s == self->surf) {


### PR DESCRIPTION
Overview of changes:
- Fixed the following compiler warnings:
  - event.c: unused variable ‘inputEvent’
    (from all compiles)
  - surface.c: right-hand operand of comma expression has no effect
    (from linux compiles)
  - gfxdraw.c: illegal character encoding in string literal
    (from OSX compiles)

System details:
- os: windows 10 (64bit)
- sphinx: 1.8.5
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 7d61558e2ded117cf9478c31cddec482e3695497


Related to #1316.