### PR TITLE
Add unit test: display.get_driver()

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -699,6 +699,7 @@ static PyObject *
 pg_get_driver(PyObject *self, PyObject *args)
 {
     const char *name = NULL;
+    VIDEO_INIT_CHECK();
     name = SDL_GetCurrentVideoDriver();
     if (!name)
         Py_RETURN_NONE;

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -105,21 +105,42 @@ class DisplayModuleTest(unittest.TestCase):
 
     def test_get_driver(self):
         drivers = [
-            'windib',
-            'directx',
-            'x11',
-            'dga',
-            'fbcon',
-            'directfb',
-            'ggi',
-            'vgl',
-            'svgalib',
             'aalib',
+            'android',
+            'arm',
             'cocoa',
-            'dummy'
+            'dga',
+            'directx',
+            'directfb',
+            'dummy',
+            'emscripten',
+            'fbcon',
+            'ggi',
+            'haiku',
+            'khronos',
+            'kmsdrm',
+            'nacl',
+            'offscreen',
+            'pandora',
+            'psp',
+            'qnx',
+            'raspberry',
+            'svgalib',
+            'uikit',
+            'vgl',
+            'vivante',
+            'wayland',
+            'windows',
+            'windib',
+            'winrt',
+            'x11'
         ]
         driver = display.get_driver()
         self.assertIn(driver, drivers)
+
+        display.quit()
+        driver = display.get_driver()
+        self.assertIsNone(driver)
 
     def test_get_init(self):
         """Ensures the module's initialization state can be retrieved."""

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -139,8 +139,8 @@ class DisplayModuleTest(unittest.TestCase):
         self.assertIn(driver, drivers)
 
         display.quit()
-        driver = display.get_driver()
-        self.assertIsNone(driver)
+        with self.assertRaises(pygame.error):
+            driver = display.get_driver()
 
     def test_get_init(self):
         """Ensures the module's initialization state can be retrieved."""

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -103,22 +103,23 @@ class DisplayModuleTest(unittest.TestCase):
         else:
             self.assertEqual(unicode_(display.get_caption()[0], "utf8"), TEST_CAPTION)
 
-    def todo_test_get_driver(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.display.get_driver:
-
-        # pygame.display.get_driver(): return name
-        # get the name of the pygame display backend
-        #
-        # Pygame chooses one of many available display backends when it is
-        # initialized. This returns the internal name used for the display
-        # backend. This can be used to provide limited information about what
-        # display capabilities might be accelerated. See the SDL_VIDEODRIVER
-        # flags in pygame.display.set_mode() to see some of the common
-        # options.
-        #
-
-        self.fail()
+    def test_get_driver(self):
+        drivers = [
+            'windib',
+            'directx',
+            'x11',
+            'dga',
+            'fbcon',
+            'directfb',
+            'ggi',
+            'vgl',
+            'svgalib',
+            'aalib',
+            'cocoa',
+            'dummy'
+        ]
+        driver = display.get_driver()
+        self.assertIn(driver, drivers)
 
     def test_get_init(self):
         """Ensures the module's initialization state can be retrieved."""


### PR DESCRIPTION
Add unit test: display.get_driver() and closes #1744 