### PR TITLE
Add missing midi init checks

### DIFF
--- a/src_py/midi.py
+++ b/src_py/midi.py
@@ -175,6 +175,7 @@ def get_default_input_id():
     Note: in the current release, the default is simply the first device
     (the input or output device with the lowest PmDeviceID).
     """
+    _check_init()
     return _pypm.GetDefaultInputDeviceID()
 
 
@@ -632,6 +633,7 @@ def time():
 
     The time is reset to 0, when the module is inited.
     """
+    _check_init()
     return _pypm.Time()
 
 


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.7.4 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at c4337dcc30373d9dc34c9331a4c3f124e8d650b9