### PR TITLE
Document BLEND_PREMULTIPLIED Surface.blit flag

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -112,6 +112,9 @@
          ``BLEND_RGB_ADD``, ``BLEND_RGB_SUB``, ``BLEND_RGB_MULT``,
          ``BLEND_RGB_MIN``, ``BLEND_RGB_MAX``.
 
+      .. versionadded:: 1.9.2
+         Optional ``special_flags``: ``BLEND_PREMULTIPLIED``
+
       The return rectangle is the area of the affected pixels, excluding any
       pixels outside the destination Surface, or outside the clipping area.
 


### PR DESCRIPTION
this is for issue #1289 and the history of it's discovery is documented there. Think there is still more work to do on the overall issue (perhaps some support for pre-multiplying alpha when loading a file?) but knowing about this will be a huge help.

I put it as added in version 1.9.2 because I think that's when it was originally added going by the date of this commit on bitbucket (2012-04-15):
https://bitbucket.org/pygame/pygame/commits/549f3fb44e55b091bf0c3d1e33529eae5ffc812a

and the release history on PyPi - though wiser scholars on pygame's history may know more accurately.