### PR TITLE
Fix draw.aaline not always solid (and wasn't passing unit tests)

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1183,7 +1183,7 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
             pixel_color = get_antialiased_color(surf, (int) intersect_y, x,
                                                 color, brightness, blend);
             set_and_check_rect(surf, (int) intersect_y, x, pixel_color, drawn_area);
-            if ((int) intersect_y < intersect_y || (x == x_pixel_end && from_y != to_y)) {
+            if ((int) intersect_y < intersect_y) {
                 brightness = intersect_y - (int) intersect_y;
                 pixel_color = get_antialiased_color(surf, (int) intersect_y + 1,
                                                     x, color, brightness, blend);
@@ -1195,7 +1195,7 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
             pixel_color = get_antialiased_color(surf, x, (int) intersect_y,
                                                 color, brightness, blend);
             set_and_check_rect(surf, x, (int) intersect_y, pixel_color, drawn_area);
-            if ((int) intersect_y < intersect_y || (x == x_pixel_end && from_y != to_y)) {
+            if ((int) intersect_y < intersect_y) {
                 brightness = intersect_y - (int) intersect_y;
                 pixel_color = get_antialiased_color(surf, x, (int) intersect_y + 1,
                                                     color, brightness, blend);

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1274,28 +1274,29 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
 
     /* main line drawing loop */
     for (x = x_pixel_start; x < x_pixel_end; x++) {
+        y = (int)floor(intersect_y);
         if (steep) {
-            brightness = 1 - intersect_y + (int) intersect_y;
-            pixel_color = get_antialiased_color(surf, (int) intersect_y, x,
+            brightness = 1 - intersect_y + y;
+            pixel_color = get_antialiased_color(surf, y, x,
                                                 color, brightness, blend);
-            set_and_check_rect(surf, (int) intersect_y, x, pixel_color, drawn_area);
-            if ((int) intersect_y < intersect_y) {
-                brightness = intersect_y - (int) intersect_y;
-                pixel_color = get_antialiased_color(surf, (int) intersect_y + 1,
-                                                    x, color, brightness, blend);
-                set_and_check_rect(surf, (int) intersect_y + 1, x, pixel_color, drawn_area);
+            set_and_check_rect(surf, y, x, pixel_color, drawn_area);
+            if (y < intersect_y) {
+                brightness = 1 - brightness;
+                pixel_color = get_antialiased_color(surf, y + 1, x,
+                                                    color, brightness, blend);
+                set_and_check_rect(surf, y + 1, x, pixel_color, drawn_area);
             }
         }
         else {
-            brightness = 1 - intersect_y + (int) intersect_y;
-            pixel_color = get_antialiased_color(surf, x, (int) intersect_y,
+            brightness = 1 - intersect_y + y;
+            pixel_color = get_antialiased_color(surf, x, y,
                                                 color, brightness, blend);
-            set_and_check_rect(surf, x, (int) intersect_y, pixel_color, drawn_area);
-            if ((int) intersect_y < intersect_y) {
-                brightness = intersect_y - (int) intersect_y;
-                pixel_color = get_antialiased_color(surf, x, (int) intersect_y + 1,
+            set_and_check_rect(surf, x, y, pixel_color, drawn_area);
+            if (y < intersect_y) {
+                brightness = 1 - brightness;
+                pixel_color = get_antialiased_color(surf, x, y + 1,
                                                     color, brightness, blend);
-                set_and_check_rect(surf, x, (int) intersect_y + 1, pixel_color, drawn_area);
+                set_and_check_rect(surf, x, y + 1, pixel_color, drawn_area);
             }
         }
         intersect_y += gradient;

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1170,10 +1170,11 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
     /* Single point.
      * A line with length 0 is drawn as a single pixel at full brightness. */
     if (fabs(dx) < 0.0001 && fabs(dy) < 0.0001) {
-        pixel_color = get_antialiased_color(surf, (int)round(from_x),
-                                            (int)round(from_y), color, 1, blend);
-        set_and_check_rect(surf, (int)round(from_x), (int)round(from_y),
-                           pixel_color, drawn_area);
+        pixel_color = get_antialiased_color(surf, (int)floor(from_x + 0.5),
+                                            (int)floor(from_y + 0.5), color,
+                                            1, blend);
+        set_and_check_rect(surf, (int)floor(from_x + 0.5),
+                           (int)floor(from_y + 0.5), pixel_color, drawn_area);
         return;
     }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1176,14 +1176,14 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
     x_pixel_start = (int) from_x;
     x_pixel_end = (int) to_x;
     gradient = dx == 0 ? 1 : dy/dx;
-    intersect_y = from_y + gradient * ((int) from_x + 0.5f - from_x);
+    intersect_y = from_y + gradient * ((int) from_x - from_x);
     for (x = x_pixel_start; x <= x_pixel_end; x++) {
         if (steep) {
             brightness = 1 - intersect_y + (int) intersect_y;
             pixel_color = get_antialiased_color(surf, (int) intersect_y, x,
                                                 color, brightness, blend);
             set_and_check_rect(surf, (int) intersect_y, x, pixel_color, drawn_area);
-            if ((int) intersect_y < to_y || (x == x_pixel_end && from_y != to_y)) {
+            if ((int) intersect_y < intersect_y || (x == x_pixel_end && from_y != to_y)) {
                 brightness = intersect_y - (int) intersect_y;
                 pixel_color = get_antialiased_color(surf, (int) intersect_y + 1,
                                                     x, color, brightness, blend);
@@ -1195,7 +1195,7 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
             pixel_color = get_antialiased_color(surf, x, (int) intersect_y,
                                                 color, brightness, blend);
             set_and_check_rect(surf, x, (int) intersect_y, pixel_color, drawn_area);
-            if ((int) intersect_y < to_y || (x == x_pixel_end && from_y != to_y)) {
+            if ((int) intersect_y < intersect_y || (x == x_pixel_end && from_y != to_y)) {
                 brightness = intersect_y - (int) intersect_y;
                 pixel_color = get_antialiased_color(surf, x, (int) intersect_y + 1,
                                                     color, brightness, blend);

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2940,8 +2940,6 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_short_non_antialiased_lines(self):
         """test very short not anti aliased lines in all directions."""
-        if isinstance(self, DrawTestCase):
-            self.skipTest("not working with draw.aaline")
 
         # Horizontal, vertical and diagonal lines should not be anti-aliased,
         # even with draw.aaline ...
@@ -2970,8 +2968,6 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         check_both_directions((6, 4), (4, 6), [(5, 5)])
 
     def test_short_line_anti_aliasing(self):
-        if isinstance(self, DrawTestCase):
-            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2632,7 +2632,7 @@ class AALineMixin(BaseLineMixin):
                 for i, sub_color in enumerate(expected_color):
                     # The color could be slightly off the expected color due to
                     # any fractional position arguments.
-                    self.assertGreaterEqual(color[i] + 5, sub_color, start_pos)
+                    self.assertGreaterEqual(color[i] + 6, sub_color, start_pos)
                 self.assertIsInstance(bounds_rect, pygame.Rect, start_pos)
 
     def test_aaline__valid_end_pos_formats(self):
@@ -3037,8 +3037,6 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_anti_aliasing_float_coordinates(self):
         """Float coordinates should be blended smoothly."""
-#        if isinstance(self, DrawTestCase):
-#            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2977,8 +2977,11 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         def check_both_directions(from_pt, to_pt, should):
             self._check_antialiasing(from_pt, to_pt, should, check_points)
 
-        # lets say dx = abs(x0 - x1) ; dy = abs(y0 - y1)
         brown = (127, 127, 0)
+        reddish = (191, 63, 0)
+        greenish = (63, 191, 0)
+
+        # lets say dx = abs(x0 - x1) ; dy = abs(y0 - y1)
 
         # dy / dx = 0.5
         check_both_directions((4, 4), (6, 5), {(5, 4): brown, (5, 5): brown})
@@ -2991,8 +2994,6 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         # some little longer lines; so we need to check more points:
         check_points = [(i, j) for i in range(2, 9) for j in range(2, 9)]
         # dy / dx = 0.25
-        reddish = (191, 63, 0)
-        greenish = (63, 191, 0)
         should = {
             (4, 3): greenish,
             (5, 3): brown,
@@ -3036,23 +3037,25 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_anti_aliasing_float_coordinates(self):
         """Float coordinates should be blended smoothly."""
-        if isinstance(self, DrawTestCase):
-            self.skipTest("not working with draw.aaline")
+#        if isinstance(self, DrawTestCase):
+#            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)
 
         check_points = [(i, j) for i in range(5) for j in range(5)]
         brown = (127, 127, 0)
+        reddish = (191, 63, 0)
+        greenish = (63, 191, 0)
 
         # 0. identical point : current implementation does no smoothing...
-        expected = {(1, 2): FG_GREEN}
+        expected = {(2, 2): FG_GREEN}
         self._check_antialiasing(
             (1.5, 2), (1.5, 2), expected, check_points, set_endpoints=False
         )
-        expected = {(2, 2): FG_GREEN}
+        expected = {(2, 3): FG_GREEN}
         self._check_antialiasing(
-            (2.5, 2.7), (2.5, 2.7), expected, check_points, set_endpoints=False
+            (2.49, 2.7), (2.49, 2.7), expected, check_points, set_endpoints=False
         )
 
         # 1. horizontal lines
@@ -3069,7 +3072,7 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         self._check_antialiasing(
             (1, 2), (1.5, 2), expected, check_points, set_endpoints=False
         )
-        expected = {(1, 2): brown, (2, 2): (63, 191, 0)}
+        expected = {(1, 2): brown, (2, 2): greenish}
         self._check_antialiasing(
             (1.5, 2), (1.75, 2), expected, check_points, set_endpoints=False
         )
@@ -3086,7 +3089,7 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         self._check_antialiasing(
             (2, 1.5), (2, 2.5), expected, check_points, set_endpoints=False
         )
-        expected = {(2, 1): brown, (2, 2): (63, 191, 0)}
+        expected = {(2, 1): brown, (2, 2): greenish}
         self._check_antialiasing(
             (2, 1.5), (2, 1.75), expected, check_points, set_endpoints=False
         )
@@ -3111,8 +3114,6 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
             (2, 1.5), (3, 2.5), expected, check_points, set_endpoints=False
         )
 
-        reddish = (191, 63, 0)
-        greenish = (63, 191, 0)
         expected = {
             (2, 1): greenish,
             (2, 2): reddish,

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -3127,8 +3127,6 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_anti_aliasing_at_and_outside_the_border(self):
         """Ensures antialiasing works correct at a surface's borders."""
-        if isinstance(self, DrawTestCase):
-            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)


### PR DESCRIPTION
- [x] Fix #2120

This should also adress most of #522 :
- [x] Make `draw.aaline()` pass all unit tests that were previously skipped
- [ ] ~~Document expected behavior of `draw.aaline()`~~ (Will do later in a separate PR)

Also:
- [x] Write and run speed tests
- [x] Improve performance if possible/needed.