### PR TITLE
Windows dependency downloader: replaced requests with urllib

### DIFF
--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -16,7 +16,7 @@ def download_sha1_unzip(url, checksum, save_to_directory, unzip=True):
     """
     try:
         import urllib.request as urllib
-    except ModuleNotFoundError:
+    except ImportError:
         import urllib2 as urllib
     import hashlib
     import zipfile

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -14,7 +14,10 @@ def download_sha1_unzip(url, checksum, save_to_directory, unzip=True):
     Does not download again if the file is there.
     Does not unzip again if the file is there.
     """
-    import requests
+    try:
+        import urllib.request as urllib
+    except ModuleNotFoundError:
+        import urllib2 as urllib
     import hashlib
     import zipfile
 
@@ -31,14 +34,17 @@ def download_sha1_unzip(url, checksum, save_to_directory, unzip=True):
                 print("Skipping download url:%s: save_to:%s:" % (url, save_to))
     else:
         print("Downloading...", url, checksum)
-        response = requests.get(url)
-        cont_checksum = hashlib.sha1(response.content).hexdigest()
+        headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, '
+                                 'like Gecko) Chrome/35.0.1916.47 Safari/537.36'}
+        request = urllib.Request(url, headers=headers)
+        response = urllib.urlopen(request).read()
+        cont_checksum = hashlib.sha1(response).hexdigest()
         if checksum != cont_checksum:
             raise ValueError(
                 'url:%s should have checksum:%s: Has:%s: ' % (url, checksum, cont_checksum)
             )
         with open(save_to, 'wb') as f:
-            f.write(response.content)
+            f.write(response)
 
     if unzip and filename.endswith('.zip'):
         print("Unzipping :%s:" % save_to)


### PR DESCRIPTION
This should fix #1391.