### PR TITLE
font: Add attribute accessors for bold, italic and underline

### DIFF
--- a/buildconfig/pygame-stubs/font.pyi
+++ b/buildconfig/pygame-stubs/font.pyi
@@ -23,6 +23,11 @@ def SysFont(
 ) -> Font: ...
 
 class Font(object):
+
+    bold: bool
+    italic: bool
+    underline: bool
+
     def __init__(self, name: Union[str, IO, None], size: int) -> None: ...
     def render(
         self,

--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -139,6 +139,56 @@ loaded instead.
    font with actual italic or bold glyphs. The rendered text can be regular
    strings or unicode.
 
+   .. attribute:: bold
+
+      | :sl:`Gets or sets whether the font should be rendered in (faked) bold.`
+      | :sg:`bold -> bool`
+
+      Whether the font should be rendered in bold.
+
+      When set to True, this enables the bold rendering of text. This
+      is a fake stretching of the font that doesn't look good on many
+      font types. If possible load the font from a real bold font
+      file. While bold, the font will have a different width than when
+      normal. This can be mixed with the italic and underline modes.
+
+      .. versionadded:: 2.0.0
+
+      .. ## Font.bold ##
+
+   .. attribute:: italic
+
+      | :sl:`Gets or sets whether the font should be rendered in (faked) italics.`
+      | :sg:`italic -> bool`
+
+      Whether the font should be rendered in italic.
+
+      When set to True, this enables fake rendering of italic
+      text. This is a fake skewing of the font that doesn't look good
+      on many font types. If possible load the font from a real italic
+      font file. While italic the font will have a different width
+      than when normal. This can be mixed with the bold and underline
+      modes.
+
+      .. versionadded:: 2.0.0
+
+      .. ## Font.italic ##
+
+   .. attribute:: underline
+
+      | :sl:`Gets or sets whether the font should be rendered with an underline.`
+      | :sg:`underline -> bool`
+
+      Whether the font should be rendered in underline.
+
+      When set to True, all rendered fonts will include an
+      underline. The underline is always one pixel thick, regardless
+      of font size. This can be mixed with the bold and italic modes.
+
+      .. versionadded:: 2.0.0
+
+      .. ## Font.underline ##
+
    .. method:: render
 
       | :sl:`draw text on a new Surface`
@@ -210,6 +260,8 @@ loaded instead.
       is always one pixel thick, regardless of font size. This can be mixed
       with the bold and italic modes.
 
+      .. note:: This is the same as the :attr:`underline` attribute.
+
       .. ## Font.set_underline ##
 
    .. method:: get_underline
@@ -218,6 +270,8 @@ loaded instead.
       | :sg:`get_underline() -> bool`
 
       Return True when the font underline is enabled.
+
+       .. note:: This is the same as the :attr:`underline` attribute.
 
       .. ## Font.get_underline ##
 
@@ -231,6 +285,8 @@ loaded instead.
       a real bold font file. While bold, the font will have a different width
       than when normal. This can be mixed with the italic and underline modes.
 
+      .. note:: This is the same as the :attr:`bold` attribute.
+
       .. ## Font.set_bold ##
 
    .. method:: get_bold
@@ -239,6 +295,8 @@ loaded instead.
       | :sg:`get_bold() -> bool`
 
       Return True when the font bold rendering mode is enabled.
+
+      .. note:: This is the same as the :attr:`bold` attribute.
 
       .. ## Font.get_bold ##
 
@@ -252,6 +310,8 @@ loaded instead.
       a real italic font file. While italic the font will have a different
       width than when normal. This can be mixed with the bold and underline
       modes.
+
+      .. note:: This is the same as the :attr:`italic` attribute.
 
       .. ## Font.set_italic ##
 
@@ -275,6 +335,8 @@ loaded instead.
       | :sg:`get_italic() -> bool`
 
       Return True when the font italic rendering mode is enabled.
+
+      .. note:: This is the same as the :attr:`italic` attribute.
 
       .. ## Font.get_italic ##
 

--- a/src_c/doc/font_doc.h
+++ b/src_c/doc/font_doc.h
@@ -8,6 +8,9 @@
 #define DOC_PYGAMEFONTMATCHFONT "match_font(name, bold=False, italic=False) -> path\nfind a specific font on the system"
 #define DOC_PYGAMEFONTSYSFONT "SysFont(name, size, bold=False, italic=False) -> Font\ncreate a Font object from the system fonts"
 #define DOC_PYGAMEFONTFONT "Font(filename, size) -> Font\nFont(object, size) -> Font\ncreate a new Font object from a file"
+#define DOC_FONTBOLD "bold -> bool\nGets or sets whether the font should be rendered in (faked) bold."
+#define DOC_FONTITALIC "bold -> bool\nGets or sets whether the font should be rendered in (faked) italics."
+#define DOC_FONTUNDERLINE "bold -> bool\nGets or sets whether the font should be rendered with an underline."
 #define DOC_FONTRENDER "render(text, antialias, color, background=None) -> Surface\ndraw text on a new Surface"
 #define DOC_FONTSIZE "size(text) -> (width, height)\ndetermine the amount of space needed to render text"
 #define DOC_FONTSETUNDERLINE "set_underline(bool) -> None\ncontrol if text is rendered with an underline"
@@ -62,6 +65,18 @@ pygame.font.Font
  Font(filename, size) -> Font
  Font(object, size) -> Font
 create a new Font object from a file
+
+pygame.font.Font.bold
+ bold -> bool
+Gets or sets whether the font should be rendered in (faked) bold.
+
+pygame.font.Font.italic
+ bold -> bool
+Gets or sets whether the font should be rendered in (faked) italics.
+
+pygame.font.Font.underline
+ bold -> bool
+Gets or sets whether the font should be rendered with an underline.
 
 pygame.font.Font.render
  render(text, antialias, color, background=None) -> Surface

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -263,17 +263,62 @@ font_get_linesize(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-font_get_bold(PyObject *self, PyObject *args)
+_font_get_style_flag_as_py_bool(PyObject *self, int flag)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_BOLD) != 0);
+    return PyBool_FromLong((TTF_GetFontStyle(font) & flag) != 0);
 }
 
