### PR TITLE
Minimum and maximum window size

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -593,7 +593,7 @@ required).
 
 .. function:: get_allow_screensaver
 
-   | :sl:`Return whether the screensaver is allowed to run.`
+   | :sl:`Return whether the screensaver is allowed to run`
    | :sg:`get_allow_screensaver() -> bool`
 
    Return whether screensaver is allowed to run whilst the app is running.
@@ -636,6 +636,45 @@ required).
 
    .. versionadded:: 2.0
 
+.. function:: set_window_minimum_size
+
+   | :sl:`Set the minimum size the window can be`
+   | :sg:`set_window_minimum_size(min_w, min_h) -> None`
+
+   Makes it so the display window cannot be resized or created smaller than minimum
+   width (min_w) and minimum height (min_h).
+   
+   .. versionadded:: 2.0.0.dev12
+
+.. function:: get_window_minimum_size
+
+   | :sl:`Get the minimum size the window can be`
+   | :sg:`get_window_minimum_size() -> (min_w, min_h)`
+
+   Returns the minimum size the window can be, if it has been set by 
+   :func:`set_window_minimum_size`. If a minimum hasn't been set, it returns (0,0).
+
+   .. versionadded:: 2.0.0.dev12
+
+.. function:: set_window_maximum_size
+
+   | :sl:`Set the maximum size the window can be`
+   | :sg:`set_window_maximum_size(max_w, max_h) -> None`
+
+   Makes it so the display cannot be resized or created larger than maximum width (max_w)
+   and maximum height (max_h).
+   
+   .. versionadded:: 2.0.0.dev12
+
+.. function:: get_window_maximum_size
+
+   | :sl:`Get the maximum size the window can be`
+   | :sg:`get_window_maximum_size() -> (max_w, max_h)`
+
+   Returns the maximum size the window can be, if it has been set by
+   :func:`set_window_maximum_size`. If a maximum hasn't been set, it returns (0,0).
+   
+   .. versionadded:: 2.0.0.dev12
 
    .. ## pygame.display.set_allow_screensaver ##
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -2043,6 +2043,76 @@ pg_update(PyObject *self, PyObject *arg)
     Py_RETURN_NONE;
 }
 
