### PR TITLE
Correct font types to match docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -563,7 +563,6 @@ if sys.platform == 'win32':
         """
         from distutils.errors import CompileError
         import tempfile
-        import os
         with tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False) as f:
             f.write('int main (int argc, char **argv) { return 0; }')
             fname = f.name

--- a/setup.py
+++ b/setup.py
@@ -557,6 +557,31 @@ if sys.platform == 'win32':
         else:
             pygame_data_files.append(f)
 
+    def has_flag(compiler, flagname):
+        """
+        Adapted from here: https://github.com/pybind/python_example/blob/master/setup.py#L37
+        """
+        from distutils.errors import CompileError
+        import tempfile
+        import os
+        with tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False) as f:
+            f.write('int main (int argc, char **argv) { return 0; }')
+            fname = f.name
+        try:
+            compiler.compile([fname], extra_postargs=[flagname])
+        except CompileError:
+            return False
+        finally:
+            try:
+                os.remove(fname)
+            except OSError:
+                pass
+        return True
+
+    # filter flags, returns list of accepted flags
+    def flag_filter(compiler, *flags):
+        return [flag for flag in flags if has_flag(compiler, flag)]
+
     class WinBuildExt(build_ext):
         """This build_ext sets necessary environment variables for MinGW"""
 
@@ -567,6 +592,14 @@ if sys.platform == 'win32':
             if e.name == 'base':
                 __sdl_lib_dir = e.library_dirs[0].replace('/', os.sep)
                 break
+
+        def build_extensions(self):
+            # Add supported optimisations flags to reduce code size with MSVC
+            opts = flag_filter(self.compiler, "/GF", "/Gy")
+            for extension in extensions:
+                extension.extra_compile_args += opts
+
+            build_ext.build_extensions(self)
 
     cmdclass['build_ext'] = WinBuildExt
 

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -266,7 +266,7 @@ static PyObject *
 font_get_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyInt_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_BOLD) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_BOLD) != 0);
 }
 
 static PyObject *
@@ -274,8 +274,11 @@ font_set_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
-
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "p", &val))
+#else
     if (!PyArg_ParseTuple(args, "i", &val))
+#endif /* PY3 */
         return NULL;
 
     style = TTF_GetFontStyle(font);
@@ -292,7 +295,7 @@ static PyObject *
 font_get_italic(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyInt_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_ITALIC) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_ITALIC) != 0);
 }
 
 static PyObject *
@@ -301,7 +304,11 @@ font_set_italic(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
 
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "p", &val))
+#else
     if (!PyArg_ParseTuple(args, "i", &val))
+#endif /* PY3 */
         return NULL;
 
     style = TTF_GetFontStyle(font);
@@ -318,7 +325,7 @@ static PyObject *
 font_get_underline(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyInt_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_UNDERLINE) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_UNDERLINE) != 0);
 }
 
 static PyObject *
@@ -327,7 +334,11 @@ font_set_underline(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
 
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "p", &val))
+#else
     if (!PyArg_ParseTuple(args, "i", &val))
+#endif /* PY3 */
         return NULL;
 
     style = TTF_GetFontStyle(font);
@@ -352,10 +363,18 @@ font_render(PyObject *self, PyObject *args)
     SDL_Color foreg, backg;
     int just_return;
 
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "OpO|O", &text, &aa, &fg_rgba_obj,
+                          &bg_rgba_obj)) {
+        return NULL;
+    }
+#else
     if (!PyArg_ParseTuple(args, "OiO|O", &text, &aa, &fg_rgba_obj,
                           &bg_rgba_obj)) {
         return NULL;
     }
+#endif /* PY3 */
+
 
     if (!pg_RGBAFromFuzzyColorObj(fg_rgba_obj, rgba)) {
         /* Exception already set for us */

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -21,6 +21,21 @@
 #endif
 #endif /* ~PG_INLINE */
 
+// Worth trying this on MSVC/win32 builds to see if provides any speed up
+#ifndef PG_FORCEINLINE
+#if defined(__clang__)
+#define PG_INLINE __inline__ __attribute__((__unused__))
+#elif defined(__GNUC__)
+#define PG_INLINE __inline__
+#elif defined(_MSC_VER)
+#define PG_INLINE __forceinline
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define PG_INLINE inline
+#else
+#define PG_INLINE
+#endif
+#endif /* ~PG_INLINE */
+
 /* This is unconditionally defined in Python.h */
 #if defined(_POSIX_C_SOURCE)
 #undef _POSIX_C_SOURCE


### PR DESCRIPTION
This in reference to the type hint fixes branch conversation about the font functions here:

https://github.com/pygame/pygame/pull/1817

In short the functions:

    get_bold()
    get_italic()
    get_underline()

currently return int types despite the docs saying they return bools. This doesn't make much difference with no typing as ints and bools are effectively the same thing underneath, but now we have type hints we should probably return the correct types.

I'm less certain about the changes to:

    set_bold()
    set_italic()
    set_underline()
    render()

because the 'p' format string for bool input was only introduced in Python 3.3 (see: https://docs.python.org/3/c-api/arg.html). Do we support python 3.2 or is it safe to just #ifdef for python 2 like I have done here?
