### PR TITLE
small speedup: Use Surface.blits in sprite.Group.draw.

### DIFF
--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -471,9 +471,12 @@ class AbstractGroup(object):
 
         """
         sprites = self.sprites()
-        surface_blit = surface.blit
-        for spr in sprites:
-            self.spritedict[spr] = surface_blit(spr.image, spr.rect)
+        self.spritedict.update(
+            zip(
+                sprites,
+                surface.blits((spr.image, spr.rect) for spr in sprites)
+            )
+        )
         self.lostsprites = []
 
     def clear(self, surface, bgd):

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -542,6 +542,9 @@ class AbstractGroupTypeTest(unittest.TestCase):
         self.assertEqual((255, 0, 0, 255), self.scr.get_at((5, 5)))
         self.assertEqual((0, 255, 0, 255), self.scr.get_at((15, 5)))
 
+        self.assertEqual(self.ag.spritedict[self.s1], pygame.Rect(0, 0, 10, 10))
+        self.assertEqual(self.ag.spritedict[self.s2], pygame.Rect(10, 0, 10, 10))
+
     def test_empty(self):
 
         self.ag.empty()


### PR DESCRIPTION
Should be able to compare with this benchmark:
```
python3 examples/testsprite.py -noupdate_rects 10000
```