### PR TITLE
Fix PixelArray compare() method

### DIFF
--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -942,7 +942,7 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                     GET_PIXELVALS(r1, g1, b1, a1,
                                   (Uint32)*pixel_p, format, ppa);
                     GET_PIXELVALS(r2, g2, b2, a2,
-                                  (Uint32)*pixel_p, other_format, other_ppa);
+                                  (Uint32)*other_pixel_p, other_format, other_ppa);
                     if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2, b2) <=
                         distance) {
                         *pixel_p = (Uint16)white;
@@ -1046,7 +1046,7 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
                 if (distance != 0.0) {
                     GET_PIXELVALS(r1, g1, b1, a1, *pixel_p, format, ppa);
                     GET_PIXELVALS(r2, g2, b2, a2,
-                                  *pixel_p, other_format, other_ppa);
+                                  *other_pixel_p, other_format, other_ppa);
                     if (COLOR_DIFF_RGB(wr, wg, wb, r1, g1, b1, r2, g2, b2) <=
                         distance) {
                         *pixel_p = white;


### PR DESCRIPTION
Overview of changes:
- Fixed the PixelArray `compare()` method not working when the distance value is non-zero and the surface has a bytes per pixel value of 2 or 4
- Added related tests
- Added surface size check to `assert_surfaces_equal()` method

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at e07618a05545947f54c62d7b498f81059128f0ad

Resolves the "non-zero distances are not working for some surfaces" item of #1519.