### PR TITLE
Fix memory leak in pygame.font.Font.metrics

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -609,6 +609,7 @@ font_metrics(PyObject *self, PyObject *args)
                 i++;
         }
         PyList_Append(list, listitem);
+        Py_DECREF(listitem);
     }
     Py_DECREF(obj);
     return list;


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at 1dccbf3b7e37a2574ff943943c23a8aa7affa7d8

Resolves #1469.