### PR TITLE
Enable MMX on amd64

### DIFF
--- a/buildconfig/Setup.SDL1.in
+++ b/buildconfig/Setup.SDL1.in
@@ -63,7 +63,7 @@ joystick src_c/joystick.c $(SDL) $(DEBUG)
 draw src_c/draw.c $(SDL) $(DEBUG)
 image src_c/image.c $(SDL) $(DEBUG)
 overlay src_c/overlay.c $(SDL) $(DEBUG)
-transform src_c/transform.c src_c/rotozoom.c src_c/scale2x.c src_c/scale_mmx.c $(SDL) $(DEBUG) -D_NO_MMX_FOR_X86_64
+transform src_c/transform.c src_c/rotozoom.c src_c/scale2x.c src_c/scale_mmx.c $(SDL) $(DEBUG)
 mask src_c/mask.c src_c/bitmask.c $(SDL) $(DEBUG)
 bufferproxy src_c/bufferproxy.c $(SDL) $(DEBUG)
 pixelarray src_c/pixelarray.c $(SDL) $(DEBUG)

--- a/buildconfig/Setup.SDL2.in
+++ b/buildconfig/Setup.SDL2.in
@@ -66,7 +66,7 @@ time src_c/time.c $(SDL) $(DEBUG)
 joystick src_c/joystick.c $(SDL) $(DEBUG)
 draw src_c/draw.c $(SDL) $(DEBUG)
 image src_c/image.c $(SDL) $(DEBUG)
-transform src_c/transform.c src_c/rotozoom.c src_c/scale2x.c src_c/scale_mmx.c $(SDL) $(DEBUG) -D_NO_MMX_FOR_X86_64
+transform src_c/transform.c src_c/rotozoom.c src_c/scale2x.c src_c/scale_mmx.c $(SDL) $(DEBUG)
 mask src_c/mask.c src_c/bitmask.c $(SDL) $(DEBUG)
 bufferproxy src_c/bufferproxy.c $(SDL) $(DEBUG)
 pixelarray src_c/pixelarray.c $(SDL) $(DEBUG)


### PR DESCRIPTION
Debian has been doing this since 2012, without issue.

See: http://bugs.debian.org/653215

Fixes: #100