### PR TITLE
Fix Virtual Mouse Input in SDL2

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -46,8 +46,8 @@ static int have_registered_events = 0;
  *objects through the event queue.
  */
 
-#define USEROBJECT_CHECK1 (Sint32)0xDEADBEEF
-#define USEROBJECT_CHECK2 (Sint32)0xFEEDF00D
+#define USEROBJECT_CHECK1 0xDEADBEEF
+#define USEROBJECT_CHECK2 0xFEEDF00D
 
 typedef struct UserEventObject {
     struct UserEventObject *next;
@@ -139,7 +139,7 @@ pg_event_filter(void *_, SDL_Event *event)
     else if (type == SDL_KEYDOWN) {
 #ifdef WIN32
         SDL_Event inputEvent[2];
-#endif /* WIN32 */
+#endif
 
         if (event->key.repeat) {
             return 0;
@@ -1157,10 +1157,16 @@ set_grab(PyObject *self, PyObject *arg)
 #else  /* IS_SDLv2 */
     win = pg_GetDefaultWindow();
     if (win) {
-        if (doit)
+        if (doit) {
             SDL_SetWindowGrab(win, SDL_TRUE);
-        else
+            if (SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE)
+                SDL_SetRelativeMouseMode(1);
+            else SDL_SetRelativeMouseMode(0);
+            }
+        else {
             SDL_SetWindowGrab(win, SDL_FALSE);
+            SDL_SetRelativeMouseMode(0);
+            }
     }
 #endif /* IS_SDLv2 */
 

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -54,11 +54,11 @@ mouse_set_pos(PyObject *self, PyObject *args)
             SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
             SDL_RenderGetViewport(sdlRenderer, &vprect);
 
-            x += vprect.x;
-            y += vprect.y;
+            x+=vprect.x;
+            y+=vprect.y;
 
-            x = (int)(x * scalex);
-            y = (int)(y * scaley);
+            x*=scalex;
+            y*=scaley;
         }
     }
 
@@ -86,8 +86,8 @@ mouse_get_pos(PyObject *self)
             SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
             SDL_RenderGetViewport(sdlRenderer, &vprect);
 
-            x = (int)(x / scalex);
-            y = (int)(y / scaley);
+            x/=scalex;
+            y/=scaley;
 
             x-=vprect.x;
             y-=vprect.y;
@@ -156,12 +156,29 @@ static PyObject *
 mouse_set_visible(PyObject *self, PyObject *args)
 {
     int toggle;
+    #if IS_SDLv2
+        int mode;
+        SDL_Window *win = NULL;
+    #endif
 
     if (!PyArg_ParseTuple(args, "i", &toggle))
         return NULL;
     VIDEO_INIT_CHECK();
 
+    #if IS_SDLv2
+        win = pg_GetDefaultWindow();
+        if (win) {
+            mode = SDL_GetWindowGrab(win);
+            if (mode == SDL_ENABLE & !toggle) {
+                SDL_SetRelativeMouseMode(1);
+            } else {
+                SDL_SetRelativeMouseMode(0);
+            }
+        }
+    #endif
+
     toggle = SDL_ShowCursor(toggle);
+
     return PyInt_FromLong(toggle);
 }
 


### PR DESCRIPTION
Calls SDL_MouseSetRelativeMouseMode from pygame.set_grab() and pygame.set_visible() as necessary.
Removed redundant and unrelated example.
Will add font_viewer.py separately
