### PR TITLE
SDL1 build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
   include:
     - python: 2.7
     - python: 3.5
+      env:
+        - WHICH_SDL_BUILD=-sdl1
     - python: 3.6
     - python: 3.7
     - python: 3.8
@@ -69,6 +71,7 @@ install:
       PYTHON_EXE=python PIP_CMD=pip
       $PIP_CMD install --upgrade pip
       $PIP_CMD install --upgrade numpy
+      $PYTHON_EXE setup.py -config -auto $WHICH_SDL_BUILD
       $PYTHON_EXE setup.py install -pygame-ci -noheaders -auto
     fi
   - |

--- a/buildconfig/Setup.SDL1.in
+++ b/buildconfig/Setup.SDL1.in
@@ -40,7 +40,7 @@ gfxdraw src_c/gfxdraw.c $(SDL) $(GFX) $(DEBUG)
 #or the configuration script will choke!)
 _freetype src_c/freetype/ft_cache.c src_c/freetype/ft_wrap.c src_c/freetype/ft_render.c  src_c/freetype/ft_render_cb.c src_c/freetype/ft_layout.c src_c/freetype/ft_unicode.c src_c/_freetype.c $(SDL) $(FREETYPE) $(DEBUG)
 
-_sprite src_c/_sprite.c $(DEBUG)
+#_sprite src_c/_sprite.c $(SDL) $(DEBUG)
 
 #these modules are required for pygame to run. they only require
 #SDL as a dependency. these should not be altered

--- a/buildconfig/Setup.SDL2.in
+++ b/buildconfig/Setup.SDL2.in
@@ -17,7 +17,7 @@ PORTTIME = -lporttime
 FREETYPE = -lfreetype
 #--EndConfig
 
-DEBUG =
+DEBUG = 
 
 #the following modules are optional. you will want to compile
 #everything you can, but you can ignore ones you don't have

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -713,7 +713,9 @@ static PyObject *
 key_code(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     const char * name;
+#if IS_SDLv2
     SDL_Keycode code;
+#endif
 
     static char *kwids[] = {
         "name",

--- a/src_c/pgcompat.h
+++ b/src_c/pgcompat.h
@@ -195,7 +195,7 @@
 
 
 #if defined(SDL_VERSION_ATLEAST)
-#if !(SDL_VERSION_ATLEAST(2, 0, 5))
+#if (SDL_VERSION_ATLEAST(2, 0, 0)) && !(SDL_VERSION_ATLEAST(2, 0, 5))
 /* These functions require SDL 2.0.5 or greater.
 
   https://wiki.libsdl.org/SDL_SetWindowResizable


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/1718

- fixes a few SDL1 build problems
- makes the travis CI linux python 3.5 worker use SDL1 (so we have one robot catching SDL1 issues). Note, that the manylinux build also tests python 3.5 with SDL2 on linux.