+static void
+_font_set_or_clear_style_flag(TTF_Font *font, int flag, int set_flag)
+{
+    int style = TTF_GetFontStyle(font);
+    if (set_flag)
+        style |= flag;
+    else
+        style &= ~flag;
+    TTF_SetFontStyle(font, style);
+}
+
+/* Implements getter for the bold attribute */
+static PyObject *
+font_getter_bold(PyObject *self, void *closure)
+{
+    return _font_get_style_flag_as_py_bool(self, TTF_STYLE_BOLD);
+}
+
+/* Implements setter for the bold attribute */
+static int
+font_setter_bold(PyObject *self, PyObject *value, void *closure)
+{
+    TTF_Font *font = PyFont_AsFont(self);
+    int val;
+
+    DEL_ATTR_NOT_SUPPORTED_CHECK("bold", value);
+
+    val = PyObject_IsTrue(value);
+    if (val == -1) {
+        return -1;
+    }
+
+    _font_set_or_clear_style_flag(font, TTF_STYLE_BOLD, val);
+    return 0;
+}
+
+
+/* Implements get_bold() */
+static PyObject *
+font_get_bold(PyObject *self, PyObject *args)
+{
+    return _font_get_style_flag_as_py_bool(self, TTF_STYLE_BOLD);
+}
+
+/* Implements set_bold(bool) */
 static PyObject *
 font_set_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int style, val;
+    int val;
 #if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
 #else
@@ -281,28 +326,49 @@ font_set_bold(PyObject *self, PyObject *args)
 #endif /* PY3 */
         return NULL;
 
-    style = TTF_GetFontStyle(font);
-    if (val)
-        style |= TTF_STYLE_BOLD;
-    else
-        style &= ~TTF_STYLE_BOLD;
-    TTF_SetFontStyle(font, style);
+    _font_set_or_clear_style_flag(font, TTF_STYLE_BOLD, val);
 
     Py_RETURN_NONE;
 }
 
+/* Implements getter for the italic attribute */
+static PyObject *
+font_getter_italic(PyObject *self, void *closure)
+{
+    return _font_get_style_flag_as_py_bool(self, TTF_STYLE_ITALIC);
+}
+
+/* Implements setter for the italic attribute */
+static int
+font_setter_italic(PyObject *self, PyObject *value, void *closure)
+{
+    TTF_Font *font = PyFont_AsFont(self);
+    int val;
+
+    DEL_ATTR_NOT_SUPPORTED_CHECK("italic", value);
+
+    val = PyObject_IsTrue(value);
+    if (val == -1) {
+        return -1;
+    }
+
+    _font_set_or_clear_style_flag(font, TTF_STYLE_ITALIC, val);
+    return 0;
+}
+
+/* Implements get_italic() */
 static PyObject *
 font_get_italic(PyObject *self, PyObject *args)
 {
-    TTF_Font *font = PyFont_AsFont(self);
-    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_ITALIC) != 0);
+    return _font_get_style_flag_as_py_bool(self, TTF_STYLE_ITALIC);
 }
 
+/* Implements set_italic(bool) */
 static PyObject *
 font_set_italic(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int style, val;
+    int val;
 
 #if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
@@ -311,28 +377,51 @@ font_set_italic(PyObject *self, PyObject *args)
 #endif /* PY3 */
         return NULL;
 
-    style = TTF_GetFontStyle(font);
-    if (val)
-        style |= TTF_STYLE_ITALIC;
-    else
-        style &= ~TTF_STYLE_ITALIC;
-    TTF_SetFontStyle(font, style);
+    _font_set_or_clear_style_flag(font, TTF_STYLE_ITALIC, val);
 
     Py_RETURN_NONE;
 }
 
