### PR TITLE
Fix a surface LGTM alert

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3379,7 +3379,7 @@ _get_buffer_1D(PyObject *obj, Py_buffer *view_p, int flags)
                 /* Should not be here */
                 PyErr_Format(PyExc_SystemError,
                              "Pygame bug caught at line %i in file %s: "
-                             "unknown pixel size %i. Please report",
+                             "unknown pixel size %zd. Please report",
                              (int)__LINE__, __FILE__, itemsize);
                 return -1;
 #endif


### PR DESCRIPTION
Overview of changes:
- Fixed “Wrong type of arguments to formatting function” LGTM alert
  (LGTM info for pygame: https://lgtm.com/projects/g/pygame/pygame)

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at e07618a05545947f54c62d7b498f81059128f0ad

Related to #1133.