### PR TITLE
Allow pygame.SCALED | pygame.OPENGL

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -878,9 +878,6 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
             if (w == 0 || h == 0)
                 return RAISE(pgExc_SDLError,
                              "Cannot set 0 sized SCALED display mode");
-            if (flags & PGS_OPENGL)
-                return RAISE(pgExc_SDLError,
-                             "Cannot use OPENGL with SCALED mode");
             /*if (flags & PGS_RESIZABLE)
                 return RAISE(pgExc_SDLError,
                 "Cannot use RESIZABLE with SCALED mode");*/


### PR DESCRIPTION
Enable the use of `SCALED` with `OPENGL` in `pygame.display.set_mode()`.

This actually works fine; the OpenGL viewport is always the rectangle `(-1, -1), (1, 1)` regardless of the viewport size, so simply scaling the window (while preserving aspect ratio) means that OpenGL does the scaling. User code can continue assuming the original dimensions when constructing matrices.

The only place where the exact dimensions matter is when allocating framebuffer objects. Using the original dimensions will give a smaller texture; but texture access is usually linearly interpolated so the impact of this will usually just be slightly reduced quality. For more refinement there's already `pygame.display.get_window_size()`.