### PR TITLE
Adds Fastevent module documentation 

### DIFF
--- a/docs/reST/ref/fastevent.rst
+++ b/docs/reST/ref/fastevent.rst
@@ -1,0 +1,105 @@
+.. include:: common.txt
+
+:mod:`pygame.fastevent`
+=======================
+
+.. module:: pygame.fastevent
+   :synopsis: pygame module for interacting with events and queues from multiple
+              threads.
+
+| :sl:`pygame module for interacting with events and queues`
+
+pygame.fastevent is a wrapper for Bob Pendleton's fastevent library.  It
+provides fast events for use in multithreaded environments.  When using
+pygame.fastevent, you can not use any of the pump, wait, poll, post, get,
+peek, etc. functions from pygame.event, but you should use the Event objects.
+
+
+.. function:: init
+
+   | :sl:`initialize pygame.fastevent`
+   | :sg:`init() -> None`
+
+   Initialize the pygame.fastevent module.
+
+   .. ## pygame.fastevent.init ##
+
+.. function:: get_init
+
+   | :sl:`returns True if the fastevent module is currently initialized`
+   | :sg:`get_init() -> bool`
+
+   Returns True if the pygame.fastevent module is currently initialized.
+
+   .. ## pygame.fastevent.get_init ##
+
+.. function:: pump
+
+   | :sl:`internally process pygame event handlers`
+   | :sg:`pump() -> None`
+
+   For each frame of your game, you will need to make some sort of call to the
+   event queue. This ensures your program can internally interact with the rest
+   of the operating system.
+
+   This function is not necessary if your program is consistently processing
+   events on the queue through the other :mod:`pygame.fastevent` functions.
+
+   There are important things that must be dealt with internally in the event
+   queue. The main window may need to be repainted or respond to the system. If
+   you fail to make a call to the event queue for too long, the system may
+   decide your program has locked up.
+
+   .. ## pygame.fastevent.pump ##
+
+.. function:: wait
+
+   | :sl:`wait for an event`
+   | :sg:`wait() -> Event`
+
+   Returns the current event on the queue. If there are no messages
+   waiting on the queue, this will not return until one is available.
+   Sometimes it is important to use this wait to get events from the queue,
+   it will allow your application to idle when the user isn't doing anything
+   with it.
+
+   .. ## pygame.fastevent.wait ##
+
+.. function:: poll
+
+   | :sl:`get an available event`
+   | :sg:`poll() -> Event`
+
+   Returns next event on queue. If there is no event waiting on the queue,
+   this will return an event with type NOEVENT.
+
+   .. ## pygame.fastevent.poll ##
+
+.. function:: get
+
+   | :sl:`get all events from the queue`
+   | :sg:`get() -> list of Events`
+
+   This will get all the messages and remove them from the queue.
+
+   .. ## pygame.fastevent.get ##
+
+.. function:: post
+
+   | :sl:`place an event on the queue`
+   | :sg:`post(Event) -> None`
+
+   This will post your own event objects onto the event queue. You can post
+   any event type you want, but some care must be taken. For example, if you
+   post a MOUSEBUTTONDOWN event to the queue, it is likely any code receiving
+   the event will expect the standard MOUSEBUTTONDOWN attributes to be
+   available, like 'pos' and 'button'.
+
+   Because pygame.fastevent.post() may have to wait for the queue to empty,
+   you can get into a dead lock if you try to append an event on to a full
+   queue from the thread that processes events. For that reason I do not
+   recommend using this function in the main thread of an SDL program.
+
+   .. ## pygame.fastevent.post ##
+
+.. ## pygame.fastevent ##

--- a/src_c/doc/fastevent_doc.h
+++ b/src_c/doc/fastevent_doc.h
@@ -1,0 +1,47 @@
+/* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
+#define DOC_PYGAMEFASTEVENT "pygame module for interacting with events and queues"
+#define DOC_PYGAMEFASTEVENTINIT "init() -> None\ninitialize pygame.fastevent"
+#define DOC_PYGAMEFASTEVENTGETINIT "get_init() -> bool\nreturns True if the fastevent module is currently initialized"
+#define DOC_PYGAMEFASTEVENTPUMP "pump() -> None\ninternally process pygame event handlers"
+#define DOC_PYGAMEFASTEVENTWAIT "wait() -> Event\nwait for an event"
+#define DOC_PYGAMEFASTEVENTPOLL "poll() -> Event\nget an available event"
+#define DOC_PYGAMEFASTEVENTGET "get() -> list of Events\nget all events from the queue"
+#define DOC_PYGAMEFASTEVENTPOST "post(Event) -> None\nplace an event on the queue"
+
+
+/* Docs in a comment... slightly easier to read. */
+
+/*
+
+pygame.fastevent
+pygame module for interacting with events and queues
+
+pygame.fastevent.init
+ init() -> None
+initialize pygame.fastevent
+
+pygame.fastevent.get_init
+ get_init() -> bool
+returns True if the fastevent module is currently initialized
+
+pygame.fastevent.pump
+ pump() -> None
+internally process pygame event handlers
+
+pygame.fastevent.wait
+ wait() -> Event
+wait for an event
+
+pygame.fastevent.poll
+ poll() -> Event
+get an available event
+
+pygame.fastevent.get
+ get() -> list of Events
+get all events from the queue
+
+pygame.fastevent.post
+ post(Event) -> None
+place an event on the queue
+
+*/

