### PR TITLE
Fix sprite.collide_circle_ratio

### DIFF
--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1483,27 +1483,27 @@ def collide_circle(left, right):
     ydistance = left.rect.centery - right.rect.centery
     distancesquared = xdistance ** 2 + ydistance ** 2
 
-    if hasattr(left, 'radius'):
+    try:
         leftradius = left.radius
-    else:
+    except AttributeError:
         leftrect = left.rect
         # approximating the radius of a square by using half of the diagonal,
         # might give false positives (especially if its a long small rect)
         leftradius = (0.5 * ((leftrect.width ** 2 +
                               leftrect.height ** 2) ** 0.5))
         # store the radius on the sprite for next time
-        setattr(left, 'radius', leftradius)
+        left.radius = leftradius
 
-    if hasattr(right, 'radius'):
+    try:
         rightradius = right.radius
-    else:
+    except AttributeError:
         rightrect = right.rect
         # approximating the radius of a square by using half of the diagonal
         # might give false positives (especially if its a long small rect)
         rightradius = (0.5 * ((rightrect.width ** 2 +
                                rightrect.height ** 2) ** 0.5))
         # store the radius on the sprite for next time
-        setattr(right, 'radius', rightradius)
+        right.radius = rightradius
     return distancesquared <= (leftradius + rightradius) ** 2
 
 
@@ -1562,24 +1562,24 @@ class collide_circle_ratio(object):  # noqa pylint: disable=invalid-name; this i
         ydistance = left.rect.centery - right.rect.centery
         distancesquared = xdistance ** 2 + ydistance ** 2
 
-        if hasattr(left, "radius"):
+        try:
             leftradius = left.radius
-        else:
+        except AttributeError:
             leftrect = left.rect
             leftradius = (0.5 * ((leftrect.width ** 2 +
                                   leftrect.height ** 2) ** 0.5))
             # store the radius on the sprite for next time
-            setattr(left, 'radius', leftradius)
+            left.radius = leftradius
         leftradius *= ratio
 
-        if hasattr(right, "radius"):
+        try:
             rightradius = right.radius
-        else:
+        except AttributeError:
             rightrect = right.rect
             rightradius = (0.5 * ((rightrect.width ** 2 +
                                    rightrect.height ** 2) ** 0.5))
             # store the radius on the sprite for next time
-            setattr(right, 'radius', rightradius)
+            right.radius = rightradius
         rightradius *= ratio
 
         return distancesquared <= (leftradius + rightradius) ** 2

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1563,22 +1563,24 @@ class collide_circle_ratio(object):  # noqa pylint: disable=invalid-name; this i
         distancesquared = xdistance ** 2 + ydistance ** 2
 
         if hasattr(left, "radius"):
-            leftradius = left.radius * ratio
+            leftradius = left.radius
         else:
             leftrect = left.rect
-            leftradius = (ratio * 0.5 * ((leftrect.width ** 2 +
-                                          leftrect.height ** 2) ** 0.5))
+            leftradius = (0.5 * ((leftrect.width ** 2 +
+                                  leftrect.height ** 2) ** 0.5))
             # store the radius on the sprite for next time
             setattr(left, 'radius', leftradius)
+        leftradius *= ratio
 
         if hasattr(right, "radius"):
-            rightradius = right.radius * ratio
+            rightradius = right.radius
         else:
             rightrect = right.rect
-            rightradius = (ratio * 0.5 * ((rightrect.width ** 2 +
-                                           rightrect.height ** 2) ** 0.5))
+            rightradius = (0.5 * ((rightrect.width ** 2 +
+                                   rightrect.height ** 2) ** 0.5))
             # store the radius on the sprite for next time
             setattr(right, 'radius', rightradius)
+        rightradius *= ratio
 
         return distancesquared <= (leftradius + rightradius) ** 2
 

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -122,6 +122,48 @@ class SpriteCollideTest(unittest.TestCase):
 
         self.assertListEqual(expected_sprites, collided_sprites)
 
+    def test_collide_circle__radius_set_by_collide_circle_ratio(self):
+        # Call collide_circle_ratio with no radius set, at a 20.0 ratio.
+        # That should return group ag2 AND set the radius attribute of the
+        # sprites in such a way that collide_circle would give same result as
+        # if it had been called without the radius being set.
+        collided_func = sprite.collide_circle_ratio(20.0)
+
+        sprite.spritecollide(
+            self.s1, self.ag2, dokill=False, collided=collided_func
+        )
+
+        self.assertEqual(
+            sprite.spritecollide(
+                self.s1, self.ag2, dokill=False, collided=sprite.collide_circle
+            ),
+            [self.s2],
+        )
+
+    def test_collide_circle_ratio__no_radius_and_ratio_of_two_twice(self):
+        # collide_circle_ratio with no radius set, at a 2.0 ratio,
+        # called twice to check if the bug where the calculated radius
+        # is not stored correctly in the radius attribute of each sprite.
+        collided_func = sprite.collide_circle_ratio(2.0)
+
+        # Calling collide_circle_ratio will set the radius attribute of the
+        # sprites. If an incorrect value is stored then we will not get the
+        # same result next time it is called:
+        expected_sprites = sorted(
+            sprite.spritecollide(
+                self.s1, self.ag2, dokill=False, collided=collided_func
+            ),
+            key=id,
+        )
+        collided_sprites = sorted(
+            sprite.spritecollide(
+                self.s1, self.ag2, dokill=False, collided=collided_func
+            ),
+            key=id,
+        )
+
+        self.assertListEqual(expected_sprites, collided_sprites)
+
     def test_collide_circle__with_radii_set(self):
         # collide_circle with a radius set.
         self.s1.radius = 50


### PR DESCRIPTION
Fixes #2029 

- Add tests that reveals the bug in issue #2029 (incorrect value stored in the "radius" attribute of sprites)
- Fix sprite.collide_circle_ratio so it now stores the correct value in the "radius" attribute of those sprites that it is collision checking, that did not have that attribute previously set.