### PR TITLE
Fix invalid character for surname in author comment

### DIFF
--- a/src_c/_sdl2/touch.c
+++ b/src_c/_sdl2/touch.c
@@ -1,6 +1,6 @@
 /*
   pygame - Python Game Library
-  Copyright (C) 2019 David Lönnhager
+  Copyright (C) 2019 David LÃ¶nnhager
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Library General Public


### PR DESCRIPTION
The "ö" showed up as an invalid character. This has been replaced with a proper "ö". See attached image of how it showed up previously (I'm aware of the fact that GitHub interprets the invalid character correctly somehow).

![Author in editor](https://user-images.githubusercontent.com/15460993/67963198-813c7a00-fbfe-11e9-8b69-e6fa1d8990f4.png)
