### PR TITLE
Backwards compatability for get_flags() in SDL2

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2638,7 +2638,6 @@ surf_get_flags(PyObject *self, PyObject *args)
         if (surf == pgSurface_AsSurface(pg_GetDefaultWindowSurface()))
             is_window_surf = 1;
             window_flags = SDL_GetWindowFlags(win);
-    pgSurfaceObject *surface = pg_GetDefaultWindowSurface();
     sdl_flags = surf->flags;
     if ((is_alpha = _PgSurface_SrcAlpha(surf)) == -1)
         return NULL;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2654,7 +2654,13 @@ surf_get_flags(PyObject *self, PyObject *args)
     {
         if (window_flags & SDL_WINDOW_FULLSCREEN_DESKTOP ||
             window_flags & SDL_WINDOW_FULLSCREEN)
-        flags |= PGS_FULLSCREEN;
+            flags |= PGS_FULLSCREEN;
+        if (window_flags & SDL_WINDOW_OPENGL)
+            flags |= PGS_OPENGL;
+        if (window_flags & SDL_WINDOW_RESIZABLE)
+            flags |= PGS_RESIZABLE;
+        if (window_flags & SDL_WINDOW_BORDERLESS)
+            flags |= PGS_NOFRAME;
     }
 
     return PyInt_FromLong((long)flags);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2642,6 +2642,9 @@ surf_get_flags(PyObject *self, PyObject *args)
         flags |= PGS_PREALLOC;
     if (sdl_flags & SDL_RLEACCEL)
         flags |= PGS_RLEACCEL;
+    if (sdl_flags & SDL_WINDOW_FULLSCREEN_DESKTOP ||
+        sdl_flags & SDL_WINDOW_FULLSCREEN)
+        flags |= PGS_FULLSCREEN;
     return PyInt_FromLong((long)flags);
 #endif /* IS_SDLv2 */
 }

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -377,6 +377,19 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 
         self.assertEqual(s1.get_flags(), pygame.SRCALPHA)
 
+    def test_get_flags__display_surf(self):
+        pygame.display.init()
+        try:
+            screen_surf = pygame.display.set_mode((600, 400),
+                                                  flags=pygame.FULLSCREEN)
+
+            found_flag = False
+            if screen_surf.get_flags() & pygame.FULLSCREEN:
+                found_flag = True
+            self.assertEqual(found_flag, True)
+        finally:
+            pygame.display.quit()
+
     ########################################################################
 
     def test_get_parent(self):
@@ -748,7 +761,7 @@ class TestSurfaceBlit(unittest.TestCase):
             self.assertEqual(self.dst_surface.get_at(k), (255, 255, 255))
 
     def test_blit_overflow_rect(self):
-        """Full coverage w/ overflow, specified with a Rect""" 
+        """Full coverage w/ overflow, specified with a Rect"""
         result = self.dst_surface.blit(self.src_surface, pygame.Rect(-1, -1, 300, 300))
         self.assertIsInstance(result, pygame.Rect)
         self.assertEqual(result.size, (64, 64))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -384,14 +384,41 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
     def test_get_flags__display_surf(self):
         pygame.display.init()
         try:
-            screen_surf = pygame.display.set_mode((600, 400),
-                                                  flags=0)
-
+            # FULLSCREEN
+            screen_surf = pygame.display.set_mode((600, 400), flags=0)
             self.assertFalse(screen_surf.get_flags() & pygame.FULLSCREEN)
 
             screen_surf = pygame.display.set_mode((600, 400),
                                                   flags=pygame.FULLSCREEN)
             self.assertTrue(screen_surf.get_flags() & pygame.FULLSCREEN)
+
+            # NOFRAME
+            screen_surf = pygame.display.set_mode((600, 400),flags=0)
+            self.assertFalse(screen_surf.get_flags() & pygame.NOFRAME)
+
+            screen_surf = pygame.display.set_mode((600, 400),
+                                                  flags=pygame.NOFRAME)
+            self.assertTrue(screen_surf.get_flags() & pygame.NOFRAME)
+
+            # RESIZABLE
+            screen_surf = pygame.display.set_mode((600, 400),flags=0)
+            self.assertFalse(screen_surf.get_flags() & pygame.RESIZABLE)
+
+            screen_surf = pygame.display.set_mode((600, 400),
+                                                  flags=pygame.RESIZABLE)
+            self.assertTrue(screen_surf.get_flags() & pygame.RESIZABLE)
+
+
+            # OPENGL
+            screen_surf = pygame.display.set_mode((600, 400), flags=0)
+            self.assertFalse(screen_surf.get_flags() & pygame.OPENGL)
+
+            try:
+                pygame.display.set_mode((200, 200), pygame.OPENGL, 32)
+            except pygame.error:
+                pass  # If we can't create OPENGL surface don't try this test
+            else:
+                self.assertTrue(screen_surf.get_flags() & pygame.OPENGL)
         finally:
             pygame.display.quit()
 

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -377,16 +377,21 @@ class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 
         self.assertEqual(s1.get_flags(), pygame.SRCALPHA)
 
+    @unittest.skipIf(
+        os.environ.get("SDL_VIDEODRIVER") == "dummy",
+        'requires a non-"dummy" SDL_VIDEODRIVER',
+    )
     def test_get_flags__display_surf(self):
         pygame.display.init()
         try:
             screen_surf = pygame.display.set_mode((600, 400),
-                                                  flags=pygame.FULLSCREEN)
+                                                  flags=0)
 
-            found_flag = False
-            if screen_surf.get_flags() & pygame.FULLSCREEN:
-                found_flag = True
-            self.assertEqual(found_flag, True)
+            self.assertFalse(screen_surf.get_flags() & pygame.FULLSCREEN)
+
+            screen_surf = pygame.display.set_mode((600, 400),
+                                                  flags=pygame.FULLSCREEN)
+            self.assertTrue(screen_surf.get_flags() & pygame.FULLSCREEN)
         finally:
             pygame.display.quit()
 


### PR DESCRIPTION
Related to #1343.

That's a complicated issue, but the biggest blocker I could see was not being able to query the FULLSCREEN flag on the display surface with `get_flags()`.

This should resolve that at least and I'll have a poke to see if I can get the output any closer to 1.9.6.