### PR TITLE
Fix an event.c compiler warning

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -137,7 +137,10 @@ pg_event_filter(void *_, SDL_Event *event)
 #pragma PG_WARN(Add event blocking here.)
 
     else if (type == SDL_KEYDOWN) {
+#ifdef WIN32
         SDL_Event inputEvent[2];
+#endif /* WIN32 */
+
         if (event->key.repeat) {
             return 0;
         }


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev5 (SDL: 2.0.10) at 3889cfdcb92c038fd134a7595590bae8bc0c34fe

Related to #1316.