### PR TITLE
Fix twitchy key tests on raspi

### DIFF
--- a/test/key_test.py
+++ b/test/key_test.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 import pygame
 import pygame.key
@@ -53,12 +54,14 @@ class KeyModuleTest(unittest.TestCase):
                 pygame.display.iconify()
                 # Apparent need to pump event queue in order to make sure iconify
                 # happens. See display_test.py's test_get_active_iconify
-                for _ in range(5000):
+                for _ in range(50):
+                    time.sleep(0.01)
                     pygame.event.pump()
                 self.assertFalse(pygame.key.get_focused())
                 # Test if focus is returned when iconify is gone
                 pygame.display.set_mode(size = display_sizes[-1], flags = pygame.FULLSCREEN)
-                for i in range(5000):
+                for i in range(50):
+                    time.sleep(0.01)
                     pygame.event.pump()
                 self.assertTrue(pygame.key.get_focused())
         # Test if a quit display raises an error:


### PR DESCRIPTION
On latest pygame version dev20, the unittests for pygame.key were consistently failing.
```
pi@raspberrypi:~ $ python3 -m pygame.tests.key_test
pygame 2.0.0.dev20 (SDL 2.0.9, python 3.7.3)
Hello from the pygame community. https://www.pygame.org/contribute.html
F......
======================================================================
FAIL: test_get_focused (__main__.KeyModuleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.7/site-packages/pygame/tests/key_test.py", line 63, in test_get_focused
    self.assertTrue(pygame.key.get_focused())
AssertionError: 0 is not true

----------------------------------------------------------------------
Ran 7 tests in 8.081s

FAILED (failures=1)
```
```
pi@raspberrypi:~ $ python3 -m pygame.tests.key_test
pygame 2.0.0.dev20 (SDL 2.0.9, python 3.7.3)
Hello from the pygame community. https://www.pygame.org/contribute.html
F......
======================================================================
FAIL: test_get_focused (__main__.KeyModuleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.7/site-packages/pygame/tests/key_test.py", line 63, in test_get_focused
    self.assertTrue(pygame.key.get_focused())
AssertionError: 0 is not true

----------------------------------------------------------------------
Ran 7 tests in 1.855s

FAILED (failures=1)
```
```
pi@raspberrypi:~ $ python3 -m pygame.tests.key_test
pygame 2.0.0.dev20 (SDL 2.0.9, python 3.7.3)
Hello from the pygame community. https://www.pygame.org/contribute.html
F......
======================================================================
FAIL: test_get_focused (__main__.KeyModuleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.7/site-packages/pygame/tests/key_test.py", line 63, in test_get_focused
    self.assertTrue(pygame.key.get_focused())
AssertionError: 0 is not true

----------------------------------------------------------------------
Ran 7 tests in 1.876s

FAILED (failures=1)
```
This PR hopefully fixes the issue.