### PR TITLE
Add 'bgcolor' attribute to freetype font to mirror existing 'fgcolor'

### DIFF
--- a/buildconfig/pygame-stubs/freetype.pyi
+++ b/buildconfig/pygame-stubs/freetype.pyi
@@ -53,6 +53,7 @@ class Font:
     vertical: bool
     rotation: int
     fgcolor: Color
+    bgcolor: Color
     origin: bool
     pad: bool
     ucs4: bool

--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -702,6 +702,17 @@ loaded. This module must be imported explicitly to be used. ::
       Gets or sets the default glyph rendering color. It is initially opaque
       black ― (0, 0, 0, 255). Applies to :meth:`render` and :meth:`render_to`.
 
+   .. attribute:: bgcolor
+
+      | :sl:`default background color`
+      | :sg:`bgcolor -> Color`
+
+      Gets or sets the default background rendering color. Initially it is
+      unset and text will render with a transparent background by default.
+      Applies to :meth:`render` and :meth:`render_to`.
+
+   .. versionadded:: 2.0.0
+
    .. attribute:: origin
 
       | :sl:`Font render to text origin mode`

--- a/src_c/doc/freetype_doc.h
+++ b/src_c/doc/freetype_doc.h
@@ -45,6 +45,7 @@
 #define DOC_FONTVERTICAL "vertical -> bool\nFont vertical mode"
 #define DOC_FONTROTATION "rotation -> int\ntext rotation in degrees counterclockwise"
 #define DOC_FONTFGCOLOR "fgcolor -> Color\ndefault foreground color"
+#define DOC_FONTBGCOLOR "bgcolor -> Color\ndefault background color"
 #define DOC_FONTORIGIN "origin -> bool\nFont render to text origin mode"
 #define DOC_FONTPAD "pad -> bool\npadded boundary mode"
 #define DOC_FONTUCS4 "ucs4 -> bool\nEnable UCS-4 mode"
@@ -240,6 +241,10 @@ text rotation in degrees counterclockwise
 pygame.freetype.Font.fgcolor
  fgcolor -> Color
 default foreground color
+
+pygame.freetype.Font.bgcolor
+ bgcolor -> Color
+default background color
 
 pygame.freetype.Font.origin
  origin -> bool

--- a/src_c/freetype.h
+++ b/src_c/freetype.h
@@ -95,6 +95,7 @@ typedef struct {
     pgFontId id;
     PyObject *path;
     int is_scalable;
+    int is_bg_col_set;
 
     Scale_t face_size;
     FT_Int16 style;
@@ -105,6 +106,7 @@ typedef struct {
     Angle_t rotation;
     FT_Matrix transform;
     FT_Byte fgcolor[4];
+    FT_Byte bgcolor[4];
 
     struct freetypeinstance_ *freetype;  /* Personal reference */
     struct fontinternals_ *_internals;

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1229,6 +1229,39 @@ class FreeTypeFontTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, setattr, f, "fgcolor", None)
 
+    def test_freetype_Font_bgcolor(self):
+        f = ft.Font(None, 12)
+        zero = "0"  # the default font 0 glyph does not have a pixel at (0, 0)
+        f.origin = False
+        f.pad = False
+
+        transparent_black = pygame.Color(0, 0, 0, 0)  # initial color
+        green = pygame.Color("green")
+        alpha128 = pygame.Color(10, 20, 30, 128)
+
+        c = f.bgcolor
+        self.assertIsInstance(c, pygame.Color)
+        self.assertEqual(c, transparent_black)
+
+        s, r = f.render(zero, pygame.Color(255, 255, 255))
+        self.assertEqual(s.get_at((0, 0)), transparent_black)
+
+        f.bgcolor = green
+        self.assertEqual(f.bgcolor, green)
+
+        s, r = f.render(zero)
+        self.assertEqual(s.get_at((0, 0)), green)
+
+        f.bgcolor = alpha128
+        s, r = f.render(zero)
+        self.assertEqual(s.get_at((0, 0)), alpha128)
+
+        surf = pygame.Surface(f.get_rect(zero).size, pygame.SRCALPHA, 32)
+        f.render_to(surf, (0, 0), None)
+        self.assertEqual(surf.get_at((0, 0)), alpha128)
+
+        self.assertRaises(AttributeError, setattr, f, "bgcolor", None)
+
     @unittest.skipIf(not pygame.HAVE_NEWBUF, "newbuf not implemented")
     def test_newbuf(self):
         from pygame.tests.test_utils import buftools


### PR DESCRIPTION
This is to close this issue:

https://github.com/pygame/pygame/issues/998

And lets you set a default background colour for a freetype font after you've loaded it - just as you can currently do for the foreground/glyph colour.