### PR TITLE
Fixes for the SDL1 build 

### DIFF
--- a/docs/reST/c_api/surflock.rst
+++ b/docs/reST/c_api/surflock.rst
@@ -42,20 +42,20 @@ Header file: src_c/include/pygame.h
    false otherwise.
    This will return false on :c:data:`pgLifetimeLock_Type` subclass instances as well.
 
-.. c:function:: void pgSurface_Prep(PyObject *surfobj)
+.. c:function:: void pgSurface_Prep(pgSurfaceObject *surfobj)
 
    If *surfobj* is a subsurface, then lock the parent surface with *surfobj*
    the owner of the lock.
 
-.. c:function:: void pgSurface_Unprep(PyObject *surfobj)
+.. c:function:: void pgSurface_Unprep(pgSurfaceObject *surfobj)
 
    If *surfobj* is a subsurface, then release its lock on the parent surface.
 
-.. c:function:: int pgSurface_Lock(PyObject *surfobj)
+.. c:function:: int pgSurface_Lock(pgSurfaceObject *surfobj)
 
    Lock pygame surface *surfobj*, with *surfobj* owning its own lock.
 
-.. c:function:: int pgSurface_LockBy(PyObject *surfobj, PyObject *lockobj)
+.. c:function:: int pgSurface_LockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
 
    Lock pygame surface *surfobj* with Python object *lockobj* the owning
    the lock.
@@ -65,11 +65,11 @@ Header file: src_c/include/pygame.h
    However, it is best if *lockobj* also keep a reference to the locked surface
    and call to :c:func:`pgSurface_UnLockBy` when finished with the surface.
 
-.. c:function:: int pgSurface_UnLock(PyObject *surfobj)
+.. c:function:: int pgSurface_UnLock(pgSurfaceObject *surfobj)
 
    Remove the pygame surface *surfobj* object's lock on itself.
 
