### PR TITLE
Fix compile error due to missing declaration

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -137,6 +137,7 @@ pg_event_filter(void *_, SDL_Event *event)
 #pragma PG_WARN(Add event blocking here.)
 
     else if (type == SDL_KEYDOWN) {
+        SDL_Event inputEvent[2];
         if (event->key.repeat) {
             return 0;
         }


### PR DESCRIPTION
Overview of changes:
- Fixed the compile error due to a missing variable declaration
  (caused by two updates changing related code)

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at b5bb7c6c86612cde7217ea25a4d2d4e69f755b90

Related to PR #1409 removing a variable declaration needed by PR #1398.