### PR TITLE
Corrects several pylint warnings in sysfont module

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -22,8 +22,11 @@
 
 import os
 import sys
-from pygame.compat import xrange_, PY_MAJOR_VERSION
 from os.path import basename, dirname, exists, join, splitext
+
+from pygame.font import Font
+from pygame.compat import xrange_, PY_MAJOR_VERSION
+
 if sys.platform == 'darwin':
     import xml.etree.ElementTree as ET
 
@@ -68,9 +71,6 @@ def initsysfonts_win32():
     """initialize fonts dictionary on Windows"""
 
     fontdir = join(os.environ.get('WINDIR', 'C:\\Windows'), 'Fonts')
-
-    TrueType_suffix = '(TrueType)'
-    mods = ('demibold', 'narrow', 'light', 'unicode', 'bt', 'mt')
 
     fonts = {}
 
@@ -117,34 +117,49 @@ def initsysfonts_win32():
         if not dirname(font):
             font = join(fontdir, font)
 
-        if name.endswith(TrueType_suffix):
-            name = name.rstrip(TrueType_suffix).rstrip()
-        name = name.lower().split()
-
-        bold = italic = 0
-        for m in mods:
-            if m in name:
-                name.remove(m)
-        if 'bold' in name:
-            name.remove('bold')
-            bold = 1
-        if 'italic' in name:
-            name.remove('italic')
-            italic = 1
-        name = ''.join(name)
-
-        name = _simplename(name)
-
-        _addfont(name, bold, italic, font, fonts)
+        _parse_font_entry_win(name, font, fonts)
 
     return fonts
+
+
+def _parse_font_entry_win(name, font, fonts):
+    """
+    Parse out a simpler name and the font style from the initial file name.
+
+    :param name: The font name
+    :param font: The font file path
+    :param fonts: The pygame font dictionary
+
+    :return: Tuple of (bold, italic, name)
+    """
+    true_type_suffix = '(TrueType)'
+    mods = ('demibold', 'narrow', 'light', 'unicode', 'bt', 'mt')
+    if name.endswith(true_type_suffix):
+        name = name.rstrip(true_type_suffix).rstrip()
+    name = name.lower().split()
+    bold = italic = 0
+    for mod in mods:
+        if mod in name:
+            name.remove(mod)
+    if 'bold' in name:
+        name.remove('bold')
+        bold = 1
+    if 'italic' in name:
+        name.remove('italic')
+        italic = 1
+    name = ''.join(name)
+    name = _simplename(name)
+
+    _addfont(name, bold, italic, font, fonts)
 
 
 def _add_font_paths(sub_elements, fonts):
     """ Gets each element, checks its tag content,
         if wanted fetches the next value in the iterable
     """
-    font_name = font_path = None
+    font_name = None
+    bold = False
+    italic = False
     for tag in sub_elements:
         if tag.text == "_name":
             font_file_name = next(sub_elements).text
@@ -155,14 +170,14 @@ def _add_font_paths(sub_elements, fonts):
             italic = "italic" in font_name
         if tag.text == "path" and font_name is not None:
             font_path = next(sub_elements).text
-            _addfont(_simplename(font_name),bold,italic,font_path,fonts)
+            _addfont(_simplename(font_name), bold, italic, font_path, fonts)
             break
 
 
 def _system_profiler_darwin():
     fonts = {}
