### PR TITLE
ftfont.Font: Fix NameError when resolution is 0

### DIFF
--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -42,7 +42,7 @@ class Font(_Font):
         if file is None:
             resolution = int(self.__get_default_resolution() * 0.6875)
             if resolution == 0:
-                kwds['resolution'] = 1
+                resolution = 1
         else:
             resolution = 0
         super(Font, self).__init__(file, size=size, resolution=resolution)


### PR DESCRIPTION
Signed-off-by: Niels Thykier <niels@thykier.net>