+static PyObject*
+pg_set_window_minimum_size(PyObject *self, PyObject *arg)
+{
+    int min_w, min_h;
+    SDL_Window *win = pg_GetDefaultWindow();
+
+    VIDEO_INIT_CHECK();
+
+    if (!win)
+        return RAISE(pgExc_SDLError, "No open window");
+
+    if (!PyArg_ParseTuple(arg, "ii", &min_w, &min_h))
+        return NULL;
+
+    SDL_SetWindowMinimumSize(win, min_w, min_h);
+
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+pg_get_window_minimum_size(PyObject *self, PyObject *arg)
+{
+    int min_w, min_h;
+    SDL_Window *win = pg_GetDefaultWindow();
+
+    VIDEO_INIT_CHECK();
+
+    if (!win)
+        return RAISE(pgExc_SDLError, "No open window");
+
+    SDL_GetWindowMinimumSize(win, &min_w, &min_h);
+
+    Py_BuildValue("(ii)", min_w, min_h);
+}
+
+static PyObject*
+pg_set_window_maximum_size(PyObject *self, PyObject *arg)
+{
+    int max_w, max_h;
+    SDL_Window *win = pg_GetDefaultWindow();
+
+    VIDEO_INIT_CHECK();
+
+    if (!win)
+        return RAISE(pgExc_SDLError, "No open window");
+
+    if (!PyArg_ParseTuple(arg, "ii", &max_w, &max_h))
+        return NULL;
+
+    SDL_SetWindowMaximumSize(win, max_w, max_h);
+
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+pg_get_window_maximum_size(PyObject *self, PyObject *arg)
+{
+    int max_w, max_h;
+    SDL_Window *win = pg_GetDefaultWindow();
+
+    VIDEO_INIT_CHECK();
+
+    if (!win)
+        return RAISE(pgExc_SDLError, "No open window");
+
+    SDL_GetWindowMinimumSize(win, &max_w, &max_h);
+
+    Py_BuildValue("(ii)", max_w, max_h);
+}
+
 #if IS_SDLv2
 static PyObject *
 pg_set_palette(PyObject *self, PyObject *args)
@@ -3070,6 +3140,15 @@ static PyMethodDef _pg_display_methods[] = {
     {"iconify", pg_iconify, METH_NOARGS, DOC_PYGAMEDISPLAYICONIFY},
     {"toggle_fullscreen", pg_toggle_fullscreen, METH_NOARGS,
      DOC_PYGAMEDISPLAYTOGGLEFULLSCREEN},
+
+    {"set_window_minimum_size", pg_set_window_minimum_size, METH_VARARGS,
+     DOC_PYGAMEDISPLAYSETWINDOWMINIMUMSIZE},
+    {"get_window_minimum_size", pg_get_window_minimum_size, METH_NOARGS,
+     DOC_PYGAMEDISPLAYGETWINDOWMINIMUMSIZE},
+    {"set_window_maximum_size", pg_set_window_maximum_size, METH_VARARGS,
+     DOC_PYGAMEDISPLAYSETWINDOWMAXIMUMSIZE},
+    {"get_window_maximum_size", pg_get_window_maximum_size, METH_NOARGS,
+     DOC_PYGAMEDISPLAYGETWINDOWMAXIMUMSIZE},
 
 #if IS_SDLv2
     {"_set_autoresize", (PyCFunction)pg_display_set_autoresize

--- a/src_c/doc/display_doc.h
+++ b/src_c/doc/display_doc.h
@@ -25,9 +25,12 @@
 #define DOC_PYGAMEDISPLAYSETPALETTE "set_palette(palette=None) -> None\nSet the display color palette for indexed displays"
 #define DOC_PYGAMEDISPLAYGETNUMDISPLAYS "get_num_displays() -> int\nReturn the number of displays"
 #define DOC_PYGAMEDISPLAYGETWINDOWSIZE "get_window_size() -> tuple\nReturn the size of the window or screen"
-#define DOC_PYGAMEDISPLAYGETALLOWSCREENSAVER "get_allow_screensaver() -> bool\nReturn whether the screensaver is allowed to run."
+#define DOC_PYGAMEDISPLAYGETALLOWSCREENSAVER "get_allow_screensaver() -> bool\nReturn whether the screensaver is allowed to run"
 #define DOC_PYGAMEDISPLAYSETALLOWSCREENSAVER "set_allow_screensaver(bool) -> None\nSet whether the screensaver may run"
-
+#define DOC_PYGAMEDISPLAYSETWINDOWMINIMUMSIZE "set_window_minimum_size(min_w, min_h) -> None\nSets a minimum size for the window"
+#define DOC_PYGAMEDISPLAYGETWINDOWMINIMUMSIZE "get_window_minimum_size() -> (min_w, min_h)\nGets the minimum size for the window"
+#define DOC_PYGAMEDISPLAYSETWINDOWMAXIMUMSIZE "set_window_maximum_size(max_w, max_h) -> None\nSets a maximum size for the window"
+#define DOC_PYGAMEDISPLAYGETWINDOWMAXIMUMSIZE "get_window_maximum_size() -> (max_w, max_h)\nGets the maximum size for the window"
 
 /* Docs in a comment... slightly easier to read. */
 
@@ -139,10 +142,25 @@ Return the size of the window or screen
 
 pygame.display.get_allow_screensaver
  get_allow_screensaver() -> bool
-Return whether the screensaver is allowed to run.
+Return whether the screensaver is allowed to run
 
 pygame.display.set_allow_screensaver
  set_allow_screensaver(bool) -> None
 Set whether the screensaver may run
 
+pygame.display.set_window_minimum_size
+ set_window_minimum_size(min_w, min_h) -> None
+Sets a minimum size for the window
+
+pygame.display.get_window_minimum_size
+ get_window_minimum_size() -> (min_w, min_h)
+Gets the minimum size for the window
+
+pygame.display.set_window_maximum_size
+ set_window_minimum_size(max_w, max_h) -> None
+Sets a maximum size for the window
+
+pygame.display.get_window_maximum_size
+ get_window_maximum_size() -> (max_w, max_h)
+Gets the maximum size for the window
 */


### PR DESCRIPTION
Makes an interface for SDL_SetWindowMinimumSize, SDL_GetWindowMinimumSize, SDL_SetWindowMaximumSize, and SDL_GetWindowMaximumSize.

In response to issue #1846 

I added everything to the docs as well.

Things to note:
- I didn't know whether these functions were SDL2 only or not, so I didn't put them in one of the "if SDL1" or "if SDL2" blocks
- Setting a maximum size is significantly less useful, so maybe it shouldn't be exposed to try to keep pygame simpler
- I don't actually know C, hopefully I was able to pick up things in the other functions well enough
- I couldn't find a way to get rid of a minimum or maximum size constraint once it was established. You can change it to something else, but you can't go back to being unconstrained.

Other idea:
If setting a maximum or minimum size is a one time operation (can't be undone), maybe it should be in pygame.display.set_mode.

Like:
`pygame.display.set_mode((480,480), pygame.RESIZABLE, minsize = (100,50), maxsize=(1920,1080))`