### PR TITLE
Fix failing freetype test

### DIFF
--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -763,7 +763,7 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertEqual(rend[0].get_rect().size, rend[1].size)
 
         s, r = font.render("", pygame.Color(0, 0, 0), None, size=24)
-        self.assertEqual(r.width, 1)
+        self.assertEqual(r.width, 0)
         self.assertEqual(r.height, font.get_sized_height(24))
         self.assertEqual(s.get_size(), r.size)
         self.assertEqual(s.get_bitsize(), 32)


### PR DESCRIPTION
This PR updates the failing freetype test to reflect the changes made in #1488.

```
>py -3 -Wd -m pygame.tests.freetype_test
pygame 2.0.0.dev7 (SDL 2.0.10, python 3.7.4)
Hello from the pygame community. https://www.pygame.org/contribute.html
...............F....s.........s...............
======================================================================
FAIL: test_freetype_Font_render (__main__.FreeTypeFontTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Program Files\Python37\Lib\site-packages\pygame-2.0.0.dev7-py3.7-win-amd64.egg\pygame\tests\freetype_test.py", line 766, in test_freetype_Font_render
    self.assertEqual(r.width, 1)
AssertionError: 0 != 1

----------------------------------------------------------------------
Ran 46 tests in 1.117s

FAILED (failures=1, skipped=2)
```

System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at fbd00a9e5493ab9334b208690a39c1b0a529af8e

Related to #1488.