### PR TITLE
Fix Python syntax warning

### DIFF
--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -179,7 +179,7 @@ def rect_outer_bounds(rect):
    O      O
 
     """
-    return (rect.left != 0 and [(rect.left - 1, rect.top)] or []) + [
+    return ([(rect.left - 1, rect.top)] if rect.left else []) + [
         rect.topright,
         rect.bottomleft,
         rect.bottomright,

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -179,7 +179,7 @@ def rect_outer_bounds(rect):
    O      O
 
     """
-    return (rect.left is not 0 and [(rect.left - 1, rect.top)] or []) + [
+    return (rect.left != 0 and [(rect.left - 1, rect.top)] or []) + [
         rect.topright,
         rect.bottomleft,
         rect.bottomright,


### PR DESCRIPTION
Overview of changes:
- Fixed the following warning (raised when using Python 3.8 to run setup install: `python setup.py install`)
  - SyntaxWarning: "is not" with a literal. Did you mean "!="?

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at 2ff089bfcf7fffc7f8a566a3cc3d0d1fb76fe9e1