### PR TITLE
smoothscale: Avoid calling GETSTATE without the gil

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1457,20 +1457,23 @@ surf_scalesmooth(PyObject *self, PyObject *arg)
     if (width && height) {
         SDL_LockSurface(newsurf);
         pgSurface_Lock(surfobj);
-        Py_BEGIN_ALLOW_THREADS;
 
         /* handle trivial case */
         if (surf->w == width && surf->h == height) {
             int y;
+            Py_BEGIN_ALLOW_THREADS;
             for (y = 0; y < height; y++) {
                 memcpy((Uint8 *)newsurf->pixels + y * newsurf->pitch,
                        (Uint8 *)surf->pixels + y * surf->pitch, width * bpp);
             }
+            Py_END_ALLOW_THREADS;
+        } else {
+            struct _module_state *st = GETSTATE(self);
+            Py_BEGIN_ALLOW_THREADS;
+            scalesmooth(surf, newsurf, st);
+            Py_END_ALLOW_THREADS;
         }
-        else {
-            scalesmooth(surf, newsurf, GETSTATE(self));
-        }
-        Py_END_ALLOW_THREADS;
+
 
         pgSurface_Unlock(surfobj);
         SDL_UnlockSurface(newsurf);


### PR DESCRIPTION
Under Python3, GETSTATE is PyModule_GetState and therefore a part of
the Python C-API (thus requiring the GIL when doing the call).
Compare with python2, where GETSTATE was just a trivial address-of
operation.

Closes: #1515
Signed-off-by: Niels Thykier <niels@thykier.net>