### PR TITLE
Add a tox.ini to ease testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py{27,36,37,38,39}
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+    numpy
+setenv =
+    SDL_VIDEODRIVER=dummy
+    SDL_AUDIODRIVER=disk
+passenv =
+    PORTMIDI_INC_PORTTIME
+commands =
+    python -m buildconfig -auto
+    pip install .
+    python -m pygame.tests


### PR DESCRIPTION
Since the test suite requires the package being installed, it is
non-trivial to run from a fresh git checkout.  Add a config file for tox
to take care of creating a virtualenv, installing the package
and testing it.