### PR TITLE
return early from surf.fill(x) on zero-size surf

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2141,6 +2141,10 @@ surf_fill(PyObject *self, PyObject *args, PyObject *keywds)
         /* printf("%d, %d, %d, %d\n", sdlrect.x, sdlrect.y, sdlrect.w,
          * sdlrect.h); */
 
+        if (sdlrect.w <=0 || sdlrect.h <=0) {
+            return pgRect_New(&sdlrect);
+        }
+
         if (blendargs != 0) {
             /*
             printf ("Using blendargs: %d\n", blendargs);


### PR DESCRIPTION
SDL 2.0.12 checks if a surf has a ->pixels pointer that is !=NULL in
SDL_FillRect and complains it should be locked. A zero-size surface also
fails this check (it has no pixels), even when locked.