### PR TITLE
Fix PixelArray compare() documentation

### DIFF
--- a/docs/reST/ref/pixelarray.rst
+++ b/docs/reST/ref/pixelarray.rst
@@ -250,16 +250,16 @@
       | :sl:`Compares the PixelArray with another one.`
       | :sg:`compare(array, distance=0, weights=(0.299, 0.587, 0.114)) -> PixelArray`
 
-      Compares the contents of the PixelArray with those from the passed
+      Compares the contents of the PixelArray with those from the passed in
       PixelArray. It returns a new PixelArray with a black/white color mask
-      that indicates the differences (white) of both arrays. Both PixelArray
+      that indicates the differences (black) of both arrays. Both PixelArray
       objects must have identical bit depths and dimensions.
 
       It uses a simple weighted Euclidean distance formula to calculate the
       distance between the colors. The distance space ranges from 0.0 to 1.0
-      and is used as threshold for the color detection. This causes the
+      and is used as a threshold for the color detection. This causes the
       comparison to mark pixels with a similar, but not exactly identical
-      color, as black.
+      color, as white.
 
       .. versionadded:: 1.8.1
 


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- sphinx: 1.8.5
- python: 3.8.1 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at e07618a05545947f54c62d7b498f81059128f0ad

Resolves the "the documentation is incorrect, black and white are reversed" item of #1519.
