### PR TITLE
midi: fix midi_to_ansi_note

### DIFF
--- a/src_py/midi.py
+++ b/src_py/midi.py
@@ -727,5 +727,5 @@ def midi_to_ansi_note(midi_note):
     notes = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#']
     num_notes = 12
     note_name = notes[int(((midi_note - 21) % num_notes))]
-    note_number = int(round(((midi_note - 21) / 11.0)))
+    note_number = (midi_note - 12) // num_notes
     return '%s%s' % (note_name, note_number)

--- a/test/midi_test.py
+++ b/test/midi_test.py
@@ -454,6 +454,13 @@ class MidiModuleNonInteractiveTest(unittest.TestCase):
         self.assertEqual(midi_to_frequency(26), 36.7)
         self.assertEqual(midi_to_frequency(108), 4186.0)
         self.assertEqual(midi_to_ansi_note(21), "A0")
+        self.assertEqual(midi_to_ansi_note(71), "B4")
+        self.assertEqual(midi_to_ansi_note(82), "A#5")
+        self.assertEqual(midi_to_ansi_note(83), "B5")
+        self.assertEqual(midi_to_ansi_note(93), "A6")
+        self.assertEqual(midi_to_ansi_note(94), "A#6")
+        self.assertEqual(midi_to_ansi_note(95), "B6")
+        self.assertEqual(midi_to_ansi_note(96), "C7")
         self.assertEqual(midi_to_ansi_note(102), "F#7")
         self.assertEqual(midi_to_ansi_note(108), "C8")
 


### PR DESCRIPTION
In order to get the octave number from our MIDI pitch, we have to substract the
pitch for a C0 from it (12) and then use the quotient of the divison by the
number of notes in an octave (12).