+
+/* Implements getter for the underline attribute */
+static PyObject *
+font_getter_underline(PyObject *self, void *closure)
+{
+    return _font_get_style_flag_as_py_bool(self, TTF_STYLE_UNDERLINE);
+}
+
+/* Implements setter for the underline attribute */
+static int
+font_setter_underline(PyObject *self, PyObject *value, void *closure)
+{
+    TTF_Font *font = PyFont_AsFont(self);
+    int val;
+
+    DEL_ATTR_NOT_SUPPORTED_CHECK("underline", value);
+
+    val = PyObject_IsTrue(value);
+    if (val == -1) {
+        return -1;
+    }
+
+    _font_set_or_clear_style_flag(font, TTF_STYLE_UNDERLINE, val);
+    return 0;
+}
+
+/* Implements get_underline() */
 static PyObject *
 font_get_underline(PyObject *self, PyObject *args)
 {
-    TTF_Font *font = PyFont_AsFont(self);
-    return PyBool_FromLong((TTF_GetFontStyle(font) & TTF_STYLE_UNDERLINE) != 0);
+    return _font_get_style_flag_as_py_bool(self, TTF_STYLE_UNDERLINE);
 }
 
+
+/* Implements set_underline(bool) */
 static PyObject *
 font_set_underline(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int style, val;
+    int val;
 
 #if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
@@ -341,12 +430,7 @@ font_set_underline(PyObject *self, PyObject *args)
 #endif /* PY3 */
         return NULL;
 
-    style = TTF_GetFontStyle(font);
-    if (val)
-        style |= TTF_STYLE_UNDERLINE;
-    else
-        style &= ~TTF_STYLE_UNDERLINE;
-    TTF_SetFontStyle(font, style);
+    _font_set_or_clear_style_flag(font, TTF_STYLE_UNDERLINE, val);
 
     Py_RETURN_NONE;
 }
@@ -636,6 +720,18 @@ font_metrics(PyObject *self, PyObject *args)
     return list;
 }
 
+/**
+ * Getters and setters for the pgFontObject.
+ */
+static PyGetSetDef font_getsets[] = {
+    {"bold", (getter)font_getter_bold, (setter)font_setter_bold,
+     DOC_FONTBOLD, NULL},
+    {"italic", (getter)font_getter_italic, (setter)font_setter_italic,
+     DOC_FONTITALIC, NULL},
+    {"underline", (getter)font_getter_underline, (setter)font_setter_underline,
+     DOC_FONTUNDERLINE, NULL},
+    {NULL, NULL, NULL, NULL, NULL}};
+
 static PyMethodDef font_methods[] = {
     {"get_height", font_get_height, METH_NOARGS,
      DOC_FONTGETHEIGHT},
@@ -838,7 +934,7 @@ static PyTypeObject PyFont_Type = {
     0,                                        /* tp_iternext */
     font_methods,                             /* tp_methods */
     0,                                        /* tp_members */
-    0,                                        /* tp_getset */
+    font_getsets,                             /* tp_getset */
     0,                                        /* tp_base */
     0,                                        /* tp_dict */
     0,                                        /* tp_descr_get */

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -85,6 +85,8 @@ class Font(_Font):
 
         return self.wide
 
+    bold = property(get_bold, set_bold)
+
     def set_italic(self, value):
         """set_italic(bool) -> None
            enable fake rendering of italic text"""
@@ -96,6 +98,8 @@ class Font(_Font):
            check if the text will be rendered italic"""
 
         return self.oblique
+
+    italic = property(get_italic, set_italic)
 
     def set_underline(self, value):
         """set_underline(bool) -> None

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -292,9 +292,9 @@ def font_constructor(fontpath, size, bold, italic):
 
     font = pygame.font.Font(fontpath, size)
     if bold:
-        font.set_bold(1)
+        font.set_bold(True)
     if italic:
-        font.set_italic(1)
+        font.set_italic(True)
 
     return font
 

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -359,6 +359,30 @@ class FontTypeTest(unittest.TestCase):
         f.set_underline(False)
         self.assertFalse(f.get_underline())
 
+    def test_bold_attr(self):
+        f = pygame_font.Font(None, 20)
+        self.assertFalse(f.bold)
+        f.bold = True
+        self.assertTrue(f.bold)
+        f.bold = False
+        self.assertFalse(f.bold)
+
+    def test_set_italic(self):
+        f = pygame_font.Font(None, 20)
+        self.assertFalse(f.italic)
+        f.italic = True
+        self.assertTrue(f.italic)
+        f.italic = False
+        self.assertFalse(f.italic)
+
+    def test_set_underline(self):
+        f = pygame_font.Font(None, 20)
+        self.assertFalse(f.underline)
+        f.underline = True
+        self.assertTrue(f.underline)
+        f.underline = False
+        self.assertFalse(f.underline)
+
     def test_size(self):
         f = pygame_font.Font(None, 20)
         text = as_unicode("Xg")


### PR DESCRIPTION
Because `f.bold = True` is nicer than `f.set_bold(True)`. :)