### PR TITLE
Install and test the tar.gz sdist on CI too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ jobs:
     - python: 3.6
       name: SDL 1.2 sdist
       env:
-        - UPLOAD_SDIST_PYPI=yes
-        - GITHUB_UPLOAD=yes
-        - RUN_SDIST=yes
         - WHICH_SDL_BUILD=-sdl1
     # enable ppc64le closer to release, it is slow.
     # - os: linux-ppc64le
@@ -31,11 +28,15 @@ jobs:
     #     - PPC=yes
 
     - os: linux
+      name: arm64 sdist
       dist: xenial
       python: 3.8
       arch: arm64
       env:
         - ARM64=yes
+        - UPLOAD_SDIST_PYPI=yes
+        - GITHUB_UPLOAD=yes
+        - RUN_SDIST=yes
 
 
     # enable s390x closer to release, it is slow.
@@ -129,8 +130,6 @@ env:
     - CIBW_SKIP="pp27*"
 
 script:
-  # - |
-  #   if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ -n "$TRAVIS_TAG" ]]; then
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       source build/conan/activate_run.sh
@@ -145,7 +144,7 @@ script:
   # to make sure setup.py sdist runs.
   - |
     if [[ "$RUN_SDIST" == "yes" ]]; then
-      $PYTHON_EXE setup.py sdist
+      source buildconfig/ci/travis/build_test_sdist.sh
     fi
 
 

--- a/buildconfig/ci/travis/build_test_sdist.sh
+++ b/buildconfig/ci/travis/build_test_sdist.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e -x
+
+$PYTHON_EXE setup.py sdist
+$PYTHON_EXE -m pip install dist/*.tar.gz
+$PYTHON_EXE -m pygame.tests.__main__ -v --exclude opengl,timing --time_out 300


### PR DESCRIPTION
This installs and tests the sdist used in releases (eg. pygame-2.0.0.dev16.tar.gz).

Related issue: [pygame-2.0.0.dev16.tar.gz is missing README.rst (required to build)](https://github.com/pygame/pygame/issues/2220)

The sdist test passes here: https://travis-ci.org/github/pygame/pygame/jobs/737658384 (I cancelled the other builds)