### PR TITLE
Added portmidi package for conan MacOS.

### DIFF
--- a/buildconfig/conanconf/README.md
+++ b/buildconfig/conanconf/README.md
@@ -64,3 +64,11 @@ In order to make a custom package, I started by [setting up bintray](https://doc
 
 Then this one for [uploading packages to remotes](https://docs.conan.io/en/latest/uploading_packages/uploading_to_remotes.html)
 
+
+
+## upload packages to bintray
+
+```
+conan upload portmidi/217 --all -r=pygame-repo
+```
+

--- a/buildconfig/conanconf/conanfile.txt
+++ b/buildconfig/conanconf/conanfile.txt
@@ -6,7 +6,7 @@ sdl2/2.0.12@pygame/testing
 sdl2_image/2.0.5@bincrafters/stable
 sdl2_mixer/2.0.4@bincrafters/stable
 sdl2_ttf/2.0.15@bincrafters/stable
-
+portmidi/217@demo/testing
 
 [generators]
 json

--- a/buildconfig/config_conan.py
+++ b/buildconfig/config_conan.py
@@ -80,6 +80,8 @@ def main(sdl2=True):
         Dependency(conanbuildinfo, "PNG", "libpng"),
         Dependency(conanbuildinfo, "JPEG", "libjpeg"),
         Dependency(conanbuildinfo, "FREETYPE", "freetype"),
+        Dependency(conanbuildinfo, "PORTMIDI", "portmidi"),
+        Dependency(conanbuildinfo, "PORTTIME", "portmidi"),
     ]
 
     return DEPS


### PR DESCRIPTION
This adds a portmidi package to conan for MacOS. So pygame.midi imports on MacOS again.

It uses a package I started in a PR to contribute to the conan-center repo of packages: https://github.com/conan-io/conan-center-index/pull/3186

It's been uploaded to the 'pygame-repo' bintray conan remote whilst we wait for it to be finished and incorporated.


Related issues:
- [No module named 'pygame.pypm' when initializing midi](https://github.com/pygame/pygame/issues/1931)
- [Conan, the C/C++ package manager for CI dependencies](https://github.com/pygame/pygame/issues/997)

Note: Mac CI passes here: https://travis-ci.org/github/pygame/pygame/jobs/735807675