### PR TITLE
setup: Error out on unused-value warnings with -pygame-ci

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if '-pygame-ci' in sys.argv:
               '-Werror=implicit-function-declaration -Werror=return-type ' + \
               '-Werror=implicit-int -Werror=main -Werror=pointer-arith ' + \
               '-Werror=format-security -Werror=uninitialized ' + \
-              '-Werror=trigraphs -Werror=parentheses ' + \
+              '-Werror=trigraphs -Werror=parentheses -Werror=unused-value ' + \
               '-Werror=cast-align'
     os.environ['CFLAGS'] = cflags
     sys.argv.remove ('-pygame-ci')


### PR DESCRIPTION
An example of a case where this is highly relevant.
```
src_c/imageext.c: In function ‘opengltosdl’:

src_c/_pygame.h:145:47: warning: right-hand operand of comma expression has no effect [-Wunused-value]

 #define RAISE(x, y) (PyErr_SetString((x), (y)), (PyObject *)NULL)
                                               ^

src_c/imageext.c:750:9: note: in expansion of macro ‘RAISE’
         RAISE(PyExc_RuntimeError, "Cannot get video surface.");
         ^

[...]
```

Signed-off-by: Niels Thykier <niels@thykier.net>