### PR TITLE
Add -Werror for a subset of compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ install:
   - "$PIP_CMD install --upgrade pip"
   - "$PIP_CMD install --upgrade numpy"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $PIP_CMD install delocate twine; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $PYTHON_EXE setup.py install -noheaders -auto; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $PYTHON_EXE setup.py install -pygame-ci -noheaders -auto; fi
   - if [[ "$MANYLINUX_WHL" == "yes" ]]; then source buildconfig/ci/travis/.travis_linux_build_wheels.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source buildconfig/ci/travis/.travis_osx_install.sh; fi
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,19 @@ if "-warnings" in sys.argv:
                        "-Wnested-externs -Wshadow -Wredundant-decls"
     sys.argv.remove ("-warnings")
 
+if '-pygame-ci' in sys.argv:
+    cflags = os.environ.get('CFLAGS', '')
+    if cflags:
+        cflags += ' '
+    cflags += '-Werror=nested-externs -Werror=switch -Werror=implicit ' + \
+              '-Werror=implicit-function-declaration -Werror=return-type ' + \
+              '-Werror=implicit-int -Werror=main -Werror=pointer-arith ' + \
+              '-Werror=format-security -Werror=uninitialized ' + \
+              '-Werror=trigraphs -Werror=parentheses ' + \
+              '-Werror=cast-align'
+    os.environ['CFLAGS'] = cflags
+    sys.argv.remove ('-pygame-ci')
+
 if 'cython' in sys.argv:
     # compile .pyx files
     # So you can `setup.py cython` or `setup.py cython install`


### PR DESCRIPTION
This commit introduces a "-pygame-ci" option that set certain compiler
warnings to errors.  It can be combined with the "-warnings" flag to
also include the warnings from that option.

The new option is also added to travis when run on Linux.

Signed-off-by: Niels Thykier <niels@thykier.net>