### PR TITLE
Fix off by one error in src_c/event.c

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1988,10 +1988,11 @@ int _custom_event = PGE_USEREVENT + 1;
 static PyObject *
 pg_event_custom_type(PyObject *self, PyObject *args)
 {
-    if (_custom_event > PG_NUMEVENTS) {
-        return RAISE(pgExc_SDLError, "pygame.event.custom_type made too many event types.");
+    if (_custom_event < PG_NUMEVENTS) {
+        return PyInt_FromLong(_custom_event++);
     }
-    return PyInt_FromLong(_custom_event++);
+    else
+        return RAISE(pgExc_SDLError, "pygame.event.custom_type made too many event types.");
 }
 
 static PyMethodDef _event_methods[] = {

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -186,6 +186,53 @@ class EventModuleArgsTest(unittest.TestCase):
         pygame.event.peek(eventtype=pygame.USEREVENT, pump=False)
 
 
+class EventCustomTypeTest(unittest.TestCase):
+    """Those tests are special in that they need the _custom_event counter to
+    be reset before and/or after being run."""
+    def setUp(self):
+        pygame.quit()
+        pygame.init()
+        pygame.display.init()
+
+    def tearDown(self):
+        pygame.quit()
+
+    def test_custom_type(self):
+        self.assertEqual(pygame.event.custom_type(), pygame.USEREVENT + 1)
+        atype = pygame.event.custom_type()
+        atype2 = pygame.event.custom_type()
+
+        self.assertEqual(atype, atype2 - 1)
+
+        ev = pygame.event.Event(atype)
+        pygame.event.post(ev)
+        queue = pygame.event.get(atype)
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].type, atype)
+
+    def test_custom_type__end_boundary(self):
+        """Ensure custom_type() raises error when no more custom types.
+
+        The last allowed custom type number should be (pygame.NUMEVENTS - 1).
+        """
+        start = pygame.event.custom_type() + 1
+        for i in range(start, pygame.NUMEVENTS):
+            last = pygame.event.custom_type()
+        self.assertEqual(last, pygame.NUMEVENTS - 1)
+        with self.assertRaises(pygame.error):
+            pygame.event.custom_type()
+
+    def test_custom_type__reset(self):
+        """Ensure custom events get 'deregistered' by quit().
+        """
+        before = pygame.event.custom_type()
+        self.assertEqual(before, pygame.event.custom_type() - 1)
+        pygame.quit()
+        pygame.init()
+        pygame.display.init()
+        self.assertEqual(before, pygame.event.custom_type())
+
+
 class EventModuleTest(unittest.TestCase):
     def _assertCountEqual(self, *args, **kwargs):
         # Handle method name differences between Python versions.
@@ -585,31 +632,6 @@ class EventModuleTest(unittest.TestCase):
         self.assertFalse(a == c)
         self.assertTrue(a != d)
         self.assertFalse(a == d)
-
-    def test_custom_type(self):
-        self.assertEqual(pygame.event.custom_type(), pygame.USEREVENT + 1)
-        atype = pygame.event.custom_type()
-        atype2 = pygame.event.custom_type()
-
-        self.assertEqual(atype, atype2 - 1)
-
-        ev = pygame.event.Event(atype)
-        pygame.event.post(ev)
-        queue = pygame.event.get(atype)
-        self.assertEqual(len(queue), 1)
-        self.assertEqual(queue[0].type, atype)
-
-    def test_custom_type__end_boundary(self):
-        """Ensure custom_type() raises error when no more custom types.
-
-        The last allowed custom type number should be (pygame.NUMEVENTS - 1).
-        """
-        start = pygame.event.custom_type() + 1
-        for i in range(start, pygame.NUMEVENTS):
-            last = pygame.event.custom_type()
-        self.assertEqual(last, pygame.NUMEVENTS - 1)
-        with self.assertRaises(pygame.error):
-            pygame.event.custom_type()
 
     def test_get_blocked(self):
         """Ensure an event's blocked state can be retrieved."""

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -599,6 +599,18 @@ class EventModuleTest(unittest.TestCase):
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].type, atype)
 
+    def test_custom_type__end_boundary(self):
+        """Ensure custom_type() raises error when no more custom types.
+
+        The last allowed custom type number should be (pygame.NUMEVENTS - 1).
+        """
+        start = pygame.event.custom_type() + 1
+        for i in range(start, pygame.NUMEVENTS):
+            last = pygame.event.custom_type()
+        self.assertEqual(last, pygame.NUMEVENTS - 1)
+        with self.assertRaises(pygame.error):
+            pygame.event.custom_type()
+
     def test_get_blocked(self):
         """Ensure an event's blocked state can be retrieved."""
         # Test each event is not blocked.


### PR DESCRIPTION
The custom user event types returned by pygame.event.custom_type()
should be up to pygame.NUMEVENTS, but not include it.

 - [x] Add unittest to catch off-by-one bug in event.c
 - [x] Fix the bug.
 - [x] Find a way to prevent the unittest to mess up other tests by not leaving any custom user event types left for them.