### PR TITLE
Have get_cursor raise TypeError in SDL

### DIFF
--- a/docs/reST/ref/mouse.rst
+++ b/docs/reST/ref/mouse.rst
@@ -162,6 +162,9 @@ configured.
    Get the information about the mouse system cursor. The return value is the
    same data as the arguments passed into ``pygame.mouse.set_cursor()``.
 
+   .. note:: This method is unavailable with SDL2, as SDL2 does not provide
+             the underlying code to implement this method.
+
    .. ## pygame.mouse.get_cursor ##
 
 .. ## pygame.mouse ##

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -278,7 +278,13 @@ interror:
     return RAISE(PyExc_TypeError, "Invalid number in mask array");
 }
 
-#if IS_SDLv1
+#if IS_SDLv2
+static PyObject *
+mouse_get_cursor(PyObject *self)
+{
+    return RAISE(PyExc_TypeError, "The get_cursor method is unavailable in SDL2");
+}
+#else /* IS_SDLv1*/
 static PyObject *
 mouse_get_cursor(PyObject *self)
 {
@@ -330,10 +336,8 @@ static PyMethodDef _mouse_methods[] = {
     {"get_focused", (PyCFunction)mouse_get_focused, METH_VARARGS,
      DOC_PYGAMEMOUSEGETFOCUSED},
     {"set_cursor", mouse_set_cursor, METH_VARARGS, DOC_PYGAMEMOUSESETCURSOR},
-#if IS_SDLv1
     {"get_cursor", (PyCFunction)mouse_get_cursor, METH_VARARGS,
      DOC_PYGAMEMOUSEGETCURSOR},
-#endif /* IS_SDLv1 */
 
     {NULL, NULL, 0, NULL}};
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2680,7 +2680,7 @@ surf_set_masks(PyObject *self, PyObject *args)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
 #if IS_SDLv2
-    return RAISE(PyExc_AttributeError, "The surface masks are read-only in SDL2");
+    return RAISE(PyExc_TypeError, "The surface masks are read-only in SDL2");
 #else /* IS_SDLv1 */
     surf->format->Rmask = (Uint32)r;
     surf->format->Gmask = (Uint32)g;
@@ -2714,7 +2714,7 @@ surf_set_shifts(PyObject *self, PyObject *args)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
 #if IS_SDLv2
-    return RAISE(PyExc_AttributeError, "The surface shifts are read-only in SDL2");
+    return RAISE(PyExc_TypeError, "The surface shifts are read-only in SDL2");
 #else /* IS_SDLv1 */
     surf->format->Rshift = (Uint8)r;
     surf->format->Gshift = (Uint8)g;

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -544,7 +544,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             r2, g2, b2, a2 = s.get_masks()
             self.assertEqual((r, g, b, a), (b2, g2, r2, a2))
         else:
-            self.assertRaises(AttributeError, s.set_masks, (b, g, r, a))
+            self.assertRaises(TypeError, s.set_masks, (b, g, r, a))
 
     def test_set_shifts(self):
         s = pygame.Surface((32, 32))
@@ -554,7 +554,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             r2, g2, b2, a2 = s.get_shifts()
             self.assertEqual((r, g, b, a), (b2, g2, r2, a2))
         else:
-            self.assertRaises(AttributeError, s.set_shifts, (b, g, r, a))
+            self.assertRaises(TypeError, s.set_shifts, (b, g, r, a))
 
     def test_blit_keyword_args(self):
         color = (1, 2, 3, 255)

--- a/test/surfarray_test.py
+++ b/test/surfarray_test.py
@@ -436,8 +436,8 @@ class SurfarrayModuleTest(unittest.TestCase):
                 pygame.surfarray.blit_array(surf, arr3d)
                 self._assert_surface(surf, palette)
             else:
-                self.assertRaises(AttributeError, surf.set_shifts, shifts)
-                self.assertRaises(AttributeError, surf.set_masks, masks)
+                self.assertRaises(TypeError, surf.set_shifts, shifts)
+                self.assertRaises(TypeError, surf.set_masks, masks)
 
         # Invalid arrays
         surf = pygame.Surface((1, 1), 0, 32)


### PR DESCRIPTION
For consistency, `set_shifts` and `set_masks` are updated to raise `TypeError` as well.  After studying the [Python's exception documentation], I realised that `TypeError` was the proper choice (over `AttributeError`).

```
     exception TypeError
    
        [...]
    
        This exception may be raised by user code to indicate that an
        attempted operation on an object is not supported, and is not
        meant to be. [...]
```

[Python's exception documentation]: https://docs.python.org/3/library/exceptions.html
    
