### PR TITLE
Add unit test to Clock.get_rawtime

### DIFF
--- a/test/time_test.py
+++ b/test/time_test.py
@@ -35,18 +35,33 @@ class ClockTypeTest(unittest.TestCase):
         # We should get around fps (+- fps*delta -- delta % of fps)
         self.assertAlmostEqual(clock.get_fps(), fps, delta=fps*delta)
 
-    def todo_test_get_rawtime(self):
+    def test_get_rawtime(self):
+        
+        iterations = 10
+        delay = 0.1
+        delay_miliseconds = delay*(10**3) #actual time difference between ticks
+        framerate_limit = 5
+        delta = 50 #allowable error in milliseconds
 
-        # __doc__ (as of 2008-08-02) for pygame.time.Clock.get_rawtime:
+        #Testing Clock Initialization
+        c = Clock()
+        self.assertEqual(c.get_rawtime(), 0)
 
-        # Clock.get_rawtime(): return milliseconds
-        # actual time used in the previous tick
-        #
-        # Similar to Clock.get_time(), but this does not include any time used
-        # while Clock.tick() was delaying to limit the framerate.
-        #
+        #Testing Raw Time with Frame Delay
+        for f in range(iterations):
+            time.sleep(delay)
+            c.tick(framerate_limit)
+            c1 = c.get_rawtime()
+            self.assertAlmostEqual(delay_miliseconds, c1, delta=delta)
+        
+       #Testing get_rawtime() = get_time()
+        for f in range(iterations):
+            time.sleep(delay)
+            c.tick()
+            c1 = c.get_rawtime()
+            c2 = c.get_time()
+            self.assertAlmostEqual(c1, c2, delta=delta)
 
-        self.fail()
 
     def test_get_time(self):
         #Testing parameters


### PR DESCRIPTION
Closes #1786 

Tests the logic:
- Clock initiation.
- `get_rawtime()`gets actual elapse time with a framerate argument in tick.
- `get_rawtime()` and `get_time()` return the same thing when there is no framerate argument.
