### PR TITLE
Fix _pg_rw_write

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -27,6 +27,11 @@
 #define _PYGAME_INTERNAL_H
 
 #include "pgplatform.h"
+/*
+    If PY_SSIZE_T_CLEAN is defined before including Python.h, length is a
+    Py_ssize_t rather than an int for all # variants of formats (s#, y#, etc.)
+*/
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <SDL.h>
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -346,7 +346,11 @@ _pg_rw_write(SDL_RWops *context, const void *ptr, size_t size, size_t num)
     if (!helper->write)
         return -1;
 
+#if PY3
+    result = PyObject_CallFunction(helper->write, "y#", ptr, size * num);
+#else  /* PY2 */
     result = PyObject_CallFunction(helper->write, "s#", ptr, size * num);
+#endif  /* PY2 */
     if (!result)
         return -1;
 
@@ -362,7 +366,11 @@ _pg_rw_write(SDL_RWops *context, const void *ptr, size_t size, size_t num)
         return -1;
     state = PyGILState_Ensure();
 
+#if PY3
+    result = PyObject_CallFunction(helper->write, "y#", ptr, size * num);
+#else  /* PY2 */
     result = PyObject_CallFunction(helper->write, "s#", ptr, size * num);
+#endif  /* PY2 */
     if (!result) {
         PyErr_Print();
         retval = -1;

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -2,6 +2,7 @@
 
 import array
 import binascii
+import io
 import os
 import tempfile
 import unittest
@@ -254,6 +255,30 @@ class ImageModuleTest(unittest.TestCase):
             finally:
                 # clean up the temp file, comment out to leave tmp file after run.
                 os.remove(temp_filename)
+
+    def test_save_to_fileobject(self):
+        s = pygame.Surface((1, 1))
+        s.fill((23, 23, 23))
+        bytes_stream = io.BytesIO()
+
+        pygame.image.save(s, bytes_stream)
+        bytes_stream.seek(0)
+        s2 = pygame.image.load(bytes_stream, "tga")
+        self.assertEqual(s.get_at((0, 0)), s2.get_at((0, 0)))
+
+    def test_save_tga(self):
+        s = pygame.Surface((1, 1))
+        s.fill((23, 23, 23))
+        with tempfile.NamedTemporaryFile(suffix=".tga", delete=False) as f:
+            temp_filename = f.name
+
+        try:
+            pygame.image.save(s, temp_filename)
+            s2 = pygame.image.load(temp_filename)
+            self.assertEqual(s2.get_at((0, 0)), s.get_at((0, 0)))
+        finally:
+            # clean up the temp file, even if test fails
+            os.remove(temp_filename)
 
     def test_save_colorkey(self):
         """ make sure the color key is not changed when saving.


### PR DESCRIPTION
Fix #1714 
Calling the helper write function should be done with a Bytes type
instead of a String type.