### PR TITLE
Add missing return statements

### DIFF
--- a/src_c/scale_mmx64_msvc.c
+++ b/src_c/scale_mmx64_msvc.c
@@ -86,6 +86,7 @@ filter_expand_X_MMX(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int 
         free(xidx0);
         if (xmult0) free(xmult0);
         if (xmult1) free(xmult1);
+        return;
     }
 
     filter_expand_X_MMX_gcc(srcpix, dstpix, xidx0, xmult0, xmult1, height, srcpitch, dstpitch, srcwidth, dstwidth);
@@ -112,6 +113,7 @@ filter_expand_X_SSE(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int 
         free(xidx0);
         if (xmult0) free(xmult0);
         if (xmult1) free(xmult1);
+        return;
     }
 
     filter_expand_X_SSE_gcc(srcpix, dstpix, xidx0, xmult0, xmult1, height, srcpitch, dstpitch, srcwidth, dstwidth);


### PR DESCRIPTION
Overview of changes:
- Added missing return statements in the error paths
- Similar to the scale_mmx32.c and scale_mmx64.c changes in #1335

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev5 (SDL: 2.0.10) at d13a044744a05b775ec26bbf8bead771583a6309

Resolves #1444.