### PR TITLE
Fix missing import for logging module in config_win.py

### DIFF
--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -10,6 +10,7 @@ except ImportError:
 
 import os, sys
 import re
+import logging
 from glob import glob
 from distutils.sysconfig import get_python_inc
 


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev5 (SDL: 2.0.10) at ccef3258bbd96f73cc0b4f075527ee7a57eca728