### PR TITLE
Disable SSE 4.2 stuff because it does not do runtime detection.

### DIFF
--- a/buildconfig/manylinux-build/README.rst
+++ b/buildconfig/manylinux-build/README.rst
@@ -155,6 +155,7 @@ Getting a shell
 To be able to run bash:
 
     docker run --name test -it pygame/manylinux2010_base_x86_64
+    docker run --name test -it pygame/manylinux2010_base_i686
 
 
 

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -21,7 +21,7 @@ fi
 # -msse4 is required by old gcc in centos, for the SSE4.2 used in image.c
 # -g0 removes debugging symbols reducing file size greatly.
 # -03 is full optimization on.
-export CFLAGS="-msse4 -g0 -O3"
+export CFLAGS="-g0 -O3"
 
 ls -la /io
 

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -290,7 +290,7 @@ image_save(PyObject *self, PyObject *arg)
             SDL_RWops *rw = pgRWops_FromFileObject(obj);
             if (rw != NULL) {
                 if (!strcasecmp(ext, "bmp")) {
-                    /* The SDL documentation didn't specify which negative number 
+                    /* The SDL documentation didn't specify which negative number
                      * is returned upon error. We want to be sure that result is
                      * either 0 or -1: */
                     result = (SDL_SaveBMP_RW(surf, rw, 0) == 0 ? 0 : -1);
@@ -306,7 +306,7 @@ image_save(PyObject *self, PyObject *arg)
         else {
             if (!strcasecmp(ext, "bmp")) {
                 Py_BEGIN_ALLOW_THREADS;
-                /* The SDL documentation didn't specify which negative number 
+                /* The SDL documentation didn't specify which negative number
                  * is returned upon error. We want to be sure that result is
                  * either 0 or -1: */
                 result = (SDL_SaveBMP(surf, name) == 0 ? 0 : -1);
@@ -364,7 +364,7 @@ image_get_extended(PyObject *self, PyObject *arg)
     return PyInt_FromLong(GETSTATE(self)->is_extended);
 }
 
-#if (__SSE4_2__ || PG_COMPILE_SSE4_2) && (SDL_VERSION_ATLEAST(2, 0, 0))
+#if PG_COMPILE_SSE4_2 && (SDL_VERSION_ATLEAST(2, 0, 0))
 #define SSE42_ALIGN_NEEDED 16
 #define SSE42_ALIGN __attribute__((aligned(SSE42_ALIGN_NEEDED)))
 

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -57,20 +57,27 @@
 #define WIN32
 #endif
 
+/* Commenting out SSE4_2 stuff because it does not do runtime detection.
 #ifndef PG_TARGET_SSE4_2
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || __GNUC__ >= 5 ))
+//The old gcc 4.8 on centos used by manylinux1 does not seem to get sse4.2 intrinsics
 #define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
-/* No else; we define the fallback later */
+// No else; we define the fallback later
 #endif
-#endif /* ~PG_TARGET_SSE4_2 */
+#endif
+*/
+/* ~PG_TARGET_SSE4_2 */
 
+/*
 #ifdef PG_FUNCTION_TARGET_SSE4_2
 #if !defined(__SSE4_2__) && !defined(PG_COMPILE_SSE4_2)
 #if defined(__x86_64__) || defined(__i386__)
 #define PG_COMPILE_SSE4_2 1
 #endif
 #endif
-#endif /* ~PG_TARGET_SSE4_2 */
+#endif
+*/
+/* ~PG_TARGET_SSE4_2 */
 
 /* Fallback definition of target attribute */
 #ifndef PG_FUNCTION_TARGET_SSE4_2


### PR DESCRIPTION
There were issues with the manylinux builds crashing on CPUs without SSE 4.2.
I'm not entirely confident runtime detection was working on other builds either.
So I disabled it everywhere not just on manylinux1 builds.

> I was messing with this SSE4.2 building stuff this morning. Tried various headers on the old gcc 4.8 on manylinux1. The manylinux2010 fails to build pypy without "-msse4" flag but with different errors to gcc 4.8. Think I'll just disable the image.tostring SSE42 function for now entirely, and open an issue for it. I'll note that SDL doesn't handle SSE42 intrinsics within SDL_cpuinfo.h, they only go up to SSE3.

Started a barebones issue here: https://github.com/pygame/pygame/issues/2227 for future work on SSE 4.2.