### PR TITLE
Account for big endian support for RGB/BGR images

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1246,24 +1246,28 @@ image_frombuffer(PyObject *self, PyObject *arg)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
         surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, w * 3, 0xFF, 0xFF << 8,
                                         0xFF << 16, 0);
-        /*
-        #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-                                                 0xFF, 0xFF<<8, 0xFF<<16,
-        0xFF<<24 #else 0xFF<<24, 0xFF<<16, 0xFF<<8, 0xFF #endif
-                       );
-
-        */
+#else
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, w * 3, 0xFF << 16,
+                                        0xFF << 8, 0xFF, 0);
+#endif
     }
     else if (!strcmp(format, "BGR")) {
         if (len != (Py_ssize_t)w * h * 3)
             return RAISE(
                 PyExc_ValueError,
                 "Buffer length does not equal format and resolution size");
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
         surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, w * 3,
                                         0xFF << 16, 0xFF << 8,
                                         0xFF, 0);
+#else
+        surf = SDL_CreateRGBSurfaceFrom(data, w, h, 24, w * 3,
+                                        0xFF, 0xFF << 8,
+                                        0xFF << 16, 0);
+#endif
     }
     else if (!strcmp(format, "RGBA") || !strcmp(format, "RGBX")) {
         int alphamult = !strcmp(format, "RGBA");


### PR DESCRIPTION
Add big endian blocks in image_frombuffer() for RGB and BGR images,
similarly to how RGBA are handled.  This also seems to match examples
in SDL documentation.  This fixes test_frombuffer_BGR
and test_frombuffer_RGB on big endian machines (see #1291).

Disclaimer: my big endian hardware is headless and I haven't looked at X forwarding yet, so I have no clue if this works correctly, or if both the tests and the code are doing it other way around ;-).