### PR TITLE
Fix segfaults caused when interacting with display surface after quit 

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -211,6 +211,7 @@ pg_display_autoquit(void)
     _DisplayState *state = DISPLAY_STATE;
     _display_state_cleanup(state);
     if (pg_GetDefaultWindowSurface()) {
+        pgSurface_AsSurface(pg_GetDefaultWindowSurface()) = NULL;
         pg_SetDefaultWindowSurface(NULL);
         pg_SetDefaultWindow(NULL);
     }


### PR DESCRIPTION
It looks like we weren't also setting the SDL surface to NULL in pygame 2. This fix mirrors the way that autoquit works in pygame 1.

I'm not sure if there was a reason for that or if it just got lost in the shuffle of hiding the display surface behind a function call.

Anyway, previously if you did something a bit like this:

    import pygame
    import sys

    pygame.display.init()
    screen = pygame.display.set_mode((800, 600))
    pygame.display.quit()
    print("refcount:", sys.getrefcount(screen))
    print(screen)
    print(screen.get_bitsize())

You would get a segfault a lot of the time in pygame 2 - meanwhile the same code correctly raises an assert in pygame 1.9.6. Not earth shattering as you shouldn't be messing with the display surface after a quit anyway, but less segfaults is better in my book.

Merging this should mean that the other unit tests for get_colorkey and get_bitsize() will pass the CI.