### PR TITLE
Allow setting several paths in PYGAME_EXTRA_BASE

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -227,8 +227,8 @@ def main(sdl2=False):
     incdirs = []
     libdirs = []
     for extrabase in extrabases:
-        incdirs = [extrabase + d for d in origincdirs]
-        libdirs = [extrabase + d for d in origlibdirs]
+        incdirs += [extrabase + d for d in origincdirs]
+        libdirs += [extrabase + d for d in origlibdirs]
     incdirs += ["/usr"+d for d in origincdirs]
     libdirs += ["/usr"+d for d in origlibdirs]
     incdirs += ["/usr/local"+d for d in origincdirs]


### PR DESCRIPTION
The variable is split on "`:`" and is stored in an array called `extrabases`, which implies that several paths are valid.

However, the loop just overwrites `incdirs` and `libdirs`, so only the last PATH in that variable is used.