### PR TITLE
Avoid PEP393 deprecated APIs.

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1520,7 +1520,12 @@ _pg_typestr_check(PyObject *op)
         return -1;
     }
     if (PyUnicode_Check(op)) {
-        if (PyUnicode_GET_SIZE(op) != 3) {
+#if PY2
+        Py_ssize_t len = PyUnicode_GET_SIZE(op);
+#else
+        Py_ssize_t len = PyUnicode_GET_LENGTH(op);
+#endif
+        if (len != 3) {
             PyErr_SetString(PyExc_ValueError,
                             "expected 'typestr' to be length 3");
             return -1;

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1587,7 +1587,11 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
     double *coords;
     Py_ssize_t i, idx, len;
     PyObject *attr_unicode = NULL;
+#if PY2
     Py_UNICODE *attr = NULL;
+#else
+    const char *attr = NULL;
+#endif
     PyObject *res = NULL;
 
     len = PySequence_Length(attr_name);
@@ -1602,7 +1606,11 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
     attr_unicode = PyUnicode_FromObject(attr_name);
     if (attr_unicode == NULL)
         goto swizzle_failed;
+#if PY2
     attr = PyUnicode_AsUnicode(attr_unicode);
+#else
+    attr = PyUnicode_AsUTF8AndSize(attr_unicode, &len);
+#endif
     if (attr == NULL)
         goto internal_error;
     /* If we are not a swizzle, go straight to GenericGetAttr. */

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -134,12 +134,21 @@ _view_kind(PyObject *obj, void *view_kind_vptr)
     _pc_view_kind_t *view_kind_ptr = (_pc_view_kind_t *)view_kind_vptr;
 
     if (PyUnicode_Check(obj)) {
+#if PY2
         if (PyUnicode_GET_SIZE(obj) != 1) {
             PyErr_SetString(PyExc_TypeError,
                             "expected a length 1 string for argument 3");
             return 0;
         }
         ch = *PyUnicode_AS_UNICODE(obj);
+#else
+        if (PyUnicode_GET_LENGTH(obj) != 1) {
+            PyErr_SetString(PyExc_TypeError,
+                            "expected a length 1 string for argument 3");
+            return 0;
+        }
+        ch = PyUnicode_READ_CHAR(obj, 0);
+#endif
     }
     else if (Bytes_Check(obj)) {
         if (Bytes_GET_SIZE(obj) != 1) {

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3825,7 +3825,7 @@ _view_kind(PyObject *obj, void *view_kind_vptr)
 #else
         if (PyUnicode_GET_LENGTH(obj) != 1) {
             PyErr_SetString(PyExc_TypeError,
-                            "expected a length 1 string for argument 3");
+                            "expected a length 1 string for argument 1");
             return 0;
         }
         ch = PyUnicode_READ_CHAR(obj, 0);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3815,12 +3815,21 @@ _view_kind(PyObject *obj, void *view_kind_vptr)
     SurfViewKind *view_kind_ptr = (SurfViewKind *)view_kind_vptr;
 
     if (PyUnicode_Check(obj)) {
+#if PY2
         if (PyUnicode_GET_SIZE(obj) != 1) {
             PyErr_SetString(PyExc_TypeError,
                             "expected a length 1 string for argument 1");
             return 0;
         }
         ch = *PyUnicode_AS_UNICODE(obj);
+#else
+        if (PyUnicode_GET_LENGTH(obj) != 1) {
+            PyErr_SetString(PyExc_TypeError,
+                            "expected a length 1 string for argument 3");
+            return 0;
+        }
+        ch = PyUnicode_READ_CHAR(obj, 0);
+#endif
     }
     else if (Bytes_Check(obj)) {
         if (Bytes_GET_SIZE(obj) != 1) {


### PR DESCRIPTION
There is remaining use of deprecated APIs in ft_unicode.c.
But it is not simple, straightforward.  So I exclude it from this pull request.