### PR TITLE
Fix get_active() function so it works as described in docs on windows under SDL2.

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -265,7 +265,8 @@ static PyObject *
 pg_get_active(PyObject *self, PyObject *args)
 {
     Uint32 flags = SDL_GetWindowFlags(pg_GetDefaultWindow());
-    return PyBool_FromLong((flags & SDL_WINDOW_SHOWN) != 0);
+    return PyBool_FromLong((flags & SDL_WINDOW_SHOWN) &&
+                           !(flags & SDL_WINDOW_MINIMIZED));
 }
 #else  /* IS_SDLv1 */
 static PyObject *


### PR DESCRIPTION
While reviewing the new tests for get_active() and toggle_fullscreen() I noticed that while get_active worked as described on linux in SDL2 and on linux and windows in SDL1, it didn't correctly report the status of the window while minimised on windows under SDL2.

**What I changed**

I noticed that SDL2 has a new `SDL_WINDOW_MINIMIZED` flag that can be checked as well as the `SDL_WINDOW_SHOWN` flag. So I changed get active to only return true if the window also *doesn't* have this flag. This is consistent with the docs which say:

> This will return False if the display Surface has been iconified or minimised (either via pygame.display.iconify() or via an OS specific method such as the minimize-icon available on most desktops).

I believe the way I've done it means it won't have any impact on platforms that don't use the minimise flag as the SDL_WINDOW_SHOWN flag is still checked and the SDL_WINDOW_MINIMIZED only comes into play if it is set on the window.

This change makes the new tests in this PR: 
https://github.com/pygame/pygame/pull/1927 

pass locally on windows (the bulk of these two new tests can't be run on the CI because of the dummy video driver).