### PR TITLE
Added unit test for mouse.get_cursor()

### DIFF
--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -57,9 +57,43 @@ class MouseModuleInteractiveTest(MouseTests):
 
 class MouseModuleTest(MouseTests):
 
-    def todo_test_get_cursor(self):
+    def test_get_cursor(self):
         """Ensures get_cursor works correctly."""
-        self.fail()
+        #error should be raised when the display is unintialized
+        with self.assertRaisesRegex(pygame.error, "video system not initialized"):
+            pygame.display.quit()
+            pygame.mouse.get_cursor()
+        
+        pygame.display.init()
+
+        if not SDL1:
+            with self.assertRaises(TypeError):
+                pygame.mouse.get_cursor()
+        else:
+            size = (8, 8)
+            hotspot = (0, 0)
+            xormask = (0, 96, 120, 126, 112, 96, 0, 0)
+            andmask = (224, 240, 254, 255, 254, 240, 96, 0)
+
+            expected_length = 4
+            expected_cursor = (size, hotspot, xormask, andmask)
+
+            try:
+                cursor = pygame.mouse.get_cursor()
+                
+                self.assertIsInstance(cursor, tuple)
+                self.assertEqual(len(cursor), expected_length)
+
+                for info in cursor:
+                    self.assertIsInstance(info, tuple)
+                
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+                self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
+
+            #SDLError should be raised when the mouse cursor is NULL
+            except pygame.error:
+                with self.assertRaises(pygame.error):
+                    pygame.mouse.get_cursor()         
 
     def todo_test_set_cursor(self):
         """Ensures set_cursor works correctly."""

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -59,17 +59,17 @@ class MouseModuleTest(MouseTests):
 
     def test_get_cursor(self):
         """Ensures get_cursor works correctly."""
-        #error should be raised when the display is unintialized
-        with self.assertRaisesRegex(pygame.error, "video system not initialized"):
-            pygame.display.quit()
-            pygame.mouse.get_cursor()
-        
-        pygame.display.init()
-
         if not SDL1:
             with self.assertRaises(TypeError):
                 pygame.mouse.get_cursor()
         else:
+            #error should be raised when the display is unintialized
+            with self.assertRaises(pygame.error):
+                pygame.display.quit()
+                pygame.mouse.get_cursor()
+
+            pygame.display.init()
+
             size = (8, 8)
             hotspot = (0, 0)
             xormask = (0, 96, 120, 126, 112, 96, 0, 0)


### PR DESCRIPTION
Hello this is my first contribution to pygame. 

This pull request is a unit test for `mouse.get_cursor` and addresses issue #1762. The test handles display initialization, SDL version, NULL mouse cursor and expected output based on the code documentation and what I understood the method does.

In regards to the display, I saw that there was a class at the top of `mouse_test.py` that was handling the initialization and quitting of `pygame.display`. There was supposed to be a `finally` block at the end where `pygame.display.quit()` would be executed, but it ended up failing the rest of the tests since `test_get_cursor` ran first and the other tests don't have `pygame.display.init()`.

If there's anything I need to change please let me know. Thank you.