### PR TITLE
Fix custom_event first call

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1898,7 +1898,7 @@ pg_event_get_blocked(PyObject *self, PyObject *args)
 }
 
 
-int _custom_event = PGE_USEREVENT;
+int _custom_event = PGE_USEREVENT + 1;
 static PyObject *
 pg_event_custom_type(PyObject *self, PyObject *args)
 {

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -587,6 +587,7 @@ class EventModuleTest(unittest.TestCase):
         self.assertFalse(a == d)
 
     def test_custom_type(self):
+        self.assertEqual(pygame.event.custom_type(), pygame.USEREVENT + 1)
         atype = pygame.event.custom_type()
         atype2 = pygame.event.custom_type()
 


### PR DESCRIPTION
This should fix #2070.

In pygame 2.0.0.dev3 (#1151) return value used to be:
```
int _custom_event = PGE_USEREVENT + 1;
    int result = _custom_event + 1;
    return PyInt_FromLong(result);
```
So at the end if default user event is 10, 12 would be returned. To fix this (it should return 11) the following was done in dev4 (#1275)
```
int _custom_event = PGE_USEREVENT;
   return PyInt_FromLong(_custom_event++);
```
It updated custom event value only AFTER returning it. Fix could be done even with replacing `_custom_event++` with `_custom_event++`, but I decided to go with returning the old initialization of _custom_event