### PR TITLE
Add mouse.set_cursor unit test

### DIFF
--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -69,46 +69,45 @@ class MouseModuleTest(MouseTests):
         andmask = (254, 255, 254, 112, 56, 28, 12, 0)
         expected_cursor = (size, hotspot, xormask, andmask)
 
+        # Error should be raised when the display is uninitialized
+        with self.assertRaises(pygame.error):
+            pygame.display.quit()
+            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
 
+        pygame.display.init()
+        
+        # TypeError raised when PyArg_ParseTuple fails to parse parameters
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
+
+        # TypeError raised when either mask is not a sequence
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
+
+        # TypeError raised when element of mask is not an integer
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
+
+        # ValueError raised when width not divisible by 8
+        with self.assertRaises(ValueError): 
+            pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
+
+        # ValueError raised when length of either mask != width * height / 8
+        with self.assertRaises(ValueError):
+            pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
+        with self.assertRaises(ValueError):
+            pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
+
+        # Working as intended
         try:
-            # Error should be raised when the display is uninitialized
-            with self.assertRaises(pygame.error):
-                pygame.display.quit()
-                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
-
-            pygame.display.init()
-            
-            # TypeError raised when PyArg_ParseTuple fails to parse parameters
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
-
-            # TypeError raised when either mask is not a sequence
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
-
-            # TypeError raised when element of mask is not an integer
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
-
-            # ValueError raised when width not divisible by 8
-            with self.assertRaises(ValueError): 
-                pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
-
-            # ValueError raised when length of either mask != width * height / 8
-            with self.assertRaises(ValueError):
-                pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
-            with self.assertRaises(ValueError):
-                pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
-
-            # Working as intended
             self.assertEqual(
                 pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None
             )
@@ -116,12 +115,11 @@ class MouseModuleTest(MouseTests):
             self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
             pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask))
             self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
-
+            
         # SDLError should be raised when mouse cursor is NULL
         except pygame.error:
             with self.assertRaises(pygame.error):
                 pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
-
 
     def test_get_focused(self):
         """Ensures get_focused returns the correct type."""

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -61,7 +61,8 @@ class MouseModuleTest(MouseTests):
         """Ensures get_cursor works correctly."""
         self.fail()
 
-    def test_set_cursor(self):
+    @unittest.skipIf(not SDL1, "mouse.get_cursor only available in SDL1")
+    def test_set_cursor_sdl1(self):
         """Ensures set_cursor works correctly."""
         size = (8, 8)
         hotspot = (0, 0)
@@ -69,65 +70,114 @@ class MouseModuleTest(MouseTests):
         andmask = (254, 255, 254, 112, 56, 28, 12, 0)
         expected_cursor = (size, hotspot, xormask, andmask)
 
-        # Unable to use mouse.get_cursor in SDL2, so check that mouse.set_cursor
-        # doesn't raise a error when called with data expected to work
-        if not SDL1:
-            try:
-                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
-            except pygame.error:
-                self.fail()
-        else:
-            # Error should be raised when the display is uninitialized
-            with self.assertRaises(pygame.error):
-                pygame.display.quit()
-                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+        # Error should be raised when the display is uninitialized
+        with self.assertRaises(pygame.error):
+            pygame.display.quit()
+            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
 
-            pygame.display.init()
+        pygame.display.init()
+        
+        # TypeError raised when PyArg_ParseTuple fails to parse parameters
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
+
+        # TypeError raised when either mask is not a sequence
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
+
+        # TypeError raised when element of mask is not an integer
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
+
+        # ValueError raised when width not divisible by 8
+        with self.assertRaises(ValueError): 
+            pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
+
+        # ValueError raised when length of either mask != width * height / 8
+        with self.assertRaises(ValueError):
+            pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
+        with self.assertRaises(ValueError):
+            pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
+
+        # Working as intended
+        try:
+            self.assertEqual(
+                pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None)
+            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+            self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
+            pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask))
+            self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
             
-            # TypeError raised when PyArg_ParseTuple fails to parse parameters
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
-
-            # TypeError raised when either mask is not a sequence
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
-
-            # TypeError raised when element of mask is not an integer
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
-            with self.assertRaises(TypeError):
-                pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
-
-            # ValueError raised when width not divisible by 8
-            with self.assertRaises(ValueError): 
-                pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
-
-            # ValueError raised when length of either mask != width * height / 8
-            with self.assertRaises(ValueError):
-                pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
-            with self.assertRaises(ValueError):
-                pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
-
-            # Working as intended
-            try:
-                self.assertEqual(
-                    pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None
-                )
+        # SDLError should be raised when mouse cursor is NULL
+        except pygame.error:
+            with self.assertRaises(pygame.error):
                 pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
