### PR TITLE
Fix docs build failure on Sphinx 3

### DIFF
--- a/docs/reST/ext/utils.py
+++ b/docs/reST/ext/utils.py
@@ -20,10 +20,10 @@ def get_descname(desc):
     except IndexError:
         raise GetError("No fullname: missing children in desc")
     try:
-        names = sig['names']
+        names = sig['ids']
     except KeyError:
         raise GetError(
-            "No fullname: missing names attribute in desc's child")
+            "No fullname: missing ids attribute in desc's child")
     try:
         return names[0]
     except IndexError:


### PR DESCRIPTION
Closes #2202.

This doesn't change the ouput on sphinx 1.8, and it allows building without error on sphinx 3.x

I was having a hard time finding what this function did until I set it to always return "OMGOMG".  It is part of the system that pulls up the functions to the top of the html file so you can jump around easily.