### PR TITLE
Add small placeholder function for future update

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -130,6 +130,12 @@ accurate_delay(int ticks)
 }
 
 static PyObject *
+time_is_preciseclock(PyObject *self)
+{
+    Py_RETURN_FALSE;
+}
+
+static PyObject *
 time_get_ticks(PyObject *self)
 {
     if (!SDL_WasInit(SDL_INIT_TIMER))
@@ -476,6 +482,8 @@ ClockInit(PyObject *self)
 }
 
 static PyMethodDef _time_methods[] = {
+    {"is_preciseclock", (PyCFunction)time_is_preciseclock, METH_NOARGS, 
+     "placeholder"},
     {"get_ticks", (PyCFunction)time_get_ticks, METH_NOARGS,
      DOC_PYGAMETIMEGETTICKS},
     {"delay", time_delay, METH_VARARGS, DOC_PYGAMETIMEDELAY},


### PR DESCRIPTION
Related to #2188 

As we know, #2188 is a WIP and a draft for a future release (post v2.0.0)

The time PR is going to be adding support for using more precise clocks in many of the functions. To make it better, I’m going to add functionality to fall back to the sdl_time module if the new clock could not be used (rather than raising errors). So it makes sense that there must be some way to check whether pygame is using a clock of added accuracy.

So I have added the function (as a placeholder), and I hope that the placeholder can make it with v2.0.0 and have actual functionality implemented later. 

I will put docs, unittests etc in future versions (post v2.0.0)

My apologies, if I am just adding a bit to your work, (but it’s useful and a super small change and will not take any of your time at all)