### PR TITLE
Fix test failure without SDL_AUDIODRIVER set

### DIFF
--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -192,7 +192,7 @@ class MixerMusicModuleTest(unittest.TestCase):
 
         self.fail()
 
-    @unittest.skipIf(os.environ['SDL_AUDIODRIVER'] == 'disk',
+    @unittest.skipIf(os.environ.get("SDL_AUDIODRIVER")  == 'disk',
                      'disk audio driver "playback" writing to disk is slow')
     def test_play__start_time(self):
 


### PR DESCRIPTION
Currently the tests fails if you have not set the SDL_AUDIODRIVER variable because of an `os.environ[...]` instead of `os.environ.get(...)`.