### PR TITLE
Replace long-deprecated Thread.isAlive() with .is_alive()

### DIFF
--- a/test/threads_test.py
+++ b/test/threads_test.py
@@ -41,7 +41,7 @@ class WorkerQueueTypeTest(unittest.TestCase):
         self.assertGreater(len(wq.pool), 0)
 
         for t in wq.pool:
-            self.assertTrue(t.isAlive())
+            self.assertTrue(t.is_alive())
 
         for i in xrange_(200):
             wq.do(lambda x: x + 1, i)
@@ -49,7 +49,7 @@ class WorkerQueueTypeTest(unittest.TestCase):
         wq.stop()
 
         for t in wq.pool:
-            self.assertFalse(t.isAlive())
+            self.assertFalse(t.is_alive())
 
         self.assertIs(wq.queue.get(), STOP)
 


### PR DESCRIPTION
Replace Thread.isAlive() calls with Thread.is_alive() to fix
compatibility with Python 3.9.  The new method was present since py2.6,
the old one got deprecated in py3.1 and was finally removed in py3.9.