-                self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
-                pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask))
-                self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
-                
-            # SDLError should be raised when mouse cursor is NULL
-            except pygame.error:
-                with self.assertRaises(pygame.error):
-                    pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+
+    
+    @unittest.skipIf(SDL1 or os.environ.get("SDL_VIDEODRIVER", "") == "dummy",
+        "Fails on SDL2 with dummy video driver, unable to use mouse.get_cursor")
+    def test_set_cursor_sdl2(self):
+        """Ensures set_cursor works correctly."""
+        size = (8, 8)
+        hotspot = (0, 0)
+        xormask = (0, 126, 64, 64, 32, 16, 0, 0)
+        andmask = (254, 255, 254, 112, 56, 28, 12, 0)
+        expected_cursor = (size, hotspot, xormask, andmask)
+
+        # Error should be raised when the display is uninitialized
+        with self.assertRaises(pygame.error):
+            pygame.display.quit()
+            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+
+        pygame.display.init()
+        
+        # TypeError raised when PyArg_ParseTuple fails to parse parameters
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
+
+        # TypeError raised when either mask is not a sequence
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
+
+        # TypeError raised when element of mask is not an integer
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
+        with self.assertRaises(TypeError):
+            pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
+
+        # ValueError raised when width not divisible by 8
+        with self.assertRaises(ValueError): 
+            pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
+
+        # ValueError raised when length of either mask != width * height / 8
+        with self.assertRaises(ValueError):
+            pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
+        with self.assertRaises(ValueError):
+            pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
+
+        # Working as intended, no checks for same value as mouse.get_cursor in SDL2
+        try:
+            self.assertEqual(
+                pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None)
+
+        # SDLError should be raised when mouse cursor is NULL
+        except pygame.error:
+            with self.assertRaises(pygame.error):
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
 
     def test_get_focused(self):
         """Ensures get_focused returns the correct type."""

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -69,57 +69,65 @@ class MouseModuleTest(MouseTests):
         andmask = (254, 255, 254, 112, 56, 28, 12, 0)
         expected_cursor = (size, hotspot, xormask, andmask)
 
-        # Error should be raised when the display is uninitialized
-        with self.assertRaises(pygame.error):
-            pygame.display.quit()
-            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
-
-        pygame.display.init()
-        
-        # TypeError raised when PyArg_ParseTuple fails to parse parameters
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
-
-        # TypeError raised when either mask is not a sequence
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
-
-        # TypeError raised when element of mask is not an integer
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
-        with self.assertRaises(TypeError):
-            pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
-
-        # ValueError raised when width not divisible by 8
-        with self.assertRaises(ValueError): 
-            pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
-
-        # ValueError raised when length of either mask != width * height / 8
-        with self.assertRaises(ValueError):
-            pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
-        with self.assertRaises(ValueError):
-            pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
-
-        # Working as intended
-        try:
-            self.assertEqual(
-                pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None
-            )
-            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
-            self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
-            pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask))
-            self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
-            
-        # SDLError should be raised when mouse cursor is NULL
-        except pygame.error:
-            with self.assertRaises(pygame.error):
+        # Unable to use mouse.get_cursor in SDL2, so check that mouse.set_cursor
+        # doesn't raise a error when called with data expected to work
+        if not SDL1:
+            try:
                 pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+            except pygame.error:
+                self.fail()
+        else:
+            # Error should be raised when the display is uninitialized
+            with self.assertRaises(pygame.error):
+                pygame.display.quit()
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+
+            pygame.display.init()
+            
+            # TypeError raised when PyArg_ParseTuple fails to parse parameters
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
+
+            # TypeError raised when either mask is not a sequence
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
+
+            # TypeError raised when element of mask is not an integer
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
+
+            # ValueError raised when width not divisible by 8
+            with self.assertRaises(ValueError): 
+                pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
+
+            # ValueError raised when length of either mask != width * height / 8
+            with self.assertRaises(ValueError):
+                pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
+            with self.assertRaises(ValueError):
+                pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
+
+            # Working as intended
+            try:
+                self.assertEqual(
+                    pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None
+                )
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+                self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
+                pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask))
+                self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
+                
+            # SDLError should be raised when mouse cursor is NULL
+            except pygame.error:
+                with self.assertRaises(pygame.error):
+                    pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
 
     def test_get_focused(self):
         """Ensures get_focused returns the correct type."""

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -61,9 +61,67 @@ class MouseModuleTest(MouseTests):
         """Ensures get_cursor works correctly."""
         self.fail()
 
