### PR TITLE
Fix the LGTM alerts in config_win.py

### DIFF
--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -101,7 +101,7 @@ class Dependency(object):
     def matchfile(self, path, match):
         try:
             entries = os.listdir(path)
-        except:
+        except OSError:
             pass
         else:
             for e in entries:
@@ -242,7 +242,7 @@ class DependencyDLL(Dependency):
             path = os.path.join(root, dir)
             try:
                 entries = os.listdir(path)
-            except:
+            except OSError:
                 pass
             else:
                 for e in entries:


### PR DESCRIPTION
Overview of changes:
- Fixed the following LGTM alerts in config_win.py
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)
  - 2 alerts labeled: Except block directly handles BaseException.

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev5 (SDL: 2.0.10) at 1b3a971df107340b6274d240552e315f1542ed14

Resolves the config_win.py alerts from the LGTM link in #1133.