### PR TITLE
Aliens example: make bomb sprite background transparent

### DIFF
--- a/examples/aliens.py
+++ b/examples/aliens.py
@@ -198,6 +198,7 @@ class Bomb(pg.sprite.Sprite):
     def __init__(self, alien):
         pg.sprite.Sprite.__init__(self, self.containers)
         self.image = self.images[0]
+        self.image.set_colorkey(self.image.get_at((0,0)))
         self.rect = self.image.get_rect(midbottom=alien.rect.move(0, 5).midbottom)
 
     def update(self):


### PR DESCRIPTION
The bomb sprite had a blue background ~~on my machine~~ since 1.9.6. It's not transparent, just blue.