### PR TITLE
Adds test for surface.mustlock()

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1181,10 +1181,17 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(surf.get_at((0, 0)), color)
 
     def test_mustlock(self):
+        #Test that subsurfaces mustlock
         surf = pygame.Surface((4,4))
         subsurf=surf.subsurface(pygame.Rect(1,1,2,2))
         self.assertTrue(subsurf.mustlock())
         self.assertFalse(surf.mustlock())
+        #Test RLEACCEL flag in set_colorkey
+        surf = pygame.Surface((100,100))
+        blit_surf = pygame.Surface((100,100))
+        blit_surf.set_colorkey((0,0,255), RLEACCEL)
+        surf.blit(blit_surf,(0,0))
+        self.assertTrue(blit_surf.mustlock())
 
     def test_set_alpha_none(self):
         """surf.set_alpha(None) disables blending"""

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1180,25 +1180,11 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         surf.set_at((0, 0), c)
         self.assertEqual(surf.get_at((0, 0)), color)
 
-    def todo_test_mustlock(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.surface.Surface.mustlock:
-
-        # Surface.mustlock(): return bool
-        # test if the Surface requires locking
-        #
-        # Returns True if the Surface is required to be locked to access pixel
-        # data. Usually pure software Surfaces do not require locking. This
-        # method is rarely needed, since it is safe and quickest to just lock
-        # all Surfaces as needed.
-        #
-        # All pygame functions will automatically lock and unlock the Surface
-        # data as needed. If a section of code is going to make calls that
-        # will repeatedly lock and unlock the Surface many times, it can be
-        # helpful to wrap the block inside a lock and unlock pair.
-        #
-
-        self.fail()
+    def test_mustlock(self):
+        surf = pygame.Surface((4,4))
+        subsurf=surf.subsurface(pygame.Rect(1,1,2,2))
+        self.assertTrue(subsurf.mustlock())
+        self.assertFalse(surf.mustlock())
 
     def test_set_alpha_none(self):
         """surf.set_alpha(None) disables blending"""

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1182,10 +1182,19 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 
     def test_mustlock(self):
         #Test that subsurfaces mustlock
-        surf = pygame.Surface((4,4))
-        subsurf=surf.subsurface(pygame.Rect(1,1,2,2))
+        surf = pygame.Surface((1024,1024))
+        subsurf=surf.subsurface((0,0,1024,1024))
         self.assertTrue(subsurf.mustlock())
         self.assertFalse(surf.mustlock())
+        #Tests nested subsurfaces
+        rects = ((0,0,512,512),(0,0,256,256),(0,0,128,128))
+        surf_stack = []
+        surf_stack.append(surf)
+        surf_stack.append(subsurf)
+        for rect in rects:
+            surf_stack.append(surf_stack[-1].subsurface(rect))
+            self.assertTrue(surf_stack[-1].mustlock())
+            self.assertTrue(surf_stack[-2].mustlock())
         #Test RLEACCEL flag in set_colorkey
         surf = pygame.Surface((100,100))
         blit_surf = pygame.Surface((100,100))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1200,7 +1200,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         blit_surf = pygame.Surface((100,100))
         blit_surf.set_colorkey((0,0,255), RLEACCEL)
         surf.blit(blit_surf,(0,0))
-        self.assertTrue(blit_surf.mustlock())
+        self.assertEqual(blit_surf.mustlock(),(blit_surf.get_flags() & pygame.RLEACCEL) !=0)
 
     def test_set_alpha_none(self):
         """surf.set_alpha(None) disables blending"""


### PR DESCRIPTION
#1812 
I'm writing tests for Surface.mustlock()
The only case I could find was subsurfaces. 
Another case might be when the HWSURFACE flag is set, but in this case on my machine the surface still returns False on mustlock(). 
I'm not sure what causes this, any feedback would be appreciated.