### PR TITLE
Skip portmidi on Debian GNU/kFreeBSD and GNU/Hurd too

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -211,7 +211,8 @@ def main(sdl2=False):
         #Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL_gfx.so', ['SDL_gfx']),
     ])
     is_freebsd = 'FreeBSD' in platform.system()
-    if not is_freebsd:
+    is_hurd = platform.system() == 'GNU'
+    if not is_freebsd and not is_hurd:
         porttime_dep = get_porttime_dep()
         DEPS.append(
             Dependency('PORTMIDI', 'portmidi.h', 'libportmidi.so', ['portmidi'])

--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -210,7 +210,7 @@ def main(sdl2=False):
         Dependency('SCRAP', '', 'libX11', ['X11']),
         #Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL_gfx.so', ['SDL_gfx']),
     ])
-    is_freebsd = platform.system() == 'FreeBSD'
+    is_freebsd = 'FreeBSD' in platform.system()
     if not is_freebsd:
         porttime_dep = get_porttime_dep()
         DEPS.append(


### PR DESCRIPTION
Where on GNU/kFreeBSD:
```
>>> platform.system()
'GNU/kFreeBSD'
```
And on GNU/Hurd:
```
>>> platform.system()
'GNU'
```

Debian has been carrying a hacky patch to do this, but now that you're looking for FreeBSD, upstream, we can handle this better.