### PR TITLE
Pipenv: Fixed incorrect base class comparison (#1997)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -507,7 +507,7 @@ cmdclass = {}
 
 def add_command(name):
     def decorator(command):
-        assert issubclass(command, Command)
+        assert issubclass(command, distutils.cmd.Command)
         cmdclass[name]=command
         return command
     return decorator


### PR DESCRIPTION
Fixes issue #1997 where comparison is made against wrong `Command` class.