### PR TITLE
Declare UTF-8 encoding

### DIFF
--- a/src_py/draw_py.py
+++ b/src_py/draw_py.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''Pygame Drawing algorithms written in Python. (Work in Progress)
 
 Implement Pygame's Drawing Algorithms in a Python version for testing


### PR DESCRIPTION
File contains a ° symbol.

This breaks importing under non-UTF-8 locales on unix.