### PR TITLE
Try out some SDL1 tests for the overlay module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
       $PIP_CMD install --upgrade pip
       $PIP_CMD install --upgrade numpy
       $PYTHON_EXE setup.py -config -auto $WHICH_SDL_BUILD
-      $PYTHON_EXE setup.py install -pygame-ci -noheaders -auto
+      $PYTHON_EXE setup.py install -pygame-ci -noheaders
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ -n "$TRAVIS_TAG" ]]; then

--- a/examples/overlay.py
+++ b/examples/overlay.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ pygame.examples.overlay
 
 The overlay module is deprecated now.
@@ -11,30 +10,28 @@ from pygame.compat import xrange_
 SR = (800, 600)
 ovl = None
 
+
 ########################################################################
 # Simple video player
 def vPlayer(fName):
     global ovl
     f = open(fName, "rb")
-    fmt = f.readline().strip()
-    res = f.readline().strip()
+    fmt = f.readline().strip().decode()
+    res = f.readline().strip().decode()
     unused_col = f.readline().strip()
     if fmt != "P5":
-        print("Unknown format( len %d ). Exiting..." % len(fmt))
+        print("Unknown format: %s ( len %d ). Exiting..." % (fmt, len(fmt)))
         return
 
     w, h = [int(x) for x in res.split(" ")]
-    h = (h * 2) / 3
+    h = int((h * 2) / 3)
     # Read into strings
     y = f.read(w * h)
-    u = []
-    v = []
-    for _ in xrange_(0, h / 2):
-        u.append(f.read(w / 2))
-        v.append(f.read(w / 2))
-
-    u = "".join(u)
-    v = "".join(v)
+    u = b''
+    v = b''
+    for _ in xrange_(0, int(h / 2)):
+        u += (f.read(int(w / 2)))
+        v += (f.read(int(w / 2)))
 
     # Open overlay with the resolution specified
     ovl = pg.Overlay(pg.YV12_OVERLAY, (w, h))
@@ -64,3 +61,8 @@ if __name__ == "__main__":
         print("Usage: play_file <file_pattern>")
     else:
         main(sys.argv[1])
+
+# Uncomment for quick test
+# ------------------------
+# if __name__ == "__main__":
+#     main('data/yuv_1.pgm')

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -26,8 +26,12 @@
 #include "_surface.h"
 
 #ifdef PG_ENABLE_ARM_NEON
-// sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
-#include "include/sse2neon.h"
+    // sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
+    #include "include/sse2neon.h"
+#else
+    #if IS_SDLv1
+        #include <immintrin.h>  // should pull in all supported intrinsic functions
+    #endif /* IS_SDLv1 */
 #endif /* PG_ENABLE_ARM_NEON */
 
 /* The structure passed to the low level blit functions */

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -584,8 +584,8 @@ pg_get_error(PyObject *self, PyObject *args)
 #if IS_SDLv1 && PY3 && !defined(PYPY_VERSION)
     /* SDL 1's encoding is ambiguous */
     PyObject *obj;
-    if (obj = PyUnicode_DecodeUTF8(SDL_GetError(),
-                                   strlen(SDL_GetError()), "strict"))
+    if ((obj = PyUnicode_DecodeUTF8(SDL_GetError(),
+                                    strlen(SDL_GetError()), "strict")))
         return obj;
     PyErr_Clear();
     return PyUnicode_DecodeLocale(SDL_GetError(), "surrogateescape");

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -30,7 +30,7 @@
 
 #include "doc/image_doc.h"
 
-#if __SSE4_2__ || PG_COMPILE_SSE4_2
+#if (__SSE4_2__ || PG_COMPILE_SSE4_2) && (SDL_VERSION_ATLEAST(2, 0, 0))
 #include <emmintrin.h>
 /* SSSE 3 */
 #include <tmmintrin.h>
@@ -320,7 +320,7 @@ image_get_extended(PyObject *self, PyObject *arg)
     return PyInt_FromLong(GETSTATE(self)->is_extended);
 }
 
-#if __SSE4_2__ || PG_COMPILE_SSE4_2
+#if (__SSE4_2__ || PG_COMPILE_SSE4_2) && (SDL_VERSION_ATLEAST(2, 0, 0))
 #define SSE42_ALIGN_NEEDED 16
 #define SSE42_ALIGN __attribute__((aligned(SSE42_ALIGN_NEEDED)))
 
