### PR TITLE
Revert the draw.aaline, and speedy draw.line changes.

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1148,193 +1148,45 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
     float gradient, dx, dy, intersect_y, brightness;
     int x, x_pixel_start, x_pixel_end;
     Uint32 pixel_color;
-    float x_gap, y_endpoint, clip_left, clip_right, clip_top, clip_bottom;
-    int steep, y;
-
-    dx = to_x - from_x;
-    dy = to_y - from_y;
-
-    /* Single point.
-     * A line with length 0 is drawn as a single pixel at full brightness. */
-    if (fabs(dx) < 0.0001 && fabs(dy) < 0.0001) {
-        pixel_color = get_antialiased_color(surf, (int)floor(from_x + 0.5),
-                                            (int)floor(from_y + 0.5), color,
-                                            1, blend);
-        set_and_check_rect(surf, (int)floor(from_x + 0.5),
-                           (int)floor(from_y + 0.5), pixel_color, drawn_area);
-        return;
-    }
-
-    /* To draw correctly the pixels at the border of the clipping area when
-     * the line crosses it, we need to clip it one pixel wider in all four
-     * directions: */
-    clip_left = (float)surf->clip_rect.x - 1.0f;
-    clip_right = (float)clip_left + surf->clip_rect.w + 1.0f;
-    clip_top = (float)surf->clip_rect.y - 1.0f;
-    clip_bottom = (float)clip_top + surf->clip_rect.h + 1.0f;
-
-    steep = fabs(dx) < fabs(dy);
+    int steep = (to_x - from_x < 0 ? - (to_x - from_x) : (to_x - from_x)) <
+                (to_y - from_y < 0 ? - (to_y - from_y) : (to_y - from_y));
     if (steep) {
-        swap(&from_x, &from_y);
-        swap(&to_x, &to_y);
-        swap(&dx, &dy);
-        swap(&clip_left, &clip_top);
-        swap(&clip_right, &clip_bottom);
+        swap(&from_x , &from_y);
+        swap(&to_x , &to_y);
     }
