### PR TITLE
pg_IntFromObj: Explicitly handle and convert floats

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -417,7 +417,17 @@ pg_get_init(PyObject *self, PyObject *args)
 static int
 pg_IntFromObj(PyObject *obj, int *val)
 {
-    int tmp_val = PyInt_AsLong(obj);
+    int tmp_val;
+
+    if (PyFloat_Check(obj)) {
+        /* Python3.8 complains with deprecation warnings if we pass
+         * floats to PyInt_AsLong.
+         */
+        double dv = PyFloat_AsDouble(obj);
+        tmp_val = (int)dv;
+    } else {
+        tmp_val = PyInt_AsLong(obj);
+    }
 
     if (tmp_val == -1 && PyErr_Occurred()) {
         PyErr_Clear();


### PR DESCRIPTION
Prior to this commit, running test/draw_test.py would trigger
deprecation warnings like below.  The floats are passed "by design" to
ensure various PyGame API calls silentl accept floats (truncated to
ints).

```
python3 test/draw_test.py
pygame 2.0.0.dev7 (SDL 2.0.10, python 3.8.2)
Hello from the pygame community. https://www.pygame.org/contribute.html
......................ssss..................................................test/draw_test.py:5475: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  draw.circle(
test/draw_test.py:5487: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  draw.circle(
test/draw_test.py:5499: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  draw.circle(pygame.Surface((2, 2)), (0, 0, 0, 50), (1.3, 1.3), 1.2)
........test/draw_test.py:5406: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  bounds_rect = self.draw_circle(**kwargs)
....................................................test/draw_test.py:1393: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  bounds_rect = self.draw_line(**kwargs)
.test/draw_test.py:1367: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  bounds_rect = self.draw_line(**kwargs)
.......................test/draw_test.py:2062: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  bounds_rect = self.draw_lines(**kwargs)
..........................test/draw_test.py:3964: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  bounds_rect = self.draw_polygon(**kwargs)
...................test/draw_test.py:4680: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  bounds_rect = self.draw_rect(**kwargs)
..
----------------------------------------------------------------------
Ran 207 tests in 7.086s

OK (skipped=4)
```

Signed-off-by: Niels Thykier <niels@thykier.net>