@@ -510,7 +510,7 @@ tostring_surf_32bpp(SDL_Surface *surf, int flipped,
     Uint32 Bloss = surf->format->Bloss;
     Uint32 Aloss = surf->format->Aloss;
 
-#if __SSE4_2__ || PG_COMPILE_SSE4_2
+#if (__SSE4_2__ || PG_COMPILE_SSE4_2) && (SDL_VERSION_ATLEAST(2, 0, 0))
     if (/* SDL uses Uint32, SSE uses int for building vectors.
          * Related, we assume that Uint32 is packed so 4 of
          * them perfectly matches an __m128i.

--- a/src_c/overlay.c
+++ b/src_c/overlay.c
@@ -23,6 +23,8 @@
  * Dmitry Borisov
  */
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 #include "pygame.h"
@@ -67,7 +69,7 @@ Overlay_Display(PyGameOverlay *self, PyObject *args)
 {
     SDL_Rect cRect;
     // Parse data params for frame
-    int ls_y, ls_u, ls_v, y;
+    Py_ssize_t ls_y, ls_u, ls_v, y;
     unsigned char *src_y = 0, *src_u = 0, *src_v = 0;
 
     if (PyTuple_Size(args)) {

--- a/test/overlay_test.py
+++ b/test/overlay_test.py
@@ -1,5 +1,6 @@
 import unittest
 import pygame
+from pygame.compat import xrange_
 
 SDL2 = pygame.get_sdl_version()[0] >= 2
 
@@ -8,41 +9,50 @@ class OverlayTypeTest(unittest.TestCase):
     @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
     def test_display(self):
         """Test we can create an overlay of all the different types"""
+
+        f = open('../examples/data/yuv_1.pgm', "rb")
+        fmt = f.readline().strip().decode()
+        res = f.readline().strip().decode()
+        unused_col = f.readline().strip()
+        if fmt != "P5":
+            print(
+                "Unknown format: %s ( len %d ). Exiting..." % (fmt, len(fmt)))
+            return
+
+        w, h = [int(x) for x in res.split(" ")]
+        h = int((h * 2) / 3)
+        # Read into strings
+        y = f.read(w * h)
+        u = b''
+        v = b''
+        for _ in xrange_(0, int(h / 2)):
+            u += (f.read(int(w / 2)))
+            v += (f.read(int(w / 2)))
+
+        f.close()
+
         pygame.display.init()
 
-        display_surface = pygame.display.set_mode((320, 240))
+        display_surface = pygame.display.set_mode((w, h))
         display_surface_rect = display_surface.get_rect()
         display_center = display_surface_rect.center
 
-        supported_formats = (pygame.YV12_OVERLAY,
-                             pygame.IYUV_OVERLAY,
-                             pygame.YUY2_OVERLAY,
-                             pygame.UYVY_OVERLAY,
-                             pygame.YVYU_OVERLAY)
+        # data from pgm file works for these two formats
+        formats_24_bit = (pygame.YV12_OVERLAY,
+                          pygame.IYUV_OVERLAY)
 
-        sizes = ((4, 4),
-                 (2, 2),
-                 (2, 2),
-                 (2, 2),
-                 (2, 2))
+        # still need good data for these three formats
+        formats_xx_bit = (pygame.YUY2_OVERLAY,
+                          pygame.UYVY_OVERLAY,
+                          pygame.YVYU_OVERLAY)
 
-        data = ((b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
-                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
-                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
-                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
-                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
-                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'),
-                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
-                 b'0xFF0xFF0xFF0xFF'),
-                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
-                 b'0xFF0xFF0xFF0xFF'),
-                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
-                 b'0xFF0xFF0xFF0xFF'),
-                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
-                 b'0xFF0xFF0xFF0xFF'))
+        sizes = ((w, h),
+                 (w, h))
+        raw_data = ((y, u, v),
+                    (y, u, v))
 
         created_overlays = 0
-        for overlay_format, size, raw in zip(supported_formats, sizes, data):
+        for overlay_format, size, raw in zip(formats_24_bit, sizes, raw_data):
             overlay = pygame.Overlay(overlay_format, size)
             overlay_location = pygame.Rect((0, 0), size)
             overlay_location.center = display_center
@@ -50,7 +60,7 @@ class OverlayTypeTest(unittest.TestCase):
             overlay.display(raw)
             created_overlays += 1
 
-        self.assertEqual(created_overlays, 5)
+        self.assertEqual(created_overlays, 2)
 
     @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
     def test_get_hardware(self):
@@ -64,23 +74,40 @@ class OverlayTypeTest(unittest.TestCase):
     @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
     def test_set_location(self):
         """Test overlay set location"""
+
+        f = open('../examples/data/yuv_1.pgm', "rb")
+        fmt = f.readline().strip().decode()
+        res = f.readline().strip().decode()
+        unused_col = f.readline().strip()
+        if fmt != "P5":
+            print(
+                "Unknown format: %s ( len %d ). Exiting..." % (fmt, len(fmt)))
+            return
+
+        w, h = [int(x) for x in res.split(" ")]
+        h = int((h * 2) / 3)
+        # Read into strings
+        y = f.read(w * h)
+        u = b''
+        v = b''
+        for _ in xrange_(0, int(h / 2)):
+            u += (f.read(int(w / 2)))
+            v += (f.read(int(w / 2)))
+
+        f.close()
+
         pygame.display.init()
 
-        display_surface = pygame.display.set_mode((320, 240))
+        display_surface = pygame.display.set_mode((w, h))
         display_surface.fill((0, 0, 0))
         pygame.display.update()
 
-        overlay = pygame.Overlay(pygame.YV12_OVERLAY, (4, 4))
+        overlay = pygame.Overlay(pygame.YV12_OVERLAY, (w, h))
 
-        raw_data = (b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
-                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
-                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
-                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
-                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
-                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF')
+        raw_data = (y, u, v)
         overlay.display(raw_data)
         pygame.display.update()
-        overlay_location = pygame.Rect((0, 0), (4, 4))
+        overlay_location = pygame.Rect((0, 0), (w, h))
 
         positions = ((1, 1), (1, 190), (270, 1), (270, 190))
         for position in positions:
@@ -89,7 +116,7 @@ class OverlayTypeTest(unittest.TestCase):
             overlay.display()
             pygame.display.update()
             self.assertEqual(display_surface.get_at(position),
-                             pygame.Color(0, 171, 0))
+                             pygame.Color(0, 151, 0))
 
 
 ################################################################################

--- a/test/overlay_test.py
+++ b/test/overlay_test.py
@@ -6,6 +6,10 @@ SDL2 = pygame.get_sdl_version()[0] >= 2
 
 
 class OverlayTypeTest(unittest.TestCase):
+    @unittest.skipIf(
+        os.environ.get("SDL_VIDEODRIVER") == "dummy",
+        'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',
+    )
     @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
     def test_display(self):
         """Test we can create an overlay of all the different types"""
@@ -62,6 +66,10 @@ class OverlayTypeTest(unittest.TestCase):
 
         self.assertEqual(created_overlays, 2)
 
+    @unittest.skipIf(
+        os.environ.get("SDL_VIDEODRIVER") == "dummy",
+        'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',
+    )
     @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
     def test_get_hardware(self):
         """Test for overlay hardware acceleration"""
@@ -71,6 +79,10 @@ class OverlayTypeTest(unittest.TestCase):
         overlay = pygame.Overlay(pygame.YV12_OVERLAY, (4, 4))
         self.assertFalse(overlay.get_hardware())
 
+    @unittest.skipIf(
+        os.environ.get("SDL_VIDEODRIVER") == "dummy",
+        'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',
+    )
     @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
     def test_set_location(self):
         """Test overlay set location"""

--- a/test/overlay_test.py
+++ b/test/overlay_test.py
@@ -1,34 +1,95 @@
 import unittest
+import pygame
+
+SDL2 = pygame.get_sdl_version()[0] >= 2
 
 
 class OverlayTypeTest(unittest.TestCase):
-    def todo_test_display(self):
+    @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
+    def test_display(self):
+        """Test we can create an overlay of all the different types"""
+        pygame.display.init()
 
-        # __doc__ (as of 2008-08-02) for pygame.overlay.overlay.display:
+        display_surface = pygame.display.set_mode((320, 240))
+        display_surface_rect = display_surface.get_rect()
+        display_center = display_surface_rect.center
 
-        # Overlay.display((y, u, v)): return None
-        # Overlay.display(): return None
-        # set the overlay pixel data
+        supported_formats = (pygame.YV12_OVERLAY,
+                             pygame.IYUV_OVERLAY,
+                             pygame.YUY2_OVERLAY,
+                             pygame.UYVY_OVERLAY,
+                             pygame.YVYU_OVERLAY)
 
-        self.fail()
+        sizes = ((4, 4),
+                 (2, 2),
+                 (2, 2),
+                 (2, 2),
+                 (2, 2))
 
-    def todo_test_get_hardware(self):
+        data = ((b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
+                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
+                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
+                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
+                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
+                 b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'),
+                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
+                 b'0xFF0xFF0xFF0xFF'),
+                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
+                 b'0xFF0xFF0xFF0xFF'),
+                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
+                 b'0xFF0xFF0xFF0xFF'),
+                (b'0xFF0xFF0xFF0xFF', b'0xFF0xFF0xFF0xFF',
+                 b'0xFF0xFF0xFF0xFF'))
 
