### PR TITLE
MSVC compiler optimisation hinting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -563,7 +563,6 @@ if sys.platform == 'win32':
         """
         from distutils.errors import CompileError
         import tempfile
-        import os
         with tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False) as f:
             f.write('int main (int argc, char **argv) { return 0; }')
             fname = f.name

--- a/setup.py
+++ b/setup.py
@@ -557,6 +557,31 @@ if sys.platform == 'win32':
         else:
             pygame_data_files.append(f)
 
+    def has_flag(compiler, flagname):
+        """
+        Adapted from here: https://github.com/pybind/python_example/blob/master/setup.py#L37
+        """
+        from distutils.errors import CompileError
+        import tempfile
+        import os
+        with tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False) as f:
+            f.write('int main (int argc, char **argv) { return 0; }')
+            fname = f.name
+        try:
+            compiler.compile([fname], extra_postargs=[flagname])
+        except CompileError:
+            return False
+        finally:
+            try:
+                os.remove(fname)
+            except OSError:
+                pass
+        return True
+
+    # filter flags, returns list of accepted flags
+    def flag_filter(compiler, *flags):
+        return [flag for flag in flags if has_flag(compiler, flag)]
+
     class WinBuildExt(build_ext):
         """This build_ext sets necessary environment variables for MinGW"""
 
@@ -567,6 +592,14 @@ if sys.platform == 'win32':
             if e.name == 'base':
                 __sdl_lib_dir = e.library_dirs[0].replace('/', os.sep)
                 break
+
+        def build_extensions(self):
+            # Add supported optimisations flags to reduce code size with MSVC
+            opts = flag_filter(self.compiler, "/GF", "/Gy")
+            for extension in extensions:
+                extension.extra_compile_args += opts
+
+            build_ext.build_extensions(self)
 
     cmdclass['build_ext'] = WinBuildExt
 

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -21,6 +21,21 @@
 #endif
 #endif /* ~PG_INLINE */
 
+// Worth trying this on MSVC/win32 builds to see if provides any speed up
+#ifndef PG_FORCEINLINE
+#if defined(__clang__)
+#define PG_INLINE __inline__ __attribute__((__unused__))
+#elif defined(__GNUC__)
+#define PG_INLINE __inline__
+#elif defined(_MSC_VER)
+#define PG_INLINE __forceinline
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define PG_INLINE inline
+#else
+#define PG_INLINE
+#endif
+#endif /* ~PG_INLINE */
+
 /* This is unconditionally defined in Python.h */
 #if defined(_POSIX_C_SOURCE)
 #undef _POSIX_C_SOURCE


### PR DESCRIPTION
Related to this issue:
https://github.com/pygame/pygame/issues/1403

So far the code I've added to setup.py adds two flags to the extension modules compile process when the system is 'win32' and the compiler supports the two flags. These flags both serve to reduce the size of the generated c code reducing our overall .egg file size by just under 1%.
