### PR TITLE
Check for presence of colorkey to determine setting BLENDMODE_BLEND

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1534,6 +1534,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     PyObject *alpha_obj = NULL, *intobj = NULL;
     Uint8 alpha;
     int result, alphaval = 255;
+    Uint32 colorkey;
 #if IS_SDLv1
     int hasalpha = 0;
 #endif /* IS_SDLv1 */
@@ -1562,8 +1563,17 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
 #if IS_SDLv1
         hasalpha = 1;
 #else  /* IS_SDLv2 */
-        if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_BLEND) != 0)
-            return RAISE(pgExc_SDLError, SDL_GetError());
+        if (SDL_GetColorKey(surf, &colorkey) != 0){
+            if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_BLEND) != 0){
+                return RAISE(pgExc_SDLError, SDL_GetError());
+            }
+        }
+        else{
+            if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0){
+                return RAISE(pgExc_SDLError, SDL_GetError());
+            }
+        }
+
 #endif /* IS_SDLv2 */
     }
 #if IS_SDLv2


### PR DESCRIPTION
I'm not sure if this will work at all because I don't have working png loading when I build from source with sdl2 on windows. However, if someone wants to grab this branch build it for sdl2 and give it a go with solarwolf, or just the test case below:

    import pygame
    
    
    pygame.display.init()
    dsurf = pygame.display.set_mode((320, 240), 0)
    
    
    def update(surface):
        dsurf.fill((0, 0, 0))
        dsurf.blit(surface, (0, 0))
        pygame.display.flip()
    
    
    img_surf = pygame.image.load('data/menu_creds_off.png')
    
    color_key = img_surf.get_colorkey()
    print('initial color_key', color_key)
    img_surf.set_colorkey(color_key, pygame.RLEACCEL)
    img_surf = img_surf.convert()
    print('initial alpha', img_surf.get_alpha())
    print('initial bitsize', img_surf.get_bitsize())
    print('initial flags', img_surf.get_flags())
    
    update(img_surf)
    
    img_surf.set_alpha(90)
    update(img_surf)
    img_surf.set_alpha(255)
    update(img_surf)
    
    running = True
    while running:
        for event in pygame.event.get():
            if event.type == pygame.QUIT:
                running = False

If it doesn't look red, we might be onto something.

Related to bugs we are having here:

https://github.com/pygame/pygame/issues/721

and here:

https://github.com/pygame/pygame/issues/456

and maybe a few other places. 