### PR TITLE
Fix repeated VIDEOEXPOSE events

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -144,6 +144,19 @@ RemovePending_PGS_VIDEORESIZE_Events(void * userdata, SDL_Event *event)
     return 1;
 }
 
+static int SDLCALL
+RemovePending_PGS_VIDEOEXPOSE_Events(void * userdata, SDL_Event *event)
+{
+    SDL_Event *new_event = (SDL_Event *)userdata;
+
+    if (event->type == SDL_VIDEOEXPOSE &&
+        event->window.windowID == new_event->window.windowID) {
+        /* We're about to post a new size event, drop the old one */
+        return 0;
+    }
+    return 1;
+}
+
 /*SDL 2 to SDL 1.2 event mapping and SDL 1.2 key repeat emulation*/
 static int SDLCALL
 pg_event_filter(void *_, SDL_Event *event)
@@ -191,6 +204,8 @@ pg_event_filter(void *_, SDL_Event *event)
                 {
                     SDL_Event newevent = *event;
                     newevent.type = SDL_ACTIVEEVENT;
+                    
+                    SDL_FilterEvents(RemovePending_PGS_VIDEOEXPOSE_Events, &newevent);
                     SDL_PushEvent(&newevent);
                     return 1;
                 }

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -192,6 +192,8 @@ pg_event_filter(void *_, SDL_Event *event)
                 {
                     SDL_Event newevent = *event;
                     newevent.type = SDL_VIDEOEXPOSE;
+                    
+                    SDL_FilterEvents(RemovePending_PGS_VIDEOEXPOSE_Events, &newevent);
                     SDL_PushEvent(&newevent);
                     return 1;
                 }
@@ -205,7 +207,6 @@ pg_event_filter(void *_, SDL_Event *event)
                     SDL_Event newevent = *event;
                     newevent.type = SDL_ACTIVEEVENT;
                     
-                    SDL_FilterEvents(RemovePending_PGS_VIDEOEXPOSE_Events, &newevent);
                     SDL_PushEvent(&newevent);
                     return 1;
                 }

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -132,7 +132,7 @@ static char _pg_last_unicode_char[32] = { 0 };
 static SDL_Event *_pg_last_keydown_event = NULL;
 
 static int SDLCALL
-RemovePending_PGS_VIDEORESIZE_Events(void * userdata, SDL_Event *event)
+_pg_remove_pending_PGS_VIDEORESIZE(void * userdata, SDL_Event *event)
 {
     SDL_Event *new_event = (SDL_Event *)userdata;
 
@@ -145,7 +145,7 @@ RemovePending_PGS_VIDEORESIZE_Events(void * userdata, SDL_Event *event)
 }
 
 static int SDLCALL
-RemovePending_PGS_VIDEOEXPOSE_Events(void * userdata, SDL_Event *event)
+_pg_remove_pending_PGS_VIDEOEXPOSE(void * userdata, SDL_Event *event)
 {
     SDL_Event *new_event = (SDL_Event *)userdata;
 
@@ -181,7 +181,7 @@ pg_event_filter(void *_, SDL_Event *event)
                        SDL2 already does this for SDL_WINDOWEVENT_RESIZED,
                        so we only need to filter our own custom event before
                        we push the new one*/
-                    SDL_FilterEvents(RemovePending_PGS_VIDEORESIZE_Events, &newevent);
+                    SDL_FilterEvents(_pg_remove_pending_PGS_VIDEORESIZE, &newevent);
                     SDL_PushEvent(&newevent);
                     return 1;
                 }
@@ -193,7 +193,7 @@ pg_event_filter(void *_, SDL_Event *event)
                     SDL_Event newevent = *event;
                     newevent.type = SDL_VIDEOEXPOSE;
                     
-                    SDL_FilterEvents(RemovePending_PGS_VIDEOEXPOSE_Events, &newevent);
+                    SDL_FilterEvents(_pg_remove_pending_PGS_VIDEOEXPOSE, &newevent);
                     SDL_PushEvent(&newevent);
                     return 1;
                 }

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -151,7 +151,7 @@ RemovePending_PGS_VIDEOEXPOSE_Events(void * userdata, SDL_Event *event)
 
     if (event->type == SDL_VIDEOEXPOSE &&
         event->window.windowID == new_event->window.windowID) {
-        /* We're about to post a new size event, drop the old one */
+        /* We're about to post a new videoexpose event, drop the old one */
         return 0;
     }
     return 1;


### PR DESCRIPTION
A PR to fix an issue where too many VIDEOEXPOSE events are placed in the event queue.

@MyreMylar suggested the code for solving this issue.

@robertpfeiffer This is the fix