### PR TITLE
Fix deprecation warnings in image_test

### DIFF
--- a/test/image_test.py
+++ b/test/image_test.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 import glob
 
-from pygame.tests.test_utils import example_path, png
+from pygame.tests.test_utils import example_path, png, tostring
 import pygame, pygame.image, pygame.pkgdata
 from pygame.compat import xrange_, ord_, unicode_
 
@@ -411,7 +411,7 @@ class ImageModuleTest(unittest.TestCase):
                 byte_buf[i * 4 + 2] = byte_buf[i * 4 + 1]
                 byte_buf[i * 4 + 1] = byte_buf[i * 4 + 0]
                 byte_buf[i * 4 + 0] = alpha
-            return byte_buf.tostring()
+            return tostring(byte_buf)
 
         ####################################################################
         def RotateARGBtoRGBA(str_buf):
@@ -423,7 +423,7 @@ class ImageModuleTest(unittest.TestCase):
                 byte_buf[i * 4 + 1] = byte_buf[i * 4 + 2]
                 byte_buf[i * 4 + 2] = byte_buf[i * 4 + 3]
                 byte_buf[i * 4 + 3] = alpha
-            return byte_buf.tostring()
+            return tostring(byte_buf)
 
         ####################################################################
         test_surface = pygame.Surface((64, 256), flags=pygame.SRCALPHA, depth=32)

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -17,6 +17,21 @@ except NameError:
     raw_input_ = input
 
 
+if sys.version_info[0] == 3:
+    def tostring(row):
+        """Convert row of bytes to string.  Expects `row` to be an
+        ``array``.
+        """
+        return row.tobytes()
+
+else:
+    def tostring(row):
+        """Convert row of bytes to string.  Expects `row` to be an
+        ``array``.
+        """
+        return row.tostring()
+
+
 def geterror():
     return sys.exc_info()[1]
 

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -163,6 +163,7 @@ __version__ = "$URL: http://pypng.googlecode.com/svn/trunk/code/png.py $ $Rev: 2
 
 from pygame.compat import geterror, imap_
 from array import array
+from pygame.tests.test_utils import tostring
 import itertools
 import math
 import operator
@@ -170,7 +171,6 @@ import struct
 import sys
 import zlib
 import warnings
-import sys
 
 __all__ = ["Image", "Reader", "Writer", "write_chunks", "from_array"]
 
@@ -200,20 +200,6 @@ def isarray(x):
     """Same as ``isinstance(x, array)``.
     """
     return isinstance(x, array)
-
-
-def tostring(row):
-    """Convert row of bytes to string.  Expects `row` to be an
-    ``array``.
-    """
-    return row.tostring()
-
-if sys.version_info.major>=3:
-    def tostring(row):
-        """Convert byte-array of type `array` into byte string
-        of type `bytes`.
-        """
-        return row.tobytes()
 
 
 # Conditionally convert to bytes.  Works on Python 2 and Python 3.


### PR DESCRIPTION
It needed the same fix as png.py.  The relevant compat code has been
moved into the test_utils module so all tests can rely on it.

Signed-off-by: Niels Thykier <niels@thykier.net>