### PR TITLE
Fix examples/fastevents.py raising NameError exception

### DIFF
--- a/examples/fastevents.py
+++ b/examples/fastevents.py
@@ -67,7 +67,7 @@ import time as pytime
 def main():
     init()
 
-    if use_fast_events:
+    if event_module == fastevent:
         fastevent.init()
 
     c = time.Clock()


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev5 (SDL: 2.0.10) at ccef3258bbd96f73cc0b4f075527ee7a57eca728