### PR TITLE
s390x build robot on travis CI for big endian testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ jobs:
       env:
         - WHICH_SDL_BUILD=-sdl1
     - python: 3.6
-    - python: 3.7
     - python: 3.8
     - os: linux-ppc64le
       python: 3.7
@@ -32,6 +31,9 @@ jobs:
       arch: arm64
       env:
         - ARM64=yes
+    - os: linux
+      python: 3.7
+      arch: s390x
     - os: linux
       python: 3.7
       env:
@@ -48,10 +50,9 @@ jobs:
         - GITHUB_UPLOAD=yes
         - UPLOAD_WHL_PYPI=yes
 
-  # allow_failures:
-  #   - python: pypy
-  #   - os: linux-ppc64le
-  #   - python: 3.8-dev
+  allow_failures:
+    - arch: s390x
+    # - python: pypy
 
 before_install:
   - |


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/1291

- s390x build robot on Travis CI for big endian testing. 
- Allowed s390x to fail, since a few tests are currently failing. 
- Also removed a py3.7+amd64 job, since we have lots of py37 jobs including another amd64 one.
