### PR TITLE
Clean up temp obj files after testing for compile flags on windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -582,13 +582,21 @@ if sys.platform == 'win32':
         """
         from distutils.errors import CompileError
         import tempfile
+        root_drive = os.path.splitdrive(sys.executable)[0] + '\\'
         with tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False) as f:
             f.write('int main (int argc, char **argv) { return 0; }')
             fname = f.name
         try:
-            compiler.compile([fname], extra_postargs=[flagname])
+            compiler.compile([fname], output_dir=root_drive, extra_postargs=[flagname])
         except CompileError:
             return False
+        else:
+            try:
+                base_file = os.path.splitext(fname)[0]
+                obj_file = base_file + '.obj'
+                os.remove(obj_file)
+            except OSError:
+                pass
         finally:
             try:
                 os.remove(fname)


### PR DESCRIPTION
In the previous PR adding the windows optimisation compile flags I added a test that determined if they were supported or not. That test cleaned up it's .cpp files afterwards, but not it's .obj files. 

This fixes that.