### PR TITLE
Fix aatrigon/aapolygon drawing horizontal edges

### DIFF
--- a/src_c/SDL_gfx/SDL_gfxPrimitives.c
+++ b/src_c/SDL_gfx/SDL_gfxPrimitives.c
@@ -2598,7 +2598,7 @@ int _aalineColor(SDL_Surface * dst, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, 
 		{
 			return (hlineColor(dst, x1, x2, y1, color));
 		} else {
-			if (dx>0) {
+			if (dx!=0) {
 				return (hlineColor(dst, xx0, xx0+dx, y1, color));
 			} else {
 				return (pixelColor(dst, x1, y1, color));

--- a/test/gfxdraw_test.py
+++ b/test/gfxdraw_test.py
@@ -593,7 +593,6 @@ class GfxdrawDefaultTest(unittest.TestCase):
             for posn in bg_test_points:
                 self.check_at(surf, posn, bg_adjusted)
 
-    @unittest.expectedFailure
     def test_aatrigon__with_horizontal_edge(self):
         """Ensure aatrigon draws horizontal edges correctly.
 
@@ -726,7 +725,6 @@ class GfxdrawDefaultTest(unittest.TestCase):
             for posn in bg_test_points:
                 self.check_at(surf, posn, bg_adjusted)
 
-    @unittest.expectedFailure
     def test_aapolygon__with_horizontal_edge(self):
         """Ensure aapolygon draws horizontal edges correctly.
 


### PR DESCRIPTION
Overview of changes:
- Fixed `gfxdraw` `aatrigon`/`aapolygon` not drawing some horizontal edges correctly (Fix taken from latest version (2.0.26) of the SDL_gfx library).
- Removed `expectedFailure` from related tests.

System details:
- os: windows 10 (64bit)
- python: 3.8.1 (64bit) and 2.7.10 (64bit)
- pygame: 2.0.0.dev11 (SDL: 2.0.12) at d79cd7de2f36c477c3eae6704ca3a2f33961d57d

---

SDL_gfx/SDL2_gfx library information: https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/

Resolves #622.
Related to #811.