### PR TITLE
Addresses Issue #1866 for render_to() to return a position rect

### DIFF
--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -594,6 +594,8 @@ SDL_Surface *_PGFT_Render_NewSurface(FreeTypeInstance *ft,
 
     r->x = -(Sint16)FX6_TRUNC(FX6_FLOOR(offset.x));
     r->y = (Sint16)FX6_TRUNC(FX6_CEIL(offset.y));
+    r->x = x;
+    r->y = y;
     r->w = (Uint16)width;
     r->h = (Uint16)height;
 

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -592,8 +592,6 @@ SDL_Surface *_PGFT_Render_NewSurface(FreeTypeInstance *ft,
     render(ft, font_text, mode, fgcolor, &font_surf,
            width, height, &offset, underline_top, underline_size);
 
-    // r->x = -(Sint16)FX6_TRUNC(FX6_FLOOR(offset.x));
-    // r->y = (Sint16)FX6_TRUNC(FX6_CEIL(offset.y));
     r->x = -(Sint16)(FX6_FLOOR(offset.x));
     r->y = -(Sint16)(FX6_CEIL(offset.y));
     r->w = (Uint16)width;

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -594,8 +594,8 @@ SDL_Surface *_PGFT_Render_NewSurface(FreeTypeInstance *ft,
 
     // r->x = -(Sint16)FX6_TRUNC(FX6_FLOOR(offset.x));
     // r->y = (Sint16)FX6_TRUNC(FX6_CEIL(offset.y));
-    r->x = -(Sint16)x;
-    r->y = -(Sint16)y;
+    r->x = -(Sint16)(FX6_FLOOR(offset.x));
+    r->y = -(Sint16)(FX6_CEIL(offset.y));
     r->w = (Uint16)width;
     r->h = (Uint16)height;
 

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -592,8 +592,9 @@ SDL_Surface *_PGFT_Render_NewSurface(FreeTypeInstance *ft,
     render(ft, font_text, mode, fgcolor, &font_surf,
            width, height, &offset, underline_top, underline_size);
 
-    r->x = -(Sint16)(FX6_FLOOR(offset.x));
-    r->y = -(Sint16)(FX6_CEIL(offset.y));
+    r->x = -(Sint16)FX6_TRUNC((FX6_FLOOR(offset.x)));
+    r->y = -(Sint16)FX6_TRUNC((FX6_CEIL(offset.y)));
+
     r->w = (Uint16)width;
     r->h = (Uint16)height;
 

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -592,10 +592,10 @@ SDL_Surface *_PGFT_Render_NewSurface(FreeTypeInstance *ft,
     render(ft, font_text, mode, fgcolor, &font_surf,
            width, height, &offset, underline_top, underline_size);
 
-    r->x = -(Sint16)FX6_TRUNC(FX6_FLOOR(offset.x));
-    r->y = (Sint16)FX6_TRUNC(FX6_CEIL(offset.y));
-    r->x = x;
-    r->y = y;
+    // r->x = -(Sint16)FX6_TRUNC(FX6_FLOOR(offset.x));
+    // r->y = (Sint16)FX6_TRUNC(FX6_CEIL(offset.y));
+    r->x = -(Sint16)x;
+    r->y = -(Sint16)y;
     r->w = (Uint16)width;
     r->h = (Uint16)height;
 

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -669,7 +669,8 @@ class FreeTypeFontTest(unittest.TestCase):
         rrect = font.render_to(surf, (32, 32), "FoobarBaz", color, None, size=24)
         self.assertIsInstance(rrect, pygame.Rect)
         self.assertEqual(rrect.top, rrect.height)
-        ## self.assertEqual(rrect.left, something or other)
+        ##test that render_to is position
+        self.assertEqual(rrect.left, something or other)
 
         rcopy = rrect.copy()
         rcopy.topleft = (32, 32)
@@ -680,7 +681,8 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertEqual(rrect.top, rrect.height)
         self.assertNotEqual(rrect.size, rect.size)
         rrect = font.render_to(surf, (20.1, 18.9), "FoobarBax", color, None, size=24)
-        ## self.assertEqual(tuple(rend[1].topleft), (20, 18))
+        # Added the test back 
+        self.assertEqual(tuple(rend[1].topleft), (20, 18))
 
         rrect = font.render_to(surf, rect, "", color, None, size=24)
         self.assertFalse(rrect)

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -670,7 +670,8 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertIsInstance(rrect, pygame.Rect)
         self.assertEqual(rrect.top, rrect.height)
         ##test that render_to is position
-        self.assertEqual(rrect.left, something or other)
+        self.assertEqual(rrect.left, 32)
+        self.assertEqual(rrect.right, 32)
 
         rcopy = rrect.copy()
         rcopy.topleft = (32, 32)
@@ -681,7 +682,7 @@ class FreeTypeFontTest(unittest.TestCase):
         self.assertEqual(rrect.top, rrect.height)
         self.assertNotEqual(rrect.size, rect.size)
         rrect = font.render_to(surf, (20.1, 18.9), "FoobarBax", color, None, size=24)
-        # Added the test back 
+        # Added the test back
         self.assertEqual(tuple(rend[1].topleft), (20, 18))
 
         rrect = font.render_to(surf, rect, "", color, None, size=24)


### PR DESCRIPTION
The FX6_TRUNC was resulting in incorrect values caused by bit-shifting 