### PR TITLE
Some colorkey test fixes

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1001,43 +1001,46 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         self.assertEqual(rectangle, (0, 0, 800, 600))
 
     def test_get_colorkey(self):
-        # if set_colorkey is not used
-        s = pygame.Surface((800, 600))
-        self.assertIsNone(s.get_colorkey())
+        pygame.display.init()
+        try:
+            # if set_colorkey is not used
+            s = pygame.Surface((800, 600))
+            self.assertIsNone(s.get_colorkey())
 
-        # if set_colorkey is used
-        s.set_colorkey(None)
-        self.assertIsNone(s.get_colorkey())
-        
-        # setting up remainder of tests...
-        r, g, b, a  = 20, 40, 60, 12
-        colorkey = pygame.Color(r, g, b)
-        s.set_colorkey(colorkey)
-        
-        #test for ideal case
-        self.assertEqual(s.get_colorkey(), (r, g, b, 255))
-        
-        #test for if the color_key is set using pygame.RLEACCEL
-        s.set_colorkey(colorkey, pygame.RLEACCEL)
-        self.assertEqual(s.get_colorkey(), (r, g, b, 255))
-        
-        #test for if the color key is not what's expected
-        s.set_colorkey(pygame.Color(r + 1, g + 1, b + 1))
-        self.assertNotEqual(s.get_colorkey(), (r, g, b, 255))
+            # if set_colorkey is used
+            s.set_colorkey(None)
+            self.assertIsNone(s.get_colorkey())
 
-        s.set_colorkey(pygame.Color(r, g, b, a)) # regardless of whether alpha is not 255, colorkey returned from surface is always 255
-        self.assertEqual(s.get_colorkey(), (r, g, b, 255))
-        
-        # test for using method after display.quit() is called...
-        with self.assertRaises(pygame.error):
+            # setting up remainder of tests...
+            r, g, b, a  = 20, 40, 60, 12
+            colorkey = pygame.Color(r, g, b)
+            s.set_colorkey(colorkey)
+
+            #test for ideal case
+            self.assertEqual(s.get_colorkey(), (r, g, b, 255))
+
+            #test for if the color_key is set using pygame.RLEACCEL
+            s.set_colorkey(colorkey, pygame.RLEACCEL)
+            self.assertEqual(s.get_colorkey(), (r, g, b, 255))
+
+            #test for if the color key is not what's expected
+            s.set_colorkey(pygame.Color(r + 1, g + 1, b + 1))
+            self.assertNotEqual(s.get_colorkey(), (r, g, b, 255))
+
+            s.set_colorkey(pygame.Color(r, g, b, a)) # regardless of whether alpha is not 255, colorkey returned from surface is always 255
+            self.assertEqual(s.get_colorkey(), (r, g, b, 255))
+
+            # test for using method when display is created with OpenGL and the SDL version is 1
+            if SDL1:  # SLD1 is a bool defined at the top...
+                s = pygame.display.set_mode(flags=pygame.OPENGL)
+                with self.assertRaises(pygame.error):
+                    s.get_colorkey()
+
+        finally:
+            # test for using method after display.quit() is called...
             s = pygame.display.set_mode()
             pygame.display.quit()
-            s.get_colorkey()
-
-        # test for using method when display is created with OpenGL and the SDL version is 1
-        if SDL1: # SLD1 is a bool defined at the top...
-            with self.assertRaises(pygame.error):   
-                s = pygame.display.set_mode(flags=pygame.OPENGL)
+            with self.assertRaises(pygame.error):
                 s.get_colorkey()
 
     def test_get_height(self):

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1004,7 +1004,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         pygame.display.init()
         try:
             # if set_colorkey is not used
-            s = pygame.Surface((800, 600))
+            s = pygame.Surface((800, 600), 0, 32)
             self.assertIsNone(s.get_colorkey())
 
             # if set_colorkey is used
@@ -1032,13 +1032,14 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 
             # test for using method when display is created with OpenGL and the SDL version is 1
             if SDL1:  # SLD1 is a bool defined at the top...
-                s = pygame.display.set_mode(flags=pygame.OPENGL)
+                s = pygame.display.set_mode((200, 200),
+                                            pygame.OPENGL, 32)
                 with self.assertRaises(pygame.error):
                     s.get_colorkey()
 
         finally:
             # test for using method after display.quit() is called...
-            s = pygame.display.set_mode()
+            s = pygame.display.set_mode((200, 200), 0, 32)
             pygame.display.quit()
             with self.assertRaises(pygame.error):
                 s.get_colorkey()

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1031,11 +1031,17 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
             self.assertEqual(s.get_colorkey(), (r, g, b, 255))
 
             # test for using method when display is created with OpenGL and the SDL version is 1
+            # Open GL is not available on the dummy video driver
             if SDL1:  # SLD1 is a bool defined at the top...
-                s = pygame.display.set_mode((200, 200),
-                                            pygame.OPENGL, 32)
-                with self.assertRaises(pygame.error):
-                    s.get_colorkey()
+                try:
+                    s = pygame.display.set_mode((200, 200),
+                                                pygame.OPENGL, 32)
+                except pygame.error:
+                    pass  # If we can't create OPENGL surface don't try this test
+                else:
+                    with self.assertRaises(pygame.error):
+                        s.get_colorkey()
+
 
         finally:
             # test for using method after display.quit() is called...


### PR DESCRIPTION
I believe this test was failing on CI here:

https://travis-ci.org/github/pygame/pygame/jobs/694413944

because another test called `display.quit()` above it and that affected the test on SDL 1. Hopefully this will make the test properly independent and it is more consistent with other tests in `surface_test.py`

**EDIT:** I ended up fixing three things in this test:

- display.init() and display.quit() and start and finish always. I think this may have been why the test was failing sometimes and succeeding other times as it was being affected by what was happening in other tests.
- Turned implicit assumptions about surface depth being 32 bit into requests. I think this was the other main thing causing this test to fail. It seems that the default assumption on SDL1 Travis is that a surface should be 24 bit if you don't specify, while it is 32bit nearly everywhere else. Since the tests were looking at alpha values and setting colorkeys and it seems reasonable to ensure the depth is consistent for this test. We may eventually want another/other tests that looks at setting & getting colorkeys for other surface depth values - especially given the trouble this is still causing.
- Made the assert tests only test the asserts from this function, previously they were testing asserts firing from set_mode() as well.