### PR TITLE
Update math docs and add test for display.set_palette()

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -148,8 +148,8 @@ Multiple coordinates can be set using slices or swizzling::
 
       Scales the vector so that it has the given length. The direction of the
       vector is not changed. You can also scale to length 0. If the vector is
-      the zero vector (i.e. has length 0 thus no direction) an
-      ZeroDivisionError is raised.
+      the zero vector (i.e. has length 0 thus no direction) a
+      ValueError is raised.
 
       .. ## Vector2.scale_to_length ##
 
@@ -421,8 +421,8 @@ Multiple coordinates can be set using slices or swizzling::
 
       Scales the vector so that it has the given length. The direction of the
       vector is not changed. You can also scale to length 0. If the vector is
-      the zero vector (i.e. has length 0 thus no direction) an
-      ZeroDivisionError is raised.
+      the zero vector (i.e. has length 0 thus no direction) a
+      ValueError is raised.
 
       .. ## Vector3.scale_to_length ##
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -401,6 +401,9 @@ class DisplayModuleTest(unittest.TestCase):
 
     @unittest.skipIf(SDL2, "set_palette() not supported in SDL2") 
     def test_set_palette(self):
+        with self.assertRaises(UnboundLocalError) :
+            palette = [1,2,3]
+            screen.set_palette(palette)
         screen = pygame.display.set_mode((1024,768),pygame.DOUBLEBUF,8)
         palette = []
         self.assertIsNone(screen.set_palette(palette))
@@ -408,6 +411,24 @@ class DisplayModuleTest(unittest.TestCase):
         screen.set_palette(palette)
         self.assertEqual(screen.get_palette_at(1),(1,1,1,255))
         self.assertEqual(screen.get_palette_at(123),(123,123,123,255))
+        with self.assertRaises(ValueError): 
+            palette = 12
+            screen.set_palette(palette)
+        with self.assertRaises(ValueError): 
+            palette = [[1,2],[1,2]]
+            screen.set_palette(palette)
+        with self.assertRaises(ValueError): 
+            palette = [[0,0,0,0,0]] + [[x,x,x,x,x] for x in range(1,255)]
+            screen.set_palette(palette)
+        with self.assertRaises(ValueError): 
+            palette = "qwerty"
+            screen.set_palette(palette)
+        with self.assertRaises(ValueError): 
+            palette = [[123,123,123]*10000]
+            screen.set_palette(palette)
+        with self.assertRaises(ValueError): 
+            palette = [1,2,3]
+            screen.set_palette(palette)
 
     def todo_test_toggle_fullscreen(self):
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -399,7 +399,7 @@ class DisplayModuleTest(unittest.TestCase):
         pygame.display.set_allow_screensaver()
         self.assertTrue(pygame.display.get_allow_screensaver())
 
-    @unittest.skipIf(SDL2, "SDL2 issues") 
+    @unittest.skipIf(SDL2, "set_palette() not supported in SDL2") 
     def test_set_palette(self):
         screen = pygame.display.set_mode((1024,768),pygame.DOUBLEBUF,8)
         palette = []

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -401,9 +401,13 @@ class DisplayModuleTest(unittest.TestCase):
 
 
     def test_set_palette(self):
-        screen = pygame.display.set_mode((640,64),pygame.DOUBLEBUF,8)
+        screen = pygame.display.set_mode((1024,768),pygame.DOUBLEBUF,8)
         palette = []
-        self.assertIsNone(pygame.display.set_palette(palette))
+        self.assertIsNone(screen.set_palette(palette))
+        palette = [[0,0,0]] + [[x,x,x] for x in range(1,255)]
+        screen.set_palette(palette)
+        self.assertEqual(screen.get_palette_at(1),(1,1,1,255))
+        self.assertEqual(screen.get_palette_at(123),(123,123,123,255))
 
     def todo_test_toggle_fullscreen(self):
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -400,21 +400,10 @@ class DisplayModuleTest(unittest.TestCase):
         self.assertTrue(pygame.display.get_allow_screensaver())
 
 
-    def todo_test_set_palette(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.display.set_palette:
-
-        # pygame.display.set_palette(palette=None): return None
-        # set the display color palette for indexed displays
-        #
-        # This will change the video display color palette for 8bit displays.
-        # This does not change the palette for the actual display Surface,
-        # only the palette that is used to display the Surface. If no palette
-        # argument is passed, the system default palette will be restored. The
-        # palette is a sequence of RGB triplets.
-        #
-
-        self.fail()
+    def test_set_palette(self):
+        screen = pygame.display.set_mode((640,64),pygame.DOUBLEBUF,8)
+        palette = []
+        self.assertIsNone(pygame.display.set_palette(palette))
 
     def todo_test_toggle_fullscreen(self):
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -399,7 +399,7 @@ class DisplayModuleTest(unittest.TestCase):
         pygame.display.set_allow_screensaver()
         self.assertTrue(pygame.display.get_allow_screensaver())
 
-
+    @unittest.skipIf(SDL2, "SDL2 issues") 
     def test_set_palette(self):
         screen = pygame.display.set_mode((1024,768),pygame.DOUBLEBUF,8)
         palette = []


### PR DESCRIPTION
Changed the docs for pygame math.Vector.2 and math.vector.3 to report that a ValueError is raised instead of ZeroDivisionError when attempting to scale a zero length vector.
fixes #1957 