### PR TITLE
Added type check for pygame.sprite.LayeredDirty.set_timing_treshold()

### DIFF
--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -637,6 +637,8 @@ Sprites are not thread safe. So lock them yourself if using threads.
       Default is 1000./80 where 80 is the fps I want to switch to full screen
       mode.  This method's name is a typo and should be fixed.
 
+      :raises TypeError: if ``time_ms`` is not int or float
+
       .. ## LayeredDirty.set_timing_treshold ##
 
    .. ## pygame.sprite.LayeredDirty ##

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1226,8 +1226,14 @@ class LayeredDirty(LayeredUpdates):
         method is taking so long to update the screen that the frame rate falls
         below 80 frames per second.
 
+        Raises TypeError if time_ms is not int or float.
+
         """
-        self._time_threshold = time_ms
+        if isinstance(time_ms, (int, float)):
+            self._time_threshold = time_ms
+        else:
+            raise TypeError("Expected numeric value, got {} instead".
+                            format(time_ms.__class__.__name__))
 
 
 class GroupSingle(AbstractGroup):
@@ -1417,7 +1423,7 @@ class collide_circle_ratio(object):
         The given ratio is expected to be a floating point value used to scale
         the underlying sprite radius before checking for collisions.
 
-        When the ratio is ratio=1.0, then it behaves exactly like the 
+        When the ratio is ratio=1.0, then it behaves exactly like the
         collide_circle method.
 
         """


### PR DESCRIPTION
set_timing_treshold() used to accept all values. the problem with it is for example in this code:
```
import pygame

class Dirty(pygame.sprite.DirtySprite):
    def __init__(self):
        pygame.sprite.DirtySprite.__init__(self)
        self.image = pygame.Surface((20, 20))
        self.rect = self.image.get_rect()

pygame.init()
screen = pygame.display.set_mode((100, 100))
layered_dirty = pygame.sprite.LayeredDirty(Dirty())
layered_dirty.set_timing_treshold("a")
layered_dirty.draw(screen)
```
used to raise `TypeError: '>' not supported between instances of 'int' and 'str'` on line `layered_dirty.draw(screen)`. With it you could think you did something wrong with your draw function, but actually you made the mistake where you set_timing_treshold to string
Now it raises `TypeError: Expected numeric value, got str instead` on the line `layered_dirty.set_timing_treshold("a")`.