### PR TITLE
Add a SSE4.2 optimized version of image_tostring for some 32bit surfaces

### DIFF
--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -42,4 +42,28 @@
 #define WIN32
 #endif
 
+#ifndef PG_TARGET_SSE4_2
+#if defined(__clang__) || defined(__GNUC__)
+#define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
+/* No else; we define the fallback later */
+#endif
+#endif /* ~PG_TARGET_SSE4_2 */
+
+#ifdef PG_FUNCTION_TARGET_SSE4_2
+#if !defined(__SSE4_2__) && !defined(PG_COMPILE_SSE4_2)
+#if defined(__x86_64__) || defined(__i386__)
+#define PG_COMPILE_SSE4_2 1
+#endif
+#endif
+#endif /* ~PG_TARGET_SSE4_2 */
+
+/* Fallback definition of target attribute */
+#ifndef PG_FUNCTION_TARGET_SSE4_2
+#define PG_FUNCTION_TARGET_SSE4_2
+#endif
+
+#ifndef PG_COMPILE_SSE4_2
+#define PG_COMPILE_SSE4_2 0
+#endif
+
 #endif /* ~PG_PLATFORM_H */

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import array
+import binascii
 import os
 import tempfile
 import unittest
@@ -327,9 +328,9 @@ class ImageModuleTest(unittest.TestCase):
                             block_start,
                             block_end,
                             len(string1),
-                            block1.encode("hex"),
-                            block2.encode("hex"),
-                            source_block.encode("hex"),
+                            binascii.hexlify(block1),
+                            binascii.hexlify(block2),
+                            binascii.hexlify(source_block),
                         )
                     )
                     self.fail(msg)
@@ -396,7 +397,9 @@ class ImageModuleTest(unittest.TestCase):
         surf_b_get_at = surf_b.get_at
         for y in xrange_(a_height):
             for x in xrange_(a_width):
-                self.assertEqual(surf_a_get_at((x, y)), surf_b_get_at((x, y)), msg)
+                self.assertEqual(surf_a_get_at((x, y)),
+                                 surf_b_get_at((x, y)),
+                                 "%s (pixel: %d, %d)" % (msg, x, y))
 
     def test_fromstring__and_tostring(self):
         """Ensure methods tostring() and fromstring() are symmetric."""


### PR DESCRIPTION
Add a SSE4.2 optimized version of tostring_surf_32bpp that can speed
up operation on surfaces that satisfy certain restrictions such as:

 * have a width of at least 4 pixels
 * have masks that are at most 0xff (256)
 * do NOT use colorkeys
 * do NOT have any losses (or completely "loss out" a value)

When compiling, remember to set "-msse4.2" in CFLAGS a la:

```sh
CFLAGS="-msse4.2" python3 setup.py build
```

(Otherwise, the relevant code will not be included in the binary).

As for speed:

 * SSE4.2: 0.183ms - 0.195ms (0.189ms ± 0.006ms)
 * master: 1.606ms - 1.610ms (1.607ms ± 0.002ms)

Which is roughly a factor 8 improvement.

Benchmarked using the following code:

```python
import timeit
import pygame
import statistics

bigsurf = pygame.Surface((500,500))

def test_this_tostring():
    rgba_buf = pygame.image.tostring(bigsurf, "RGBA")

test_this = test_this_tostring

if __name__ == '__main__':
    number = 1000
    res = timeit.repeat('test_this()', number=number, setup="from __main__ import test_this")
    min_val = min(res) * 1000 / number
    max_val = max(res) * 1000 / number
    avg_val = (sum(res) * 1000 / len(res)) / number
    std_dev = statistics.stdev(res)
    print("%.3fms - %.3fms (%.3fms ± %.3fms)" % (min_val, max_val, avg_val, std_dev))

```
