### PR TITLE
Fix various compiler warnings

### DIFF
--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -389,7 +389,7 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
                 for (i = 0; i < astripes; i++) {
                     for (ap = a_entry, bp = b_entry; ap < a_end; ap++, bp++)
                         if (*ap & (*bp << shift)) {
-                            *y = ap - a_entry + yoffset;
+                            *y = (int)(ap - a_entry) + yoffset;
                             *x = (xbase + i) * BITMASK_W_LEN +
                                  firstsetbit(*ap & (*bp << shift));
                             return 1;
@@ -398,7 +398,7 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
                     a_end += a->h;
                     for (ap = a_entry, bp = b_entry; ap < a_end; ap++, bp++)
                         if (*ap & (*bp >> rshift)) {
-                            *y = ap - a_entry + yoffset;
+                            *y = (int)(ap - a_entry) + yoffset;
                             *x = (xbase + i + 1) * BITMASK_W_LEN +
                                  firstsetbit(*ap & (*bp >> rshift));
                             return 1;
@@ -407,7 +407,7 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
                 }
                 for (ap = a_entry, bp = b_entry; ap < a_end; ap++, bp++)
                     if (*ap & (*bp << shift)) {
-                        *y = ap - a_entry + yoffset;
+                        *y = (int)(ap - a_entry) + yoffset;
                         *x = (xbase + astripes) * BITMASK_W_LEN +
                              firstsetbit(*ap & (*bp << shift));
                         return 1;
@@ -419,7 +419,7 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
                 for (i = 0; i < bstripes; i++) {
                     for (ap = a_entry, bp = b_entry; ap < a_end; ap++, bp++)
                         if (*ap & (*bp << shift)) {
-                            *y = ap - a_entry + yoffset;
+                            *y = (int)(ap - a_entry) + yoffset;
                             *x = (xbase + i) * BITMASK_W_LEN +
                                  firstsetbit(*ap & (*bp << shift));
                             return 1;
@@ -428,7 +428,7 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
                     a_end += a->h;
                     for (ap = a_entry, bp = b_entry; ap < a_end; ap++, bp++)
                         if (*ap & (*bp >> rshift)) {
-                            *y = ap - a_entry + yoffset;
+                            *y = (int)(ap - a_entry) + yoffset;
                             *x = (xbase + i + 1) * BITMASK_W_LEN +
                                  firstsetbit(*ap & (*bp >> rshift));
                             return 1;
@@ -446,7 +446,7 @@ bitmask_overlap_pos(const bitmask_t *a, const bitmask_t *b, int xoffset,
             for (i = 0; i < astripes; i++) {
                 for (ap = a_entry, bp = b_entry; ap < a_end; ap++, bp++) {
                     if (*ap & *bp) {
-                        *y = ap - a_entry + yoffset;
+                        *y = (int)(ap - a_entry) + yoffset;
                         *x = (xbase + i) * BITMASK_W_LEN +
                              firstsetbit(*ap & *bp);
                         return 1;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -432,7 +432,7 @@ font_render(PyObject *self, PyObject *args)
             return NULL;
         }
         astring = Bytes_AsString(bytes);
-        if (strlen(astring) != Bytes_GET_SIZE(bytes)) {
+        if (strlen(astring) != (size_t)Bytes_GET_SIZE(bytes)) {
             Py_DECREF(bytes);
             return RAISE(PyExc_ValueError,
                          "A null character was found in the text");
@@ -459,7 +459,7 @@ font_render(PyObject *self, PyObject *args)
     else if (Bytes_Check(text)) {
         const char *astring = Bytes_AsString(text);
 
-        if (strlen(astring) != Bytes_GET_SIZE(text)) {
+        if (strlen(astring) != (size_t)Bytes_GET_SIZE(text)) {
             return RAISE(PyExc_ValueError,
                          "A null character was found in the text");
         }
@@ -581,7 +581,7 @@ font_metrics(PyObject *self, PyObject *args)
         Py_DECREF(obj);
         return NULL;
     }
-    buffer = Bytes_AS_STRING(obj);
+    buffer = (Uint16 *)Bytes_AS_STRING(obj);
     length = Bytes_GET_SIZE(obj) / sizeof(Uint16);
     for (i = 1 /* skip BOM */; i < length; i++) {
         ch = buffer[i];

--- a/src_c/freetype/ft_cache.c
+++ b/src_c/freetype/ft_cache.c
@@ -77,7 +77,7 @@ set_node_key(NodeKey *key, GlyphIndex_t id, const FontRenderMode *mode)
 static int
 equal_node_keys(const NodeKey *a, const NodeKey *b)
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < sizeof(a->dwords) / sizeof(a->dwords[0]); ++i) {
         if (a->dwords[i] != b->dwords[i]) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -39,7 +39,9 @@
 
 /* stdint.h is missing from some versions of MSVC. */
 #ifdef _MSC_VER
+#ifndef UINT32_MAX
 #define UINT32_MAX 0xFFFFFFFF
+#endif
 #else
 #include <stdint.h>
 #endif /* _MSC_VER */

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -37,6 +37,13 @@
 
 #include "pgbufferproxy.h"
 
+/* stdint.h is missing from some versions of MSVC. */
+#ifdef _MSC_VER
+#define UINT32_MAX 0xFFFFFFFF
+#else
+#include <stdint.h>
+#endif /* _MSC_VER */
+
 typedef enum {
     VIEWKIND_0D = 0,
     VIEWKIND_1D = 1,
@@ -1684,7 +1691,7 @@ surf_convert(PyObject *self, PyObject *args)
     PyObject *argobject = NULL;
     SDL_Surface *src;
     SDL_Surface *newsurf;
-    Uint32 flags = -1;
+    Uint32 flags = UINT32_MAX;
 
 #if IS_SDLv2
     Uint32 colorkey;
@@ -1738,9 +1745,9 @@ surf_convert(PyObject *self, PyObject *args)
                 Uint32 Rmask, Gmask, Bmask, Amask;
 
 #if IS_SDLv1
-                if (flags != -1 && flags & SDL_SRCALPHA) {
+                if (flags != UINT32_MAX && flags & SDL_SRCALPHA) {
 #else  /* IS_SDLv2 */
-                if (flags != -1 && flags & PGS_SRCALPHA) {
+                if (flags != UINT32_MAX && flags & PGS_SRCALPHA) {
 #endif /* IS_SDLv2 */
                     switch (bpp) {
                         case 16:
@@ -1841,7 +1848,7 @@ surf_convert(PyObject *self, PyObject *args)
                  */
                 format.palette = NULL;
 #if IS_SDLv1
-            if (flags == -1)
+            if (flags == UINT32_MAX)
                 flags = surf->flags;
             if (format.Amask)
                 flags |= SDL_SRCALPHA;


### PR DESCRIPTION
Overview of changes:
- Fix some font.c compiler warnings
- Fix some bitmask.c compiler warnings
- Fix a ft_cache.c warning
- Fix some surface.c compiler warnings

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev3 (SDL: 2.0.10) at 6cf4d1fdf2a14d739da5d593fb69967c0604600b

Related to #1316.