### PR TITLE
Fix audio device events

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -348,14 +348,12 @@ _pg_name_from_eventtype(int type)
     switch (type) {
         case SDL_ACTIVEEVENT:
             return "ActiveEvent";
-#if IS_SDLv2
-#ifndef NO_SDL_AUDIODEVICE
+#ifdef SDL2_AUDIODEVICE_SUPPORTED
         case SDL_AUDIODEVICEADDED:
             return "AudioDeviceAdded";
         case SDL_AUDIODEVICEREMOVED:
             return "AudioDeviceRemoved";
-#endif
-#endif
+#endif /* SDL2_AUDIODEVICE_SUPPORTED */
         case SDL_KEYDOWN:
             return "KeyDown";
         case SDL_KEYUP:
@@ -581,12 +579,12 @@ dict_from_event(SDL_Event *event)
             _pg_insobj(dict, "gain", PyInt_FromLong(gain));
             _pg_insobj(dict, "state", PyInt_FromLong(state));
             break;
-#ifndef NO_SDL_AUDIODEVICE
+#ifdef SDL2_AUDIODEVICE_SUPPORTED
         case SDL_AUDIODEVICEADDED:
         case SDL_AUDIODEVICEREMOVED:
-            _pg_insobj(dict, "which", PyInt_FromLong(&event->adevice.which));
-            _pg_insobj(dict, "iscapture", PyInt_FromLong(&event->adevice.iscapture));
-#endif
+            _pg_insobj(dict, "which", PyInt_FromLong(event->adevice.which));
+            _pg_insobj(dict, "iscapture", PyInt_FromLong(event->adevice.iscapture));
+#endif /* SDL2_AUDIODEVICE_SUPPORTED */
             break;
         case SDL_KEYDOWN:
             _pg_insobj(dict, "unicode", Text_FromUTF8(_pg_last_unicode_char));

--- a/src_c/include/pgcompat.h
+++ b/src_c/include/pgcompat.h
@@ -158,9 +158,15 @@ typedef uint8_t Uint8;
 #define SDL_WINDOW_POPUP_MENU 0
 #endif
 
-
-#ifndef SDL_AUDIODEVICEREMOVED
-#define NO_SDL_AUDIODEVICE
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+/* To control the use of:
+ * SDL_AUDIODEVICEADDED
+ * SDL_AUDIODEVICEREMOVED
+ *
+ * Ref: https://wiki.libsdl.org/SDL_EventType
+ * Ref: https://wiki.libsdl.org/SDL_AudioDeviceEvent
+ */
+#define SDL2_AUDIODEVICE_SUPPORTED
 #endif
 
 #ifndef SDL_MOUSEWHEEL_FLIPPED
@@ -168,8 +174,7 @@ typedef uint8_t Uint8;
 #endif
 
 
-
-#endif
+#endif /* defined(SDL_VERSION_ATLEAST) */
 
 
 #endif /* ~defined(PGCOMPAT_H) */

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -79,11 +79,8 @@ if pygame.get_sdl_version()[0] >= 2:
     # Add in any SDL 2.0.4 specific events.
     if pygame.get_sdl_version() >= (2, 0, 4):
         NAMES_AND_EVENTS += (
-            # These can be corrected when issue #1221 is resolved.
-            # Should be: 'AudioDeviceAdded'
-            ("Unknown", pygame.AUDIODEVICEADDED),
-            # Should be: 'AudioDeviceRemoved'
-            ("Unknown", pygame.AUDIODEVICEREMOVED),
+            ("AudioDeviceAdded", pygame.AUDIODEVICEADDED),
+            ("AudioDeviceRemoved", pygame.AUDIODEVICEREMOVED),
         )
 
     # Add in any SDL 2.0.5 specific events.


### PR DESCRIPTION
Overview of changes:
- Fixed audio device events from being identified as 'Unknown'
- Fixed the incorrect decoding of audio device event data

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at e07618a05545947f54c62d7b498f81059128f0ad

Resolves #1221.