### PR TITLE
Conan repo with custom sdl2 package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ install:
       $PIP_CMD install conan
       $PIP_CMD install cibuildwheel==1.3.0
       conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+      conan remote add pygame-repo https://api.bintray.com/conan/pygame/pygame
       # $PYTHON_EXE buildconfig/config.py -conan --build libtiff --build opusfile --build sdl2_image --build sdl2_ttf
       $PYTHON_EXE buildconfig/config.py -conan --build
       cp build/conan/*.dylib .

--- a/buildconfig/conanconf/README.md
+++ b/buildconfig/conanconf/README.md
@@ -24,6 +24,9 @@ python3 -m pip install conan
 # add the bincrafters conan repository.
 conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
+# add the pygame conan repository.
+conan remote add pygame-repo https://api.bintray.com/conan/pygame/pygame
+
 # install dependencies with conan, and write a `Setup` file for pygame to build with.
 python3 buildconfig/config.py -conan
 
@@ -47,3 +50,17 @@ python3 setup.py install
 python3 -m pygame.example.aliens
 python3 -m pygame.tests
 ```
+
+
+## pygame conan repo on 'bintray'.
+
+Here's the pygame organization on "[bintray.com/pygame](https://bintray.com/pygame)". It's where some conan packages can be uploaded.
+
+Custom packages are useful to work around major bugs in released dependencies that may not have new releases with the fixes in them for several months.
+
+Another use case for a conan repo is uploading binaries.
+
+In order to make a custom package, I started by [setting up bintray](https://docs.conan.io/en/latest/uploading_packages/using_bintray.html)
+
+Then this one for [uploading packages to remotes](https://docs.conan.io/en/latest/uploading_packages/uploading_to_remotes.html)
+

--- a/buildconfig/conanconf/conanfile.txt
+++ b/buildconfig/conanconf/conanfile.txt
@@ -2,7 +2,7 @@
 libpng/1.6.37
 zlib/1.2.11
 freetype/2.10.1
-sdl2/2.0.12@bincrafters/stable
+sdl2/2.0.12@pygame/testing
 sdl2_image/2.0.5@bincrafters/stable
 sdl2_mixer/2.0.4@bincrafters/stable
 sdl2_ttf/2.0.15@bincrafters/stable


### PR DESCRIPTION
- Some documentation on the pygame conan package repo.
- Use pygame version of conan package for sdl2.
- Add conan pygame repo to travis ci mac build.


Related: 
- conan issue: https://github.com/pygame/pygame/issues/997
- PR open for conan-sdl2 with MacOS metal changes. https://github.com/bincrafters/conan-sdl2/pull/29
- issue about [Default SDL render driver back to opengl on mac os](https://github.com/pygame/pygame/issues/1725)

