### PR TITLE
Update manifest to include readme file (PR needs priority)

### DIFF
--- a/buildconfig/MANIFEST.in
+++ b/buildconfig/MANIFEST.in
@@ -8,5 +8,7 @@ recursive-include test *
 recursive-exclude buildconfig/ci *
 recursive-exclude buildconfig/manylinux-build *
 
+include README.rst
+
 exclude buildconfig/appveyor.yml
 exclude .travis.yml


### PR DESCRIPTION
The readme file is important and must be included in the sdist. Without this PR, all attempts to build pygame from source (source installed from PyPI) are going to fail immediately (as discussed on discord)