### PR TITLE
Remove unused imports

### DIFF
--- a/src_py/freetype.py
+++ b/src_py/freetype.py
@@ -1,15 +1,7 @@
 """Enhanced Pygame module for loading and rendering computer fonts"""
 
-from pygame._freetype import (
-   Font,
-   STYLE_NORMAL, STYLE_OBLIQUE, STYLE_STRONG, STYLE_UNDERLINE, STYLE_WIDE,
-   STYLE_DEFAULT,
-   init, quit, get_init,
-   was_init, get_cache_size, get_default_font, get_default_resolution,
-   get_error, get_version, set_default_resolution,
-   _PYGAME_C_API, __PYGAMEinit__,
-   )
-from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
+from pygame._freetype import Font
+from pygame.sysfont import SysFont as _SysFont
 
 
 def SysFont(name, size, bold=0, italic=0, constructor=None):

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -4,8 +4,7 @@ __all__ = ['Font', 'init', 'quit', 'get_default_font', 'get_init', 'SysFont']
 
 from pygame._freetype import init, Font as _Font, get_default_resolution
 from pygame._freetype import quit, get_default_font, get_init as _get_init
-from pygame._freetype import __PYGAMEinit__
-from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
+from pygame.sysfont import SysFont as _SysFont
 from pygame import encode_file_path
 from pygame.compat import bytes_, unicode_, as_unicode, as_bytes
 

--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -65,8 +65,6 @@ and wonder about the values.
 numpysf = None
 
 
-from pygame.pixelcopy import array_to_surface, make_surface as pc_make_surface
-
 def blit_array (surface, array):
     """pygame.surfarray.blit_array(Surface, array): return None
 


### PR DESCRIPTION
See these LGTM alerts for reference. I used flake8 to verify that the imports weren't actually used.

https://lgtm.com/projects/g/pygame/pygame/snapshot/5ee0d3bf2ef4464a1031b89f9222e1c345779211/files/src_py/surfarray.py#xba4bec973938d53b:1
https://lgtm.com/projects/g/pygame/pygame/snapshot/5ee0d3bf2ef4464a1031b89f9222e1c345779211/files/src_py/freetype.py#xb1e899caa6e2e8ac:1
https://lgtm.com/projects/g/pygame/pygame/snapshot/5ee0d3bf2ef4464a1031b89f9222e1c345779211/files/src_py/ftfont.py#xa5121d4658b3d854:1