### PR TITLE
Strengthen warning in event docs about handling the event queue

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -19,9 +19,10 @@ events into the queue from other threads, please use the
 The event queue has an upper limit on the number of events it can hold
 (128 for standard SDL 1.2). When the queue becomes full new events are quietly
 dropped. To prevent lost events, especially input events which signal a quit
-command, your program must regularly check for events and process them.
-To speed up queue processing use :func:`pygame.event.set_blocked()` to
-limit which events get queued.
+command, your program must handle events every frame (with
+``pygame.event.get()``, ``pygame.event.pump()`` or ``pygame.event.clear()``)
+and process them. To speed up queue processing use
+:func:`pygame.event.set_blocked()` to limit which events get queued.
 
 To get the state of various input devices, you can forego the event queue and
 access the input devices directly with their appropriate modules:

--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -20,8 +20,10 @@ The event queue has an upper limit on the number of events it can hold
 (128 for standard SDL 1.2). When the queue becomes full new events are quietly
 dropped. To prevent lost events, especially input events which signal a quit
 command, your program must handle events every frame (with
-``pygame.event.get()``, ``pygame.event.pump()`` or ``pygame.event.clear()``)
-and process them. To speed up queue processing use
+``pygame.event.get()``, ``pygame.event.pump()``, ``pygame.event.wait()``,
+``pygame.event.peek()`` or ``pygame.event.clear()``)
+and process them. Not handling events may cause your system to decide your
+program has locked up. To speed up queue processing use
 :func:`pygame.event.set_blocked()` to limit which events get queued.
 
 To get the state of various input devices, you can forego the event queue and


### PR DESCRIPTION
For this issue:

https://github.com/pygame/pygame/issues/1392

If you don't call `pygame.event.pump()` somehow (it's called by `pygame.event.get()` by default) every frame your app's event handling is going to behave weirdly. I think the docs for `pump()` make this clear already but the warning in the main event module docs was a bit ambiguous.