### PR TITLE
image.load throws FileNotFoundError instead of the generic pygame.error

### DIFF
--- a/examples/camera.py
+++ b/examples/camera.py
@@ -85,7 +85,7 @@ class VideoCapturePlayer(object):
             for e in events:
                 if e.type == pg.QUIT or (e.type == pg.KEYDOWN and e.key == pg.K_ESCAPE):
                     going = False
-                if e.type == KEYDOWN:
+                if e.type == pg.KEYDOWN:
                     if e.key in range(pg.K_0, pg.K_0 + 10):
                         self.init_cams(e.key - pg.K_0)
 

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -215,9 +215,14 @@ image_load_ext(PyObject *self, PyObject *arg)
     }
 
     if (surf == NULL){
-        SDL_ClearError();
-        PyErr_SetString(PyExc_FileNotFoundError, "No such file or directory.");
-        return NULL;
+        if (!strcmp(IMG_GetError(), "Couldn't open fname.asdf")){
+            SDL_ClearError();
+            PyErr_SetString(PyExc_FileNotFoundError, "No such file or directory.");
+            return NULL;
+        }
+        else{
+            return RAISE(pgExc_SDLError, IMG_GetError());
+        }
     }
     final = pgSurface_New(surf);
     if (final == NULL) {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -216,7 +216,8 @@ image_load_ext(PyObject *self, PyObject *arg)
 
     if (surf == NULL){
         SDL_ClearError();
-        return RAISE(PyExc_FileNotFoundError, "No such file or directory.");
+        PyErr_SetString(PyExc_FileNotFoundError, "No such file or directory.");
+        return NULL;
     }
     final = pgSurface_New(surf);
     if (final == NULL) {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -215,9 +215,13 @@ image_load_ext(PyObject *self, PyObject *arg)
     }
 
     if (surf == NULL){
-        if (!strcmp(IMG_GetError(), "Couldn't open fname.asdf")){
+        if (!strncmp(IMG_GetError(), "Couldn't open", 12)){
             SDL_ClearError();
+#if PY3
             PyErr_SetString(PyExc_FileNotFoundError, "No such file or directory.");
+#else
+            PyErr_SetString(PyExc_IOError, "No such file or directory.");
+#endif
             return NULL;
         }
         else{

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -214,8 +214,9 @@ image_load_ext(PyObject *self, PyObject *arg)
         PyMem_Free(ext);
     }
 
-    if (surf == NULL) {
-        return RAISE(pgExc_SDLError, IMG_GetError());
+    if (surf == NULL){
+        SDL_ClearError();
+        return RAISE(PyExc_FileNotFoundError, "No such file or directory.");
     }
     final = pgSurface_New(surf);
     if (final == NULL) {

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -43,7 +43,7 @@ class ImageextModuleTest(unittest.TestCase):
 
     def test_load_unknown_file(self):
         s = "nonexistent.png"
-        self.assertRaises(pygame.error, imageext.load_extended, s)
+        self.assertRaises(FileNotFoundError, imageext.load_extended, s)
 
     def test_load_unicode_path_0(self):
         u = unicode_(example_path("data/alien1.png"))

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -39,7 +39,7 @@ class ImageextModuleTest(unittest.TestCase):
 
     def test_load_unknown_extension(self):
         s = "foo.bar"
-        self.assertRaises(pygame.error, imageext.load_extended, s)
+        self.assertRaises(FileNotFoundError, imageext.load_extended, s)
 
     def test_load_unknown_file(self):
         s = "nonexistent.png"

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -36,14 +36,22 @@ class ImageextModuleTest(unittest.TestCase):
         im = pygame.Surface((10, 10), 0, 32)
         s = "foo.bar"
         self.assertRaises(pygame.error, imageext.save_extended, im, s)
+    if sys.version_info >= (3, 0):
+        def test_load_unknown_extension(self):
+            s = "foo.bar"
+            self.assertRaises(FileNotFoundError, imageext.load_extended, s)
 
-    def test_load_unknown_extension(self):
-        s = "foo.bar"
-        self.assertRaises(FileNotFoundError, imageext.load_extended, s)
+        def test_load_unknown_file(self):
+            s = "nonexistent.png"
+            self.assertRaises(FileNotFoundError, imageext.load_extended, s)
+    else:
+        def test_load_unknown_extension(self):
+            s = "foo.bar"
+            self.assertRaises(IOError, imageext.load_extended, s)
 
-    def test_load_unknown_file(self):
-        s = "nonexistent.png"
-        self.assertRaises(FileNotFoundError, imageext.load_extended, s)
+        def test_load_unknown_file(self):
+            s = "nonexistent.png"
+            self.assertRaises(IOError, imageext.load_extended, s)
 
     def test_load_unicode_path_0(self):
         u = unicode_(example_path("data/alien1.png"))


### PR DESCRIPTION
This PR is an answer to issue #1535. 
-Unit test for FileNotFoundError.
-pygame.image.load("nonexistent.png") throws a FileNotFoundError now.
-Fixed error in examples/camera.py