### PR TITLE
Font bgcolor SDL1 test fix

### DIFF
--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1230,7 +1230,7 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertRaises(AttributeError, setattr, f, "fgcolor", None)
 
     def test_freetype_Font_bgcolor(self):
-        f = ft.Font(None, 12)
+        f = ft.Font(None, 32)
         zero = "0"  # the default font 0 glyph does not have a pixel at (0, 0)
         f.origin = False
         f.pad = False

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -679,7 +679,7 @@ class FreeTypeFontTest(unittest.TestCase):
         rrect = font.render_to(surf, rect, "FoobarBax", color, None, size=24)
         self.assertEqual(rrect.top, rrect.height)
         self.assertNotEqual(rrect.size, rect.size)
-        rrect = font.render_to(surf, (int(20.1), int(18.9)), "FoobarBax", color, None, size=24)
+        rrect = font.render_to(surf, (20.1, 18.9), "FoobarBax", color, None, size=24)
         ## self.assertEqual(tuple(rend[1].topleft), (20, 18))
 
         rrect = font.render_to(surf, rect, "", color, None, size=24)

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -679,7 +679,7 @@ class FreeTypeFontTest(unittest.TestCase):
         rrect = font.render_to(surf, rect, "FoobarBax", color, None, size=24)
         self.assertEqual(rrect.top, rrect.height)
         self.assertNotEqual(rrect.size, rect.size)
-        rrect = font.render_to(surf, (20.1, 18.9), "FoobarBax", color, None, size=24)
+        rrect = font.render_to(surf, (int(20.1), int(18.9)), "FoobarBax", color, None, size=24)
         ## self.assertEqual(tuple(rend[1].topleft), (20, 18))
 
         rrect = font.render_to(surf, rect, "", color, None, size=24)


### PR DESCRIPTION
Fixes #1852 

Looks like the test render of a '0' wasn't in a large enough font for the SDL 1 font rendering to not make some mess in the top left pixel.

I also changed an implicit int cast to an explict int one as implict int casts are deprecated in python 3.8 and it was popping an annoying warning.