### PR TITLE
Use manylinux2010 for pypy and manylinux1 for other pythons

### DIFF
--- a/buildconfig/ci/travis/.travis_linux_build_wheels.sh
+++ b/buildconfig/ci/travis/.travis_linux_build_wheels.sh
@@ -3,8 +3,7 @@ set -e -x
 
 # build the wheels.
 cd buildconfig/manylinux-build
-make pull
-make wheels
+make pull pull-manylinux wheels wheels-manylinux
 cd ../..
 
 mkdir -p dist/

--- a/buildconfig/manylinux-build/README.rst
+++ b/buildconfig/manylinux-build/README.rst
@@ -155,6 +155,7 @@ Getting a shell
 To be able to run bash:
 
     docker run --name test -it pygame/manylinux2010_base_x86_64
+    docker run --name test -it pygame/manylinux2010_base_i686
 
 
 

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -21,7 +21,7 @@ fi
 # -msse4 is required by old gcc in centos, for the SSE4.2 used in image.c
 # -g0 removes debugging symbols reducing file size greatly.
 # -03 is full optimization on.
-export CFLAGS="-msse4 -g0 -O3"
+export CFLAGS="-g0 -O3"
 
 ls -la /io
 

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e -x
 
-SUPPORTED_PYTHONS="cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
+export SUPPORTED_PYTHONS="cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
 
 if [[ "$1" == "buildpypy" ]]; then
-	SUPPORTED_PYTHONS="${SUPPORTED_PYTHONS} pp27-pypy_73 pp36-pypy36_pp73 pp37-pypy37_pp73"
+	export SUPPORTED_PYTHONS="pp27-pypy_73 pp36-pypy36_pp73 pp37-pypy37_pp73"
 fi
 
 

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -290,7 +290,7 @@ image_save(PyObject *self, PyObject *arg)
             SDL_RWops *rw = pgRWops_FromFileObject(obj);
             if (rw != NULL) {
                 if (!strcasecmp(ext, "bmp")) {
-                    /* The SDL documentation didn't specify which negative number 
+                    /* The SDL documentation didn't specify which negative number
                      * is returned upon error. We want to be sure that result is
                      * either 0 or -1: */
                     result = (SDL_SaveBMP_RW(surf, rw, 0) == 0 ? 0 : -1);
@@ -306,7 +306,7 @@ image_save(PyObject *self, PyObject *arg)
         else {
             if (!strcasecmp(ext, "bmp")) {
                 Py_BEGIN_ALLOW_THREADS;
-                /* The SDL documentation didn't specify which negative number 
+                /* The SDL documentation didn't specify which negative number
                  * is returned upon error. We want to be sure that result is
                  * either 0 or -1: */
                 result = (SDL_SaveBMP(surf, name) == 0 ? 0 : -1);
@@ -364,7 +364,7 @@ image_get_extended(PyObject *self, PyObject *arg)
     return PyInt_FromLong(GETSTATE(self)->is_extended);
 }
 
-#if (__SSE4_2__ || PG_COMPILE_SSE4_2) && (SDL_VERSION_ATLEAST(2, 0, 0))
+#if PG_COMPILE_SSE4_2 && (SDL_VERSION_ATLEAST(2, 0, 0))
 #define SSE42_ALIGN_NEEDED 16
 #define SSE42_ALIGN __attribute__((aligned(SSE42_ALIGN_NEEDED)))
 

--- a/src_c/include/pgplatform.h
+++ b/src_c/include/pgplatform.h
@@ -57,20 +57,27 @@
 #define WIN32
 #endif
 
+/* Commenting out SSE4_2 stuff because it does not do runtime detection.
 #ifndef PG_TARGET_SSE4_2
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || __GNUC__ >= 5 ))
+//The old gcc 4.8 on centos used by manylinux1 does not seem to get sse4.2 intrinsics
 #define PG_FUNCTION_TARGET_SSE4_2 __attribute__((target("sse4.2")))
-/* No else; we define the fallback later */
+// No else; we define the fallback later
 #endif
-#endif /* ~PG_TARGET_SSE4_2 */
+#endif
+*/
+/* ~PG_TARGET_SSE4_2 */
 
+/*
 #ifdef PG_FUNCTION_TARGET_SSE4_2
 #if !defined(__SSE4_2__) && !defined(PG_COMPILE_SSE4_2)
 #if defined(__x86_64__) || defined(__i386__)
 #define PG_COMPILE_SSE4_2 1
 #endif
 #endif
-#endif /* ~PG_TARGET_SSE4_2 */
+#endif
+*/
+/* ~PG_TARGET_SSE4_2 */
 
 /* Fallback definition of target attribute */
 #ifndef PG_FUNCTION_TARGET_SSE4_2


### PR DESCRIPTION
Mainly because `Ubuntu 18.04 Bionic` does not support `manylinux2010` with the out of the box `pip 9`.

So we have manylinux2010 for pypy, because that is the minimum version pypy supports.