### PR TITLE
CI speedups.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.cache/pip
     - $HOME/Library/Caches/pip/wheels
     - /Library/Caches/pip/wheels
-    - $HOME/.conan/
 
 
 # So commits do not get built twice.
@@ -17,45 +16,40 @@ if: type != push OR branch = master OR branch =~ /^\d+\.\d+(\.\d+)?(-\S*)?$/ OR 
 
 jobs:
   include:
-    - python: 2.7
-      env:
-        - RUN_SDIST=yes
-    - python: 3.5
-      name: SDL 1.2
-      env:
-        - WHICH_SDL_BUILD=-sdl1
-        - RUN_SDIST=yes
     - python: 3.6
+      name: SDL 1.2 sdist
       env:
+        - UPLOAD_SDIST_PYPI=yes
+        - GITHUB_UPLOAD=yes
         - RUN_SDIST=yes
-    - python: 3.8
-      env:
-        - RUN_SDIST=yes
-    - python: 3.9-dev
-    - os: linux-ppc64le
-      python: 3.8
-      arch: ppc64le
-      env:
-        - PPC=yes
+        - WHICH_SDL_BUILD=-sdl1
+    # enable ppc64le closer to release, it is slow.
+    # - os: linux-ppc64le
+    #   python: 3.8
+    #   arch: ppc64le
+    #   env:
+    #     - PPC=yes
+
     - os: linux
       dist: xenial
       python: 3.8
       arch: arm64
       env:
         - ARM64=yes
+
+
+    # enable s390x closer to release, it is slow.
+    # - os: linux
+    #   python: 3.7
+    #   arch: s390x
     - os: linux
       python: 3.7
-      arch: s390x
-    - os: linux
-      python: 3.7
-      name: manylinux x86/amd64 python 2.7, 3.4-3.8.
+      name: manylinux x86/amd64 python 2.7, 3.4-3.9.
       env:
         - MANYLINUX_WHL=yes
         - UPLOAD_WHL_PYPI=yes
-        - UPLOAD_SDIST_PYPI=yes
         - GITHUB_UPLOAD=yes
         - PYTHON_EXE=python3
-        - RUN_SDIST=yes
       services:
         - docker
     - os: osx
@@ -63,45 +57,67 @@ jobs:
       env:
         - GITHUB_UPLOAD=yes
         - UPLOAD_WHL_PYPI=yes
+      cache:
+        directories:
+          - $HOME/.conan/data
 
-  allow_failures:
-    - arch: s390x
+  # allow_failures:
+  #   - arch: s390x
     # - python: pypy
 
 before_install:
   - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$WHICH_SDL_BUILD" == "-sdl1" ]] && [[ "$MANYLINUX_WHL" != "yes" ]]; then
       sudo apt-get update
       sudo apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev \
         libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev \
+        libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi \
+        xfonts-cyrillic fluid-soundfont-gm timgm6mb-soundfont
+    fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$WHICH_SDL_BUILD" != "-sdl1" ]] && [[ "$MANYLINUX_WHL" != "yes" ]]; then
+      sudo apt-get update
+      sudo apt-get install python-dev python-numpy libportmidi-dev libjpeg-dev \
         libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi \
         xfonts-cyrillic fluid-soundfont-gm timgm6mb-soundfont \
         libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
     fi
 
+
 install:
   - $(set | grep PYPI_ | python -c "import sys;print('\n'.join(['unset %s' % l.split('=')[0] for l in sys.stdin.readlines() if l.startswith('PYPI')]))")
   - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$MANYLINUX_WHL" != "yes" ]]; then
       PYTHON_EXE=python PIP_CMD=pip
       $PIP_CMD install --upgrade pip
       $PIP_CMD install --upgrade numpy
       $PYTHON_EXE setup.py -config -auto $WHICH_SDL_BUILD
-      $PYTHON_EXE setup.py install -pygame-ci -noheaders
+      $PYTHON_EXE setup.py build -j4 install -pygame-ci -noheaders
     fi
   - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ -n "$TRAVIS_TAG" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       PYTHON_EXE=python3 PIP_CMD="python3 -m pip"
       $PIP_CMD install --upgrade pip
-      $PIP_CMD install conan
-      $PIP_CMD install cibuildwheel==1.3.0
+      $PIP_CMD install conan -U
+      $PIP_CMD install cibuildwheel==1.6.3
+      conan config set storage.download_cache="$HOME/.conan/data/download_cache"
       conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
       conan remote add pygame-repo https://api.bintray.com/conan/pygame/pygame
       # $PYTHON_EXE buildconfig/config.py -conan --build libtiff --build opusfile --build sdl2_image --build sdl2_ttf
+    fi
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ -n "$TRAVIS_TAG" ]]; then
       $PYTHON_EXE buildconfig/config.py -conan --build