-        # __doc__ (as of 2008-08-02) for pygame.overlay.overlay.get_hardware:
+        created_overlays = 0
+        for overlay_format, size, raw in zip(supported_formats, sizes, data):
+            overlay = pygame.Overlay(overlay_format, size)
+            overlay_location = pygame.Rect((0, 0), size)
+            overlay_location.center = display_center
+            overlay.set_location(overlay_location)
+            overlay.display(raw)
+            created_overlays += 1
 
-        # Overlay.get_hardware(rect): return int
-        # test if the Overlay is hardware accelerated
+        self.assertEqual(created_overlays, 5)
 
-        self.fail()
+    @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
+    def test_get_hardware(self):
+        """Test for overlay hardware acceleration"""
+        pygame.display.init()
 
-    def todo_test_set_location(self):
+        display_surface = pygame.display.set_mode((320, 240))
+        overlay = pygame.Overlay(pygame.YV12_OVERLAY, (4, 4))
+        self.assertFalse(overlay.get_hardware())
 
-        # __doc__ (as of 2008-08-02) for pygame.overlay.overlay.set_location:
+    @unittest.skipIf(SDL2, "Overlay not ported to SDL2")
+    def test_set_location(self):
+        """Test overlay set location"""
+        pygame.display.init()
 
-        # Overlay.set_location(rect): return None
-        # control where the overlay is displayed
+        display_surface = pygame.display.set_mode((320, 240))
+        display_surface.fill((0, 0, 0))
+        pygame.display.update()
 
