### PR TITLE
Update SDL_ttf version

### DIFF
--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -233,12 +233,12 @@ def place_downloaded_prebuilts(temp_dir, move_to_dir, x86=True, x64=True, sdl2=T
         copy(
             os.path.join(
                 temp_dir,
-                'SDL2_ttf-devel-2.0.14-VC/SDL2_ttf-2.0.14'
+                'SDL2_ttf-devel-2.0.15-VC/SDL2_ttf-2.0.15'
             ),
             os.path.join(
                 move_to_dir,
                 prebuilt_dir,
-                'SDL2_ttf-2.0.14'
+                'SDL2_ttf-2.0.15'
             )
         )
         copy(

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -72,8 +72,8 @@ def get_urls(x86=True, x64=True, sdl2=True):
             '137f86474691f4e12e76e07d58d5920c8d844d5b',
             ],
             [
-            'https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip',
-            'c64d90c1f7d1bb3f3dcfcc255074611f017cdcc4',
+            'https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-VC.zip',
+            '1436df41ebc47ac36e02ec9bda5699e80ff9bd27',
             ],
             [
             'https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-VC.zip',


### PR DESCRIPTION
This should fix #1413 for SDL2 builds. I tested this on Windows, as far as I found out Linux already use 2.0.15, and for the other OS I was unable to find what version do they use, so if can someone else check that I would be grateful.