-.. c:function:: int pgSurface_UnLockBy(PyObject *surfobj, PyObject *lockobj)
+.. c:function:: int pgSurface_UnLockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
 
    Remove the lock on pygame surface *surfobj* owned by Python object *lockobj*.
 

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -1838,7 +1838,6 @@ _ftfont_render(pgFontObject *self, PyObject *args, PyObject *kwds)
     }
     else{
         if (self->is_bg_col_set){
-            bg_color_obj = 1; // Using this as a boolean flag now
             bg_color.r = self->bgcolor[0];
             bg_color.g = self->bgcolor[1];
             bg_color.b = self->bgcolor[2];
@@ -1862,8 +1861,9 @@ _ftfont_render(pgFontObject *self, PyObject *args, PyObject *kwds)
         goto error;
 
     surface =
-        _PGFT_Render_NewSurface(self->freetype, self, &render, text, &fg_color,
-                                bg_color_obj ? &bg_color : 0, &r);
+        _PGFT_Render_NewSurface(
+            self->freetype, self, &render, text, &fg_color,
+            (bg_color_obj || self->is_bg_col_set) ? &bg_color : 0, &r);
     if (!surface)
         goto error;
     free_string(text);
@@ -1970,7 +1970,6 @@ _ftfont_render_to(pgFontObject *self, PyObject *args, PyObject *kwds)
     }
     else{
         if (self->is_bg_col_set){
-            bg_color_obj = 1; // Using this as a boolean flag now
             bg_color.r = self->bgcolor[0];
             bg_color.g = self->bgcolor[1];
             bg_color.b = self->bgcolor[2];
@@ -2000,9 +1999,10 @@ _ftfont_render_to(pgFontObject *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(pgExc_SDLError, "display Surface quit");
         goto error;
     }
-    if (_PGFT_Render_ExistingSurface(self->freetype, self, &render, text,
-                                     surface, xpos, ypos, &fg_color,
-                                     bg_color_obj ? &bg_color : 0, &r))
+    if (_PGFT_Render_ExistingSurface(
+            self->freetype, self, &render, text,
+            surface, xpos, ypos, &fg_color,
+            (bg_color_obj || self->is_bg_col_set) ? &bg_color : 0, &r))
         goto error;
     free_string(text);
 

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -163,158 +163,157 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
         if (SDL_GetSurfaceBlendMode(src, &info.src_blend) ||
             SDL_GetSurfaceBlendMode(dst, &info.dst_blend)) {
             okay = 0;
-            goto LEAVE;
         }
 #endif /* IS_SDLv2 */
-
-        if (info.d_pixels > info.s_pixels)
-        {
-            int span = info.width * info.src->BytesPerPixel;
-            Uint8 *srcpixend =
-                info.s_pixels + (info.height - 1) * src->pitch + span;
-
-            if (info.d_pixels < srcpixend)
+        if (okay){
+            if (info.d_pixels > info.s_pixels)
             {
-                int dstoffset = (info.d_pixels - info.s_pixels) % src->pitch;
+                int span = info.width * info.src->BytesPerPixel;
+                Uint8 *srcpixend =
+                    info.s_pixels + (info.height - 1) * src->pitch + span;
 
-                if (dstoffset < span || dstoffset > src->pitch - span)
+                if (info.d_pixels < srcpixend)
                 {
-                    /* Overlapping Self blit with positive destination offset.
-                       Reverse direction of the blit.
-                    */
-                    info.s_pixels = srcpixend - info.s_pxskip;
-                    info.s_pxskip = -info.s_pxskip;
-                    info.s_skip = -info.s_skip;
-                    info.d_pixels = (info.d_pixels +
-                                     (info.height - 1) * dst->pitch +
-                                     span - info.d_pxskip);
-                    info.d_pxskip = -info.d_pxskip;
-                    info.d_skip = -info.d_skip;
+                    int dstoffset = (info.d_pixels - info.s_pixels) % src->pitch;
+
+                    if (dstoffset < span || dstoffset > src->pitch - span)
+                    {
+                        /* Overlapping Self blit with positive destination offset.
+                           Reverse direction of the blit.
+                        */
+                        info.s_pixels = srcpixend - info.s_pxskip;
+                        info.s_pxskip = -info.s_pxskip;
+                        info.s_skip = -info.s_skip;
+                        info.d_pixels = (info.d_pixels +
+                                         (info.height - 1) * dst->pitch +
+                                         span - info.d_pxskip);
+                        info.d_pxskip = -info.d_pxskip;
+                        info.d_skip = -info.d_skip;
+                    }
                 }
             }
-        }
 
-        switch (the_args)
-        {
-        case 0:
-        {
+            switch (the_args)
+            {
+            case 0:
+            {
 #if IS_SDLv1
-            if (src->flags & SDL_SRCALPHA && src->format->Amask)
-                alphablit_alpha (&info);
-            else if (src->flags & SDL_SRCCOLORKEY)
-                alphablit_colorkey (&info);
-            else
-                alphablit_solid (&info);
-            break;
+                if (src->flags & SDL_SRCALPHA && src->format->Amask)
+                    alphablit_alpha (&info);
+                else if (src->flags & SDL_SRCCOLORKEY)
+                    alphablit_colorkey (&info);
+                else
+                    alphablit_solid (&info);
+                break;
 #else /* IS_SDLv2 */
-            if (info.src_blend != SDL_BLENDMODE_NONE && src->format->Amask) {
-                alphablit_alpha (&info);
-            } else if (info.src_has_colorkey) {
-                alphablit_colorkey (&info);
-            } else {
-                alphablit_solid (&info);
-            }
-            break;
+                if (info.src_blend != SDL_BLENDMODE_NONE &&
+                    src->format->Amask) {
+                    alphablit_alpha (&info);
+                } else if (info.src_has_colorkey) {
+                    alphablit_colorkey (&info);
+                } else {
+                    alphablit_solid (&info);
+                }
+                break;
 #endif /* IS_SDLv2 */
-        }
-        case PYGAME_BLEND_ADD:
-        {
-            blit_blend_add (&info);
-            break;
-        }
-        case PYGAME_BLEND_SUB:
-        {
-            blit_blend_sub (&info);
-            break;
-        }
-        case PYGAME_BLEND_MULT:
-        {
-            blit_blend_mul (&info);
-            break;
-        }
-        case PYGAME_BLEND_MIN:
-        {
-            blit_blend_min (&info);
-            break;
-        }
-        case PYGAME_BLEND_MAX:
-        {
-            blit_blend_max (&info);
-            break;
-        }
+            }
+            case PYGAME_BLEND_ADD:
+            {
+                blit_blend_add (&info);
+                break;
+            }
+            case PYGAME_BLEND_SUB:
+            {
+                blit_blend_sub (&info);
+                break;
+            }
+            case PYGAME_BLEND_MULT:
+            {
+                blit_blend_mul (&info);
+                break;
+            }
+            case PYGAME_BLEND_MIN:
+            {
+                blit_blend_min (&info);
+                break;
+            }
+            case PYGAME_BLEND_MAX:
+            {
+                blit_blend_max (&info);
+                break;
+            }
 
-        case PYGAME_BLEND_RGBA_ADD:
-        {
-        blit_blend_rgba_add (&info);
-        break;
-        }
-        case PYGAME_BLEND_RGBA_SUB:
-        {
-            blit_blend_rgba_sub (&info);
+            case PYGAME_BLEND_RGBA_ADD:
+            {
+            blit_blend_rgba_add (&info);
             break;
-        }
-        case PYGAME_BLEND_RGBA_MULT:
-        {
-            blit_blend_rgba_mul (&info);
-            break;
-        }
-        case PYGAME_BLEND_RGBA_MIN:
-        {
-            blit_blend_rgba_min (&info);
-            break;
-        }
-        case PYGAME_BLEND_RGBA_MAX:
-        {
-            blit_blend_rgba_max (&info);
-            break;
-        }
-        case PYGAME_BLEND_PREMULTIPLIED:
-        {
+            }
+            case PYGAME_BLEND_RGBA_SUB:
+            {
+                blit_blend_rgba_sub (&info);
+                break;
+            }
+            case PYGAME_BLEND_RGBA_MULT:
+            {
+                blit_blend_rgba_mul (&info);
+                break;
+            }
+            case PYGAME_BLEND_RGBA_MIN:
+            {
+                blit_blend_rgba_min (&info);
+                break;
+            }
+            case PYGAME_BLEND_RGBA_MAX:
+            {
+                blit_blend_rgba_max (&info);
+                break;
+            }
+            case PYGAME_BLEND_PREMULTIPLIED:
+            {
 #if  defined(__MMX__) || defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)
-            if (src->format->Rmask == dst->format->Rmask
-                && src->format->Gmask == dst->format->Gmask
-                && src->format->Bmask == dst->format->Bmask
-                && src->format->BytesPerPixel == 4
-                && src->format->Rshift % 8 == 0
-                && src->format->Gshift % 8 == 0
-                && src->format->Bshift % 8 == 0
-                && src->format->Ashift % 8 == 0
-                && src->format->Aloss == 0){
+                if (src->format->Rmask == dst->format->Rmask
+                    && src->format->Gmask == dst->format->Gmask
+                    && src->format->Bmask == dst->format->Bmask
+                    && src->format->BytesPerPixel == 4
+                    && src->format->Rshift % 8 == 0
+                    && src->format->Gshift % 8 == 0
+                    && src->format->Bshift % 8 == 0
+                    && src->format->Ashift % 8 == 0
+                    && src->format->Aloss == 0){
 
 #if PG_ENABLE_ARM_NEON
-                if (SDL_HasNEON() == SDL_TRUE){
-                    blit_blend_premultiplied_sse2 (&info);
-                    break;
-                }
+                    if (SDL_HasNEON() == SDL_TRUE){
+                        blit_blend_premultiplied_sse2 (&info);
+                        break;
+                    }
 #endif /* PG_ENABLE_ARM_NEON */
 #ifdef __SSE2__
-                if (SDL_HasSSE2() == SDL_TRUE){
-                    blit_blend_premultiplied_sse2 (&info);
-                    break;
-                }
+                    if (SDL_HasSSE2() == SDL_TRUE){
+                        blit_blend_premultiplied_sse2 (&info);
+                        break;
+                    }
 #endif /* __SSE2__*/
 #ifdef __MMX__
-                if (SDL_HasMMX() == SDL_TRUE) {
-                    blit_blend_premultiplied_mmx (&info);
-                    break;
-                }
+                    if (SDL_HasMMX() == SDL_TRUE) {
+                        blit_blend_premultiplied_mmx (&info);
+                        break;
+                    }
 #endif /*__MMX__*/
 
-            }
+                }
 #endif /*__MMX__ || __SSE2__ || PG_ENABLE_ARM_NEON*/
-            blit_blend_premultiplied (&info);
-            break;
-        }
-        default:
-        {
-            SDL_SetError ("Invalid argument passed to blit.");
-            okay = 0;
-            break;
-        }
+                blit_blend_premultiplied (&info);
+                break;
+            }
+            default:
+            {
+                SDL_SetError ("Invalid argument passed to blit.");
+                okay = 0;
+                break;
+            }
+            }
         }
     }
-
-LEAVE:
 
     /* We need to unlock the surfaces if they're locked */
     if (dst_locked)

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -93,7 +93,8 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
 static PyObject *
 aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *start = NULL, *end = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject* colorobj = NULL, *start = NULL, *end = NULL;
     SDL_Surface *surf = NULL;
     float startx, starty, endx, endy;
     int blend = 1; /* Default blend. */
@@ -160,7 +161,8 @@ aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 line(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *start = NULL, *end = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL, *start = NULL, *end = NULL;
     SDL_Surface *surf = NULL;
     int startx, starty, endx, endy;
     int pts[4];
@@ -231,7 +233,8 @@ line(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *closedobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL, *closedobj = NULL;
     PyObject *points = NULL, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint32 color;
@@ -363,7 +366,8 @@ aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 lines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *closedobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL, *closedobj = NULL;
     PyObject *points = NULL, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint32 color;
@@ -494,7 +498,8 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 arc(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *rectobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL, *rectobj = NULL;
     GAME_Rect *rect = NULL, temp;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
@@ -571,7 +576,8 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *rectobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL, *rectobj = NULL;
     GAME_Rect *rect = NULL, temp;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
@@ -647,7 +653,8 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 circle(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
@@ -739,7 +746,8 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    PyObject *surfobj = NULL, *colorobj = NULL, *points = NULL, *item = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *colorobj = NULL, *points = NULL, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
@@ -862,10 +870,12 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
     int t, l, b, r, width = 0, radius = 0; /* Default values. */
     int top_left_radius = -1, top_right_radius = -1, bottom_left_radius = -1,
         bottom_right_radius = -1;
+#if IS_SDLv2
     SDL_Rect sdlrect;
     SDL_Rect cliprect;
     int result;
     SDL_Rect clipped;
+#endif /* IS_SDLv2 */
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     static char *keywords[] = {"surface",

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -907,6 +907,7 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (radius <= 0 && top_left_radius <= 0 && top_right_radius <= 0 &&
         bottom_left_radius <= 0 && bottom_right_radius <= 0) {
+#if IS_SDLv2
         if(width > 0){
             l = rect->x;
             r = rect->x + rect->w - 1;
@@ -947,6 +948,21 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
                 return RAISE(pgExc_SDLError, SDL_GetError());
             return pgRect_New(&clipped);
         }
+#else
+        l = rect->x;
+        r = rect->x + rect->w - 1;
+        t = rect->y;
+        b = rect->y + rect->h - 1;
+        points = Py_BuildValue("((ii)(ii)(ii)(ii))", l, t, r, t, r, b, l, b);
+        poly_args = Py_BuildValue("(OONi)", surfobj, colorobj, points, width);
+        if (NULL == poly_args) {
+            return NULL; /* Exception already set. */
+        }
+
+        ret = polygon(NULL, poly_args, NULL);
+        Py_DECREF(poly_args);
+        return ret;
+#endif
     }
     else {
         if (!pgSurface_Lock(surfobj)) {

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -322,7 +322,7 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
         r->x = 0;
         r->y = 0;
         r->w = 0;
-        r->h = _PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
+        r->h = (Uint16)_PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
         return 0;
     }
 
@@ -336,7 +336,7 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
         r->x = 0;
         r->y = 0;
         r->w = 0;
-        r->h = _PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
+        r->h = (Uint16)_PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
         return 0;
     }
     surf_offset.x = INT_TO_FX6(x);
@@ -744,7 +744,7 @@ _PGFT_Render_Array(FreeTypeInstance *ft, pgFontObject *fontobj,
         r->x = 0;
         r->y = 0;
         r->w = 0;
-        r->h = _PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
+        r->h = (Uint16)_PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
         return 0;
     }
 
@@ -756,7 +756,7 @@ _PGFT_Render_Array(FreeTypeInstance *ft, pgFontObject *fontobj,
         r->x = 0;
         r->y = 0;
         r->w = 0;
-        r->h = _PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
+        r->h = (Uint16)_PGFT_Font_GetHeightSized(ft, fontobj, mode->face_size);
         return 0;
     }
     array_offset.x = INT_TO_FX6(x);

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -130,13 +130,15 @@ opengltosdl()
     surf = SDL_GetVideoSurface();
 
     if (!surf) {
-        RAISE(PyExc_RuntimeError, "Cannot get video surface.");
-        return NULL;
+        return (SDL_Surface *)RAISE(PyExc_RuntimeError,
+                                    "Cannot get video surface.");
+
     }
 
     if (!p_glReadPixels) {
-        RAISE(PyExc_RuntimeError, "Cannot find glReadPixels function.");
-        return NULL;
+        return (SDL_Surface *)RAISE(PyExc_RuntimeError,
+                                    "Cannot find glReadPixels function.");
+
     }
 
     /*
@@ -147,8 +149,10 @@ opengltosdl()
     pixels = (unsigned char *)malloc(surf->w * surf->h * 3);
 
     if (!pixels) {
-        RAISE(PyExc_MemoryError, "Cannot allocate enough memory for pixels.");
-        return NULL;
+        return (SDL_Surface *)RAISE(
+                                  PyExc_MemoryError,
+                                  "Cannot allocate enough memory for pixels.");
+
     }
     // p_glReadPixels(0, 0, surf->w, surf->h, 6407, 5121, pixels);
     // glReadPixels(0, 0, surf->w, surf->h, 0x1907, 0x1401, pixels);
@@ -168,8 +172,7 @@ opengltosdl()
                                 gmask, bmask, 0);
     if (!surf) {
         free(pixels);
-        RAISE(pgExc_SDLError, SDL_GetError());
-        return NULL;
+        return (SDL_Surface *)RAISE(pgExc_SDLError, SDL_GetError());
     }
 
     for (i = 0; i < surf->h; ++i) {

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -569,7 +569,8 @@ tostring_surf_32bpp(SDL_Surface *surf, int flipped,
 PyObject *
 image_tostring(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj, *string = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *string = NULL;
     char *format, *data, *pixels;
     SDL_Surface *surf;
     int w, h, flipped = 0;

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -747,16 +747,19 @@ opengltosdl(void)
     surf = SDL_GetVideoSurface();
 
     if (!surf) {
-        return RAISE(PyExc_RuntimeError, "Cannot get video surface.");
+        RAISE(PyExc_RuntimeError, "Cannot get video surface.");
+        return NULL;
     }
     if (!p_glReadPixels) {
-        return RAISE(PyExc_RuntimeError, "Cannot find glReadPixels function.");
+        RAISE(PyExc_RuntimeError, "Cannot find glReadPixels function.");
+        return NULL;
     }
 
     pixels = (unsigned char *)malloc(surf->w * surf->h * 3);
 
     if (!pixels) {
-        return RAISE(PyExc_MemoryError, "Cannot allocate enough memory for pixels.");
+        RAISE(PyExc_MemoryError, "Cannot allocate enough memory for pixels.");
+        return NULL;
     }
 
     /* GL_RGB, GL_UNSIGNED_BYTE */
@@ -776,7 +779,8 @@ opengltosdl(void)
                                 gmask, bmask, 0);
     if (!surf) {
         free(pixels);
-        return RAISE(pgExc_SDLError, SDL_GetError());
+        RAISE(pgExc_SDLError, SDL_GetError());
+        return NULL;
     }
 
     for (i = 0; i < surf->h; ++i) {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -747,19 +747,21 @@ opengltosdl(void)
     surf = SDL_GetVideoSurface();
 
     if (!surf) {
-        RAISE(PyExc_RuntimeError, "Cannot get video surface.");
-        return NULL;
+        return (SDL_Surface *)RAISE(PyExc_RuntimeError,
+                                    "Cannot get video surface.");
     }
     if (!p_glReadPixels) {
-        RAISE(PyExc_RuntimeError, "Cannot find glReadPixels function.");
-        return NULL;
+        return (SDL_Surface *)RAISE(PyExc_RuntimeError,
+                                    "Cannot find glReadPixels function.");
+
     }
 
     pixels = (unsigned char *)malloc(surf->w * surf->h * 3);
 
     if (!pixels) {
-        RAISE(PyExc_MemoryError, "Cannot allocate enough memory for pixels.");
-        return NULL;
+        return (SDL_Surface *)RAISE(
+                                  PyExc_MemoryError,
+                                  "Cannot allocate enough memory for pixels.");
     }
 
     /* GL_RGB, GL_UNSIGNED_BYTE */
@@ -779,8 +781,7 @@ opengltosdl(void)
                                 gmask, bmask, 0);
     if (!surf) {
         free(pixels);
-        RAISE(pgExc_SDLError, SDL_GetError());
-        return NULL;
+        return (SDL_Surface *)RAISE(pgExc_SDLError, SDL_GetError());
     }
 
     for (i = 0; i < surf->h; ++i) {

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -436,19 +436,19 @@ typedef struct {
         PYGAMEAPI_GET_SLOT(surflock, 2)))(x)
 
 #define pgSurface_Lock \
-    (*(int (*)(PyObject *)) \
+    (*(int (*)(pgSurfaceObject *)) \
         PYGAMEAPI_GET_SLOT(surflock, 3))
 
 #define pgSurface_Unlock \
-    (*(int (*)(PyObject *)) \
+    (*(int (*)(pgSurfaceObject *)) \
         PYGAMEAPI_GET_SLOT(surflock, 4))
 
 #define pgSurface_LockBy   \
-    (*(int (*)(PyObject *, PyObject *)) \
+    (*(int (*)(pgSurfaceObject *, PyObject *)) \
         PYGAMEAPI_GET_SLOT(surflock, 5))
 
 #define pgSurface_UnlockBy \
-    (*(int (*)(PyObject *, PyObject *)) \
+    (*(int (*)(pgSurfaceObject *, PyObject *)) \
         PYGAMEAPI_GET_SLOT(surflock, 6))
 
 #define pgSurface_LockLifetime                 \

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -24,17 +24,17 @@
 // Worth trying this on MSVC/win32 builds to see if provides any speed up
 #ifndef PG_FORCEINLINE
 #if defined(__clang__)
-#define PG_INLINE __inline__ __attribute__((__unused__))
+#define PG_FORCEINLINE __inline__ __attribute__((__unused__))
 #elif defined(__GNUC__)
-#define PG_INLINE __inline__
+#define PG_FORCEINLINE __inline__
 #elif defined(_MSC_VER)
-#define PG_INLINE __forceinline
+#define PG_FORCEINLINE __forceinline
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#define PG_INLINE inline
+#define PG_FORCEINLINE inline
 #else
-#define PG_INLINE
+#define PG_FORCEINLINE
 #endif
-#endif /* ~PG_INLINE */
+#endif /* ~PG_FORCEINLINE */
 
 /* This is unconditionally defined in Python.h */
 #if defined(_POSIX_C_SOURCE)

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -761,7 +761,7 @@ static PyObject *
 mask_from_surface(PyObject *self, PyObject *args)
 {
     SDL_Surface *surf = NULL;
-    PyObject *surfobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
     pgMaskObject *maskobj = NULL;
     Uint32 colorkey;
     int threshold = 127; /* default value */
@@ -991,7 +991,8 @@ bitmask_threshold(bitmask_t *m, SDL_Surface *surf, SDL_Surface *surf2,
 static PyObject *
 mask_from_threshold(PyObject *self, PyObject *args)
 {
-    PyObject *surfobj, *surfobj2 = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    pgSurfaceObject *surfobj2 = NULL;
     pgMaskObject *maskobj = NULL;
     SDL_Surface *surf = NULL, *surf2 = NULL;
     PyObject *rgba_obj_color, *rgba_obj_threshold = NULL;
@@ -2185,21 +2186,22 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
         }
     }
 
-    if (!pgSurface_Lock(surfobj)) {
+    if (!pgSurface_Lock((pgSurfaceObject *)surfobj)) {
         PyErr_SetString(PyExc_RuntimeError, "cannot lock surface");
         goto to_surface_error;
     }
 
     /* Only lock the setsurface if it is being used.
      * i.e. setsurf is non-NULL */
-    if (NULL != setsurf && !pgSurface_Lock(setsurfobj)) {
+    if (NULL != setsurf && !pgSurface_Lock((pgSurfaceObject *)setsurfobj)) {
         PyErr_SetString(PyExc_RuntimeError, "cannot lock setsurface");
         goto to_surface_error;
     }
 
     /* Only lock the unsetsurface if it is being used.
      * i.e.. unsetsurf is non-NULL. */
-    if (NULL != unsetsurf && !pgSurface_Lock(unsetsurfobj)) {
+    if (NULL != unsetsurf &&
+        !pgSurface_Lock((pgSurfaceObject *)unsetsurfobj)) {
         PyErr_SetString(PyExc_RuntimeError, "cannot lock unsetsurface");
         goto to_surface_error;
     }
@@ -2212,17 +2214,19 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
     Py_END_ALLOW_THREADS; /* Obtain the GIL. */
 
-    if (NULL != unsetsurf && !pgSurface_Unlock(unsetsurfobj)) {
+    if (NULL != unsetsurf &&
+        !pgSurface_Unlock((pgSurfaceObject *)unsetsurfobj)) {
         PyErr_SetString(PyExc_RuntimeError, "cannot unlock unsetsurface");
         goto to_surface_error;
     }
 
-    if (NULL != setsurf && !pgSurface_Unlock(setsurfobj)) {
+    if (NULL != setsurf &&
+        !pgSurface_Unlock((pgSurfaceObject *)setsurfobj)) {
         PyErr_SetString(PyExc_RuntimeError, "cannot unlock setsurface");
         goto to_surface_error;
     }
 
-    if (!pgSurface_Unlock(surfobj)) {
+    if (!pgSurface_Unlock((pgSurfaceObject *)surfobj)) {
         PyErr_SetString(PyExc_RuntimeError, "cannot unlock surface");
         goto to_surface_error;
     }

--- a/src_c/pgcompat.h
+++ b/src_c/pgcompat.h
@@ -215,5 +215,11 @@ SDL_Surface * SDL_CreateRGBSurfaceWithFormat(Uint32 flags, int width, int height
 #endif
 #endif /* defined(SDL_VERSION_ATLEAST) */
 
+// Needed to build with Windows SDK 10.0.18362.0
+#ifdef _MSC_VER
+    #ifndef WINDOWS_IGNORE_PACKING_MISMATCH
+        #define WINDOWS_IGNORE_PACKING_MISMATCH
+    #endif
+#endif
 
 #endif /* ~PGCOMPAT_INTERNAL_H */

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -44,7 +44,7 @@ struct _pixelarray_t;
 typedef struct _pixelarray_t {
     PyObject_HEAD PyObject *dict; /* dict for subclassing */
     PyObject *weakrefs;           /* Weakrefs for subclassing */
-    PyObject *surface;            /* Surface associated with the array */
+    pgSurfaceObject *surface;     /* Surface associated with the array */
     Py_ssize_t shape[2];          /* (row,col) shape of array in pixels */
     Py_ssize_t strides[2];        /* (row,col) offsets in bytes */
     Uint8 *pixels;                /* Start of array data */
@@ -56,7 +56,7 @@ static int
 array_is_contiguous(pgPixelArrayObject *, char);
 
 static pgPixelArrayObject *
-_pxarray_new_internal(PyTypeObject *, PyObject *, pgPixelArrayObject *,
+_pxarray_new_internal(PyTypeObject *, pgSurfaceObject *, pgPixelArrayObject *,
                       Uint8 *, Py_ssize_t, Py_ssize_t, Py_ssize_t, Py_ssize_t);
 
 static PyObject *
@@ -68,7 +68,7 @@ _pxarray_traverse(pgPixelArrayObject *, visitproc, void *);
 
 static PyObject *
 _pxarray_get_dict(pgPixelArrayObject *, void *);
-static PyObject *
+static pgSurfaceObject *
 _pxarray_get_surface(pgPixelArrayObject *, void *);
 static PyObject *
 _pxarray_get_itemsize(pgPixelArrayObject *, void *);
@@ -167,7 +167,8 @@ _cleanup_array(pgPixelArrayObject *array)
         Py_DECREF(array->parent);
     }
     else {
-        pgSurface_UnlockBy(array->surface, (PyObject *)array);
+        pgSurface_UnlockBy(array->surface,
+                           (PyObject *)array);
     }
     Py_DECREF(array->surface);
     Py_XDECREF(array->dict);
@@ -343,7 +344,7 @@ static PyTypeObject pgPixelArray_Type = {
 };
 
 static pgPixelArrayObject *
-_pxarray_new_internal(PyTypeObject *type, PyObject *surface,
+_pxarray_new_internal(PyTypeObject *type, pgSurfaceObject *surface,
                       pgPixelArrayObject *parent, Uint8 *pixels,
                       Py_ssize_t dim0, Py_ssize_t dim1, Py_ssize_t stride0,
                       Py_ssize_t stride1)
@@ -396,7 +397,7 @@ _pxarray_new_internal(PyTypeObject *type, PyObject *surface,
 static PyObject *
 _pxarray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    PyObject *surfobj;
+    pgSurfaceObject *surfobj;
     SDL_Surface *surf;
     Py_ssize_t dim0;
     Py_ssize_t dim1;
@@ -478,7 +479,7 @@ _pxarray_get_dict(pgPixelArrayObject *self, void *closure)
 /**
  * Getter for PixelArray.surface
  */
-static PyObject *
+static pgSurfaceObject *
 _pxarray_get_surface(pgPixelArrayObject *self, void *closure)
 {
     Py_INCREF(self->surface);
@@ -1936,7 +1937,7 @@ pgPixelArray_New(PyObject *surfobj)
     }
 
     return (PyObject *)_pxarray_new_internal(
-        &pgPixelArray_Type, surfobj, 0, pixels, dim0, dim1, stride0, stride1);
+        &pgPixelArray_Type, (pgSurfaceObject *)surfobj, 0, pixels, dim0, dim1, stride0, stride1);
 }
 
 MODINIT_DEFINE(pixelarray)

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -480,7 +480,8 @@ _copy_unmapped(Py_buffer *view_p, SDL_Surface *surf)
 static PyObject *
 array_to_surface(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj, *arrayobj;
+    pgSurfaceObject *surfobj;
+    PyObject *arrayobj;
     pg_buffer pg_view;
     Py_buffer *view_p = (Py_buffer *)&pg_view;
     char *array_data;
@@ -774,7 +775,7 @@ static PyObject *
 surface_to_array(PyObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *arrayobj;
-    PyObject *surfobj;
+    pgSurfaceObject *surfobj;
     pg_buffer pg_view;
     Py_buffer *view_p = (Py_buffer *)&pg_view;
     _pc_view_kind_t view_kind = VIEWKIND_RGB;
@@ -854,7 +855,7 @@ map_array(PyObject *self, PyObject *args)
 #define PIXELCOPY_MAX_DIM 10
     PyObject *src_array;
     PyObject *tar_array;
-    PyObject *format_surf;
+    pgSurfaceObject *format_surf;
     SDL_PixelFormat *format;
     pg_buffer src_pg_view;
     Py_buffer *src_view_p = 0;

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -20,6 +20,7 @@
 */
 
 /* Handle clipboard text and data in arbitrary formats */
+#include "pgcompat.h"
 
 #include <limits.h>
 #include <stdio.h>
@@ -34,7 +35,7 @@
 
 #include "doc/scrap_doc.h"
 
-#include "pgcompat.h"
+
 
 /**
  * Indicates, whether pygame.scrap was initialized or not.
@@ -280,7 +281,7 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
 #if defined(PYGAME_SCRAP_FREE_STRING)
     free(scrap);
 #endif
-   
+
     return retval;
 }
 #endif

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -884,7 +884,7 @@ surf_get_at(PyObject *self, PyObject *args)
     if (format->BytesPerPixel < 1 || format->BytesPerPixel > 4)
         return RAISE(PyExc_RuntimeError, "invalid color depth for surface");
 
-    if (!pgSurface_Lock(self))
+    if (!pgSurface_Lock((pgSurfaceObject *)self))
         return NULL;
 
     pixels = (Uint8 *)surf->pixels;
@@ -933,7 +933,7 @@ surf_get_at(PyObject *self, PyObject *args)
             break;
 #endif /* IS_SDLv2 */
     }
-    if (!pgSurface_Unlock(self))
+    if (!pgSurface_Unlock((pgSurfaceObject *)self))
         return NULL;
 
 #if IS_SDLv1
@@ -990,7 +990,7 @@ surf_set_at(PyObject *self, PyObject *args)
     else
         return NULL; /* pg_RGBAFromFuzzyColorObj set an except for us */
 
-    if (!pgSurface_Lock(self))
+    if (!pgSurface_Lock((pgSurfaceObject *)self))
         return NULL;
     pixels = (Uint8 *)surf->pixels;
 
@@ -1018,7 +1018,7 @@ surf_set_at(PyObject *self, PyObject *args)
             break;
     }
 
-    if (!pgSurface_Unlock(self))
+    if (!pgSurface_Unlock((pgSurfaceObject *)self))
         return NULL;
     Py_RETURN_NONE;
 }
@@ -1051,7 +1051,7 @@ surf_get_at_mapped(PyObject *self, PyObject *args)
     if (format->BytesPerPixel < 1 || format->BytesPerPixel > 4)
         return RAISE(PyExc_RuntimeError, "invalid color depth for surface");
 
-    if (!pgSurface_Lock(self))
+    if (!pgSurface_Lock((pgSurfaceObject *)self))
         return NULL;
 
     pixels = (Uint8 *)surf->pixels;
@@ -1075,7 +1075,7 @@ surf_get_at_mapped(PyObject *self, PyObject *args)
             color = *((Uint32 *)(pixels + y * surf->pitch) + x);
             break;
     }
-    if (!pgSurface_Unlock(self))
+    if (!pgSurface_Unlock((pgSurfaceObject *)self))
         return NULL;
 
     return PyInt_FromLong((long)color);
@@ -1129,7 +1129,7 @@ surf_unmap_rgb(PyObject *self, PyObject *arg)
 static PyObject *
 surf_lock(PyObject *self, PyObject *args)
 {
-    if (!pgSurface_Lock(self))
+    if (!pgSurface_Lock((pgSurfaceObject *)self))
         return NULL;
     Py_RETURN_NONE;
 }
@@ -1137,7 +1137,7 @@ surf_lock(PyObject *self, PyObject *args)
 static PyObject *
 surf_unlock(PyObject *self, PyObject *args)
 {
-    pgSurface_Unlock(self);
+    pgSurface_Unlock((pgSurfaceObject *)self);
     Py_RETURN_NONE;
 }
 
@@ -2153,9 +2153,9 @@ surf_fill(PyObject *self, PyObject *args, PyObject *keywds)
         }
         else {
             pgSurface_Prep(self);
-            pgSurface_Lock(self);
+            pgSurface_Lock((pgSurfaceObject *)self);
             result = SDL_FillRect(surf, &sdlrect, color);
-            pgSurface_Unlock(self);
+            pgSurface_Unlock((pgSurfaceObject *)self);
             pgSurface_Unprep(self);
         }
         if (result == -1)
@@ -2501,7 +2501,7 @@ surf_scroll(PyObject *self, PyObject *args, PyObject *keywds)
         Py_RETURN_NONE;
     }
 
-    if (!pgSurface_Lock(self)) {
+    if (!pgSurface_Lock((pgSurfaceObject *)self)) {
         return NULL;
     }
 
@@ -2535,7 +2535,7 @@ surf_scroll(PyObject *self, PyObject *args, PyObject *keywds)
     }
     surface_move(src, dst, h, w * bpp, pitch, pitch);
 
-    if (!pgSurface_Unlock(self)) {
+    if (!pgSurface_Unlock((pgSurfaceObject *)self)) {
         return NULL;
     }
 
@@ -2787,7 +2787,7 @@ surf_subsurface(PyObject *self, PyObject *args)
         return RAISE(PyExc_ValueError,
                      "subsurface rectangle outside surface area");
 
-    pgSurface_Lock(self);
+    pgSurface_Lock((pgSurfaceObject *)self);
 
     pixeloffset = rect->x * format->BytesPerPixel + rect->y * surf->pitch;
     startpixel = ((char *)surf->pixels) + pixeloffset;
@@ -2796,7 +2796,7 @@ surf_subsurface(PyObject *self, PyObject *args)
         startpixel, rect->w, rect->h, format->BitsPerPixel, surf->pitch,
         format->Rmask, format->Gmask, format->Bmask, format->Amask);
 
-    pgSurface_Unlock(self);
+    pgSurface_Unlock((pgSurfaceObject *)self);
 
 #if IS_SDLv1
     if (!sub)
@@ -3004,7 +3004,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
-    if (!pgSurface_Lock(self))
+    if (!pgSurface_Lock((pgSurfaceObject *)self))
         return RAISE(pgExc_SDLError, "could not lock surface");
 
     format = surf->format;
@@ -3156,7 +3156,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
             break;
         }
     }
-    if (!pgSurface_Unlock(self))
+    if (!pgSurface_Unlock((pgSurfaceObject *)self))
         return RAISE(pgExc_SDLError, "could not unlock surface");
 
     rect = pgRect_New4(min_x, min_y, max_x - min_x, max_y - min_y);
@@ -3697,7 +3697,7 @@ _init_buffer(PyObject *surf, Py_buffer *view_p, int flags)
         PyMem_Free(internal);
         return -1;
     }
-    if (!pgSurface_LockBy(surf, consumer)) {
+    if (!pgSurface_LockBy((pgSurfaceObject *)surf, consumer)) {
         PyErr_Format(pgExc_BufferError,
                      "Unable to lock <%s at %p> by <%s at %p>",
                      Py_TYPE(surf)->tp_name, (void *)surf,
@@ -3740,7 +3740,7 @@ _release_buffer(Py_buffer *view_p)
     assert(consumer_ref && PyWeakref_CheckRef(consumer_ref));
     consumer = PyWeakref_GetObject(consumer_ref);
     if (consumer) {
-        if (!pgSurface_UnlockBy(view_p->obj, consumer)) {
+        if (!pgSurface_UnlockBy((pgSurfaceObject *)view_p->obj, consumer)) {
             PyErr_Clear();
         }
     }

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -49,7 +49,7 @@ pgSurface_Prep(pgSurfaceObject *surfobj)
     if (data != NULL) {
         SDL_Surface *surf = pgSurface_AsSurface(surfobj);
         SDL_Surface *owner = pgSurface_AsSurface(data->owner);
-        pgSurface_LockBy(data->owner, surfobj);
+        pgSurface_LockBy((pgSurfaceObject *)data->owner, (PyObject *)surfobj);
         surf->pixels = ((char *)owner->pixels) + data->pixeloffset;
     }
 }
@@ -59,20 +59,21 @@ pgSurface_Unprep(pgSurfaceObject *surfobj)
 {
     struct pgSubSurface_Data *data = ((pgSurfaceObject *)surfobj)->subsurface;
     if (data != NULL) {
-        pgSurface_UnlockBy(data->owner, surfobj);
+        pgSurface_UnlockBy((pgSurfaceObject *)data->owner,
+                           (PyObject *)surfobj);
     }
 }
 
 static int
 pgSurface_Lock(pgSurfaceObject *surfobj)
 {
-    return pgSurface_LockBy(surfobj, surfobj);
+    return pgSurface_LockBy(surfobj, (PyObject *)surfobj);
 }
 
 static int
 pgSurface_Unlock(pgSurfaceObject *surfobj)
 {
-    return pgSurface_UnlockBy(surfobj, surfobj);
+    return pgSurface_UnlockBy(surfobj, (PyObject *)surfobj);
 }
 
 static int
@@ -226,7 +227,8 @@ _lifelock_dealloc(PyObject *self)
         PyObject_ClearWeakRefs(self);
     }
 
-    pgSurface_UnlockBy(lifelock->surface, lifelock->lockobj);
+    pgSurface_UnlockBy((pgSurfaceObject *)lifelock->surface,
+                       lifelock->lockobj);
     Py_DECREF(lifelock->surface);
     PyObject_DEL(self);
 }
@@ -245,7 +247,7 @@ pgSurface_LockLifetime(PyObject *surfobj, PyObject *lockobj)
         life->lockobj = lockobj;
         life->weakrefs = NULL;
         Py_INCREF(surfobj);
-        if (!pgSurface_LockBy(surfobj, lockobj)) {
+        if (!pgSurface_LockBy((pgSurfaceObject *)surfobj, lockobj)) {
             return NULL;
         }
     }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -531,7 +531,8 @@ stretch(SDL_Surface *src, SDL_Surface *dst)
 static PyObject *
 surf_scale(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj, *surfobj2;
+    pgSurfaceObject *surfobj;
+    PyObject *surfobj2;
     SDL_Surface *surf, *newsurf;
     int width, height;
     surfobj2 = NULL;
@@ -647,7 +648,7 @@ surf_scale2x(PyObject *self, PyObject *arg)
 static PyObject *
 surf_rotate(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj;
+    pgSurfaceObject *surfobj;
     SDL_Surface *surf, *newsurf;
     float angle;
 
@@ -748,7 +749,7 @@ surf_rotate(PyObject *self, PyObject *arg)
 static PyObject *
 surf_flip(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj;
+    pgSurfaceObject *surfobj;
     SDL_Surface *surf, *newsurf;
     int xaxis, yaxis;
     int loopx, loopy;
@@ -900,7 +901,7 @@ surf_flip(PyObject *self, PyObject *arg)
 static PyObject *
 surf_rotozoom(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj;
+    pgSurfaceObject *surfobj;
     SDL_Surface *surf, *newsurf, *surf32;
     float scale, angle;
 
@@ -1416,7 +1417,8 @@ scalesmooth(SDL_Surface *src, SDL_Surface *dst, struct _module_state *st)
 static PyObject *
 surf_scalesmooth(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj, *surfobj2;
+    pgSurfaceObject *surfobj;
+    PyObject *surfobj2;
     SDL_Surface *surf, *newsurf;
     int width, height, bpp;
     surfobj2 = NULL;
@@ -1745,7 +1747,7 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *dest_surf_obj;
     SDL_Surface *dest_surf = NULL;
 
-    PyObject *surf_obj = NULL;
+    pgSurfaceObject *surf_obj = NULL;
     SDL_Surface *surf = NULL;
 
     PyObject *search_color_obj;
@@ -1883,10 +1885,10 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (dest_surf)
-        pgSurface_Lock(dest_surf_obj);
+        pgSurface_Lock((pgSurfaceObject*)dest_surf_obj);
     pgSurface_Lock(surf_obj);
     if (search_surf)
-        pgSurface_Lock(search_surf_obj);
+        pgSurface_Lock((pgSurfaceObject*)search_surf_obj);
 
     Py_BEGIN_ALLOW_THREADS;
     num_threshold_pixels =
@@ -1895,10 +1897,10 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     Py_END_ALLOW_THREADS;
 
     if (dest_surf)
-        pgSurface_Unlock(dest_surf_obj);
+        pgSurface_Unlock((pgSurfaceObject*)dest_surf_obj);
     pgSurface_Unlock(surf_obj);
     if (search_surf)
-        pgSurface_Unlock(search_surf_obj);
+        pgSurface_Unlock((pgSurfaceObject*)search_surf_obj);
 
     return PyInt_FromLong(num_threshold_pixels);
 }
@@ -2708,7 +2710,8 @@ average_color(SDL_Surface *surf, int x, int y, int width, int height, Uint8 *r,
 static PyObject *
 surf_average_color(PyObject *self, PyObject *arg)
 {
-    PyObject *surfobj, *rectobj = NULL;
+    pgSurfaceObject *surfobj = NULL;
+    PyObject *rectobj = NULL;
     SDL_Surface *surf;
     GAME_Rect *rect, temp;
     Uint8 r, g, b, a;


### PR DESCRIPTION
Three main fixes so far:

- For draw.c, the recent optimisations don't compile on SDL1 because SDL_IntersectRect wasn't exposed outside the library until SDL 2.

- With the recent windows SDK SDL 1 doesn't compile unless you define `WINDOWS_IGNORE_PACKING_MISMATCH` it doesn't seem like defining this does any harm apart from suppressing this warning in the windows headers (discovered here: https://github.com/microsoft/vcpkg/pull/10302)

- I noticed I messed up the FORCEINLINE macro so it was spamming warnings everywhere when building SDL 1.

- [x] It looks like there are a few more MSVC warnings in `surflock.c`:

    src_c/surflock.c(52): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surflock.c(52): warning C4133: 'function': incompatible types - from 'pgSurfaceObject *' to 'PyObject *'
    src_c/surflock.c(62): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surflock.c(62): warning C4133: 'function': incompatible types - from 'pgSurfaceObject *' to 'PyObject *'
    src_c/surflock.c(69): warning C4133: 'function': incompatible types - from 'pgSurfaceObject *' to 'PyObject *'
    src_c/surflock.c(75): warning C4133: 'function': incompatible types - from 'pgSurfaceObject *' to 'PyObject *'
    src_c/surflock.c(229): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surflock.c(248): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'


- [x] and in `draw.c`:

    src_c/draw.c(968): warning C4133: 'function': incompatible types - from 'pgSurfaceObject *' to 'PyObject *'
    src_c/draw.c(975): warning C4133: 'function': incompatible types - from 'pgSurfaceObject *' to 'PyObject *'
    src_c/draw.c(868): warning C4101: 'clipped': unreferenced local variable
    src_c/draw.c(867): warning C4101: 'result': unreferenced local variable
    src_c/draw.c(866): warning C4101: 'cliprect': unreferenced local variable
    src_c/draw.c(865): warning C4101: 'sdlrect': unreferenced local variable

- [x] and `imageext`:

    src_c/imageext.c(750): warning C4133: 'return': incompatible types - from 'PyObject *' to 'SDL_Surface *'
    src_c/imageext.c(753): warning C4133: 'return': incompatible types - from 'PyObject *' to 'SDL_Surface *'
    src_c/imageext.c(759): warning C4133: 'return': incompatible types - from 'PyObject *' to 'SDL_Surface *'
    src_c/imageext.c(779): warning C4133: 'return': incompatible types - from 'PyObject *' to 'SDL_Surface *'

- ~~and `pypm.c`:~~

    ~~src_c/pypm.c(4466): warning C4113: 'PtTimestamp (__cdecl *)()' differs in parameter lists from 'PmTimeProcPtr'~~ This is in generated Cython code

- [x] and `ft_render.c`:

    src_c/freetype/ft_render.c(325): warning C4244: '=': conversion from 'long' to 'Uint16', possible loss of data
    src_c/freetype/ft_render.c(339): warning C4244: '=': conversion from 'long' to 'Uint16', possible loss of data
    src_c/freetype/ft_render.c(747): warning C4244: '=': conversion from 'long' to 'Uint16', possible loss of data
    src_c/freetype/ft_render.c(759): warning C4244: '=': conversion from 'long' to 'Uint16', possible loss of data

- [x] and `freetype.c`:

    src_c/_freetype.c(1841): warning C4047: '=': 'PyObject *' differs in levels of indirection from 'int'
    src_c/_freetype.c(1973): warning C4047: '=': 'PyObject *' differs in levels of indirection from 'int'

- [x] and `alphablit.c`:

    src_c/alphablit.c(317): warning C4102: 'LEAVE': unreferenced label

-  ~~and `bitmask.c`:~~
  
    ~~src_c/bitmask.c(70): warning C4293: '>>': shift count negative or too big, undefined behavior~~ This looks correct to me, but I could be wrong.

Which I will also take a look at.

Round 2:

- [x] `mask.c`:

    src_c/mask.c(793): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(818): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(1053): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(1055): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(1063): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(1065): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(2188): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(2195): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(2202): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(2215): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(2220): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/mask.c(2225): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'

- [x] `transform.c` : 

    src_c/transform.c(569): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(579): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(669): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(675): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(736): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(742): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(772): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(895): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(919): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(935): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1459): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1478): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1886): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1887): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1889): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1898): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1899): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(1901): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(2721): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/transform.c(2742): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'

- [x] `image.c` : 

    src_c/image.c(629): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(634): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(645): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(713): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(728): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(794): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(805): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(864): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(880): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(957): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(973): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/image.c(1050): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'

- [x] `surface.c` : 

    src_c/surface.c(887): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(936): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(993): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(1021): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(1054): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(1078): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(1132): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(1140): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(1981): WARNING: "srcsurf doesn't actually do anything?"
    src_c/surface.c(2156): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(2158): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(2504): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(2538): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(2790): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(2799): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(3007): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(3159): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(3700): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'
    src_c/surface.c(3743): warning C4133: 'function': incompatible types - from 'PyObject *' to 'pgSurfaceObject *'