-    if (dx < 0) {
+    if (from_x > to_x) {
         swap(&from_x, &to_x);
         swap(&from_y, &to_y);
-        dx = -dx;
-        dy = -dy;
     }
-
-    if (to_x <= clip_left || from_x >= clip_right) {
-        /* The line is completly to the side of the surface */
-        return;
-    }
-
-    /* Note. There is no need to guard against a division by zero here. If dx
-     * was zero then either we had a single point (and we've returned) or it
-     * has been swapped with a non-zero dy. */
-    gradient = dy/dx;
-
-    /* No need to waste CPU cycles on pixels not on the surface. */
-    if (from_x < clip_left) {
-        from_y += gradient * (clip_left - from_x);
-        from_x = clip_left;
-    }
-    if (to_x > clip_right) {
-        to_y += gradient * (clip_right - to_x);
-        to_x = clip_right;
-    }
-
-    if (gradient > 0.0f) {
-        /* from_ is the topmost endpoint */
-        if (to_y <= clip_top || from_y >= clip_bottom) {
-            /* The line does not enter the surface */
-            return;
-        }
-        if (from_y < clip_top) {
-            from_x += (clip_top - from_y) / gradient;
-            from_y = clip_top;
-        }
-        if (to_y > clip_bottom) {
-            to_x += (clip_bottom - to_y) / gradient;
-            to_y = clip_bottom;
-        }
-    }
-    else {
-        /* to_ is the topmost endpoint */
-        if (from_y <= clip_top || to_y >= clip_bottom) {
-            /* The line does not enter the surface */
-            return;
-        }
-        if (to_y < clip_top) {
-            to_x += (clip_top - to_y) / gradient;
-            to_y = clip_top;
-        }
-        if (from_y > clip_bottom) {
-            from_x += (clip_bottom - from_y) / gradient;
-            from_y = clip_bottom;
-        }
-    }
-    /* By moving the points one pixel down, we can assume y is never negative.
-     * That permit us to use (int)y to round down intead of having to use
-     * floor(y). We then draw the pixels one higher.*/
-    from_y += 1.0f;
-    to_y += 1.0f;
-
-    /* Handle endpoints separatly.
-     * The line is not a mathematical line of thickness zero. The same
-     * goes for the endpoints. The have a height and width of one pixel. */
-    /* First endpoint */
-    x_pixel_start = (int)from_x;
-    y_endpoint = intersect_y = from_y + gradient * (x_pixel_start - from_x);
-    if (to_x > clip_left + 1.0f) {
-        x_gap = 1 + x_pixel_start - from_x;
-        brightness = y_endpoint - (int)y_endpoint;
+    dx = to_x - from_x;
+    dy = to_y - from_y;
+    x_pixel_start = (int) from_x;
+    x_pixel_end = (int) to_x;
+    gradient = dx == 0 ? 1 : dy/dx;
+    intersect_y = from_y + gradient * ((int) from_x + 0.5f - from_x);
+    for (x = x_pixel_start; x <= x_pixel_end; x++) {
         if (steep) {
-            x = (int)y_endpoint;
-            y = x_pixel_start;
-        }
-        else {
-            x = x_pixel_start;
-            y = (int)y_endpoint;
-        }
-        if ((int)y_endpoint < y_endpoint) {
-            pixel_color = get_antialiased_color(surf, x, y, color,
-                                                brightness * x_gap, blend);
-            set_and_check_rect(surf, x, y, pixel_color, drawn_area);
-        }
-        if (steep) {
-            x--;
-        }
-        else {
-            y--;
-        }
-        brightness = 1 - brightness;
-        pixel_color = get_antialiased_color(surf, x, y, color,
-                                            brightness * x_gap, blend);
-        set_and_check_rect(surf, x, y, pixel_color, drawn_area);
-        intersect_y += gradient;
-        x_pixel_start++;
-    }
-    /* Second endpoint */
-    x_pixel_end = (int)ceil(to_x);
-    if (from_x < clip_right - 1.0f) {
-        y_endpoint = to_y + gradient * (x_pixel_end - to_x);
-        x_gap = 1 - x_pixel_end + to_x;
-        brightness = y_endpoint - (int)y_endpoint;
-        if (steep) {
-            x = (int)y_endpoint;
-            y = x_pixel_end;
-        }
-        else {
-            x = x_pixel_end;
-            y = (int)y_endpoint;
-        }
-        if ((int)y_endpoint < y_endpoint) {
-            pixel_color = get_antialiased_color(surf, x, y, color,
-                                                brightness * x_gap, blend);
-            set_and_check_rect(surf, x, y, pixel_color, drawn_area);
-        }
-        if (steep) {
-            x--;
-        }
-        else {
-            y--;
-        }
-        brightness = 1 - brightness;
-        pixel_color = get_antialiased_color(surf, x, y, color,
-                                            brightness * x_gap, blend);
-        set_and_check_rect(surf, x, y, pixel_color, drawn_area);
-    }
-
-    /* main line drawing loop */
-    for (x = x_pixel_start; x < x_pixel_end; x++) {
-        y = (int)intersect_y;
-        if (steep) {
-            brightness = 1 - intersect_y + y;
-            pixel_color = get_antialiased_color(surf, y - 1, x,
+            brightness = 1 - intersect_y + (int) intersect_y;
+            pixel_color = get_antialiased_color(surf, (int) intersect_y, x,
                                                 color, brightness, blend);
-            set_and_check_rect(surf, y - 1, x, pixel_color, drawn_area);
-            if (y < intersect_y) {
-                brightness = 1 - brightness;
-                pixel_color = get_antialiased_color(surf, y, x,
-                                                    color, brightness, blend);
-                set_and_check_rect(surf, y, x, pixel_color, drawn_area);
+            set_and_check_rect(surf, (int) intersect_y, x, pixel_color, drawn_area);
+            if ((int) intersect_y < to_y || (x == x_pixel_end && from_y != to_y)) {
+                brightness = intersect_y - (int) intersect_y;
+                pixel_color = get_antialiased_color(surf, (int) intersect_y + 1,
+                                                    x, color, brightness, blend);
+                set_and_check_rect(surf, (int) intersect_y + 1, x, pixel_color, drawn_area);
             }
         }
         else {
-            brightness = 1 - intersect_y + y;
-            pixel_color = get_antialiased_color(surf, x, y - 1,
+            brightness = 1 - intersect_y + (int) intersect_y;
+            pixel_color = get_antialiased_color(surf, x, (int) intersect_y,
                                                 color, brightness, blend);
-            set_and_check_rect(surf, x, y - 1, pixel_color, drawn_area);
-            if (y < intersect_y) {
-                brightness = 1 - brightness;
-                pixel_color = get_antialiased_color(surf, x, y,
+            set_and_check_rect(surf, x, (int) intersect_y, pixel_color, drawn_area);
+            if ((int) intersect_y < to_y || (x == x_pixel_end && from_y != to_y)) {
+                brightness = intersect_y - (int) intersect_y;
+                pixel_color = get_antialiased_color(surf, x, (int) intersect_y + 1,
                                                     color, brightness, blend);
-                set_and_check_rect(surf, x, y, pixel_color, drawn_area);
+                set_and_check_rect(surf, x, (int) intersect_y + 1, pixel_color, drawn_area);
             }
         }
         intersect_y += gradient;

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -39,7 +39,7 @@
 
 /* Declaration of drawing algorithms */
 static void
-draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2, int y2, int width,
+draw_line_width(SDL_Surface *surf, Uint32 color, int width, int *pts,
                          int *drawn_area);
 static void
 draw_line(SDL_Surface *surf, int x1, int y1, int x2, int y2, Uint32 color,
@@ -168,6 +168,7 @@ line(PyObject *self, PyObject *arg, PyObject *kwargs)
     PyObject *colorobj = NULL, *start = NULL, *end = NULL;
     SDL_Surface *surf = NULL;
     int startx, starty, endx, endy;
+    int pts[4];
     Uint8 rgba[4];
     Uint32 color;
     int width = 1; /* Default width. */
@@ -208,7 +209,11 @@ line(PyObject *self, PyObject *arg, PyObject *kwargs)
         return RAISE(PyExc_RuntimeError, "error locking surface");
     }
 
-    draw_line_width(surf, color, startx, starty, endx, endy, width, drawn_area);
+    pts[0] = startx;
+    pts[1] = starty;
+    pts[2] = endx;
+    pts[3] = endy;
+    draw_line_width(surf, color, width, pts, drawn_area);
 
     if (!pgSurface_Unlock(surfobj)) {
         return RAISE(PyExc_RuntimeError, "error unlocking surface");
@@ -370,6 +375,7 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
     SDL_Surface *surf = NULL;
     Uint32 color;
     Uint8 rgba[4];
+    int pts[4];
     int x, y, closed, result;
     int *xlist = NULL, *ylist = NULL;
     int width = 1; /* Default width. */
@@ -458,11 +464,21 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     for (loop = 1; loop < length; ++loop) {
-        draw_line_width(surf, color, xlist[loop - 1], ylist[loop - 1], xlist[loop], ylist[loop], width, drawn_area);
+        pts[0] = xlist[loop - 1];
+        pts[1] = ylist[loop - 1];
+        pts[2] = xlist[loop];
+        pts[3] = ylist[loop];
+
+        draw_line_width(surf, color, width, pts, drawn_area);
     }
 
     if (closed && length > 2) {
-        draw_line_width(surf, color, xlist[length - 1], ylist[length - 1], xlist[0], ylist[0], width, drawn_area);
+        pts[0] = xlist[length - 1];
+        pts[1] = ylist[length - 1];
+        pts[2] = xlist[0];
+        pts[3] = ylist[0];
+
+        draw_line_width(surf, color, width, pts, drawn_area);
     }
 
     PyMem_Del(xlist);
@@ -1038,62 +1054,59 @@ add_pixel_to_drawn_list(int x, int y, int *pts)
     }
 }
 
-static int
-clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2) {
-    int p1 = *x1 - *x2;
-    int p2 = -p1;
-    int p3 = *y1 - *y2;
-    int p4 = -p3;
-    int q1 = *x1 - surf->clip_rect.x;
-    int q2 = surf->clip_rect.w + surf->clip_rect.x - *x1;
-    int q3 = *y1 - surf->clip_rect.y;
-    int q4 = surf->clip_rect.h + surf->clip_rect.y - *y1;
-    int old_x1 = *x1;
-    int old_y1 = *y1;
-    double nmax = 0;
-    double pmin = 1;
-    double r1, r2;
-    if ((p1 == 0 && q1 < 0) || (p2 == 0 && q2 < 0) || (p3 == 0 && q3 < 0) || (p4 == 0 && q4 < 0))
-        return 0;
-    if (p1) {
-        r1 = (double) q1 / p1;
-        r2 = (double) q2 / p2;
-        if (p1 < 0) {
-            if (r1 > nmax)
-                nmax = r1;
-            if (r2 < pmin)
-                pmin = r2;
-        }
-        else {
-            if (r2 > nmax)
-                nmax = r2;
-            if (r1 < pmin)
-                pmin = r1;
+/* This is an internal helper function.
+ *
+ * This function draws a line that is clipped by the given rect. To draw thick
+ * lines (width > 1), multiple parallel lines are drawn.
+ *
+ * Params:
+ *     surf - pointer to surface to draw on
+ *     color - color of line to draw
+ *     width - width/thickness of line to draw (expected to be > 0)
+ *     pts - array of 4 points which are the endpoints of the line to
+ *         draw: {x0, y0, x1, y1}
+ *     drawn_area - array of 4 points which are the corners of the
+ *         bounding rect
+ */
+static void
+draw_line_width(SDL_Surface *surf, Uint32 color, int width, int *pts,
+                int *drawn_area)
+{
+    int xinc = 0, yinc = 0;
+    int original_values[4];
+    int loop;
+    memcpy(original_values, pts, sizeof(int) * 4);
+    /* Decide which direction to grow (width/thickness). */
+    if (abs(pts[0] - pts[2]) > abs(pts[1] - pts[3])) {
+        /* The line's thickness will be in the y direction. The left/right
+         * ends of the line will be flat. */
+        yinc = 1;
+    }
+    else {
+        /* The line's thickness will be in the x direction. The top/bottom
+         * ends of the line will be flat. */
+        xinc = 1;
+    }
+    /* Draw central line */
+    draw_line(surf, pts[0], pts[1], pts[2], pts[3], color, drawn_area);
+    /* If width is > 1 start drawing lines connected to the central line, first
+     * try to draw to the right / down, and then to the left / right. */
+    if (width != 1) {
+        for (loop = 1; loop < width; loop += 2) {
+            pts[0] = original_values[0] + xinc * (loop / 2 + 1);
+            pts[1] = original_values[1] + yinc * (loop / 2 + 1);
+            pts[2] = original_values[2] + xinc * (loop / 2 + 1);
+            pts[3] = original_values[3] + yinc * (loop / 2 + 1);
+            draw_line(surf, pts[0], pts[1], pts[2], pts[3], color, drawn_area);
+            if (loop + 1 < width) {
+                pts[0] = original_values[0] - xinc * (loop / 2 + 1);
+                pts[1] = original_values[1] - yinc * (loop / 2 + 1);
+                pts[2] = original_values[2] - xinc * (loop / 2 + 1);
+                pts[3] = original_values[3] - yinc * (loop / 2 + 1);
+                draw_line(surf, pts[0], pts[1], pts[2], pts[3], color, drawn_area);
+            }
         }
     }
-    if (p3) {
-        r1 = (double) q3 / p3;
-        r2 = (double) q4 / p4;
-        if (p3 < 0) {
-            if (r1 > nmax)
-                nmax = r1;
-            if (r2 < pmin)
-                pmin = r2;
-        }
-        else {
-            if (r2 > nmax)
-                nmax = r2;
-            if (r1 < pmin)
-                pmin = r1;
-        }
-    }
-    if (nmax > pmin)
-        return 0;
-    *x1 = old_x1 + (int) (p2 * nmax < 0 ? (p2 * nmax - 0.5) : (p2 * nmax + 0.5));
-    *y1 = old_y1 + (int) (p4 * nmax < 0 ? (p4 * nmax - 0.5) : (p4 * nmax + 0.5));
-    *x2 = old_x1 + (int) (p2 * pmin < 0 ? (p2 * pmin - 0.5) : (p2 * pmin + 0.5));
-    *y2 = old_y1 + (int) (p4 * pmin < 0 ? (p4 * pmin - 0.5) : (p4 * pmin + 0.5));
-    return 1;
 }
 
 static int
@@ -1268,48 +1281,6 @@ drawhorzlineclip(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2, int *p
     add_pixel_to_drawn_list(x2, y1, pts);
 
     drawhorzline(surf, color, x1, y1, x2);
-}
-
-static void
-draw_line_width(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2, int y2, int width,
-                int *drawn_area)
-{
-    int dx, dy, err, e2, sx, sy, i;
-    int xinc = 0;
-    /* Decide which direction to grow (width/thickness). */
-    if (abs(x1 - x2) <= abs(y1 - y2)) {
-        /* The line's thickness will be in the x direction. The top/bottom
-         * ends of the line will be flat. */
-        xinc = 1;
-    }
-    if (clip_line(surf, &x1, &y1, &x2, &y2)) {
-        if (width == 1)
-            draw_line(surf, x1, y1, x2, y2, color, drawn_area);
-        else {
-            dx = abs(x2 - x1);
-            sx = x1 < x2 ? 1 : -1;
-            dy = abs(y2 - y1);
-            sy = y1 < y2 ? 1 : -1;
-            err = (dx > dy ? dx : -dy) / 2;
-            while (x1 != x2 || y1 != y2) {
-                if (xinc)
-                    drawhorzlineclip(surf, color, x1 - (width - 1) / 2, y1, x1 + width / 2, drawn_area);
-                else {
-                    for (i = -(width - 1) / 2; i <= width / 2; i++)
-                        set_and_check_rect(surf, x1, y1 + i, color, drawn_area);
-                }
-                e2 = err;
-                if (e2 >-dx) { err -= dy; x1 += sx; }
-                if (e2 < dy) { err += dx; y1 += sy; }
-            }
-            if (xinc)
-                drawhorzlineclip(surf, color, x2 - (width - 1) / 2, y2, x2 + width / 2, drawn_area);
-            else {
-                for (i = -(width - 1) / 2; i <= width / 2; i++)
-                    set_and_check_rect(surf, x2, y2 + i, color, drawn_area);
-            }
-        }
-    }
 }
 
 /* Algorithm modified from
@@ -2030,46 +2001,58 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                              bottom_right, 0, color, 0, 0, 0, 1, drawn_area);
     }
     else {
-        if (x2 - top_right == x1 + top_left) {
+        pts[0] = x1 + top_left;
+        pts[1] = y1 + (int)(width / 2) - 1 + width % 2;
+        pts[2] = x2 - top_right;
+        pts[3] = y1 + (int)(width / 2) - 1 + width % 2;
+        if (pts[2] == pts[0]) {
             for (i = 0; i < width; i++) {
-                set_and_check_rect(surf, x1 + top_left, y1 + i, color,
+                set_and_check_rect(surf, pts[0], y1 + i, color,
                        drawn_area); /* Fill gap if reduced radius */
             }
         }
         else
-            draw_line_width(surf, color, x1 + top_left, y1 + (int)(width / 2) - 1 + width % 2,
-                            x2 - top_right, y1 + (int)(width / 2) - 1 + width % 2, width,
-                            drawn_area); /* Top line */
-        if (y2 - bottom_left == y1 + top_left) {
+            draw_line_width(surf, color, width, pts,
+                                     drawn_area); /* Top line */
+        pts[0] = x1 + (int)(width / 2) - 1 + width % 2;
+        pts[1] = y1 + top_left;
+        pts[2] = x1 + (int)(width / 2) - 1 + width % 2;
+        pts[3] = y2 - bottom_left;
+        if (pts[3] == pts[1]) {
             for (i = 0; i < width; i++) {
-                set_and_check_rect(surf, x1 + i, y1 + top_left, color,
+                set_and_check_rect(surf, x1 + i, pts[1], color,
                        drawn_area); /* Fill gap if reduced radius */
             }
         }
         else
-            draw_line_width(surf, color, x1 + (int)(width / 2) - 1 + width % 2,
-                            y1 + top_left, x1 + (int)(width / 2) - 1 + width % 2,
-                            y2 - bottom_left, width, drawn_area); /* Left line */
-        if (x2 - bottom_right == x1 + bottom_left) {
+            draw_line_width(surf, color, width, pts,
+                                     drawn_area); /* Left line */
+        pts[0] = x1 + bottom_left;
+        pts[1] = y2 - (int)(width / 2);
+        pts[2] = x2 - bottom_right;
+        pts[3] = y2 - (int)(width / 2);
+        if (pts[2] == pts[0]) {
             for (i = 0; i < width; i++) {
-                set_and_check_rect(surf, x1 + bottom_left, y2 - i, color,
+                set_and_check_rect(surf, pts[0], y2 - i, color,
                        drawn_area); /* Fill gap if reduced radius */
             }
         }
         else
-            draw_line_width(surf, color, x1 + bottom_left, y2 - (int)(width / 2),
-                            x2 - bottom_right, y2 - (int)(width / 2), width,
-                            drawn_area); /* Bottom line */
-        if (y2 - bottom_right == y1 + top_right) {
+            draw_line_width(surf, color, width, pts,
+                                     drawn_area); /* Bottom line */
+        pts[0] = x2 - (int)(width / 2);
+        pts[1] = y1 + top_right;
+        pts[2] = x2 - (int)(width / 2);
+        pts[3] = y2 - bottom_right;
+        if (pts[3] == pts[1]) {
             for (i = 0; i < width; i++) {
-                set_and_check_rect(surf, x2 - i, y1 + top_right, color,
+                set_and_check_rect(surf, x2 - i, pts[1], color,
                        drawn_area); /* Fill gap if reduced radius */
             }
         }
         else
-            draw_line_width(surf, color, x2 - (int)(width / 2), y1 + top_right,
-                            x2 - (int)(width / 2), y2 - bottom_right, width,
-                            drawn_area); /* Right line */
+            draw_line_width(surf, color, width, pts,
+                                     drawn_area); /* Right line */
 
         draw_circle_quadrant(surf, x2 - top_right + 1, y1 + top_right,
                              top_right, width, color, 1, 0, 0, 0, drawn_area);

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2632,7 +2632,7 @@ class AALineMixin(BaseLineMixin):
                 for i, sub_color in enumerate(expected_color):
                     # The color could be slightly off the expected color due to
                     # any fractional position arguments.
-                    self.assertGreaterEqual(color[i] + 6, sub_color, start_pos)
+                    self.assertGreaterEqual(color[i] + 5, sub_color, start_pos)
                 self.assertIsInstance(bounds_rect, pygame.Rect, start_pos)
 
     def test_aaline__valid_end_pos_formats(self):
@@ -2940,6 +2940,8 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_short_non_antialiased_lines(self):
         """test very short not anti aliased lines in all directions."""
+        if isinstance(self, DrawTestCase):
+            self.skipTest("not working with draw.aaline")
 
         # Horizontal, vertical and diagonal lines should not be anti-aliased,
         # even with draw.aaline ...
@@ -2968,6 +2970,8 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         check_both_directions((6, 4), (4, 6), [(5, 5)])
 
     def test_short_line_anti_aliasing(self):
+        if isinstance(self, DrawTestCase):
+            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)
@@ -2977,11 +2981,8 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         def check_both_directions(from_pt, to_pt, should):
             self._check_antialiasing(from_pt, to_pt, should, check_points)
 
-        brown = (127, 127, 0)
-        reddish = (191, 63, 0)
-        greenish = (63, 191, 0)
-
         # lets say dx = abs(x0 - x1) ; dy = abs(y0 - y1)
+        brown = (127, 127, 0)
 
         # dy / dx = 0.5
         check_both_directions((4, 4), (6, 5), {(5, 4): brown, (5, 5): brown})
@@ -2994,6 +2995,8 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         # some little longer lines; so we need to check more points:
         check_points = [(i, j) for i in range(2, 9) for j in range(2, 9)]
         # dy / dx = 0.25
+        reddish = (191, 63, 0)
+        greenish = (63, 191, 0)
         should = {
             (4, 3): greenish,
             (5, 3): brown,
@@ -3037,23 +3040,23 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_anti_aliasing_float_coordinates(self):
         """Float coordinates should be blended smoothly."""
+        if isinstance(self, DrawTestCase):
+            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)
 
         check_points = [(i, j) for i in range(5) for j in range(5)]
         brown = (127, 127, 0)
-        reddish = (191, 63, 0)
-        greenish = (63, 191, 0)
 
         # 0. identical point : current implementation does no smoothing...
-        expected = {(2, 2): FG_GREEN}
+        expected = {(1, 2): FG_GREEN}
         self._check_antialiasing(
             (1.5, 2), (1.5, 2), expected, check_points, set_endpoints=False
         )
-        expected = {(2, 3): FG_GREEN}
+        expected = {(2, 2): FG_GREEN}
         self._check_antialiasing(
-            (2.49, 2.7), (2.49, 2.7), expected, check_points, set_endpoints=False
+            (2.5, 2.7), (2.5, 2.7), expected, check_points, set_endpoints=False
         )
 
         # 1. horizontal lines
@@ -3070,7 +3073,7 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         self._check_antialiasing(
             (1, 2), (1.5, 2), expected, check_points, set_endpoints=False
         )
-        expected = {(1, 2): brown, (2, 2): greenish}
+        expected = {(1, 2): brown, (2, 2): (63, 191, 0)}
         self._check_antialiasing(
             (1.5, 2), (1.75, 2), expected, check_points, set_endpoints=False
         )
@@ -3087,7 +3090,7 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
         self._check_antialiasing(
             (2, 1.5), (2, 2.5), expected, check_points, set_endpoints=False
         )
-        expected = {(2, 1): brown, (2, 2): greenish}
+        expected = {(2, 1): brown, (2, 2): (63, 191, 0)}
         self._check_antialiasing(
             (2, 1.5), (2, 1.75), expected, check_points, set_endpoints=False
         )
@@ -3112,6 +3115,8 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
             (2, 1.5), (3, 2.5), expected, check_points, set_endpoints=False
         )
 
+        reddish = (191, 63, 0)
+        greenish = (63, 191, 0)
         expected = {
             (2, 1): greenish,
             (2, 2): reddish,
@@ -3127,6 +3132,8 @@ class DrawAALineTest(AALineMixin, DrawTestCase):
 
     def test_anti_aliasing_at_and_outside_the_border(self):
         """Ensures antialiasing works correct at a surface's borders."""
+        if isinstance(self, DrawTestCase):
+            self.skipTest("not working with draw.aaline")
 
         self.surface = pygame.Surface((10, 10))
         draw.rect(self.surface, BG_RED, (0, 0, 10, 10), 0)


### PR DESCRIPTION
After merging with other changes it started to cause errors on appveyor.

- Note, that the draw.aaline changes did pass the tests in the PR before merging: https://github.com/pygame/pygame/pull/2126
- The speedy draw.line changes did pass tests in the PR before merging #2151

Reverting the draw.aaline changes (by themselves) leaves python 3.7 on windows appveyor failing. https://ci.appveyor.com/project/pygame/pygame/builds/35683803/job/9owb6dowx0oqxwul From this we can deduce that the speedy line changes have a problem.

Reverting the speedy line changes (by them selves) cause a python2.7 failure on windows appveyor. https://ci.appveyor.com/project/pygame/pygame/builds/35684059/job/yur9nymk3ffsrln3 We can deduce from this that the draw.aaline changes have a problem.
