### PR TITLE
Freetype font int casting fix

### DIFF
--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -420,9 +420,8 @@ loaded. This module must be imported explicitly to be used. ::
       That is, the alpha values of the foreground, background, and destination
       target surface all affect the blit.
 
-      The return value is a :class:`Rect <pygame.Rect>` instance containing the
-      width and height of the text's bounding box and the position of the
-      text's origin. This is the same as ``get_rect()``.
+      The return value is a rectangle giving the size and position of the
+      rendered text within the surface.
 
       If an empty string is passed for text then the returned
       :class:`Rect <pygame.Rect>` is zero width and the height of the font.

--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -420,8 +420,9 @@ loaded. This module must be imported explicitly to be used. ::
       That is, the alpha values of the foreground, background, and destination
       target surface all affect the blit.
 
-      The return value is a rectangle giving the size and position of the
-      rendered text within the surface.
+      The return value is a :class:`Rect <pygame.Rect>` instance containing the
+      width and height of the text's bounding box and the position of the
+      text's origin. This is the same as ``get_rect()``.
 
       If an empty string is passed for text then the returned
       :class:`Rect <pygame.Rect>` is zero width and the height of the font.

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -318,15 +318,21 @@ parse_dest(PyObject *dest, int *x, int *y)
         Py_DECREF(oj);
         return -1;
     }
-    i = PyInt_AsLong(oi);
+    if (!pg_IntFromObj(oi, &i)){
+        i = -1;
+    }
     Py_DECREF(oi);
-    if (i == -1 && PyErr_Occurred()) {
+    if (i == -1 ) {
         Py_DECREF(oj);
+        PyErr_SetString(PyExc_TypeError, "dest expects a pair of numbers");
         return -1;
     }
-    j = PyInt_AsLong(oj);
+    if (!pg_IntFromObj(oj, &j)){
+        j = -1;
+    }
     Py_DECREF(oj);
-    if (j == -1 && PyErr_Occurred()) {
+    if (j == -1 ) {
+        PyErr_SetString(PyExc_TypeError, "dest expects a pair of numbers");
         return -1;
     }
     *x = i;


### PR DESCRIPTION
**What this does**

@charlesej pointed out that there was a better way to solve implict int cast warnings when I applied a quick fix to the freetype tests. The change to `freetype.c` applies this fix by getting ints from the passed in dest param using the function `pg_IntFromObj` to get ints rather than the standard `PyIntAsLong()`.