### PR TITLE
Fix some compiler warnings (linux/gcc)

### DIFF
--- a/src_c/key.c
+++ b/src_c/key.c
@@ -454,7 +454,7 @@ static const char *SDL1_scancode_names[SDL_NUM_SCANCODES] = {
 };
 
 static void
-_use_sdl1_key_names()
+_use_sdl1_key_names(void)
 {
     /* mostly copied from SDL_keyboard.c */
     SDL1_scancode_names[SDL_SCANCODE_BACKSPACE] = "backspace";

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -341,7 +341,7 @@ pgMixer_AutoQuit(void)
 }
 
 static PyObject*
-import_music()
+import_music(void)
 {
     PyObject *music = PyImport_ImportModule(IMPPREFIX "mixer_music");
     if (music == NULL) {


### PR DESCRIPTION
Overview of changes:
- Fixed "function declaration isn’t a prototype" warnings

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.10) at 306d866fdb8f6e56afa9781a9b8ef4f4eca3a83b

Related to #1316.