### PR TITLE
image_fromstring: Use memcpy instead of re-inventing it

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -924,10 +924,8 @@ image_fromstring(PyObject *self, PyObject *arg)
         for (looph = 0; looph < h; ++looph) {
             Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
                                             h, flipped);
-            for (loopw = 0; loopw < w; ++loopw) {
-                *pix++ = *((Uint32 *)data);
-                data += 4;
-            }
+            memcpy(pix, data, w * sizeof(Uint32));
+            data += w * sizeof(Uint32);
         }
         SDL_UnlockSurface(surf);
     }
@@ -948,10 +946,8 @@ image_fromstring(PyObject *self, PyObject *arg)
         for (looph = 0; looph < h; ++looph) {
             Uint32 *pix = (Uint32 *)DATAROW(surf->pixels, looph, surf->pitch,
                                             h, flipped);
-            for (loopw = 0; loopw < w; ++loopw) {
-                *pix++ = *((Uint32 *)data);
-                data += 4;
-            }
+            memcpy(pix, data, w * sizeof(Uint32));
+            data += w * sizeof(Uint32);
         }
         SDL_UnlockSurface(surf);
     }


### PR DESCRIPTION
The commit replaces the "hand-rolled" memcpy in image_fromstring with
the libc-provided memcpy.  As the latter is vastly more optimized,
this speeds up image_fromstring considerably.  While the exact improvement
will vary between OS and hardware, it should be considerable.

The following code was used as benchmark, and showed a factor x2
improvement (YMMV):

```python
import timeit
import pygame
import statistics

bigsurf = pygame.Surface((500,500))
rgba_pre_buf = pygame.image.tostring(bigsurf, "RGBA")
rgba_pre_buf_size = bigsurf.get_size()

def test_this():
    surf = pygame.image.fromstring(rgba_pre_buf, rgba_pre_buf_size, "RGBA")

if __name__ == '__main__':
    number = 1000
    res = timeit.repeat('test_this()', number=number, setup="from __main__ import test_this")
    min_val = min(res) * 1000 / number
    max_val = max(res) * 1000 / number
    avg_val = (sum(res) * 1000 / len(res)) / number
    std_dev = statistics.stdev(res)
    print("%.3fms - %.3fms (%.3fms ± %.3fms)" % (min_val, max_val, avg_val, std_dev))
```

Signed-off-by: Niels Thykier <niels@thykier.net>