### PR TITLE
Fixed rect collision with negative size and image.frombuffer not working with ARGB

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1056,9 +1056,9 @@ image_frombuffer(PyObject *self, PyObject *arg)
         surf =
             SDL_CreateRGBSurfaceFrom(data, w, h, 32, w * 4,
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                                     0xFF << 24, 0xFF, 0xFF << 8, 0xFF << 16);
+                                    0xFF << 8, 0xFF << 16, 0xFF << 24, 0xFF);
 #else
-                                     0xFF, 0xFF << 24, 0xFF << 16, 0xFF << 8);
+                                    0xFF << 16, 0xFF << 8, 0xFF, 0xFF << 24);
 #endif
         surf->flags |= SDL_SRCALPHA;
     }

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -349,15 +349,19 @@ pgRect_Normalize(GAME_Rect *rect)
 static int
 _pg_do_rects_intersect(GAME_Rect *A, GAME_Rect *B)
 {
-    if (A->w == 0 || A->h == 0 || B->w == 0 || B->h == 0) {
+    if ((A->w == 0 && A->h == 0) || (B->w == 0 && B->h == 0)) {
         // zero sized rects should not collide with anything #1197
         return 0;
     }
 
-    // A.topleft < B.bottomright &&
-    // A.bottomright > B.topleft
-    return (A->x < B->x + B->w && A->y < B->y + B->h && A->x + A->w > B->x &&
-            A->y + A->h > B->y);
+    // A.left < B.right &&
+    // A.top < A.bottom &&
+    // A.right > B.left &&
+    // A.bottom > b.top
+    return (min(A->x, A->x + A->w) < max(B->x, B->x + B->w) &&
+            min(A->y, A->y + A->h) < max(B->y, B->y + B->h) &&
+            max(A->x, A->x + A->w) > min(B->x, B->x + B->w) &&
+            max(A->y, A->y + A->h) > min(B->y, B->y + B->h));
 }
 
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -349,7 +349,7 @@ pgRect_Normalize(GAME_Rect *rect)
 static int
 _pg_do_rects_intersect(GAME_Rect *A, GAME_Rect *B)
 {
-    if ((A->w == 0 && A->h == 0) || (B->w == 0 && B->h == 0)) {
+    if (A->w == 0 || A->h == 0 || B->w == 0 || B->h == 0) {
         // zero sized rects should not collide with anything #1197
         return 0;
     }

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -358,10 +358,10 @@ _pg_do_rects_intersect(GAME_Rect *A, GAME_Rect *B)
     // A.top < A.bottom &&
     // A.right > B.left &&
     // A.bottom > b.top
-    return (min(A->x, A->x + A->w) < max(B->x, B->x + B->w) &&
-            min(A->y, A->y + A->h) < max(B->y, B->y + B->h) &&
-            max(A->x, A->x + A->w) > min(B->x, B->x + B->w) &&
-            max(A->y, A->y + A->h) > min(B->y, B->y + B->h));
+    return (MIN(A->x, A->x + A->w) < MAX(B->x, B->x + B->w) &&
+            MIN(A->y, A->y + A->h) < MAX(B->y, B->y + B->h) &&
+            MAX(A->x, A->x + A->w) > MIN(B->x, B->x + B->w) &&
+            MAX(A->y, A->y + A->h) > MIN(B->y, B->y + B->h));
 }
 
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -354,9 +354,9 @@ _pg_do_rects_intersect(GAME_Rect *A, GAME_Rect *B)
         return 0;
     }
 
-    // A.left < B.right &&
-    // A.top < A.bottom &&
-    // A.right > B.left &&
+    // A.left   < B.right  &&
+    // A.top    < A.bottom &&
+    // A.right  > B.left   &&
     // A.bottom > b.top
     return (MIN(A->x, A->x + A->w) < MAX(B->x, B->x + B->w) &&
             MIN(A->y, A->y + A->h) < MAX(B->y, B->y + B->h) &&

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -1557,8 +1557,6 @@ class RectTypeTest(unittest.TestCase):
 
             self.assertIsNone(collide_item)
 
-    # This decorator can be removed when issue #1198 is resolved.
-    @unittest.expectedFailure
     def test_collidedict__negative_sized_rects(self):
         """Ensures collidedict works correctly with negative sized rects."""
         neg_rect = Rect(1, 1, -1, -1)
@@ -1588,8 +1586,6 @@ class RectTypeTest(unittest.TestCase):
             # The detected collision could be any of the possible items.
             self.assertIn(collide_item, collide_items)
 
-    # This decorator can be removed when issue #1198 is resolved.
-    @unittest.expectedFailure
     def test_collidedict__negative_sized_rects_as_args(self):
         """Ensures collidedict works correctly with negative sized rect args.
         """
@@ -1826,8 +1822,6 @@ class RectTypeTest(unittest.TestCase):
 
             self._assertCountEqual(collide_items, expected_items)
 
-    # This decorator can be removed when issue #1198 is resolved.
-    @unittest.expectedFailure
     def test_collidedictall__negative_sized_rects(self):
         """Ensures collidedictall works correctly with negative sized rects."""
         neg_rect = Rect(2, 2, -2, -2)
@@ -1856,8 +1850,6 @@ class RectTypeTest(unittest.TestCase):
 
             self._assertCountEqual(collide_items, expected_items)
 
-    # This decorator can be removed when issue #1198 is resolved.
-    @unittest.expectedFailure
     def test_collidedictall__negative_sized_rects_as_args(self):
         """Ensures collidedictall works correctly with negative sized rect
         args.

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -1828,7 +1828,7 @@ class RectTypeTest(unittest.TestCase):
 
         collide_item1 = ("collide 1", neg_rect.copy())
         collide_item2 = ("collide 2", Rect(0, 0, 20, 20))
-        no_collide_item1 = ("no collide 1", Rect(1, 1, 20, 20))
+        no_collide_item1 = ("no collide 1", Rect(2, 2, 20, 20))
 
         # Dict to check collisions with values.
         rect_values = dict((collide_item1, collide_item2, no_collide_item1))


### PR DESCRIPTION
This should fix #1198 (I modified collision function to compare "normalized" values of the rect).

This should also fix #1599 (I don't really know why does this work, but I just copied values from from fromstring method (and that method is working fine))