+    fi
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+      $PYTHON_EXE buildconfig/config.py -conan --build=missing
+    fi
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       cp build/conan/*.dylib .
     fi
-  - if [[ "$MANYLINUX_WHL" == "yes" ]]; then source buildconfig/ci/travis/.travis_linux_build_wheels.sh; fi
+  - |
+    if [[ "$MANYLINUX_WHL" == "yes" ]]; then
+      source buildconfig/ci/travis/.travis_linux_build_wheels.sh
+    fi
 
 env:
   global:
@@ -115,16 +131,18 @@ env:
     - CIBW_SKIP="pp*"
 
 script:
+  # - |
+  #   if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ -n "$TRAVIS_TAG" ]]; then
   - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ -n "$TRAVIS_TAG" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       source build/conan/activate_run.sh
       $PYTHON_EXE -m cibuildwheel --output-dir dist
       $PYTHON_EXE buildconfig/ci/travis/.travis_osx_rename_whl.py
     fi
   - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$MANYLINUX_WHL" != "yes" ]]; then
       $(set | grep PYPI_ | python -c "import sys;print('\n'.join(['unset %s' % l.split('=')[0] for l in sys.stdin.readlines() if l.startswith('PYPI')]))")
-      $PYTHON_EXE -m pygame.tests.__main__ -v --exclude opengl --time_out 300
+      $PYTHON_EXE -m pygame.tests.__main__ -v --exclude opengl,timing --time_out 300
     fi
   # to make sure setup.py sdist runs.
   - |

--- a/buildconfig/appveyor.yml
+++ b/buildconfig/appveyor.yml
@@ -192,7 +192,7 @@ install:
   - "%PYTHON% -m ensurepip"
   - "%PYTHON% -m pip install -U wheel pip twine requests"
   - "%WITH_COMPILER% %PYTHON% -m buildconfig %USE_SDL2%"
-  - "%WITH_COMPILER% %PYTHON% setup.py build %USE_ANALYZE%"
+  - "%WITH_COMPILER% %PYTHON% setup.py build -j4 %USE_ANALYZE%"
   - "%WITH_COMPILER% %PYTHON% setup.py -setuptools %DISTRIBUTIONS%"
   - ps: "ls dist"
 
@@ -209,7 +209,7 @@ skip_branch_with_pr: true
 test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
-  - "%PYTHON% -m pygame.tests -v --exclude opengl"
+  - "%PYTHON% -m pygame.tests -v --exclude opengl,timing"
 
   # Move back to the project folder
   - "cd .."

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -16,7 +16,7 @@ ls -la /io
 for PYVER in $SUPPORTED_PYTHONS; do
     rm -rf /io/Setup /io/build/
     PYBIN="/opt/python/${PYVER}/bin"
-    ${PYBIN}/pip wheel -vvv /io/ -w wheelhouse/
+    ${PYBIN}/pip wheel --global-option="build_ext" --global-option="-j4" -vvv /io/ -w wheelhouse/
 done
 
 # Bundle external shared libraries into the wheels
@@ -32,5 +32,5 @@ export SDL_VIDEODRIVER=dummy
 for PYVER in $SUPPORTED_PYTHONS; do
     PYBIN="/opt/python/${PYVER}/bin"
     ${PYBIN}/pip install pygame --no-index -f /io/buildconfig/manylinux-build/wheelhouse
-    (cd $HOME; ${PYBIN}/python -m pygame.tests --exclude opengl,music)
+    (cd $HOME; ${PYBIN}/python -m pygame.tests --exclude opengl,music,timing)
 done

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,12 @@ if consume_arg('-pygame-ci'):
               '-Werror=incompatible-pointer-types'
     os.environ['CFLAGS'] = cflags
 
+# For python 2 we remove the -j options.
+if sys.version_info[0] < 3:
+    # Used for parallel builds with setuptools. Not supported by py2.
+    [consume_arg('-j%s' % x) for x in range(32)]
+
+
 STRIPPED=False
 
 # STRIPPED builds don't have developer resources like docs or tests


### PR DESCRIPTION
Total saving of about 46 less minutes spent building. 

Travis was taking 16 min 4 sec (total time: 1 hour 23) (not including mac builds). Now it takes 23 min 53 sec (total time: 43 minutes 52 sec). It used to have 10 jobs, now it has 4 jobs.

Appveyor was taking 21 minutes 51 seconds. Now it takes 15 minutes 43.


- Turn on mac builds for PRs on travis (using precompiled conan deps that are not suitable for release, but fine for running tests)
- Compile in parallel with -j4 (on travis linux, appveyor and manylinux).
- Make python2 setup.py not crash with a -j4 flag.
- Exclude slow and unreliable timing tests on linux, appveyor and manylinux builds. Closes https://github.com/pygame/pygame/issues/2109 VMs have unexpected time slices.
- Only include SDL1 dependencies on linux SDL1 builds, and do not install SDL1 deps on SDL2 builds.
- On manylinux job do not run linux tests, install apt deps, or test generating an sdist.
- Only test creating an sdist once on travis (and nowhere else).
- Removed some of the linux python builds on travis, because we cover all the pythons with the manylinux job on there. The trade off is faster builds, for a slightly more confusing situation finding the error. Probably appveyor will also fail for python related issues, and that has individual python jobs.
- Commented out the s390x, and ppc64le builds. We can enable them closer to releases, or whenever people are doing C code with possible endian issues.
- There are 4 total Travis CI builds now. With 5 concurrent jobs, one pull request will take 4 jobs leaving 1 job for another PR. Also only 2 of the jobs are slow ones. This means 3 PRs all started at once can have at least 1 job finished within 8 minutes.
- New version of cibuildwheel on mac, now python 3.9 builds are actually done.