-    flout, flerr = subprocess.Popen(
-        ' '.join(['system_profiler', '-xml','SPFontsDataType']),
+    flout, _ = subprocess.Popen(
+        ' '.join(['system_profiler', '-xml', 'SPFontsDataType']),
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -173,7 +188,6 @@ def _system_profiler_darwin():
         _add_font_paths(font_node.iter("*"), fonts)
 
     return fonts
-
 
 
 def initsysfonts_darwin():
@@ -206,39 +220,52 @@ def initsysfonts_unix(path="fc-list"):
     try:
         # note, we capture stderr so if fc-list isn't there to stop stderr
         # printing.
-        flout, flerr = subprocess.Popen('%s : file family style' % path, shell=True,
-                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                        close_fds=True).communicate()
-    except Exception:
+        flout, _ = subprocess.Popen('%s : file family style' % path,
+                                    shell=True,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    close_fds=True).communicate()
+    except (OSError, ValueError):
         return fonts
 
     entries = toascii(flout)
     try:
-        for line in entries.split('\n'):
+        for entry in entries.split('\n'):
 
             try:
-                filename, family, style = line.split(':', 2)
-                if splitext(filename)[1].lower() in OpenType_extensions:
-                    bold = 'Bold' in style
-                    italic = 'Italic' in style
-                    oblique = 'Oblique' in style
-                    for name in family.strip().split(','):
-                        if name:
-                            break
-                    else:
-                        name = splitext(basename(filename))[0]
-
-                    _addfont(
-                        _simplename(name), bold, italic or oblique, filename, fonts)
-
-            except Exception:
+                _parse_font_entry_unix(entry, fonts)
+            except ValueError:
                 # try the next one.
                 pass
 
-    except Exception:
+    except ValueError:
         pass
 
     return fonts
+
+
+def _parse_font_entry_unix(entry, fonts):
+    """
+    Parses an entry in the unix font data to add to the pygame font
+    dictionary.
+
+    :param entry: A entry from the unix font list.
+    :param fonts: The pygame font dictionary to add the parsed font data to.
+
+    """
+    filename, family, style = entry.split(':', 2)
+    if splitext(filename)[1].lower() in OpenType_extensions:
+        bold = 'Bold' in style
+        italic = 'Italic' in style
+        oblique = 'Oblique' in style
+        for name in family.strip().split(','):
+            if name:
+                break
+        else:
+            name = splitext(basename(filename))[0]
+
+        _addfont(_simplename(name), bold, italic or oblique,
+                 filename, fonts)
 
 
 def create_aliases():
@@ -272,8 +299,13 @@ def create_aliases():
                 Sysalias[name] = found
 
 
-# initialize it all, called once
 def initsysfonts():
+    """
+    Initialise the sysfont module, called once. Locates the installed fonts
+    and creates some aliases for common font categories.
+
+    Has different initialisation functions for different platforms.
+    """
     if sys.platform == 'win32':
         fonts = initsysfonts_win32()
     elif sys.platform == 'darwin':
@@ -286,11 +318,19 @@ def initsysfonts():
         Sysfonts[None] = None
 
 
-# pygame.font specific declarations
 def font_constructor(fontpath, size, bold, italic):
-    import pygame.font
+    """
+    pygame.font specific declarations
 
-    font = pygame.font.Font(fontpath, size)
+    :param fontpath: path to a font.
+    :param size: size of a font.
+    :param bold: bold style, True or False.
+    :param italic: italic style, True or False.
+
+    :return: A font.Font object.
+    """
+
+    font = Font(fontpath, size)
     if bold:
         font.set_bold(True)
     if italic:
@@ -332,16 +372,15 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
     gotbold = gotitalic = False
     fontname = None
     if name:
-        allnames = name
-        for name in allnames.split(','):
-            name = _simplename(name)
-            styles = Sysfonts.get(name)
+        for single_name in name.split(','):
+            single_name = _simplename(single_name)
+            styles = Sysfonts.get(single_name)
             if not styles:
-                styles = Sysalias.get(name)
+                styles = Sysalias.get(single_name)
             if styles:
                 plainname = styles.get((False, False))
                 fontname = styles.get((bold, italic))
-                if not fontname and not plainname:
+                if not (fontname or plainname):
                     # Neither requested style, nor plain font exists, so
                     # return a font with the name requested, but an
                     # arbitrary style.
@@ -399,12 +438,11 @@ def match_font(name, bold=0, italic=0):
         initsysfonts()
 
     fontname = None
-    allnames = name
-    for name in allnames.split(','):
-        name = _simplename(name)
-        styles = Sysfonts.get(name)
+    for single_name in name.split(','):
+        single_name = _simplename(single_name)
+        styles = Sysfonts.get(single_name)
         if not styles:
-            styles = Sysalias.get(name)
+            styles = Sysalias.get(single_name)
         if styles:
             while not fontname:
                 fontname = styles.get((bold, italic))


### PR DESCRIPTION
**Initial Warnings before this PR**

	************* Module src_py.sysfont
	src_py\sysfont.py:158:43: C0326: Exactly one space required after comma
				_addfont(_simplename(font_name),bold,italic,font_path,fonts)
											   ^ (bad-whitespace)
	src_py\sysfont.py:158:48: C0326: Exactly one space required after comma
				_addfont(_simplename(font_name),bold,italic,font_path,fonts)
													^ (bad-whitespace)
	src_py\sysfont.py:158:55: C0326: Exactly one space required after comma
				_addfont(_simplename(font_name),bold,italic,font_path,fonts)
														   ^ (bad-whitespace)
	src_py\sysfont.py:158:65: C0326: Exactly one space required after comma
				_addfont(_simplename(font_name),bold,italic,font_path,fonts)
																	 ^ (bad-whitespace)
	src_py\sysfont.py:165:43: C0326: Exactly one space required after comma
			' '.join(['system_profiler', '-xml','SPFontsDataType']),
											   ^ (bad-whitespace)
	src_py\sysfont.py:49:8: E0401: Unable to import '_winreg' (import-error)
	src_py\sysfont.py:72:4: C0103: Variable name "TrueType_suffix" doesn't conform to snake_case naming style (invalid-name)
	src_py\sysfont.py:125:12: C0103: Variable name "m" doesn't conform to snake_case naming style (invalid-name)
	src_py\sysfont.py:67:0: R0912: Too many branches (14/12) (too-many-branches)
	src_py\sysfont.py:164:11: W0612: Unused variable 'flerr' (unused-variable)
	src_py\sysfont.py:212:11: W0703: Catching too general exception Exception (broad-except)
	src_py\sysfont.py:238:11: W0703: Catching too general exception Exception (broad-except)
	src_py\sysfont.py:234:19: W0703: Catching too general exception Exception (broad-except)
	src_py\sysfont.py:216:4: R1702: Too many nested blocks (6/5) (too-many-nested-blocks)
	src_py\sysfont.py:209:15: W0612: Unused variable 'flerr' (unused-variable)
	src_py\sysfont.py:276:0: C0116: Missing function or method docstring (missing-function-docstring)
	src_py\sysfont.py:290:0: C0116: Missing function or method docstring (missing-function-docstring)
	src_py\sysfont.py:291:4: C0415: Import outside toplevel (pygame.font) (import-outside-toplevel)
	src_py\sysfont.py:304:0: C0103: Function name "SysFont" doesn't conform to snake_case naming style (invalid-name)
	src_py\sysfont.py:336:12: R1704: Redefining argument with the local name 'name' (redefined-argument-from-local)
	src_py\sysfont.py:304:0: R0912: Too many branches (14/12) (too-many-branches)
	src_py\sysfont.py:403:8: R1704: Redefining argument with the local name 'name' (redefined-argument-from-local)
	src_py\sysfont.py:26:0: C0411: standard import "from os.path import basename, dirname, exists, join, splitext" should be placed before "from pygame.compat import xrange_, PY_MAJOR_VERSION" (wrong-import-order)

	-----------------------------------
	Your code has been rated at 8.76/10


**Remaining Warnings after this PR**

    ************* Module src_py.sysfont
    src_py\sysfont.py:52:8: E0401: Unable to import '_winreg' (import-error)
    src_py\sysfont.py:344:0: C0103: Function name "SysFont" doesn't conform to snake_case naming style (invalid-name)
    src_py\sysfont.py:344:0: R0912: Too many branches (14/12) (too-many-branches)

    ------------------------------------------------------------------
    Your code has been rated at 9.68/10 (previous run: 9.64/10, +0.05)

I don't think we can fix the first two, the first is for python 2 compatibility and changing the other one would break back compat. 

The last one just didn't seem that bad to me, but you could probably squash it with a little fiddling.