### PR TITLE
Added link in event docs to key constants list.

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -86,6 +86,9 @@ specific attributes.
     VIDEOEXPOSE       none
     USEREVENT         code
 
+You can also find a list of constants for keyboard keys
+:ref:`here <key-constants-label>`.
+
 |
 
 .. versionadded:: 1.9.2


### PR DESCRIPTION
There was a PR ([here](https://github.com/pygame/pygame/pull/1954)) that pointed out that it wasn't easy to find the key constants from the event module docs, they are however already included in the 'key' module docs so I added a link from the event docs to the list in the key docs.

I think it'll be useful to new users as the K_ type key constants are frequently used in combination with the KEYUP & KEYDOWN event type constants that are explained on this page.