### PR TITLE
Corrects two pylint warnings in version module

### DIFF
--- a/buildconfig/version.py.in
+++ b/buildconfig/version.py.in
@@ -29,6 +29,9 @@ releases. (hmm, until we get to versions > 10)
 from pygame.base import get_sdl_version
 
 class SoftwareVersion(tuple):
+    """
+    A class for storing data about software versions.
+    """
     __slots__ = ()
     fields = 'major', 'minor', 'patch'
     def __new__(cls, major, minor, patch):
@@ -53,4 +56,4 @@ class SDLVersion(SoftwareVersion):
     """
 
 _sdl_tuple = get_sdl_version()
-SDL = SDLVersion(_sdl_tuple[0],_sdl_tuple[1],_sdl_tuple[2])
+SDL = SDLVersion(_sdl_tuple[0], _sdl_tuple[1], _sdl_tuple[2])

--- a/setup.py
+++ b/setup.py
@@ -499,9 +499,9 @@ def write_version_module(pygame_version, revision):
         header = header_file.read()
     with open(os.path.join('src_py', 'version.py'), 'w') as version_file:
         version_file.write(header)
-        version_file.write('ver = "' + pygame_version + '"\n')
+        version_file.write('ver = "' + pygame_version + '"  # pylint: disable=invalid-name\n')
         version_file.write('vernum = PygameVersion(%s)\n' % vernum)
-        version_file.write('rev = "' + revision + '"\n')
+        version_file.write('rev = "' + revision + '"  # pylint: disable=invalid-name\n')
         version_file.write('\n__all__ = ["SDL", "ver", "vernum", "rev"]\n')
 
 write_version_module(METADATA['version'], revision)


### PR DESCRIPTION
The only remaining warnings _after_ this are not really fixable without breaking back compat:

**Original Warnings**

	src_py\version.py:56:30: C0326: Exactly one space required after comma
	SDL = SDLVersion(_sdl_tuple[0],_sdl_tuple[1],_sdl_tuple[2])
				      ^ (bad-whitespace)
	src_py\version.py:56:44: C0326: Exactly one space required after comma
	SDL = SDLVersion(_sdl_tuple[0],_sdl_tuple[1],_sdl_tuple[2])
						    ^ (bad-whitespace)
	src_py\version.py:31:0: C0115: Missing class docstring (missing-class-docstring)
	src_py\version.py:57:0: C0103: Constant name "ver" doesn't conform to UPPER_CASE naming style (invalid-name)
	src_py\version.py:59:0: C0103: Constant name "rev" doesn't conform to UPPER_CASE naming style (invalid-name)


**Remaining warnings after PR:**

    src_py\version.py:60:0: C0103: Constant name "ver" doesn't conform to UPPER_CASE naming style (invalid-name)
    src_py\version.py:62:0: C0103: Constant name "rev" doesn't conform to UPPER_CASE naming style (invalid-name)

    ------------------------------------------------------------------
    Your code has been rated at 9.09/10 (previous run: 5.45/10, +3.64)

tested using:

`pylint src_py/version.py --extension-pkg-whitelist=pygame`
