### PR TITLE
SDL2: Ensure that SDL_GetWindowSurface is called on flip (Request for review)

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1924,6 +1924,14 @@ static PyObject *
 pg_GetDefaultWindowSurface(void)
 {
     /*return a borrowed reference*/
+    if (pg_default_window) {
+        /* With SDL2, resizing invalidates the existing surface.  Calling
+         * SDL_GetWindowSurface will recreate the surface when it is
+         * invalid (or return the current surface if it is still valid)
+         */
+        SDL_Surface *new_surface = SDL_GetWindowSurface(pg_default_window);
+        ((pgSurfaceObject *)pg_default_screen)->surf = new_surface;
+    }
     return pg_default_screen;
 }
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1396,6 +1396,13 @@ pg_flip_internal(_DisplayState *state)
             SDL_RenderPresent(pg_renderer);
         }
         else {
+#if IS_SDLv2
+            /* Force a re-initialization of the surface in case it
+             * has been resized to avoid "please call SDL_GetWindowSurface"
+             * errors that the programmer cannot fix
+             */
+            (void)pg_GetDefaultWindowSurface();
+#endif
             status = SDL_UpdateWindowSurface(win);
         }
     }


### PR DESCRIPTION
Without this commit, resizing a pygame window under SDL2 immediately crashes with the error below.  I am not entirely sure why the `set_mode` call is not enough with this change either, so I am opening this as a draft pull request for now until can review whether this is the right approach.

```
Traceback (most recent call last):
  File "debugging/resize.py", line 28, in <module>
    pygame.display.flip()
pygame.error: Window surface is invalid, please call SDL_GetWindowSurface() to get a new surface
```

The `debugging/resize.py` has the following content:

```python
import pygame

pygame.init()
window = pygame.display.set_mode((800, 600), pygame.RESIZABLE)

running = True
resize = None
while running:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            running = False
        elif event.type == pygame.ACTIVEEVENT:
            print(event)
        elif event.type == pygame.VIDEORESIZE:
            resize = event.size
            print(event)
        elif event.type == pygame.KEYDOWN:
            print(f"width={window.get_width()}, height={window.get_height()}")

    if resize:
        pygame.event.set_blocked(pygame.VIDEORESIZE)
        pygame.event.clear(pygame.VIDEORESIZE)
        window = pygame.display.set_mode(resize, pygame.RESIZABLE)

        resize = None
            
    rect = window.fill((255, 0, 0))
    pygame.display.flip()
    pygame.event.set_allowed(pygame.VIDEORESIZE)
```
