### PR TITLE
Have set_shifts and set_masks raise AttributeError in SDL2

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -768,6 +768,9 @@
 
       This is not needed for normal pygame usage.
 
+      .. note:: In SDL2, the masks are read-only and accordingly this method will raise
+                an AttributeError if called.
+
       .. versionadded:: 1.8.1
 
       .. ## Surface.set_masks ##
@@ -790,6 +793,9 @@
       | :sg:`set_shifts((r,g,b,a)) -> None`
 
       This is not needed for normal pygame usage.
+
+      .. note:: In SDL2, the shifts are read-only and accordingly this method will raise
+                an AttributeError if called.
 
       .. versionadded:: 1.8.1
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2679,18 +2679,16 @@ surf_set_masks(PyObject *self, PyObject *args)
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
-    /*
-    printf("passed in: %d, %d, %d, %d\n", r,g,b,a );
-    printf("what are: %d, %d, %d, %d\n", surf->format->Rmask,
-    surf->format->Gmask, surf->format->Bmask, surf->format->Amask);
-    */
-
+#if IS_SDLv2
+    return RAISE(PyExc_AttributeError, "The surface masks are read-only in SDL2");
+#else /* IS_SDLv1 */
     surf->format->Rmask = (Uint32)r;
     surf->format->Gmask = (Uint32)g;
     surf->format->Bmask = (Uint32)b;
     surf->format->Amask = (Uint32)a;
 
     Py_RETURN_NONE;
+#endif /* IS_SDLv1 */
 }
 
 static PyObject *
@@ -2715,12 +2713,16 @@ surf_set_shifts(PyObject *self, PyObject *args)
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
+#if IS_SDLv2
+    return RAISE(PyExc_AttributeError, "The surface shifts are read-only in SDL2");
+#else /* IS_SDLv1 */
     surf->format->Rshift = (Uint8)r;
     surf->format->Gshift = (Uint8)g;
     surf->format->Bshift = (Uint8)b;
     surf->format->Ashift = (Uint8)a;
 
     Py_RETURN_NONE;
+#endif /* IS_SDLv1 */
 }
 
 static PyObject *

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -539,16 +539,22 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
     def test_set_masks(self):
         s = pygame.Surface((32, 32))
         r, g, b, a = s.get_masks()
-        s.set_masks((b, g, r, a))
-        r2, g2, b2, a2 = s.get_masks()
-        self.assertEqual((r, g, b, a), (b2, g2, r2, a2))
+        if pygame.get_sdl_version()[0] == 1:
+            s.set_masks((b, g, r, a))
+            r2, g2, b2, a2 = s.get_masks()
+            self.assertEqual((r, g, b, a), (b2, g2, r2, a2))
+        else:
+            self.assertRaises(AttributeError, s.set_masks, (b, g, r, a))
 
     def test_set_shifts(self):
         s = pygame.Surface((32, 32))
         r, g, b, a = s.get_shifts()
-        s.set_shifts((b, g, r, a))
-        r2, g2, b2, a2 = s.get_shifts()
-        self.assertEqual((r, g, b, a), (b2, g2, r2, a2))
+        if pygame.get_sdl_version()[0] == 1:
+            s.set_shifts((b, g, r, a))
+            r2, g2, b2, a2 = s.get_shifts()
+            self.assertEqual((r, g, b, a), (b2, g2, r2, a2))
+        else:
+            self.assertRaises(AttributeError, s.set_shifts, (b, g, r, a))
 
     def test_blit_keyword_args(self):
         color = (1, 2, 3, 255)

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -429,10 +429,15 @@ class SurfarrayModuleTest(unittest.TestCase):
             palette = None
             if bitsize == 16:
                 palette = [surf.unmap_rgb(surf.map_rgb(c)) for c in self.test_palette]
-            surf.set_shifts(shifts)
-            surf.set_masks(masks)
-            pygame.surfarray.blit_array(surf, arr3d)
-            self._assert_surface(surf, palette)
+
+            if pygame.get_sdl_version()[0] == 1:
+                surf.set_shifts(shifts)
+                surf.set_masks(masks)
+                pygame.surfarray.blit_array(surf, arr3d)
+                self._assert_surface(surf, palette)
+            else:
+                self.assertRaises(AttributeError, surf.set_shifts, shifts)
+                self.assertRaises(AttributeError, surf.set_masks, masks)
 
         # Invalid arrays
         surf = pygame.Surface((1, 1), 0, 32)


### PR DESCRIPTION
PixelFormat is read-only in SDL2 (because it is shared between
multiple surfaces).  Changing the PixelFormat can trigger seg. faults
when working with other surfaces.

This commit "solves" the problem by having the set_shifts and
set_masks methods raise an AttributeError to inform that programmer
that we cannot change these values any more.

Closes: #1383
Signed-off-by: Niels Thykier <niels@thykier.net>