### PR TITLE
Added unit test for surface.get_colorkey(). Closes #1801

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1029,16 +1029,20 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
         
         # test for using method after display.quit() is called...
-        with self.assertRaises(pygame.error):
+        def f():
             s = pygame.display.set_mode()
             pygame.display.quit()
-            s.get_colorkey() 
+            s.get_colorkey()
+
+        self.assertRaises(pygame.error, f)
 
         # test for using method when display is created with OpenGL and the SDL version is 1
-        if pygame.get_sdl_version()[0] > 1:
-            with self.assertRaises(pygame.error):
+        if SDL1: # SLD1 is a bool defined at the top...
+            def f():
                 s = pygame.display.set_mode(flags=pygame.OPENGL)
                 s.get_colorkey()
+
+            self.assertRaises(pygame.error, f)
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1029,14 +1029,14 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
         
         # test for using method after display.quit() is called...
-        pygame.display.set_mode()
         pygame.display.quit()
-        self.assertRaises(pygame.error)
+        s = pygame.display.set_mode()
+        self.assertRaises(pygame.error, s.get_colorkey())
 
         # test for using method when display is created with OpenGL and the SDL version is 1
         if pygame.get_sdl_version()[0] > 1: # this function returns a tuple
             pygame.display.set_mode(flags=pygame.OpenGL)
-            self.assertRaises(pygame.error)
+            self.assertRaises(pygame.error, s.get_colorkey())
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1032,17 +1032,16 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         def f():
             s = pygame.display.set_mode()
             pygame.display.quit()
-            s.get_colorkey()
+            with self.assertRaises(pygame.error)
+                s.get_colorkey()
 
-        self.assertRaises(pygame.error, f)
 
         # test for using method when display is created with OpenGL and the SDL version is 1
         if SDL1: # SLD1 is a bool defined at the top...
-            def f():
-                s = pygame.display.set_mode(flags=pygame.OPENGL)
+            s = pygame.display.set_mode(flags=pygame.OPENGL)
+            with self.assertRaises(pygame.error):   
                 s.get_colorkey()
 
-            self.assertRaises(pygame.error, f)
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1014,16 +1014,29 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         colorkey = pygame.Color(r, g, b)
         s.set_colorkey(colorkey)
         
+        #test for ideal case
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
         
+        #test for if the color_key is set using pygame.RLEACCEL
         s.set_colorkey(colorkey, pygame.RLEACCEL)
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
         
+        #test for if the color key is not what's expected
         s.set_colorkey(pygame.Color(r + 1, g + 1, b + 1))
         self.assertNotEqual(s.get_colorkey(), (r, g, b, 255))
 
         s.set_colorkey(pygame.Color(r, g, b, a)) # regardless of whether alpha is not 255, colorkey returned from surface is always 255
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
+        
+        # test for using method after display.quit() is called...
+        pygame.display.set_mode()
+        pygame.display.quit()
+        self.assertRaises(pygame.error)
+
+        # test for using method when display is created with OpenGL and the SDL version is 1
+        if pygame.get_sdl_version()[0] > 1: # this function returns a tuple
+            pygame.display.set_mode(flags=pygame.OpenGL)
+            self.assertRaises(pygame.error)
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1000,14 +1000,30 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         rectangle = s.get_clip()
         self.assertEqual(rectangle, (0, 0, 800, 600))
 
-    def todo_test_get_colorkey(self):
-        surf = pygame.surface((2, 2), 0, 24)
-        self.assertIsNone(surf.get_colorykey())
-        colorkey = pygame.Color(20, 40, 60)
-        surf.set_colorkey(colorkey)
-        ck = surf.get_colorkey()
-        self.assertIsInstance(ck, pygame.Color)
-        self.assertEqual(ck, colorkey)
+    def test_get_colorkey(self):
+        # if set_colorkey is not used
+        s = pygame.Surface((800, 600))
+        self.assertIsNone(s.get_colorkey())
+
+        # if set_colorkey is used
+        s.set_colorkey(None)
+        self.assertIsNone(s.get_colorkey())
+        
+        # setting up remainder of tests...
+        r, g, b, a  = 20, 40, 60, 12
+        colorkey = pygame.Color(r, g, b)
+        s.set_colorkey(colorkey)
+        
+        self.assertEqual(s.get_colorkey(), (r, g, b, 255))
+        
+        s.set_colorkey(colorkey, pygame.RLEACCEL)
+        self.assertEqual(s.get_colorkey(), (r, g, b, 255))
+        
+        s.set_colorkey(pygame.Color(r + 1, g + 1, b + 1))
+        self.assertNotEqual(s.get_colorkey(), (r, g, b, 255))
+
+        s.set_colorkey(pygame.Color(r, g, b, a)) # regardless of whether alpha is not 255, colorkey returned from surface is always 255
+        self.assertEqual(s.get_colorkey(), (r, g, b, 255))
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1029,19 +1029,16 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
         
         # test for using method after display.quit() is called...
-        def f():
+        with self.assertRaises(pygame.error):
             s = pygame.display.set_mode()
             pygame.display.quit()
-            with self.assertRaises(pygame.error)
-                s.get_colorkey()
-
+            s.get_colorkey()
 
         # test for using method when display is created with OpenGL and the SDL version is 1
         if SDL1: # SLD1 is a bool defined at the top...
-            s = pygame.display.set_mode(flags=pygame.OPENGL)
             with self.assertRaises(pygame.error):   
+                s = pygame.display.set_mode(flags=pygame.OPENGL)
                 s.get_colorkey()
-
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1029,14 +1029,16 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(s.get_colorkey(), (r, g, b, 255))
         
         # test for using method after display.quit() is called...
-        pygame.display.quit()
-        s = pygame.display.set_mode()
-        self.assertRaises(pygame.error, s.get_colorkey())
+        with self.assertRaises(pygame.error):
+            s = pygame.display.set_mode()
+            pygame.display.quit()
+            s.get_colorkey() 
 
         # test for using method when display is created with OpenGL and the SDL version is 1
-        if pygame.get_sdl_version()[0] > 1: # this function returns a tuple
-            pygame.display.set_mode(flags=pygame.OPENGL)
-            self.assertRaises(pygame.error, s.get_colorkey())
+        if pygame.get_sdl_version()[0] > 1:
+            with self.assertRaises(pygame.error):
+                s = pygame.display.set_mode(flags=pygame.OPENGL)
+                s.get_colorkey()
 
     def test_get_height(self):
         sizes = ((1, 1), (119, 10), (10, 119), (1, 1000), (1000, 1), (1000, 1000))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1035,7 +1035,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 
         # test for using method when display is created with OpenGL and the SDL version is 1
         if pygame.get_sdl_version()[0] > 1: # this function returns a tuple
-            pygame.display.set_mode(flags=pygame.OpenGL)
+            pygame.display.set_mode(flags=pygame.OPENGL)
             self.assertRaises(pygame.error, s.get_colorkey())
 
     def test_get_height(self):


### PR DESCRIPTION
Some of the original code was actually wrong. For instance, checking the type of the returned value from surface.get_colorkey() to see if it is a Color object or an instance of a child class of Color. 

I also added some more cases to make the test more comprehensive. For example, checking what happens when you set the color key using an RGBA value, the alpha not 255, and what surface.get_colorkey() should return.