### PR TITLE
Fix documentation for Vector3's rotate methods

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -498,7 +498,7 @@ Multiple coordinates can be set using slices or swizzling::
    .. method:: rotate
 
       | :sl:`rotates a vector by a given angle in degrees.`
-      | :sg:`rotate(Vector3, angle) -> Vector3`
+      | :sg:`rotate(angle, Vector3) -> Vector3`
 
       Returns a vector which has the same length as self but is rotated
       counterclockwise by the given angle in degrees around the given axis.
@@ -508,7 +508,7 @@ Multiple coordinates can be set using slices or swizzling::
    .. method:: rotate_rad
 
       | :sl:`rotates a vector by a given angle in radians.`
-      | :sg:`rotate_rad(Vector3, angle) -> Vector3`
+      | :sg:`rotate_rad(angle, Vector3) -> Vector3`
 
       Returns a vector which has the same length as self but is rotated
       counterclockwise by the given angle in radians around the given axis.
@@ -520,7 +520,7 @@ Multiple coordinates can be set using slices or swizzling::
    .. method:: rotate_ip
 
       | :sl:`rotates the vector by a given angle in degrees in place.`
-      | :sg:`rotate_ip(Vector3, angle) -> None`
+      | :sg:`rotate_ip(angle, Vector3) -> None`
 
       Rotates the vector counterclockwise around the given axis by the given
       angle in degrees. The length of the vector is not changed.
@@ -530,7 +530,7 @@ Multiple coordinates can be set using slices or swizzling::
    .. method:: rotate_ip_rad
 
       | :sl:`rotates the vector by a given angle in radians in place.`
-      | :sg:`rotate_ip_rad(Vector3, angle) -> None`
+      | :sg:`rotate_ip_rad(angle, Vector3) -> None`
 
       Rotates the vector counterclockwise around the given axis by the given
       angle in radians. The length of the vector is not changed.

--- a/src_c/doc/math_doc.h
+++ b/src_c/doc/math_doc.h
@@ -44,10 +44,10 @@
 #define DOC_VECTOR3LERP "lerp(Vector3, float) -> Vector3\nreturns a linear interpolation to the given vector."
 #define DOC_VECTOR3SLERP "slerp(Vector3, float) -> Vector3\nreturns a spherical interpolation to the given vector."
 #define DOC_VECTOR3ELEMENTWISE "elementwise() -> VectorElementwiseProxy\nThe next operation will be performed elementwise."
-#define DOC_VECTOR3ROTATE "rotate(Vector3, angle) -> Vector3\nrotates a vector by a given angle in degrees."
-#define DOC_VECTOR3ROTATERAD "rotate_rad(Vector3, angle) -> Vector3\nrotates a vector by a given angle in radians."
-#define DOC_VECTOR3ROTATEIP "rotate_ip(Vector3, angle) -> None\nrotates the vector by a given angle in degrees in place."
-#define DOC_VECTOR3ROTATEIPRAD "rotate_ip_rad(Vector3, angle) -> None\nrotates the vector by a given angle in radians in place."
+#define DOC_VECTOR3ROTATE "rotate(angle, Vector3) -> Vector3\nrotates a vector by a given angle in degrees."
+#define DOC_VECTOR3ROTATERAD "rotate_rad(angle, Vector3) -> Vector3\nrotates a vector by a given angle in radians."
+#define DOC_VECTOR3ROTATEIP "rotate_ip(angle, Vector3) -> None\nrotates the vector by a given angle in degrees in place."
+#define DOC_VECTOR3ROTATEIPRAD "rotate_ip_rad(angle, Vector3) -> None\nrotates the vector by a given angle in radians in place."
 #define DOC_VECTOR3ROTATEX "rotate_x(angle) -> Vector3\nrotates a vector around the x-axis by the angle in degrees."
 #define DOC_VECTOR3ROTATEXRAD "rotate_x_rad(angle) -> Vector3\nrotates a vector around the x-axis by the angle in radians."
 #define DOC_VECTOR3ROTATEXIP "rotate_x_ip(angle) -> None\nrotates the vector around the x-axis by the angle in degrees in place."
@@ -267,19 +267,19 @@ pygame.math.Vector3.elementwise
 The next operation will be performed elementwise.
 
 pygame.math.Vector3.rotate
- rotate(Vector3, angle) -> Vector3
+ rotate(angle, Vector3) -> Vector3
 rotates a vector by a given angle in degrees.
 
 pygame.math.Vector3.rotate_rad
- rotate_rad(Vector3, angle) -> Vector3
+ rotate_rad(angle, Vector3) -> Vector3
 rotates a vector by a given angle in radians.
 
 pygame.math.Vector3.rotate_ip
- rotate_ip(Vector3, angle) -> None
+ rotate_ip(angle, Vector3) -> None
 rotates the vector by a given angle in degrees in place.
 
 pygame.math.Vector3.rotate_ip_rad
- rotate_ip_rad(Vector3, angle) -> None
+ rotate_ip_rad(angle, Vector3) -> None
 rotates the vector by a given angle in radians in place.
 
 pygame.math.Vector3.rotate_x


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- sphinx: 1.8.5
- python: 3.8.1 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at 7719d927417be16e6f6c9dfdb81cce2530883d9d

Resolves #1507.