### PR TITLE
Add a 'sound' module with load function as wrapper around mixer.Sound

### DIFF
--- a/buildconfig/pygame-stubs/__init__.pyi
+++ b/buildconfig/pygame-stubs/__init__.pyi
@@ -14,6 +14,7 @@ import pygame.image
 import pygame.key
 import pygame.mixer
 import pygame.mouse
+import pygame.sound
 import pygame.time
 import pygame.version
 

--- a/buildconfig/pygame-stubs/sound.pyi
+++ b/buildconfig/pygame-stubs/sound.pyi
@@ -1,0 +1,8 @@
+from typing import Union, Any, IO
+
+import numpy
+
+from pygame.mixer import Sound
+
+
+def load(file: Union[IO, numpy.ndarray, Any]) -> Sound: ...

--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -158,6 +158,9 @@ Reference
 :doc:`ref/sndarray`
   Manipulate sound sample data.
 
+:doc:`ref/sound`
+  Wrapper for loading sounds.
+
 :doc:`ref/sprite`
   Higher level objects to represent game images.
 

--- a/docs/reST/ref/sound.rst
+++ b/docs/reST/ref/sound.rst
@@ -1,0 +1,45 @@
+.. include:: common.txt
+
+:mod:`pygame.sound`
+===================
+
+.. module:: pygame.sound
+   :synopsis: pygame module for loading sounds
+
+| :sl:`pygame module for sound loading`
+
+The sound module is a thin wrapper around :mod:`pygame.mixer` and it's Sound
+class. For more extensive documentation you should check there.
+
+.. versionadded:: 2.0
+
+.. function:: load
+
+   | :sl:`load new sound from a file`
+   | :sg:`load(file) -> mixer.Sound`
+
+   Load a sound from a file source. You can pass either a file path or a Python
+   file-like object.
+
+   Pygame will automatically determine the sound type (your choices are
+   uncompressed ``wav`` or ``ogg``) and create a new Sound object from the
+   data.
+
+   The returned Sound can be played by calling it's ``.play()`` method.
+
+   This function is a thin wrapper around the constructor of the
+   pygame.mixer.Sound class. See :mod:`pygame.mixer` which has more detailed
+   documentation on the capabilities of the Sound class.
+
+   You should use ``os.path.join()`` for multi-platform compatibility when
+   loading from paths.
+
+   Example usage:
+   ::
+
+     my_sound = pygame.sound.load(os.path.join('data', 'metronome.wav'))
+     my_sound.play()
+
+   .. ## pygame.sound.load ##
+
+.. ## pygame.sound ##

--- a/docs/reST/ref/sound.rst
+++ b/docs/reST/ref/sound.rst
@@ -8,7 +8,7 @@
 
 | :sl:`pygame module for sound loading`
 
-The sound module is a thin wrapper around :mod:`pygame.mixer` and it's Sound
+The sound module is a thin wrapper around :mod:`pygame.mixer` and its Sound
 class. For more extensive documentation you should check there.
 
 .. versionadded:: 2.0
@@ -25,7 +25,7 @@ class. For more extensive documentation you should check there.
    uncompressed ``wav`` or ``ogg``) and create a new Sound object from the
    data.
 
-   The returned Sound can be played by calling it's ``.play()`` method.
+   The returned Sound can be played by calling its ``.play()`` method.
 
    This function is a thin wrapper around the constructor of the
    pygame.mixer.Sound class. See :mod:`pygame.mixer` which has more detailed

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -34,7 +34,7 @@
 We render three sets of items based on how useful to most apps.
 
 #}
-{%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
+{%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'sound', 'time'] %}
 {%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'Overlay', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
 {%-   if pyg_sections %}
 	  <p class="bottom"><b>Most useful stuff</b>:

--- a/src_c/doc/sound_doc.h
+++ b/src_c/doc/sound_doc.h
@@ -1,0 +1,17 @@
+/* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
+#define DOC_PYGAMESOUND "pygame module for sound loading"
+#define DOC_PYGAMESOUNDLOAD "load(file) -> mixer.Sound\nload new sound from a file"
+
+
+/* Docs in a comment... slightly easier to read. */
+
+/*
+
+pygame.sound
+pygame module for sound loading
+
+pygame.sound.load
+ load(file) -> mixer.Sound
+load new sound from a file
+
+*/

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -143,6 +143,11 @@ except (ImportError, IOError):
     mouse = MissingModule("mouse", urgent=1)
 
 try:
+    import pygame.sound
+except (ImportError, IOError):
+    sound = MissingModule("sound", urgent=1)
+
+try:
     import pygame.sprite
 except (ImportError, IOError):
     sprite = MissingModule("sprite", urgent=1)

--- a/src_py/sound.py
+++ b/src_py/sound.py
@@ -1,0 +1,27 @@
+"""pygame.sound
+
+pygame wrapper module for loading a sound. The real work is done by
+the mixer module.
+"""
+
+import pygame.mixer
+
+
+__all__ = ['load']
+
+
+def load(file):
+    """
+    Load a sound file and return a Sound object. This is a loose wrapper
+    around the mixer.Sound class initializer to give a similar interface to
+    image.load().
+
+    :param file: The file to load. This can be a buffer or a file name.
+
+    :return: A mixer.Sound object.
+    """
+
+    # check we have initialised the mixer and initialise it if we haven't
+    if not pygame.mixer.get_init():
+        pygame.mixer.init()
+    return pygame.mixer.Sound(file)

--- a/test/sound_test.py
+++ b/test/sound_test.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+import pygame
+import pygame.sound
+from pygame.tests.test_utils import example_path
+
+
+class SoundModuleTest(unittest.TestCase):
+
+    def test_load(self):
+        wave_path = example_path(os.path.join("data", "house_lo.wav"))
+        snd = pygame.sound.load(file=wave_path)
+        self.assertTrue(snd.get_length() > 0.5)
+        snd_bytes = snd.get_raw()
+        self.assertTrue(len(snd_bytes) > 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This was suggested by @nthykier in this issue:

https://github.com/pygame/pygame/issues/836

The idea is basically so you can do:

    pygame.sound.load('blah.wav')

in a similar way to how you can currently do:

    pygame.image.load('blah.png')

There is no exciting code, just a thin wrapper around the already existing mixer code and a bunch of documentation and boilerplate to integrate it as a new module with a single function.