### PR TITLE
pygame.music.play() looping docs consistent with pygame and SDL behaviour

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -50,9 +50,8 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
    This will play the loaded music stream. If the music is already playing it
    will be restarted.
 
-   :param int loops: (optional) How many times to repeat the music after it
-       plays once. Setting it to 5 will play the music once, then repeat it 
-       5 more times, for a total of six times. Set to -1 to make the music
+   :param int loops: (optional) How many times to repeat the music. Setting it
+       to 5 will play the music five times. Set to -1 to make the music
        repeat indefinately.
 
    :param float start: (optional) The position where the music starts playing


### PR DESCRIPTION
Changes the pygame docs to correctly describe the existing behaviour of music.play(), which basically mirrors the behaviour of SDLMix_PlayMusic.

In SDL the behaviour of the loops variable is inconsistent between Sounds/Channels and Music and so pygame is too, see the SDL docs for evidence:

**SDL Docs:**

**Mix_PlayMusic:** https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC57
**Mix_PlayChannel:** https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC28

The docs say they are for Mixer 1.2 but they seem to be using the same docs for SDL 2, and the behaviour is the same.

Downsides: 
 - loops variable is inconsistent between Sounds.play() and music.play()

Upsides:
- We don't break the code of the 8,000 people who are using the loops value in it's current, wrongly documented, fashion.