### PR TITLE
Issue templates

### DIFF
--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -1,0 +1,30 @@
+<!-- This issue tracker is for bug reports and feature requests in PyGame. -->
+<!-- If you have a simple question about PyGame, please ask in the #help channel on Discord at https://discord.gg/EKfEbTd -->
+
+**Environment:**
+<!-- You can get most of this info from the interactive python prompt -->
+<!-- And from the output of "import pygame" -->
+
+- operating system:
+- Python version:
+- SDL version:
+- PyGame version:
+- notable hardware:
+
+**Current behavior:**
+<!-- Describe how the bug manifests. -->
+```
+paste stack traces here, if applicable
+```
+
+**Expected behavior:**
+<!-- Describe what the behavior would be without the bug. -->
+
+**Steps to reproduce:**
+<!--  Please explain the steps required to duplicate the issue, especially if you are able to provide a sample application. -->
+<!-- if the bug is caused by a specific file (image, font, sound, level, please upload it as an attachment -->
+```
+import pygame
+pygame.init()
+print("Hello, world")
+```


### PR DESCRIPTION
I propose using github issue templates. Maybe not just like this, maybe much more involved, split into bugs, features, and pull request, but I thought I'd start here. I don't want to have to ask people what version of pygame and python they are on, only to find out a bug can only be reproduced with PyGame 1.9.6 on a 32-bit Debian with Python 3.8 on a RaspberryPi.