### PR TITLE
Add missing gfxdraw module creation NULL check

### DIFF
--- a/src_c/gfxdraw.c
+++ b/src_c/gfxdraw.c
@@ -1131,5 +1131,9 @@ MODINIT_DEFINE(gfxdraw)
                             DOC_PYGAMEGFXDRAW);
 #endif
 
+    if (module == NULL) {
+        MODINIT_ERROR;
+    }
+
     MODINIT_RETURN(module);
 }


### PR DESCRIPTION
System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev7 (SDL: 2.0.12) at 306d866fdb8f6e56afa9781a9b8ef4f4eca3a83b