### PR TITLE
sysfont: Update windows, and ubuntu xenial font names and tests.

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -245,13 +245,16 @@ def create_aliases():
     alias_groups = (
         ('monospace', 'misc-fixed', 'courier', 'couriernew', 'console',
          'fixed', 'mono', 'freemono', 'bitstreamverasansmono',
-         'verasansmono', 'monotype', 'lucidaconsole', 'consolas'),
+         'verasansmono', 'monotype', 'lucidaconsole', 'consolas',
+         'dejavusansmono', 'liberationmono'),
         ('sans', 'arial', 'helvetica', 'swiss', 'freesans',
          'bitstreamverasans', 'verasans', 'verdana', 'tahoma',
-         'calibri', 'gillsans', 'segoeui', 'trebuchetms', 'ubuntu'),
+         'calibri', 'gillsans', 'segoeui', 'trebuchetms', 'ubuntu',
+         'dejavusans', 'liberationsans'),
         ('serif', 'times', 'freeserif', 'bitstreamveraserif', 'roman',
          'timesroman', 'timesnewroman', 'dutch', 'veraserif',
-         'georgia', 'cambria', 'constantia'),
+         'georgia', 'cambria', 'constantia', 'dejavuserif',
+         'liberationserif'),
         ('wingdings', 'wingbats'),
     )
     for alias_set in alias_groups:

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -248,7 +248,7 @@ def create_aliases():
          'verasansmono', 'monotype', 'lucidaconsole', 'consolas'),
         ('sans', 'arial', 'helvetica', 'swiss', 'freesans',
          'bitstreamverasans', 'verasans', 'verdana', 'tahoma',
-         'calibri', 'gillsans', 'segoeui', 'trebuchetms'),
+         'calibri', 'gillsans', 'segoeui', 'trebuchetms', 'ubuntu'),
         ('serif', 'times', 'freeserif', 'bitstreamveraserif', 'roman',
          'timesroman', 'timesnewroman', 'dutch', 'veraserif',
          'georgia', 'cambria', 'constantia'),

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -245,12 +245,13 @@ def create_aliases():
     alias_groups = (
         ('monospace', 'misc-fixed', 'courier', 'couriernew', 'console',
          'fixed', 'mono', 'freemono', 'bitstreamverasansmono',
-         'verasansmono', 'monotype', 'lucidaconsole'),
+         'verasansmono', 'monotype', 'lucidaconsole', 'consolas'),
         ('sans', 'arial', 'helvetica', 'swiss', 'freesans',
-         'bitstreamverasans', 'verasans', 'verdana', 'tahoma'),
+         'bitstreamverasans', 'verasans', 'verdana', 'tahoma',
+         'calibri', 'gillsans', 'segoeui', 'trebuchetms'),
         ('serif', 'times', 'freeserif', 'bitstreamveraserif', 'roman',
          'timesroman', 'timesnewroman', 'dutch', 'veraserif',
-         'georgia'),
+         'georgia', 'cambria', 'constantia'),
         ('wingdings', 'wingbats'),
     )
     for alias_set in alias_groups:

--- a/test/sysfont_test.py
+++ b/test/sysfont_test.py
@@ -7,7 +7,11 @@ class SysfontModuleTest(unittest.TestCase):
         import pygame.sysfont
         pygame.sysfont.initsysfonts()
         pygame.sysfont.create_aliases()
-        self.assertTrue(len(pygame.sysfont.Sysalias) > 0)
+
+        # failing test to get Travis xenial font list
+        self.maxDiff = 5000
+        self.assertEqual(pygame.sysfont.get_fonts(), ['ubuntu'])
+        # self.assertTrue(len(pygame.sysfont.Sysalias) > 0)
 
     def test_initsysfonts(self):
         import pygame.sysfont
@@ -25,6 +29,7 @@ class SysfontModuleTest(unittest.TestCase):
 
         pygame.font.init()
         arial = pygame.font.SysFont("Arial", 40)
+        self.assertTrue(isinstance(arial, pygame.font.Font))
 
     @unittest.skipIf(("Darwin" in platform.platform() or
                       "Windows" in platform.platform()), "Not unix we skip.")
@@ -41,7 +46,7 @@ class SysfontModuleTest(unittest.TestCase):
         self.assertTrue(len(pygame.sysfont.get_fonts()) > 10)
 
 
-################################################################################
+###############################################################################
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/sysfont_test.py
+++ b/test/sysfont_test.py
@@ -3,11 +3,16 @@ import platform
 
 
 class SysfontModuleTest(unittest.TestCase):
-    def todo_test_create_aliases(self):
-        self.fail()
+    def test_create_aliases(self):
+        import pygame.sysfont
+        pygame.sysfont.initsysfonts()
+        pygame.sysfont.create_aliases()
+        self.assertTrue(len(pygame.sysfont.Sysalias) > 0)
 
-    def todo_test_initsysfonts(self):
-        self.fail()
+    def test_initsysfonts(self):
+        import pygame.sysfont
+        pygame.sysfont.initsysfonts()
+        self.assertTrue(len(pygame.sysfont.get_fonts()) > 1)
 
     @unittest.skipIf("Darwin" not in platform.platform(), "Not mac we skip.")
     def test_initsysfonts_darwin(self):
@@ -21,11 +26,19 @@ class SysfontModuleTest(unittest.TestCase):
         pygame.font.init()
         arial = pygame.font.SysFont("Arial", 40)
 
-    def todo_test_initsysfonts_unix(self):
-        self.fail()
+    @unittest.skipIf(("Darwin" in platform.platform() or
+                      "Windows" in platform.platform()), "Not unix we skip.")
+    def test_initsysfonts_unix(self):
+        import pygame.sysfont
 
-    def todo_test_initsysfonts_win32(self):
-        self.fail()
+        self.assertTrue(len(pygame.sysfont.get_fonts()) > 1)
+
+    @unittest.skipIf("Windows" not in platform.platform(),
+                     "Not windows we skip.")
+    def test_initsysfonts_win32(self):
+        import pygame.sysfont
+
+        self.assertTrue(len(pygame.sysfont.get_fonts()) > 10)
 
 
 ################################################################################

--- a/test/sysfont_test.py
+++ b/test/sysfont_test.py
@@ -7,11 +7,7 @@ class SysfontModuleTest(unittest.TestCase):
         import pygame.sysfont
         pygame.sysfont.initsysfonts()
         pygame.sysfont.create_aliases()
-
-        # failing test to get Travis xenial font list
-        self.maxDiff = 5000
-        self.assertEqual(pygame.sysfont.get_fonts(), ['ubuntu'])
-        # self.assertTrue(len(pygame.sysfont.Sysalias) > 0)
+        self.assertTrue(len(pygame.sysfont.Sysalias) > 0)
 
     def test_initsysfonts(self):
         import pygame.sysfont


### PR DESCRIPTION
Trying to close off this issue here:

https://github.com/pygame/pygame/issues/179

Someone has already done the code on windows to automatically collect the installed system fonts, but the list in create aliases was out of date so I went through it and added standard fonts from more recent versions of windows.

I also noticed we weren't really testing this module, possibly for good reason, but I thought I'd try some basic multi-platform tests anyway. 