### PR TITLE
Add display.set_gamma unit test

### DIFF
--- a/test/display_test.py
+++ b/test/display_test.py
@@ -315,7 +315,7 @@ class DisplayModuleTest(unittest.TestCase):
         self.assertFalse(display.get_init())
 
     @unittest.skipIf(
-    os.environ.get("SDL_VIDEODRIVER") == "dummy",
+    os.environ.get("SDL_VIDEODRIVER") == "dummy" and not SDL2,
     "Can't set gamma on SDL 1 with the dummy video driver",
     )
     def test_set_gamma(self):

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -315,14 +315,14 @@ class DisplayModuleTest(unittest.TestCase):
         self.assertFalse(display.get_init())
 
     def test_set_gamma(self):
-        pygame.display.set_mode((1, 1))
+        if(not SDL2):
+            pygame.display.set_mode((1, 1))
         gammas = [0.0,0.25,0.5,0.88,1.0]
         for gamma in gammas:
             self.assertEqual(pygame.display.set_gamma(gamma),True)
         gammas = [(0.5,0.5,0.5),(1.0,1.0,1.0),(0.22,0.33,0.44),(0.0,0.0,0.0)]
         for gammaTuple in gammas:
             self.assertEqual(pygame.display.set_gamma(gammaTuple[0],gammaTuple[1],gammaTuple[2]),True)
-
 
     def todo_test_set_gamma_ramp(self):
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -314,23 +314,15 @@ class DisplayModuleTest(unittest.TestCase):
 
         self.assertFalse(display.get_init())
 
-    def todo_test_set_gamma(self):
+    def test_set_gamma(self):
+        pygame.display.set_mode((1, 1))
+        gammas = [0.0,0.25,0.5,0.88,1.0]
+        for gamma in gammas:
+            self.assertEqual(pygame.display.set_gamma(gamma),True)
+        gammas = [(0.5,0.5,0.5),(1.0,1.0,1.0),(0.22,0.33,0.44),(0.0,0.0,0.0)]
+        for gammaTuple in gammas:
+            self.assertEqual(pygame.display.set_gamma(gammaTuple[0],gammaTuple[1],gammaTuple[2]),True)
 
-        # __doc__ (as of 2008-08-02) for pygame.display.set_gamma:
-
-        # pygame.display.set_gamma(red, green=None, blue=None): return bool
-        # change the hardware gamma ramps
-        #
-        # Set the red, green, and blue gamma values on the display hardware.
-        # If the green and blue arguments are not passed, they will both be
-        # the same as red. Not all systems and hardware support gamma ramps,
-        # if the function succeeds it will return True.
-        #
-        # A gamma value of 1.0 creates a linear color table. Lower values will
-        # darken the display and higher values will brighten.
-        #
-
-        self.fail()
 
     def todo_test_set_gamma_ramp(self):
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -316,7 +316,7 @@ class DisplayModuleTest(unittest.TestCase):
 
     @unittest.skipIf(
     os.environ.get("SDL_VIDEODRIVER") == "dummy",
-    'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',
+    "Can't set gamma on SDL 1 with the dummy video driver",
     )
     def test_set_gamma(self):
         if(not SDL2):

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -314,6 +314,10 @@ class DisplayModuleTest(unittest.TestCase):
 
         self.assertFalse(display.get_init())
 
+    @unittest.skipIf(
+    os.environ.get("SDL_VIDEODRIVER") == "dummy",
+    'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',
+    )
     def test_set_gamma(self):
         if(not SDL2):
             pygame.display.set_mode((1, 1))


### PR DESCRIPTION
Adds a unit test function for display.set_gamma for   Issue #1750

I do that by first creating a list containing different gamma values ranging from 0.0 to 1.0 and I use them for the red=blue=green gamma values by only inputting the red value. 
Similarly, I re-create the list, filling it with tuples in (r,g,b) style and input them as different r,g,b values in the function.
In order for the test to pass, I expect the function to return True for every case.