### PR TITLE
Fix pygame.mixer.Sound.get_num_channels()

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -290,6 +290,7 @@ endsound_callback(int channel)
             Py_XDECREF(channeldata[channel].sound);
             channeldata[channel].sound = NULL;
             PyGILState_Release(gstate);
+            Mix_GroupChannel(channel, -1);
         }
     }
 }


### PR DESCRIPTION
Fix for #1430 
It's the first time I do all this, so I hope everything is ok. 🤞
 
Pygame uses SDL_Mixer groups to figure out what sounds are still playing in the mixer. When a sound is played, the selected channel is associated with a group specific to the sound data itself. Sound.get_num_channels() then looks for channels with the Sound's tag.
The channels groups were not removed when a channel was done so it was still showing when get_num_channels was called, at least until another sound was played in the same channel.

endsound_callback is called when a channel stops playing, so I simply reset the group to the default one (-1) there.

http://libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html