### PR TITLE
Add PyCharm config directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@
 # Visual Studio Code cache/config directory
 .vscode/
 
+# PyCharm cache/config directory
+.idea/
+
 # mypy
 .mypy_cache/
 


### PR DESCRIPTION
Nothing special, I did this just because when I edit python part of code from PyCharm (like type hints or tests) git auto adds following files: 
![image](https://user-images.githubusercontent.com/29337110/84273983-9c298200-ab2f-11ea-9f9b-794cb45b93a5.png)
and then I have to manually unselect them (and we already do the same thing for VS/VSCode
