### PR TITLE
test_do was sometimes failing Appveyor CI/CD due to time.time resolution.

### DIFF
--- a/test/threads_test.py
+++ b/test/threads_test.py
@@ -49,7 +49,7 @@ class WorkerQueueTypeTest(unittest.TestCase):
 
         self.assertEqual(sleep_return.result, None)
         self.assertEqual(calc_return.result, 2)
-        self.assertGreater(time_diff, 0.5)
+        self.assertGreaterEqual(time_diff, 0.5)
 
     def test_stop(self):
         """Ensure stop() stops the worker queue"""


### PR DESCRIPTION
@MyreMylar I was watching the builds happen on master and saw my test for test_do raised an issue in certain environments. Apparently in some environments (py 2.7?) time.time was rounding to integers and this was causing that test to fail intermittently. This commit is to fix that.