### PR TITLE
KMOD_MODE was not properly described. Is supposed to indicate that th…

### DIFF
--- a/docs/reST/ref/key.rst
+++ b/docs/reST/ref/key.rst
@@ -203,7 +203,7 @@ can be assembled by bitwise-ORing them together.
       KMOD_META     left meta or right meta or both
       KMOD_CAPS     caps lock
       KMOD_NUM      num lock
-      KMOD_MODE     mode
+      KMOD_MODE     AltGr
 
 
 The modifier information is contained in the ``mod`` attribute of the


### PR DESCRIPTION
…e AltGr modifier key is in use

The description for the key modifier KMOD_MODE was described as 'mode' which does not indicate what modifer key is being depressed.
In SDL, KMOD_MODE is described as indicating that the AltGr modifier key is being pressed. This should be the same here in pygame.