--- a/src_c/fastevent.c
+++ b/src_c/fastevent.c
@@ -28,6 +28,8 @@
 
 #include "pgcompat.h"
 
+#include "doc/fastevent_doc.h"
+
 #include "fastevents.h"
 
 static int FE_WasInit = 0;
@@ -48,12 +50,6 @@ fastevent_cleanup(void)
 }
 
 /* fastevent module functions */
-
-/* DOC */ static char doc_init[] =
-    /* DOC */
-    "pygame.fastevent.init() -> None\n"
-    /* DOC */ "initialize pygame.fastevent.\n"
-    /* DOC */;
 static PyObject *
 fastevent_init(PyObject *self, PyObject *args)
 {
@@ -75,47 +71,12 @@ fastevent_init(PyObject *self, PyObject *args)
 #endif /* WITH_THREAD */
 }
 
-/* DOC */ static char doc_get_init[] =
-    /* DOC */
-    "pygame.fastevent.get_init() -> bool\n"
-    /* DOC */ "returns True if the fastevent module is currently initialized\n"
-    /* DOC */;
 static PyObject *
 fastevent_get_init(PyObject *self, PyObject *args)
 {
     return PyBool_FromLong(FE_WasInit);
 }
 
-/* DOC */ static char doc_pump[] =
-    /* DOC */
-    "pygame.fastevent.pump() -> None\n"
-    /* DOC */
-    "update the internal messages\n"
-    /* DOC */
-    "\n"
-    /* DOC */
-    "For each frame of your game, you will need to make some sort\n"
-    /* DOC */
-    "of call to the event queue. This ensures your program can internally\n"
-    /* DOC */
-    "interact with the rest of the operating system. If you are not using\n"
-    /* DOC */
-    "other event functions in your game, you should call pump() to allow\n"
-    /* DOC */
-    "pygame to handle internal actions.\n"
-    /* DOC */
-    "\n"
-    /* DOC */
-    "There are important things that must be dealt with internally in the\n"
-    /* DOC */
-    "event queue. The main window may need to be repainted. Certain "
-    "joysticks\n"
-    /* DOC */
-    "must be polled for their values. If you fail to make a call to the "
-    "event\n"
-    /* DOC */
-    "queue for too long, the system may decide your program has locked up.\n"
-    /* DOC */;
 static PyObject *
 fastevent_pump(PyObject *self, PyObject *args)
 {
@@ -124,23 +85,6 @@ fastevent_pump(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-/* DOC */ static char doc_wait[] =
-    /* DOC */
-    "pygame.fastevent.wait() -> Event\n"
-    /* DOC */
-    "wait for an event\n"
-    /* DOC */
-    "\n"
-    /* DOC */
-    "Returns the current event on the queue. If there are no messages\n"
-    /* DOC */
-    "waiting on the queue, this will not return until one is\n"
-    /* DOC */
-    "available. Sometimes it is important to use this wait to get\n"
-    /* DOC */
-    "events from the queue, it will allow your application to idle\n"
-    /* DOC */ "when the user isn't doing anything with it.\n"
-    /* DOC */;
 static PyObject *
 fastevent_wait(PyObject *self, PyObject *args)
 {
@@ -160,17 +104,6 @@ fastevent_wait(PyObject *self, PyObject *args)
     return pgEvent_New(&event);
 }
 
-/* DOC */ static char doc_poll[] =
-    /* DOC */
-    "pygame.fastevent.poll() -> Event\n"
-    /* DOC */
-    "get an available event\n"
-    /* DOC */
-    "\n"
-    /* DOC */
-    "Returns next event on queue. If there is no event waiting on the\n"
-    /* DOC */ "queue, this will return an event with type NOEVENT.\n"
-    /* DOC */;
 static PyObject *
 fastevent_poll(PyObject *self, PyObject *args)
 {
@@ -188,11 +121,6 @@ fastevent_poll(PyObject *self, PyObject *args)
     }
 }
 
-/* DOC */ static char doc_get[] =
-    /* DOC */
-    "pygame.fastevent.get() -> list of Events\n"
-    /* DOC */ "get all events from the queue\n"
-    /* DOC */;
 static PyObject *
 fastevent_get(PyObject *self, PyObject *args)
 {
@@ -229,37 +157,6 @@ fastevent_get(PyObject *self, PyObject *args)
     return list;
 }
 
-/*DOC*/ static char doc_post[] =
-    /*DOC*/
-    "pygame.fastevent.post(Event) -> None\n"
-    /*DOC*/
-    "place an event on the queue\n"
-    /*DOC*/
-    "\n"
-    /*DOC*/
-    "This will post your own event objects onto the event queue.\n"
-    /*DOC*/
-    "You can past any event type you want, but some care must be\n"
-    /*DOC*/
-    "taken. For example, if you post a MOUSEBUTTONDOWN event to the\n"
-    /*DOC*/
-    "queue, it is likely any code receiving the event will expect\n"
-    /*DOC*/
-    "the standard MOUSEBUTTONDOWN attributes to be available, like\n"
-    /*DOC*/
-    "'pos' and 'button'.\n"
-    /*DOC*/
-    "\n"
-    /*DOC*/
-    "Because pygame.fastevent.post() may have to wait for the queue\n"
-    /*DOC*/
-    "to empty, you can get into a dead lock if you try to append an\n"
-    /*DOC*/
-    "event on to a full queue from the thread that processes events.\n"
-    /*DOC*/
-    "For that reason I do not recommend using this function in the\n"
-    /*DOC*/ "main thread of an SDL program.\n"
-    /*DOC*/;
 static PyObject *
 fastevent_post(PyObject *self, PyObject *arg)
 {
@@ -288,27 +185,16 @@ fastevent_post(PyObject *self, PyObject *arg)
 }
 
 static PyMethodDef _fastevent_methods[] = {
-    {"init", fastevent_init, METH_NOARGS, doc_init},
-    {"get_init", fastevent_get_init, METH_NOARGS, doc_get_init},
-    {"get", fastevent_get, METH_NOARGS, doc_get},
-    {"pump", fastevent_pump, METH_NOARGS, doc_pump},
-    {"wait", fastevent_wait, METH_NOARGS, doc_wait},
-    {"poll", fastevent_poll, METH_NOARGS, doc_poll},
-    {"post", fastevent_post, METH_O, doc_post},
+    {"init", fastevent_init, METH_NOARGS, DOC_PYGAMEFASTEVENTINIT},
+    {"get_init", fastevent_get_init, METH_NOARGS, DOC_PYGAMEFASTEVENTGETINIT},
+    {"get", fastevent_get, METH_NOARGS, DOC_PYGAMEFASTEVENTGET},
+    {"pump", fastevent_pump, METH_NOARGS, DOC_PYGAMEFASTEVENTPUMP},
+    {"wait", fastevent_wait, METH_NOARGS, DOC_PYGAMEFASTEVENTWAIT},
+    {"poll", fastevent_poll, METH_NOARGS, DOC_PYGAMEFASTEVENTPOLL},
+    {"post", fastevent_post, METH_O, DOC_PYGAMEFASTEVENTPOST},
 
     {NULL, NULL, 0, NULL}};
 
-/*DOC*/ static char doc_fastevent_MODULE[] =
-    /*DOC*/
-    "pygame.fastevent is a wrapper for Bob Pendleton's fastevent\n"
-    /*DOC*/
-    "library.  It provides fast events for use in multithreaded\n"
-    /*DOC*/
-    "environments.  When using pygame.fastevent, you can not use\n"
-    /*DOC*/
-    "any of the pump, wait, poll, post, get, peek, etc. functions\n"
-    /*DOC*/ "from pygame.event, but you should use the Event objects.\n"
-    /*DOC*/;
 MODINIT_DEFINE(fastevent)
 {
     PyObject *module, *eventmodule, *dict;
@@ -317,7 +203,7 @@ MODINIT_DEFINE(fastevent)
 #if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "fastevent",
-                                         doc_fastevent_MODULE,
+                                         DOC_PYGAMEFASTEVENT,
                                          -1,
                                          _fastevent_methods,
                                          NULL,
@@ -343,7 +229,7 @@ MODINIT_DEFINE(fastevent)
     module = PyModule_Create(&_module);
 #else
     module = Py_InitModule3(MODPREFIX "fastevent", _fastevent_methods,
-                            doc_fastevent_MODULE);
+                            DOC_PYGAMEFASTEVENT);
 #endif
     if (module == NULL) {
         MODINIT_ERROR;


### PR DESCRIPTION
This is to solve ##774

First pass is just transplanting the existing documentation from where it is buried in the code to using the existing system used by other modules so it appears in the auto generated docs.

I think this documentation also likely needs a review by someone at least passingly familiar with the fastevent module.

There are also a few issues and a related old pull request that mention the module here:

https://github.com/pygame/pygame/issues/946
https://github.com/pygame/pygame/issues/202
https://github.com/pygame/pygame/pull/1003

That may be relevent.