### PR TITLE
Fix for emtpty string/None font render

### DIFF
--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -161,7 +161,7 @@ loaded instead.
 
       The Surface returned will be of the dimensions required to hold the text.
       (the same as those returned by Font.size()). If an empty string is passed
-      for the text, a blank surface will be returned that is one pixel wide and
+      for the text, a blank surface will be returned that is zero pixel wide and
       the height of the font.
 
       Depending on the type of background and antialiasing used, this returns

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -411,7 +411,7 @@ font_render(PyObject *self, PyObject *args)
             PyErr_Clear();
             return RAISE_TEXT_TYPE_ERROR();
         }
-        surf = SDL_CreateRGBSurface(SDL_SWSURFACE, 1, height, 32, 0xff << 16,
+        surf = SDL_CreateRGBSurface(SDL_SWSURFACE, 0, height, 32, 0xff << 16,
                                     0xff << 8, 0xff, 0);
         if (surf == NULL) {
             return RAISE(pgExc_SDLError, SDL_GetError());

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -462,7 +462,7 @@ SDL_Surface *_PGFT_Render_NewSurface(FreeTypeInstance *ft,
                                &underline_top, &underline_size);
     }
     else {
-        width = 1;
+        width = 0;
         height = _PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
         offset.x = -font_text->min_x;
         offset.y = -font_text->min_y;

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -292,12 +292,12 @@ class FontTypeTest(unittest.TestCase):
         s = f.render("xxx", False, [0, 0, 0])
         s = f.render("   ", False, [0, 0, 0])
         s = f.render("   ", False, [0, 0, 0], [255, 255, 255])
-        # null text should be 1 pixel wide.
+        # null text should be 0 pixel wide.
         s = f.render("", False, [0, 0, 0], [255, 255, 255])
-        self.assertEqual(s.get_size()[0], 1)
-        # None text should be 1 pixel wide.
+        self.assertEqual(s.get_size()[0], 0)
+        # None text should be 0 pixel wide.
         s = f.render(None, False, [0, 0, 0], [255, 255, 255])
-        self.assertEqual(s.get_size()[0], 1)
+        self.assertEqual(s.get_size()[0], 0)
         # Non-text should raise a TypeError.
         self.assertRaises(TypeError, f.render, [], False, [0, 0, 0], [255, 255, 255])
         self.assertRaises(TypeError, f.render, 1, False, [0, 0, 0], [255, 255, 255])


### PR DESCRIPTION
This should fix #1478.

I would like if we can use this pull for discussion about what should be the result of the pygame.Font.render() if you use empty string or None as the first parameter. So far it used to be Surface with the size of (1, height_of_font). This means it would be drawn with the surface.fill(). I changed this to be the size of (0, height_of_font). With this you won't see anything on the screen, so basically this bug won't exist anymore. Now other possibility are to return size (0, 0). This would maybe mean less memory usage, but could maybe disable other functionalities of the Font (not sure, just thought).

To conclude, should the result of pygame.font.Font().render("") be 
<Surface(0xf(height)x32 SW)>
or
<Surface(0x0x32 SW)>