### PR TITLE
Correction to attribute name in pygame.sprite.LayeredUpdates - it is …

### DIFF
--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -405,7 +405,7 @@ Sprites are not thread safe. So lock them yourself if using threads.
    You can set the default layer through kwargs using 'default_layer' and an
    integer for the layer. The default layer is 0.
 
-   If the sprite you add has an attribute layer then that layer will be used.
+   If the sprite you add has an attribute _layer then that layer will be used.
    If the \**kwarg contains 'layer' then the sprites passed will be added to
    that layer (overriding the ``sprite.layer`` attribute). If neither sprite
    has attribute layer nor \**kwarg then the default layer is used to add the


### PR DESCRIPTION
…_layer, not layer

The attribute name is incorrect in the documentation for pygame.sprite.LayeredUpdates. The attribute that the sprite has to have for it to be managed automatically is _layer not layer (note the leading underscore). A attribute in the sprite with the name 'layer' has no effect but '_layer' works perfectly.

Note: This is likely also true for pygame.sprite.DirtySprite where it says 'layer = 0' and it probably should say '_layer = 0' but I have not tested or investigated this, so I am only mentioning it here and not correcting it.