### PR TITLE
[WIP] Improve precision of pygame clock

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -295,6 +295,7 @@ static PyObject *
 clock_tick(PyObject *self, PyObject *arg)
 {
     PyClockObject *_clock = (PyClockObject *)self;
+    float cycle_time;
     float framerate = 0.0f;
     int nowtime;
 
@@ -309,7 +310,7 @@ clock_tick(PyObject *self, PyObject *arg)
             }
         }
         _clock->rawpassed = SDL_GetTicks() - _clock->last_tick;
-        float cycle_time = 1.0f / framerate;
+        cycle_time = 1.0f / framerate;
         while (_clock->accumulated_time - cycle_time < 0.00001f) {
             _clock->current_ticks = SDL_GetPerformanceCounter() - _clock->start_of_clock;
             _clock->delta = _clock->current_ticks - _clock->last_tick;


### PR DESCRIPTION
Time module is not covered with tests so I can't say will this work, but I get smoother movement (reported in #304) with this version of Clock.

SIDE NOTE: With this version I got better precision than both Clock.tick(FPS) and Clock.tick_busy_loop(FPS) and much less CPU utilization than in busy_loop so I replaced this 2 functions with one (you can still call both of them because of backwards compatibility, but both of them call the same function).