### PR TITLE
Small addition to cursors docs

### DIFF
--- a/docs/reST/ref/cursors.rst
+++ b/docs/reST/ref/cursors.rst
@@ -55,6 +55,8 @@ The following strings can be converted into cursor bitmaps with
    * ``pygame.cursors.sizer_y_strings``
 
    * ``pygame.cursors.sizer_xy_strings``
+   
+   * ``pygame.cursor.textmarker_strings``
 
 .. function:: compile
 

--- a/docs/reST/ref/cursors.rst
+++ b/docs/reST/ref/cursors.rst
@@ -16,24 +16,15 @@ This cursors module contains functions for loading and decoding various
 cursor formats. These allow you to easily store your cursors in external files
 or directly as encoded python strings.
 
-The module includes several standard cursors. The ``pygame.mouse.set_cursor()``
+The module includes several standard cursors. The :func:`pygame.mouse.set_cursor()`
 function takes several arguments. All those arguments have been stored in a
 single tuple you can call like this:
 
 ::
 
    >>> pygame.mouse.set_cursor(*pygame.cursors.arrow)
-
-This module also contains a few cursors as formatted strings. You'll need to
-pass these to ``pygame.cursors.compile()`` function before you can use them.
-The example call would look like this:
-
-::
-
-   >>> cursor = pygame.cursors.compile(pygame.cursors.textmarker_strings)
-   >>> pygame.mouse.set_cursor((8, 16), (0, 0), *cursor)
-
-The following variables are cursor bitmaps that can be used as cursor:
+   
+The following variables can be passed to ``pygame.mouse.set_cursor`` function:
 
    * ``pygame.cursors.arrow``
 
@@ -44,6 +35,15 @@ The following variables are cursor bitmaps that can be used as cursor:
    * ``pygame.cursors.tri_left``
 
    * ``pygame.cursors.tri_right``
+
+This module also contains a few cursors as formatted strings. You'll need to
+pass these to ``pygame.cursors.compile()`` function before you can use them.
+The example call would look like this:
+
+::
+
+   >>> cursor = pygame.cursors.compile(pygame.cursors.textmarker_strings)
+   >>> pygame.mouse.set_cursor((8, 16), (0, 0), *cursor)
 
 The following strings can be converted into cursor bitmaps with
 ``pygame.cursors.compile()`` :
@@ -64,16 +64,19 @@ The following strings can be converted into cursor bitmaps with
    | :sg:`compile(strings, black='X', white='.', xor='o') -> data, mask`
 
    A sequence of strings can be used to create binary cursor data for the
-   system cursor. The return values are the same format needed by
-   ``pygame.mouse.set_cursor()``.
+   system cursor. This returns the binary data in the form of two tuples.
+   Those can be passed as the third and fourth arguments respectively of the 
+   :func:`pygame.mouse.set_cursor()` function.
 
    If you are creating your own cursor strings, you can use any value represent
    the black and white pixels. Some system allow you to set a special toggle
    color for the system color, this is also called the xor color. If the system
    does not support xor cursors, that color will simply be black.
-
-   The width of the strings must all be equal and be divisible by 8. An example
-   set of cursor strings looks like this
+   
+   The height must be divisible by 8. The width of the strings must all be equal 
+   and be divisible by 8. If these two conditions are not met, ``ValueError`` is
+   raised.
+   An example set of cursor strings looks like this
 
    ::
 

--- a/docs/reST/ref/mouse.rst
+++ b/docs/reST/ref/mouse.rst
@@ -183,14 +183,22 @@ to access data about the mouse scroll, such as ``which`` (it will tell you what 
    | :sg:`set_cursor(size, hotspot, xormasks, andmasks) -> None`
 
    When the mouse cursor is visible, it will be displayed as a black and white
-   bitmap using the given bitmask arrays. The size is a sequence containing the
-   cursor width and height. Hotspot is a sequence containing the cursor hotspot
-   position. xormasks is a sequence of bytes containing the cursor xor data
+   bitmap using the given bitmask arrays. The ``size`` is a sequence containing 
+   the cursor width and height. ``hotspot`` is a sequence containing the cursor 
+   hotspot
+ position. A cursor has a width and height, but a mouse position is represented 
+   by a set of point coordinates. So the value passed into the cursor hotspot 
+   variable helps pygame to actually determine at what exact point the cursor 
+   is at.
+   
+   xormasks is a sequence of bytes containing the cursor xor data
    masks. Lastly is andmasks, a sequence of bytes containing the cursor
    bitmask data.
+   To create these variables, we can make use of the 
+   :func:`pygame.cursors.compile()` function.
 
-   Width must be a multiple of 8, and the mask arrays must be the correct size
-   for the given width and height. Otherwise an exception is raised.
+   Width and height must be a multiple of 8, and the mask arrays must be the 
+   correct size for the given width and height. Otherwise an exception is raised.
 
    See the ``pygame.cursor`` module for help creating default and custom masks
    for the mouse cursor.

--- a/docs/reST/ref/mouse.rst
+++ b/docs/reST/ref/mouse.rst
@@ -185,9 +185,10 @@ to access data about the mouse scroll, such as ``which`` (it will tell you what 
    When the mouse cursor is visible, it will be displayed as a black and white
    bitmap using the given bitmask arrays. The ``size`` is a sequence containing 
    the cursor width and height. ``hotspot`` is a sequence containing the cursor 
-   hotspot
- position. A cursor has a width and height, but a mouse position is represented 
-   by a set of point coordinates. So the value passed into the cursor hotspot 
+   hotspot position. 
+   
+   A cursor has a width and height, but a mouse position is represented by a 
+   set of point coordinates. So the value passed into the cursor ``hotspot`` 
    variable helps pygame to actually determine at what exact point the cursor 
    is at.
    
@@ -201,7 +202,7 @@ to access data about the mouse scroll, such as ``which`` (it will tell you what 
    correct size for the given width and height. Otherwise an exception is raised.
 
    See the ``pygame.cursor`` module for help creating default and custom masks
-   for the mouse cursor.
+   for the mouse cursor and also for more examples related to cursors.
 
    .. ## pygame.mouse.set_cursor ##
 


### PR DESCRIPTION
A small update to the cursor docs. 

I noticed that the source code for cursors module contain the textmarker_strings variable, but there is no reference to this variable in the docs. I don’t know wether this is intentional or not, if it is then please ignore this PR. 

I felt it needed to be in the docs, so I have put this PR. Please let me know if I did something wrong while submitting this PR, as it’s my first time contributing. 