-        self.fail()
+        overlay = pygame.Overlay(pygame.YV12_OVERLAY, (4, 4))
+
+        raw_data = (b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
+                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
+                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
+                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF',
+                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF'
+                    b'0xFF0xFF0xFF0xFF0xFF0xFF0xFF0xFF')
+        overlay.display(raw_data)
+        pygame.display.update()
+        overlay_location = pygame.Rect((0, 0), (4, 4))
+
+        positions = ((1, 1), (1, 190), (270, 1), (270, 190))
+        for position in positions:
+            overlay_location.topleft = position
+            overlay.set_location(overlay_location)
+            overlay.display()
+            pygame.display.update()
+            self.assertEqual(display_surface.get_at(position),
+                             pygame.Color(0, 171, 0))
 
 
 ################################################################################


### PR DESCRIPTION
The overlay module is pretty neglected, probably because it doesn't exist in SDL2 but we have one issue open about it here:

https://github.com/pygame/pygame/issues/1199

And I ran across a potential porting guide here:

https://stackoverflow.com/questions/17579286/sdl2-0-alternative-for-sdl-overlay

So, I thought I'd see if I could get some tests going for SDL1 and see if it will at least work under SDL1.

- [ ]  first issue: it occasionally crashes with my test data running on Python 3.8 and Pygame 1.9.6. I get this DeprecationWarning:
`DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
  overlay.display(raw)`. I followed the guidance in this issue: https://github.com/python-pillow/Pillow/issues/3750 and made a few modifications to overlay.c to see if that will fix it.

