### PR TITLE
Fix drawing ellipses with width values > 1

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -565,7 +565,7 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
-    int loop, t, l, b, r;
+    int t, l, b, r;
     int width = 0; /* Default width. */
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
@@ -597,10 +597,6 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
         return pgRect_New4(rect->x, rect->y, 0, 0);
     }
 
-    if (width > rect->w / 2 || width > rect->h / 2) {
-        width = MAX(rect->w / 2, rect->h / 2);
-    }
-
     if (!pgSurface_Lock(surfobj)) {
         return RAISE(PyExc_RuntimeError, "error locking surface");
     }
@@ -611,10 +607,17 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
                      rect->w, rect->h, 1, color, drawn_area);
     }
     else {
-        width = MIN(width, MIN(rect->w, rect->h) / 2);
-        for (loop = 0; loop < width; ++loop) {
-            draw_ellipse(surf, rect->x + rect->w / 2, rect->y + rect->h / 2,
-                         rect->w - loop, rect->h - loop, 0, color, drawn_area);
+        int loop;
+        int w = rect->w;
+        int h = rect->h;
+        int x = rect->x + w / 2;
+        int y = rect->y + h / 2;
+
+        /* Using +1 to round up. */
+        width = MIN(width, (MIN(w, h) + 1) / 2);
+
+        for (loop = 0; loop < width; ++loop, w -= 2, h -= 2) {
+            draw_ellipse(surf, x, y, w, h, 0, color, drawn_area);
         }
     }
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -536,6 +536,116 @@ class DrawEllipseMixin(object):
                 for left, top in left_top:
                     not_same_size(width, height, border_width, left, top)
 
+    def test_ellipse__thick_line(self):
+        """Ensures a thick lined ellipse is drawn correctly."""
+        ellipse_color = pygame.Color("yellow")
+        surface_color = pygame.Color("black")
+        surface = pygame.Surface((40, 40))
+        rect = pygame.Rect((0, 0), (31, 23))
+        rect.center = surface.get_rect().center
+
+        # As the lines get thicker the internals of the ellipse are not
+        # cleanly defined. So only test up to a few thicknesses before the
+        # maximum thickness.
+        for thickness in range(1, min(*rect.size) // 2 - 2):
+            surface.fill(surface_color)  # Clear for each test.
+
+            self.draw_ellipse(surface, ellipse_color, rect, thickness)
+
+            surface.lock()  # For possible speed up.
+
+            # Check vertical thickness on the ellipse's top.
+            x = rect.centerx
+            y_start = rect.top
+            y_end = rect.top + thickness - 1
+
+            for y in range(y_start, y_end + 1):
+                self.assertEqual(surface.get_at((x, y)), ellipse_color, thickness)
+
+            # Check pixels above and below this line.
+            self.assertEqual(surface.get_at((x, y_start - 1)), surface_color, thickness)
+            self.assertEqual(surface.get_at((x, y_end + 1)), surface_color, thickness)
+
+            # Check vertical thickness on the ellipse's bottom.
+            x = rect.centerx
+            y_start = rect.bottom - thickness
+            y_end = rect.bottom - 1
+
+            for y in range(y_start, y_end + 1):
+                self.assertEqual(surface.get_at((x, y)), ellipse_color, thickness)
+
+            # Check pixels above and below this line.
+            self.assertEqual(surface.get_at((x, y_start - 1)), surface_color, thickness)
+            self.assertEqual(surface.get_at((x, y_end + 1)), surface_color, thickness)
+
+            # Check horizontal thickness on the ellipse's left.
+            x_start = rect.left
+            x_end = rect.left + thickness - 1
+            y = rect.centery
+
+            for x in range(x_start, x_end + 1):
+                self.assertEqual(surface.get_at((x, y)), ellipse_color, thickness)
+
+            # Check pixels to the left and right of this line.
+            self.assertEqual(surface.get_at((x_start - 1, y)), surface_color, thickness)
+            self.assertEqual(surface.get_at((x_end + 1, y)), surface_color, thickness)
+
+            # Check horizontal thickness on the ellipse's right.
+            x_start = rect.right - thickness
+            x_end = rect.right - 1
+            y = rect.centery
+
+            for x in range(x_start, x_end + 1):
+                self.assertEqual(surface.get_at((x, y)), ellipse_color, thickness)
+
+            # Check pixels to the left and right of this line.
+            self.assertEqual(surface.get_at((x_start - 1, y)), surface_color, thickness)
+            self.assertEqual(surface.get_at((x_end + 1, y)), surface_color, thickness)
+
+            surface.unlock()
+
+    def test_ellipse__max_width(self):
+        """Ensures an ellipse with max width (and greater) is drawn correctly."""
+        ellipse_color = pygame.Color("yellow")
+        surface_color = pygame.Color("black")
+        surface = pygame.Surface((40, 40))
+        rect = pygame.Rect((0, 0), (31, 21))
+        rect.center = surface.get_rect().center
+        max_thickness = (min(*rect.size) + 1) // 2
+
+        for thickness in range(max_thickness, max_thickness + 3):
+            surface.fill(surface_color)  # Clear for each test.
+
+            self.draw_ellipse(surface, ellipse_color, rect, thickness)
+
+            surface.lock()  # For possible speed up.
+
+            # Check vertical thickness.
+            for y in range(rect.top, rect.bottom):
+                self.assertEqual(surface.get_at((rect.centerx, y)), ellipse_color)
+
+            # Check horizontal thickness.
+            for x in range(rect.left, rect.right):
+                self.assertEqual(surface.get_at((x, rect.centery)), ellipse_color)
+
+            # Check pixels above and below ellipse.
+            self.assertEqual(
+                surface.get_at((rect.centerx, rect.top - 1)), surface_color
+            )
+            self.assertEqual(
+                surface.get_at((rect.centerx, rect.bottom + 1)), surface_color
+            )
+
+            # Check pixels to the left and right of the ellipse.
+            self.assertEqual(
+                surface.get_at((rect.left - 1, rect.centery)), surface_color
+            )
+            self.assertEqual(
+                surface.get_at((rect.right + 1, rect.centery)), surface_color
+            )
+
+            surface.unlock()
+
     def _check_1_pixel_sized_ellipse(
         self, surface, collide_rect, surface_color, ellipse_color
     ):


### PR DESCRIPTION
Overview of changes:
- Fixed drawing ellipses with width values greater than 1
- Added related tests

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at e07618a05545947f54c62d7b498f81059128f0ad

Resolves #968.