### PR TITLE
Surface.set_alpha(255) should turn off blending (1.9.6 compat) part 2

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1584,6 +1584,11 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     else
         alpha = (Uint8)alphaval;
 
+    if (alpha==255 && !SDL_ISPIXELFORMAT_ALPHA(surf->format->format)) {
+        if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0)
+            return RAISE(pgExc_SDLError, SDL_GetError());
+    }
+
     pgSurface_Prep(self);
 #if IS_SDLv1
     result = SDL_SetAlpha(surf, flags, alpha);
@@ -1627,8 +1632,8 @@ surf_get_alpha(pgSurfaceObject *self, PyObject *args)
     if (SDL_GetSurfaceBlendMode(surf, &mode) != 0)
         return RAISE(pgExc_SDLError, SDL_GetError());
 
-    if (mode != SDL_BLENDMODE_BLEND)
-        Py_RETURN_NONE;
+    if (mode == SDL_BLENDMODE_NONE)
+        return PyInt_FromLong(255);
 
     if (SDL_GetSurfaceAlphaMod(surf, &alpha) != 0)
         return RAISE(pgExc_SDLError, SDL_GetError());

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1584,10 +1584,12 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     else
         alpha = (Uint8)alphaval;
 
+#if IS_SDLv2
     if (alpha==255 && !SDL_ISPIXELFORMAT_ALPHA(surf->format->format)) {
         if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0)
             return RAISE(pgExc_SDLError, SDL_GetError());
     }
+#endif /* IS_SDLv1 */
 
     pgSurface_Prep(self);
 #if IS_SDLv1

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1580,7 +1580,7 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         s = pygame.Surface((1, 1), SRCALPHA, 32)
         s.fill((0, 255, 0, 128))
         s.set_alpha(None)
-        self.assertEqual(None, s.get_alpha())
+        self.assertEqual(255, s.get_alpha())
 
         s2 = pygame.Surface((1, 1), SRCALPHA, 32)
         s2.fill((255, 0, 0, 255))
@@ -3132,6 +3132,46 @@ class SurfaceSelfBlitTest(unittest.TestCase):
                 surf.fill(rectc_left, (0, 0, 25, 50))
                 surf.blit(surf, (d_x, d_y), (s_x, s_y, 50, 50))
                 self.assertEqual(surf.get_at(test_posn), rectc_right)
+
+    def test_overlap_check_unrolled(self):
+
+        surf = pygame.Surface((100, 100), 0, 32)
+        surf.set_alpha(255)
+
+        # iteration 1
+        surf.fill((0, 0, 0, 255))
+        surf.fill((255, 255, 255, 255), (25, 0, 25, 50))
+        surf.fill((128, 64, 32, 255), (0, 0, 25, 50))
+        surf.blit(surf, (1, 0), pygame.Rect(0, 0, 50, 50))
+        self.assertEqual(surf.get_at((50, 0)), (255, 255, 255, 255))
+
+        # iteration 2
+        surf.fill((0, 0, 0, 255))
+        surf.fill((255, 255, 255, 255), (25, 0, 25, 50))
+        surf.fill((128, 64, 32, 255), (0, 0, 25, 50))
+        surf.blit(surf, (49, 1), pygame.Rect(0, 0, 50, 50))
+        self.assertEqual(surf.get_at((98, 2)), (255, 255, 255, 255))
+
+        # iteration 3
+        surf.fill((0, 0, 0, 255))
+        surf.fill((255, 255, 255, 255), (25, 0, 25, 50))
+        surf.fill((128, 64, 32, 255), (0, 0, 25, 50))
+        surf.blit(surf, (49, 49), pygame.Rect(0, 0, 50, 50))
+        self.assertEqual(surf.get_at((98, 98)), (255, 255, 255, 255))
+
+        # iteration 4
+        surf.fill((0, 0, 0, 255))
+        surf.fill((255, 255, 255, 255), (25, 0, 25, 50))
+        surf.fill((128, 64, 32, 255), (0, 0, 25, 50))
+        surf.blit(surf, (0, 1), pygame.Rect(49, 0, 50, 50))
+        self.assertEqual(surf.get_at((0, 2)), (255, 255, 255, 255))
+
+        # iteration 5
+        surf.fill((0, 0, 0, 255))
+        surf.fill((255, 255, 255, 255), (25, 0, 25, 50))
+        surf.fill((128, 64, 32, 255), (0, 0, 25, 50))
+        surf.blit(surf, (0, 49), pygame.Rect(49, 0, 50, 50))
+        self.assertEqual(surf.get_at((0, 98)), (255, 255, 255, 255))
 
     # https://github.com/pygame/pygame/issues/370#issuecomment-364625291
     @unittest.skipIf("ppc64le" in platform.uname(), "known ppc64le issue")


### PR DESCRIPTION
Continuing on from: https://github.com/pygame/pygame/pull/1681 in this pygame repo branch so we can collaborate more easily.