### PR TITLE
mixer.c: Fix leak on out of memory with realloc

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1348,8 +1348,14 @@ set_num_channels(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
     if (numchans > numchanneldata) {
+        struct ChannelData *cd_org = channeldata;
         channeldata = (struct ChannelData *)realloc(
             channeldata, sizeof(struct ChannelData) * numchans);
+        if (!channeldata) {
+            /* Restore the original to avoid leaking it */
+            channeldata = cd_org;
+            return PyErr_NoMemory();
+        }
         for (i = numchanneldata; i < numchans; ++i) {
             channeldata[i].sound = NULL;
             channeldata[i].queue = NULL;


### PR DESCRIPTION
There is a common, but faulty code pattern, involving realloc of the
form:

    x = realloc(x, ...);

The bug occurs if realloc fails to allocate memory (usually in out of
memory situations).  In this case, realloc will return NULL *without*
free'ing the input leaking to a leak.

In the concrete situation, the code did not appear to handle realloc
failures at all and would immediately attempt to dereference the NULL
pointer.

Found with cppcheck.

Signed-off-by: Niels Thykier <niels@thykier.net>