### PR TITLE
Travis arm64 build, fix uploading whl files to pypi on tag push.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,14 @@ jobs:
     - python: 3.8
     - os: linux-ppc64le
       python: 3.7
+      arch: ppc64le
       env:
         - PPC=yes
+    - os: linux
+      python: 3.7
+      arch: arm64
+      env:
+        - ARM64=yes
     - os: linux
       python: 3.7
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       env:
         - MANYLINUX_WHL=yes
         - UPLOAD_WHL_PYPI=yes
+        - UPLOAD_SDIST_PYPI=yes
         - GITHUB_UPLOAD=yes
         - PYTHON_EXE=python3
       services:
@@ -103,7 +104,18 @@ script:
 
 # Upload dist/*.whl to pypi on tags.
 after_success:
-  - if [[ "${UPLOAD_WHL_PYPI}" = "yes" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ -n "${TRAVIS_TAG}" ]]; then   $PYTHON_EXE -m twine upload dist/*.whl; fi
+  - |
+    if [[ "${UPLOAD_WHL_PYPI}" = "yes" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ -n "${TRAVIS_TAG}" ]]; then
+      $PYTHON_EXE -m pip install twine
+      $PYTHON_EXE -m twine upload dist/*.whl
+    fi
+  - |
+    if [[ "${UPLOAD_SDIST_PYPI}" = "yes" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ -n "${TRAVIS_TAG}" ]]; then
+      $PYTHON_EXE -m pip install twine
+      $PYTHON_EXE -m twine upload dist/*.tar.gz
+    fi
+
+
 
 deploy:
   # https://docs.travis-ci.com/user/deployment/releases/
@@ -123,13 +135,3 @@ deploy:
       tags: true
       repo: pygame/pygame
       condition: $GITHUB_UPLOAD = yes
-
-  - provider: pypi
-    user: pygameci
-    distributions: sdist
-    on:
-      tags: true
-    password:
-      secure: "o2abs6mREyAoBzThGYiUvgnFF0y/ADtpQt/Zbdu3d79cLynuNH6X++xW+qoxumLsR5Lci/xQRCKIiRLnVYUgb+p+i79Z1K6lSMf/ElEeDCpE3ooW16fDC/mNmcf2oxTNg8exnoGilgzA5MPgLoDldTiQXUuRPDwM5LYTJ8T1ypJrqP+U2GD2GynX6AJ00KkqMGsdlh8Ii3XW853YlBo1cbUc8f1LJWj8wdIrrGViG0zSNVAPnoVKehxjnu1s7N4yQmq4TFxB0+vL/cGovCazzcpJqOfhpRzJKMUqN8cuFxPj3YuFZAS3J1aqy+T8bnahmt50u5HBFfN1nlfyWpYEyGfiqUpmKSFCKYWaQupC7KIOUWqMR1QGkeKZfbmX7lJOAz1m51mc900lsKEhvBtnyJqNgFljtk4MtygwmyW4ykno4oR95+7plco4yucWSo+cm+iYOKcdLhwQujveQwbv35Jgh1E1aw0dXjP8iVIr9Hnzz3r039ifqUkRb0SP6eViJBdXABRnJgpceuGpYkliSLDK2nvspcE9bdfgbfSrVbZ9O5I5sNtyosMRFnPEKky6UOQjAFL0HrAaqhGyXMK3WHgp8Pwunk9ZHL2/hcVyv9EWVkoj87rQZwOTSqcXHCxiDb5ulyWQU1MHR6PoRf7UXXtTgcyDKGs/0jDRDkK1gNo="
-    skip_cleanup: true
-    skip_existing: true


### PR DESCRIPTION
Here are the docs for the travis multi architecture support:
https://docs.travis-ci.com/user/multi-cpu-architectures/

Here's the successful:
- build: https://travis-ci.org/github/pygame/pygame/builds/685551669 (Note the `Arm64` label)
- arm64 job in that build: https://travis-ci.org/github/pygame/pygame/jobs/685551676

---

For uploading wheels in the last release I did(2.0.0.dev8), the wheels didn't upload on the travis ci manylinux build. I had to build them manually, and then upload them.

The travis ci sdist upload part was removed because it also uploaded linux .egg files which we don't want to do.