### PR TITLE
build issue fixes for manylinux + Travis CI issues

### DIFF
--- a/buildconfig/ci/travis/.travis_linux_build_wheels.sh
+++ b/buildconfig/ci/travis/.travis_linux_build_wheels.sh
@@ -5,6 +5,7 @@ set -e -x
 cd buildconfig/manylinux-build
 make pull
 make wheels
-mkdir -p ../../dist/
-mv wheelhouse/*.whl ../../dist/
 cd ../..
+
+mkdir -p dist/
+cp buildconfig/manylinux-build/wheelhouse/*.whl dist/

--- a/buildconfig/ci/travis/.travis_linux_build_wheels.sh
+++ b/buildconfig/ci/travis/.travis_linux_build_wheels.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e -x
+
 # build the wheels.
 cd buildconfig/manylinux-build
 make pull

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -5,6 +5,11 @@ SUPPORTED_PYTHONS="cp27-cp27mu cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m cp38-
 
 export PORTMIDI_INC_PORTTIME=1
 
+# -msse4 is required by old gcc in centos, for the SSE4.2 used in image.c
+# -g0 removes debugging symbols reducing file size greatly.
+# -03 is full optimization on.
+export CFLAGS="-msse4 -g0 -O3"
+
 ls -la /io
 
 # Compile wheels


### PR DESCRIPTION
For 
- manylinux CI job not failing when manylinux build fails: https://github.com/pygame/pygame/issues/1904
- travis CI job failed to move wheel files into dist/ folder... permission denied (for some weird reason). Changed it to copying them, and didn't have an error.
- sse4 issue in image.c when compiling with ancient centos gcc: https://github.com/pygame/pygame/issues/1905
