### PR TITLE
Fix OOB access in swizzle; add '0' and '1' swizzles

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1584,6 +1584,7 @@ vector_str(pgVector *self)
 static PyObject *
 vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
 {
+    double value;
     double *coords;
     Py_ssize_t i, idx, len;
     PyObject *attr_unicode = NULL;
@@ -1634,22 +1635,32 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
             case 'y':
             case 'z':
                 idx = attr[i] - 'x';
-                break;
+                goto swizzle_idx;
             case 'w':
                 idx = 3;
+
+        swizzle_idx:
+                if (idx >= self->dim) {
+                    goto swizzle_failed;
+                };
+                value = coords[idx];
                 break;
+
+            case '0':
+                value = 0.0f;
+                break;
+            case '1':
+                value = 1.0f;
+                break;
+
             default:
                 goto swizzle_failed;
         }
         if (len == 2 || len == 3) {
-            ((pgVector *)res)->coords[i] = coords[idx];
-        }
-        else if (idx < self->dim) {
-            if (PyTuple_SetItem(res, i, PyFloat_FromDouble(coords[idx])) != 0)
+            ((pgVector *)res)->coords[i] = value;
+        } else {
+            if (PyTuple_SetItem(res, i, PyFloat_FromDouble(value)) != 0)
                 goto internal_error;
-        }
-        else {
-            goto swizzle_failed;
         }
     }
     /* swizzling succeeded! */

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -2111,6 +2111,34 @@ class Vector3TypeTest(unittest.TestCase):
         v *= 2
         self.assertEqual(v, (4.0, 4.0, 4.0))
 
+    def test_swizzle_constants(self):
+        """We can get constant values from a swizzle."""
+        v = Vector2(7, 6)
+        self.assertEqual(
+            v.xy1,
+            (7.0, 6.0, 1.0),
+        )
+
+    def test_swizzle_four_constants(self):
+        """We can get 4 constant values from a swizzle."""
+        v = Vector2(7, 6)
+        self.assertEqual(
+            v.xy01,
+            (7.0, 6.0, 0.0, 1.0),
+        )
+
+    def test_swizzle_oob(self):
+        """An out-of-bounds swizzle raises an AttributeError."""
+        v = Vector2(7, 6)
+        with self.assertRaises(AttributeError):
+            v.xyz
+
+    def test_swizzle_set_oob(self):
+        """An out-of-bounds swizzle set raises an AttributeError."""
+        v = Vector2(7, 6)
+        with self.assertRaises(AttributeError):
+            v.xz = (1, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #2023.

This adds bounds checks on swizzles like `Vector2().xyz`.

What I actually dived into this code for was to add swizzles with the digits `0` and `1`. I can't easily make the two changes independent now so it's one PR.

```
>>> Vector2(3, 2).xy1
Vector3(3, 2, 1) 
>>> Vector2(3, 2).xy01
(3, 2, 0, 1) 
```

These will be useful to prepare [homogenous coordinates for affine transforms by matrix multiplication](https://en.wikipedia.org/wiki/Transformation_matrix#Affine_transformations). Here is a matrix representing a 2x scale + (3, -1) translation:

```
>>> import numpy as np
>>> from pygame.math import Vector2
>>> v = Vector2(0.5, 0.8)
>>> mat = np.array([
...   [2, 0, 3],
...   [0, 2, -1],
... ])
>>> mat @ v.xy1
array([4. , 0.6])
```

Given that the intended usage would be `.xy1`, `.xyz1` or `.xy01`, it's not really a disadvantage that we can't syntactically write `.10yx` or something strange.