### PR TITLE
Fix Travis build

### DIFF
--- a/buildconfig/ci/travis/.travis_osx.sh
+++ b/buildconfig/ci/travis/.travis_osx.sh
@@ -22,40 +22,31 @@ else
 export HOMEBREW_NO_AUTO_UPDATE=1
 source "buildconfig/ci/travis/.travis_osx_utils.sh"
 
-
-git clone https://github.com/illume/terryfy.git
-# git clone https://github.com/MacPython/terryfy.git
-cd terryfy
-# Work with a specific commit
-#git checkout 703737bd7be3a5d388146d5a95241ec2a17a4b2c
-cd ..
-source terryfy/travis_tools.sh
-
 # Ensure that 'python' is on $PATH
 if [[ "$PY_VERSION" == "2" ]]; then
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 fi
 
-# try and install an old python3.6 formula
 if [[ "$PY_VERSION_" == "3.6" ]]; then
 	brew uninstall python --force --ignore-dependencies
-	retry install_or_upgrade "https://raw.githubusercontent.com/pygame/homebrew-portmidi/master/Formula/python36/python.rb"
+	retry brew install "https://raw.githubusercontent.com/pygame/homebrew-portmidi/master/Formula/python36/python.rb"
 	export PYTHON_EXE=python3.6
 	export PIP_CMD="python3.6 -m pip"
 elif [[ "$PY_VERSION_" == "3.7" ]]; then
 	brew uninstall python --force --ignore-dependencies
-	retry install_or_upgrade python
+	retry brew install "https://raw.githubusercontent.com/pygame/homebrew-portmidi/master/Formula/python37/python.rb"
 	export PYTHON_EXE=python3.7
 	export PIP_CMD="python3.7 -m pip"
 elif [[ "$PY_VERSION_" == "3.8" ]]; then
 	brew uninstall python --force --ignore-dependencies
-	brew install "https://raw.githubusercontent.com/pygame/homebrew-portmidi/master/Formula/python38/python.rb"
+	retry brew install "https://raw.githubusercontent.com/pygame/homebrew-portmidi/master/Formula/python38/python.rb"
 	export PYTHON_EXE=python3.8
 	export PIP_CMD="python3.8 -m pip"
 else
 	brew uninstall --force --ignore-dependencies python@2
-	install_or_upgrade_deps "python@2"
-	get_python_environment homebrew $PY_VERSION $(pwd)/_test_env
+	retry brew install "pygame/portmidi/python@2"
+	export PYTHON_EXE=python2.7
+	export PIP_CMD="python2.7 -m pip"
 fi
 
 

--- a/buildconfig/ci/travis/.travis_osx_before_install.sh
+++ b/buildconfig/ci/travis/.travis_osx_before_install.sh
@@ -103,31 +103,29 @@ fi
 
 set +e
 
-# TODO: tap-pin deprecated. Need `brew install pygame/portmidi/sdl2`
-#       https://github.com/pygame/pygame/issues/1272
-brew tap pygame/portmidi
-brew tap-pin pygame/portmidi
+TAP_SOURCE="pygame/portmidi/"
+brew tap "pygame/portmidi"
 
 check_local_bottles
 
 # install_or_upgrade sdl ${UNIVERSAL_FLAG}
 install_or_upgrade jpeg ${UNIVERSAL_FLAG}
 UPDATE_UNBOTTLED='1' install_or_upgrade libpng ${UNIVERSAL_FLAG}
-UPDATE_UNBOTTLED='1' install_or_upgrade xz ${UNIVERSAL_FLAG}
+UPDATE_UNBOTTLED='1' install_or_upgrade "${TAP_SOURCE}xz" ${UNIVERSAL_FLAG}
 UPDATE_UNBOTTLED='1' install_or_upgrade libtiff ${UNIVERSAL_FLAG}
 install_or_upgrade webp ${UNIVERSAL_FLAG}
-install_or_upgrade libogg ${UNIVERSAL_FLAG}
-install_or_upgrade libvorbis ${UNIVERSAL_FLAG}
-install_or_upgrade flac ${UNIVERSAL_FLAG}
-install_or_upgrade fluid-synth
-install_or_upgrade libmikmod ${UNIVERSAL_FLAG}
-# install_or_upgrade smpeg
-# install_or_upgrade smpeg2
+install_or_upgrade "${TAP_SOURCE}libogg" ${UNIVERSAL_FLAG}
+install_or_upgrade "${TAP_SOURCE}libvorbis" ${UNIVERSAL_FLAG}
+install_or_upgrade "${TAP_SOURCE}flac" ${UNIVERSAL_FLAG}
+install_or_upgrade "${TAP_SOURCE}fluid-synth"
+install_or_upgrade "${TAP_SOURCE}libmikmod" ${UNIVERSAL_FLAG}
+# install_or_upgrade "${TAP_SOURCE}smpeg"
+# install_or_upgrade "${TAP_SOURCE}smpeg2"
 
 
 # Because portmidi hates us... and installs python2, which messes homebrew up.
 # So we install portmidi from our own formula.
-install_or_upgrade portmidi ${UNIVERSAL_FLAG}
+install_or_upgrade "${TAP_SOURCE}portmidi" ${UNIVERSAL_FLAG}
 
 install_or_upgrade freetype ${UNIVERSAL_FLAG}
 # install_or_upgrade sdl_ttf ${UNIVERSAL_FLAG}
@@ -135,15 +133,13 @@ install_or_upgrade freetype ${UNIVERSAL_FLAG}
 # install_or_upgrade sdl_mixer ${UNIVERSAL_FLAG} --with-flac --with-fluid-synth --with-smpeg
 
 
-install_or_upgrade sdl2
+install_or_upgrade "${TAP_SOURCE}sdl2"
 install_or_upgrade sdl2_gfx
 install_or_upgrade sdl2_image
-install_or_upgrade sdl2_mixer
+install_or_upgrade "${TAP_SOURCE}sdl2_mixer"
 install_or_upgrade sdl2_ttf
 
 set -e
-
-# brew install https://gist.githubusercontent.com/illume/08f9d3ca872dc2b61d80f665602233fd/raw/0fbfd6657da24c419d23a6678b5715a18cd6560a/portmidi.rb
 
 unset HOMEBREW_BUILD_BOTTLE
 unset HOMEBREW_BOTTLE_ARCH


### PR DESCRIPTION
Additional changes that could speed things up:
* Add bottle for openssl@1.1 to pygame/homebrew-portmidi. (Approx. 7 minutes)
* Add bottles for all Python versions. (Approx. 2:45 minutes)

It's time-consuming to maintain this Homebrew tap. Is there another way?