### PR TITLE
Testing mixer.music.play() start parameter & adding mp3 warning

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -56,9 +56,12 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
 
    :param float start: (optional) The position where the music starts playing
        from. The starting position depends on the format of the music played.
-       ``MP3`` and ``OGG`` use the position as time in seconds. For ``MOD``
-       music it is the pattern order number. Passing a start position will
-       raise a NotImplementedError if the start position cannot be set.
+       ``MP3`` and ``OGG`` use the position as time in seconds. For mp3s the
+       start time position selected may not be accurate as things like variable
+       bit rate encoding and ID3 tags can throw off the timing calculations.
+       For ``MOD``  music it is the pattern order number. Passing a start
+       position will raise a NotImplementedError if the start position cannot
+       be set.
 
    :param int fade_ms: (optional) Make the music start playing at 0 volume and
       fade up to full volume over the given time. The sample may end before

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -192,6 +192,30 @@ class MixerMusicModuleTest(unittest.TestCase):
 
         self.fail()
 
+    def test_play__start_time(self):
+
+        pygame.display.init()
+
+        # music file is 7 seconds long
+        filename = example_path(os.path.join("data", "house_lo.ogg"))
+        pygame.mixer.music.load(filename)
+        start_time_in_seconds = 6.0  # 6 seconds
+
+        music_finished = False
+        clock = pygame.time.Clock()
+        start_time_in_ms = clock.tick()
+        # should play the last 1 second
+        pygame.mixer.music.play(0, start=start_time_in_seconds)
+        running = True
+        while running:
+            pygame.event.pump()
+
+            if not (pygame.mixer.music.get_busy() or music_finished):
+                music_finished = True
+                time_to_finish = (clock.tick() - start_time_in_ms) // 1000
+                self.assertEqual(time_to_finish, 1)
+                running = False
+
     def todo_test_play(self):
 
         # __doc__ (as of 2008-08-02) for pygame.mixer_music.play:

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -192,6 +192,8 @@ class MixerMusicModuleTest(unittest.TestCase):
 
         self.fail()
 
+    @unittest.skipIf(os.environ['SDL_AUDIODRIVER'] == 'disk',
+                     'disk audio driver "playback" writing to disk is slow')
     def test_play__start_time(self):
 
         pygame.display.init()


### PR DESCRIPTION
Looking into this old issue:

https://github.com/pygame/pygame/issues/671

I discovered that the start parameter _does_ work on linux & windows now, but after trying a couple of different mp3 files its 'seeking' accuracy with that file type depends on the file used. This is basically a difficulty with the mp3 file format itself, it includes no timing information so you have to guess based on the file size but doe to things like variable bit rate and tags applied to the file these guessed timings can be thrown off.

I thought the best way to resolve the issue was to add a unit test for the parameter using .ogg files which should be more reliable and add a note to the docs that indicates that for mp3s, the start time parameter is unreliable. 