### PR TITLE
Attempt to correct python types for font functions

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -266,7 +266,7 @@ static PyObject *
 font_get_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyInt_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_BOLD) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_BOLD) != 0);
 }
 
 static PyObject *
@@ -274,8 +274,11 @@ font_set_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
-
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "p", &val))
+#else
     if (!PyArg_ParseTuple(args, "i", &val))
+#endif /* PY3 */
         return NULL;
 
     style = TTF_GetFontStyle(font);
@@ -292,7 +295,7 @@ static PyObject *
 font_get_italic(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyInt_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_ITALIC) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_ITALIC) != 0);
 }
 
 static PyObject *
@@ -301,7 +304,11 @@ font_set_italic(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
 
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "p", &val))
+#else
     if (!PyArg_ParseTuple(args, "i", &val))
+#endif /* PY3 */
         return NULL;
 
     style = TTF_GetFontStyle(font);
@@ -318,7 +325,7 @@ static PyObject *
 font_get_underline(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyInt_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_UNDERLINE) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_UNDERLINE) != 0);
 }
 
 static PyObject *
@@ -327,7 +334,11 @@ font_set_underline(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
 
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "p", &val))
+#else
     if (!PyArg_ParseTuple(args, "i", &val))
+#endif /* PY3 */
         return NULL;
 
     style = TTF_GetFontStyle(font);
@@ -352,10 +363,18 @@ font_render(PyObject *self, PyObject *args)
     SDL_Color foreg, backg;
     int just_return;
 
+#ifdef PY3
+    if (!PyArg_ParseTuple(args, "OpO|O", &text, &aa, &fg_rgba_obj,
+                          &bg_rgba_obj)) {
+        return NULL;
+    }
+#else
     if (!PyArg_ParseTuple(args, "OiO|O", &text, &aa, &fg_rgba_obj,
                           &bg_rgba_obj)) {
         return NULL;
     }
+#endif /* PY3 */
+
 
     if (!pg_RGBAFromFuzzyColorObj(fg_rgba_obj, rgba)) {
         /* Exception already set for us */

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -274,7 +274,7 @@ font_set_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
-#ifdef PY3
+#if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
 #else
     if (!PyArg_ParseTuple(args, "i", &val))
@@ -304,7 +304,7 @@ font_set_italic(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
 
-#ifdef PY3
+#if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
 #else
     if (!PyArg_ParseTuple(args, "i", &val))
@@ -334,7 +334,7 @@ font_set_underline(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int style, val;
 
-#ifdef PY3
+#if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
 #else
     if (!PyArg_ParseTuple(args, "i", &val))
@@ -363,7 +363,7 @@ font_render(PyObject *self, PyObject *args)
     SDL_Color foreg, backg;
     int just_return;
 
-#ifdef PY3
+#if PY3
     if (!PyArg_ParseTuple(args, "OpO|O", &text, &aa, &fg_rgba_obj,
                           &bg_rgba_obj)) {
         return NULL;


### PR DESCRIPTION
This in reference to the type hint fixes branch conversation about the font functions here:

https://github.com/pygame/pygame/pull/1817

In short the functions:

    get_bold()
    get_italic()
    get_underline()

currently return int types despite the docs saying they return bools. This doesn't make much difference with no typing as ints and bools are effectively the same thing underneath, but now we have type hints we should probably return the correct types.

I'm less certain about the changes to:

    set_bold()
    set_italic()
    set_underline()
    render()

because the 'p' format string for bool input was only introduced in Python 3.3 (see: https://docs.python.org/3/c-api/arg.html). Do we support python 3.2 or is it safe to just #ifdef for python 2 like I have done here?
