### PR TITLE
Just playing around with mouse.get_cursor

### DIFF
--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -319,14 +319,6 @@ mouse_set_system_cursor(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-
-#if IS_SDLv2
-static PyObject *
-mouse_get_cursor(PyObject *self)
-{
-    return RAISE(PyExc_TypeError, "The get_cursor method is unavailable in SDL2");
-}
-#else /* IS_SDLv1*/
 static PyObject *
 mouse_get_cursor(PyObject *self)
 {
@@ -362,7 +354,6 @@ mouse_get_cursor(PyObject *self)
 
     return Py_BuildValue("((ii)(ii)NN)", w, h, spotx, spoty, xordata, anddata);
 }
-#endif /* IS_SDLv1 */
 
 static PyMethodDef _mouse_methods[] = {
     {"set_pos", mouse_set_pos, METH_VARARGS, DOC_PYGAMEMOUSESETPOS},

--- a/test/mouse_test.py
+++ b/test/mouse_test.py
@@ -58,10 +58,7 @@ class MouseModuleInteractiveTest(MouseTests):
 class MouseModuleTest(MouseTests):
     def test_get_cursor(self):
         """Ensures get_cursor works correctly."""
-        if not SDL1:
-            with self.assertRaises(TypeError):
-                pygame.mouse.get_cursor()
-        else:
+        if True:
             # error should be raised when the display is unintialized
             with self.assertRaises(pygame.error):
                 pygame.display.quit()


### PR DESCRIPTION
Related to #2098 

Just testing why get cursor fails on sdl2. According to docs, it should be available.
https://wiki.libsdl.org/SDL_GetCursor