### PR TITLE
Corrects several pylint warnings in pkgdata module

### DIFF
--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -1,10 +1,10 @@
 """
-pkgdata is a simple, extensible way for a package to acquire data file 
+pkgdata is a simple, extensible way for a package to acquire data file
 resources.
 
 The getResource function is equivalent to the standard idioms, such as
 the following minimal implementation:
-    
+
     import sys, os
 
     def getResource(identifier, pkgname=__name__):
@@ -26,10 +26,22 @@ BytesIO = get_BytesIO()
 try:
     from pkg_resources import resource_stream, resource_exists
 except ImportError:
-    def resource_exists(package_or_requirement, resource_name):
+    def resource_exists(_package_or_requirement, _resource_name):
+        """
+        A stub for when we fail to import this function.
+
+        :return: Always returns False
+        """
         return False
-    def resource_stream(package_of_requirement, resource_name):
+
+    def resource_stream(_package_of_requirement, _resource_name):
+        """
+        A stub for when we fail to import this function.
+
+        Always raises a NotImplementedError when called.
+        """
         raise NotImplementedError
+
 
 def getResource(identifier, pkgname=__name__):
     """
@@ -51,10 +63,10 @@ def getResource(identifier, pkgname=__name__):
         return resource_stream(pkgname, identifier)
 
     mod = sys.modules[pkgname]
-    fn = getattr(mod, '__file__', None)
-    if fn is None:
+    path_to_file = getattr(mod, '__file__', None)
+    if path_to_file is None:
         raise IOError("%s has no __file__!" % repr(mod))
-    path = os.path.join(os.path.dirname(fn), identifier)
+    path = os.path.join(os.path.dirname(path_to_file), identifier)
     if sys.version_info < (3, 3):
         loader = getattr(mod, '__loader__', None)
         if loader is not None:


### PR DESCRIPTION
**Original warnings before this PR:**

    ************* Module src_py.pkgdata
    src_py\pkgdata.py:2:70: C0303: Trailing whitespace (trailing-whitespace)
    src_py\pkgdata.py:7:0: C0303: Trailing whitespace (trailing-whitespace)
    src_py\pkgdata.py:29:4: C0116: Missing function or method docstring (missing-function-docstring)
    src_py\pkgdata.py:29:24: W0613: Unused argument 'package_or_requirement' (unused-argument)
    src_py\pkgdata.py:29:48: W0613: Unused argument 'resource_name' (unused-argument)
    src_py\pkgdata.py:31:4: C0116: Missing function or method docstring (missing-function-docstring)
    src_py\pkgdata.py:34:0: C0103: Function name "getResource" doesn't conform to snake_case naming style (invalid-name)
    src_py\pkgdata.py:54:4: C0103: Variable name "fn" doesn't conform to snake_case naming style (invalid-name)

    -----------------------------------
    Your code has been rated at 7.24/10

**After this PR:**

    ************* Module src_py.pkgdata
    src_py\pkgdata.py:46:0: C0103: Function name "getResource" doesn't conform to snake_case naming style (invalid-name)

    ------------------------------------------------------------------
    Your code has been rated at 9.66/10 (previous run: 9.31/10, +0.34)

That last one isn't fixable without breaking back compat. getResource() seems to be used a suprisingly large amount all over GitHub.

I did notice while looking at this code that it uses the `__file__` attribute which I believe is something we should eventually move away from in the future to make it easier to package pygame projects (but the alternatives are not really usable until python 3.7 so that's a fair ways off). See: `importlib.resource` if you are interested.