### PR TITLE
Python3 needs __bool__ instead of __nonzero__

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -59,7 +59,9 @@ class MissingModule:
         raise NotImplementedError(missing_msg)
 
     def __nonzero__(self):
-        return 0
+        return False
+
+    __bool__ = __nonzero__
 
     def warn(self):
         msg_type = 'import' if self.urgent else 'use'

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -591,6 +591,8 @@ class AbstractGroup(object):
     def __nonzero__(self):
         return truth(self.sprites())
 
+    __bool__ = __nonzero__
+
     def __len__(self):
         """return number of sprites in group
 
@@ -1354,6 +1356,8 @@ class GroupSingle(AbstractGroup):
 
     def __nonzero__(self):
         return self.__sprite is not None
+
+    __bool__ = __nonzero__
 
     def _get_sprite(self):
         return self.__sprite


### PR DESCRIPTION
I noticed that bool(MissingModule) == True, and it should equal False.

I looked through src_py for more __nonzero__, which I found in the sprite module.

I set up __bool__ to link to __nonzero__ so the code with it will work on Python 2 and 3.