### PR TITLE
Add mypy support, fix pygame._sdl2 importing touch module type hints

### DIFF
--- a/buildconfig/pygame-stubs/_sdl2/__init__.pyi
+++ b/buildconfig/pygame-stubs/_sdl2/__init__.pyi
@@ -1,1 +1,1 @@
-from .touch import *
+

--- a/setup.py
+++ b/setup.py
@@ -380,6 +380,7 @@ data_files = [('pygame', pygame_data_files)]
 add_stubs = True
 # add *.pyi files into distribution directory
 if add_stubs:
+    pygame_data_files.append(os.path.join('buildconfig', 'pygame-stubs', 'py.typed'))
     type_files = glob.glob(os.path.join('buildconfig', 'pygame-stubs', '*.pyi'))
     for type_file in type_files:
         pygame_data_files.append(type_file)


### PR DESCRIPTION
As discussed in https://github.com/pygame/pygame/issues/839#issuecomment-687723556, mypy relies on py.typed if stubs are bundled together with modules.  Since it's an empty file, I think it'd be OK to include it in the stub source folder instead of using a tempfile.NamedTemporaryFile which will requires cleanup.