### PR TITLE
surface.c: Replace a redundant conditional with an assert

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2289,16 +2289,18 @@ surf_blits(PyObject *self, PyObject *args, PyObject *keywds)
             goto bliterror;
         }
         bliterrornum = 0;
-        srcobject = NULL;
-        argpos = NULL;
         argrect = NULL;
         special_flags = NULL;
         the_args = 0;
-        if (itemlength >= 2) {
-            /* (Surface, dest) */
-            srcobject = PySequence_GetItem(item, 0);
-            argpos = PySequence_GetItem(item, 1);
-        }
+
+        /* We know that there will be at least two items due to the
+           conditional at the start of the loop */
+        assert(itemlength >= 2);
+
+        /* (Surface, dest) */
+        srcobject = PySequence_GetItem(item, 0);
+        argpos = PySequence_GetItem(item, 1);
+
         if (itemlength >= 3) {
             /* (Surface, dest, area) */
             argrect = PySequence_GetItem(item, 2);


### PR DESCRIPTION
The conditional is confusing cppcheck into believing that
e.g. srcobject might be NULL assuming "itemlength < 2".  This is not
possible due to a conditional a bit earlier, but cppcheck does not
understand that.

Signed-off-by: Niels Thykier <niels@thykier.net>