### PR TITLE
Export various SDL2 functions for resolution scaling

### DIFF
--- a/src_c/doc/display_doc.h
+++ b/src_c/doc/display_doc.h
@@ -25,6 +25,17 @@
 #define DOC_PYGAMEDISPLAYSETPALETTE "set_palette(palette=None) -> None\nSet the display color palette for indexed displays"
 #define DOC_PYGAMEDISPLAYGETNUMDISPLAYS "get_num_displays() -> int\nReturn the number of displays"
 #define DOC_PYGAMEDISPLAYGETWINDOWSIZE "get_window_size() -> tuple\nReturn the size of the window or screen"
+#define DOC_PYGAMEDISPLAYSETWINDOWSIZE "set_window_size((width, height)) -> bool\nChange the current window size"
+#define DOC_PYGAMEDISPLAYSETSCALE "set_scale((x, y)) -> bool\nChange the current render scale"
+#define DOC_PYGAMEDISPLAYGETSCALE "get_scale() -> (x, y)\nGet the current render scale"
+#define DOC_PYGAMEDISPLAYSETVIEWPORT "set_viewport(Rect) -> bool\nChange the current render viewport"
+#define DOC_PYGAMEDISPLAYGETVIEWPORT "get_viewport() -> Rect\nGet the current render viewport"
+#define DOC_PYGAMEDISPLAYSETHINT "set_hint(hint, value) -> bool\nChange a hint towards SDL. Both hint and value must be strings."
+#define DOC_PYGAMEDISPLAYGETHINT "get_hint(hint) -> str\nGet the value of a specific hint."
+#define DOC_PYGAMEDISPLAYSETINTEGERSCALE "set_integer_scale(bool) -> None\nChange whether integer scaling should be applied or not"
+#define DOC_PYGAMEDISPLAYGETINTEGERSCALE "get_integer_scale() -> bool\nGet whether integer scaling is enabled"
+#define DOC_PYGAMEDISPLAYGETLOGICALSIZE "get_logical_size() -> (w, h)\nGet the current render logical size"
+#define DOC_PYGAMEDISPLAYSETLOGICALSIZE "set_logical_size((w, h)) -> bool\nChange the current render logical size"
 
 
 /* Docs in a comment... slightly easier to read. */


### PR DESCRIPTION
This patch exports various needed functions for SDL2 resolution scaling, including `set_window_size()`, `get_logical_size()`, `set_logical_size()`, `set_scale()`, `get_scale()`, `set_integer_scale()`, `get_integer_scale()`, `set_hint()`, `get_hint()`, `get_viewport()` and
`set_viewport()`.

This patch also always make a renderer (which is needed for scaling), regardless of whether the `SCALED` flag is set. The `SDL_PumpEvents` is also gone, as it forced realignment of the window with the monitor, making the code fail in our multi monitor environment.

A bit of background perhaps up front: in our company we use C & SDL, and use various scaling techniques to bring a multimedia application that has been programmed in one particular resolution, to a wide variety of different embedded devices which have a wide variety of different monitors connected. We also have various multi monitor setups, where our SDL window stretches across various screens (often 2, sometimes three at a time). C gives us full control to implement various stretching/scaling methods, while pygame does not. And we really want to move to Python :)

Here are some stretching/scaling methods that are now available through these newly exported functions. First, let's assume that the physical monitor's best resolution is 1280x1024 (4:3), while the resolution of the media application is 1920x1080 (aka Full HD).

The first method is called "letter boxing", where SDL puts black bars top and bottom to fill the space that is remaining after scaling up as high as possible. This is implemented per default in SDL, if the physical aspect ratio and the logical aspect ratio are not the same.

```python
pygame.display.set_mode((1280, 1024), flags = 0)
pygame.display.set_logical_size((1920, 1080))
```

The next method is the inverse of letter boxing, called "overscan". Here the height (instead of the width) is scaled accordingly, and the difference in width from the actual and the logical aspect ratio is simply cut off left and right:

```python
pygame.display.set_mode((1280, 1024), flags = 0)
pygame.display.set_hint("SDL_RENDER_LOGICAL_SIZE_MODE", "overscan")
pygame.display.set_logical_size((1920, 1080))
```

The next method simply stretches the smallest possible fraction of the logical screen into the actual physical aspect ratio. Cubes now become rectangles, circles become ellipse. This might not be what you want, but it is useful in some scenarios. For example when the logical, and actual ratio are not that far apart (i.e. 16:10 vs. 16:9), and you don't mind a bit of stretching:

```python
pygame.display.set_mode((1280, 1024), flags = 0)
pygame.display.set_logical_size((1920, 1080))
# Calculate scaling factor between the two, and tell SDL2 the new factor
pygame.display.set_scale((1280 / 1920, 1024 / 1080))
# Set the view port to hard values, causing stretching
pygame.display.set_viewport(pygame.Rect(0, 0, 1920, 1080))
```

Last method is: fiddle with the letter boxing used in part one. The letter boxing algorithm of SDL2 does the following (roughly):

```python
pygame.display.set_mode((1280, 1024), flags = 0)
pygame.display.set_logical_size((1920, 1080))
# Reset scale so that any SDL/pygame internal shenanigans are removed
pygame.display.set_scale((1.0, 1.0))
# Figure out scaling factor for the width
scale = (1280 * 1.0) / 1920
x = 0
w = 1280
# And apply that to the height
h = int(math.ceil(1080 * scale))
# Magic happens here:
y = (1024 - h) / 2
pygame.display.set_viewport(pygame.Rect(x, y, w, h))
pygame.display.set_scale((scale, scale))
```

You can now fiddle with `y` to make letter boxing as you want it. Remove the division, and the black bar that is needed to fill the remaining space is on top, or set it to zero, and you have it at the bottom. Depending on your graphical particularities, you can actually draw something into this black space to make your media application look like it was designed for this resolution while preserving aspect ratio.

There are a lot of caveats to the changed code. Firstly, resizing is not handled. You'd have to do that manually (but its not hard). And secondly, many methods of SDL are rather peculiar **when** they want to be called. For example move the call to `set_hint()` before `set_mode()` and you have a segfault.