-    def todo_test_set_cursor(self):
+    def test_set_cursor(self):
         """Ensures set_cursor works correctly."""
-        self.fail()
+        size = (8, 8)
+        hotspot = (0, 0)
+        xormask = (0, 126, 64, 64, 32, 16, 0, 0)
+        andmask = (254, 255, 254, 112, 56, 28, 12, 0)
+        expected_cursor = (size, hotspot, xormask, andmask)
+
+
+        try:
+            # Error should be raised when the display is uninitialized
+            with self.assertRaises(pygame.error):
+                pygame.display.quit()
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+
+            pygame.display.init()
+            
+            # TypeError raised when PyArg_ParseTuple fails to parse parameters
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(("w", "h"), hotspot, xormask, andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, ("0", "0"), xormask, andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, ("x", "y", "z"), xormask, andmask)
+
+            # TypeError raised when either mask is not a sequence
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, 12345678, andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, xormask, 12345678)            
+
+            # TypeError raised when element of mask is not an integer
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, "00000000", andmask)
+            with self.assertRaises(TypeError):
+                pygame.mouse.set_cursor(size, hotspot, xormask, (2, [0], 4, 0, 0, 8, 0, 1))
+
+            # ValueError raised when width not divisible by 8
+            with self.assertRaises(ValueError): 
+                pygame.mouse.set_cursor((3, 8), hotspot, xormask, andmask)
+
+            # ValueError raised when length of either mask != width * height / 8
+            with self.assertRaises(ValueError):
+                pygame.mouse.set_cursor((16, 2), hotspot, (128, 64, 32), andmask)
+            with self.assertRaises(ValueError):
+                pygame.mouse.set_cursor((16, 2), hotspot, xormask, (192, 96, 48, 0, 1))
+
+            # Working as intended
+            self.assertEqual(
+                pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None
+            )
+            pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+            self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
+            pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask))
+            self.assertEqual(pygame.mouse.get_cursor(), expected_cursor)
+
+        # SDLError should be raised when mouse cursor is NULL
+        except pygame.error:
+            with self.assertRaises(pygame.error):
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask)
+
 
     def test_get_focused(self):
         """Ensures get_focused returns the correct type."""

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -130,7 +130,6 @@ class MouseModuleTest(MouseTests):
         hotspot = (0, 0)
         xormask = (0, 126, 64, 64, 32, 16, 0, 0)
         andmask = (254, 255, 254, 112, 56, 28, 12, 0)
-        expected_cursor = (size, hotspot, xormask, andmask)
 
         # Error should be raised when the display is uninitialized
         with self.assertRaises(pygame.error):
@@ -172,7 +171,9 @@ class MouseModuleTest(MouseTests):
         # Working as intended, no checks for same value as mouse.get_cursor in SDL2
         try:
             self.assertEqual(
-                pygame.mouse.set_cursor((16, 1), hotspot, (8, 0), (0, 192)), None)
+                pygame.mouse.set_cursor(size, hotspot, xormask, andmask), None)
+            self.assertEqual(
+                pygame.mouse.set_cursor(size, hotspot, list(xormask), list(andmask)), None)
 
         # SDLError should be raised when mouse cursor is NULL
         except pygame.error:


### PR DESCRIPTION
This pull request is to add a unit test for `mouse.set_cursor` and addresses issue #1763. 

I think I got all of the test cases except for when there is no memory left to allocate either bit mask.
The code below is what I need an assert for, but I don't know how to test for a lack of memory since the amount RAM is different depending on the system running and I don't know of any methods to help me. 

Does anyone have any ideas?
```
if ((NULL == xordata) || (NULL == anddata)) {
        free(xordata);
        free(anddata);
        return PyErr_NoMemory();
    }
```

Also, for clarification, the documentation for `mouse.set_cursor` says that the width for the size of the cursor has to be a multiple of 8 but not for height. Is it safe to assume that the height does not need to be a multiple of 8?

If there's anything I need to change or add, please feel free to let me know. Thank you.