### PR TITLE
Add pgRect_Normalize to C API

### DIFF
--- a/docs/reST/c_api/rect.rst
+++ b/docs/reST/c_api/rect.rst
@@ -72,3 +72,8 @@ Header file: src_c/include/pygame.h
    On success return a pointer to a :c:type:`GAME_Rect` representation
    of the rectangle.
    One failure may raise a Python exception before returning *NULL*.
+
+.. c:function:: void pgRect_Normalize(GAME_Rect *rect)
+
+   Normalize the given rect. A rect with a negative size (negative width and/or
+   height) will be adjusted to have a positive size.

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -217,7 +217,7 @@ struct pgColorObject {
  * Remember to keep these constants up to date.
  */
 
-#define PYGAMEAPI_RECT_NUMSLOTS 4
+#define PYGAMEAPI_RECT_NUMSLOTS 5
 #define PYGAMEAPI_JOYSTICK_NUMSLOTS 2
 #define PYGAMEAPI_DISPLAY_NUMSLOTS 2
 #define PYGAMEAPI_SURFACE_NUMSLOTS 4

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -241,6 +241,8 @@ typedef struct {
     (*(GAME_Rect * (*)(PyObject *, GAME_Rect *)) \
         PYGAMEAPI_GET_SLOT(rect, 3))
 
+#define pgRect_Normalize (*(void (*)(GAME_Rect *)) PYGAMEAPI_GET_SLOT(rect, 4))
+
 #define import_pygame_rect() IMPORT_PYGAME_MODULE(rect)
 #endif /* ~PYGAMEAPI_RECT_INTERNAL */
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -2139,6 +2139,7 @@ MODINIT_DEFINE(rect)
     c_api[1] = pgRect_New;
     c_api[2] = pgRect_New4;
     c_api[3] = pgRect_FromObject;
+    c_api[4] = pgRect_Normalize;
     apiobj = encapsulate_api(c_api, "rect");
     if (apiobj == NULL) {
         DECREF_MOD(module);


### PR DESCRIPTION
This is prep work related to adding the `area` kwarg to `Mask.to_surface` (#1070).

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev9 (SDL: 2.0.12) at 6df1c80df92fe7ff9e401351b4f548b21e09e3c0
