### PR TITLE
SDL2: fix Virtual Mouse mode

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1157,10 +1157,16 @@ set_grab(PyObject *self, PyObject *arg)
 #else  /* IS_SDLv2 */
     win = pg_GetDefaultWindow();
     if (win) {
-        if (doit)
+        if (doit) {
             SDL_SetWindowGrab(win, SDL_TRUE);
-        else
+            if (SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE)
+                SDL_SetRelativeMouseMode(1);
+            else SDL_SetRelativeMouseMode(0);
+            }
+        else {
             SDL_SetWindowGrab(win, SDL_FALSE);
+            SDL_SetRelativeMouseMode(0);
+            }
     }
 #endif /* IS_SDLv2 */
 

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -169,7 +169,7 @@ mouse_set_visible(PyObject *self, PyObject *args)
         win = pg_GetDefaultWindow();
         if (win) {
             mode = SDL_GetWindowGrab(win);
-            if (mode == SDL_ENABLE & !toggle) {
+            if ((mode == SDL_ENABLE) & !toggle) {
                 SDL_SetRelativeMouseMode(1);
             } else {
                 SDL_SetRelativeMouseMode(0);

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -156,10 +156,26 @@ static PyObject *
 mouse_set_visible(PyObject *self, PyObject *args)
 {
     int toggle;
+    #if IS_SDLv2
+        int mode;
+        SDL_Window *win = NULL;
+    #endif
 
     if (!PyArg_ParseTuple(args, "i", &toggle))
         return NULL;
     VIDEO_INIT_CHECK();
+
+    #if IS_SDLv2
+        win = pg_GetDefaultWindow();
+        if (win) {
+            mode = SDL_GetWindowGrab(win);
+            if (mode == SDL_ENABLE & !toggle) {
+                SDL_SetRelativeMouseMode(1);
+            } else {
+                SDL_SetRelativeMouseMode(0);
+            }
+        }
+    #endif
 
     toggle = SDL_ShowCursor(toggle);
     return PyInt_FromLong(toggle);


### PR DESCRIPTION
Calls SDL_MouseSetRelativeMouseMode from pygame.set_grab() and pygame.set_visible() as necessary.