### PR TITLE
New Alpha blitter - fixes and speed ups

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -25,6 +25,20 @@
 #define NO_PYGAME_C_API
 #include "_surface.h"
 
+/* See if we are compiled 64 bit on GCC or MSVC */
+#if _WIN32 || _WIN64
+   #if _WIN64
+     #define ENV64BIT
+   #endif
+#endif
+
+// Check GCC
+#if __GNUC__
+  #if __x86_64__ || __ppc64__
+    #define ENV64BIT
+  #endif
+#endif
+
 #ifdef PG_ENABLE_ARM_NEON
     // sse2neon.h is from here: https://github.com/DLTcollab/sse2neon
     #include "include/sse2neon.h"
@@ -73,7 +87,6 @@ static void alphablit_alpha (SDL_BlitInfo * info);
 
 #if IS_SDLv2 && (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
 static void alphablit_alpha_sse2_argb_surf_alpha (SDL_BlitInfo * info);
-static void alphablit_alpha_sse2_argb_surf_alpha_big_end (SDL_BlitInfo * info);
 static void alphablit_alpha_sse2_argb_no_surf_alpha (SDL_BlitInfo * info);
 static void alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst (SDL_BlitInfo * info);
 #endif /* IS_SDLv2 && (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
@@ -230,7 +243,8 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
-                        src != dst)
+                        src != dst &&
+                        SDL_BYTEORDER == SDL_LIL_ENDIAN)
                     {
                     /* If our source and destination are the same ARGB 32bit
                        format we can use SSE2 to speed up the blend */
@@ -238,10 +252,7 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                         if (SDL_HasNEON() == SDL_TRUE){
                             if (info.src_blanket_alpha != 255)
                             {
-                                if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-                                    alphablit_alpha_sse2_argb_surf_alpha (&info);
-                                else
-                                    alphablit_alpha_sse2_argb_surf_alpha_big_end (&info);
+                                alphablit_alpha_sse2_argb_surf_alpha (&info);
                             }
                             else if (info.dst_blend == SDL_BLENDMODE_NONE)
                             {
@@ -258,10 +269,7 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                         if (SDL_HasSSE2()){
                             if (info.src_blanket_alpha != 255)
                             {
-                                if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-                                    alphablit_alpha_sse2_argb_surf_alpha (&info);
-                                else
-                                    alphablit_alpha_sse2_argb_surf_alpha_big_end (&info);
+                                 alphablit_alpha_sse2_argb_surf_alpha (&info);
                             }
                             else if (info.dst_blend == SDL_BLENDMODE_NONE)
                             {
@@ -2511,10 +2519,6 @@ blit_blend_max (SDL_BlitInfo * info)
     }
 }
 
-
-
-
-
 /* --------------------------------------------------------- */
 
 #if IS_SDLv2 && (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
@@ -2592,149 +2596,6 @@ alphablit_alpha_sse2_argb_surf_alpha (SDL_BlitInfo * info)
                 /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
                 mm_src_alpha = _mm_srli_si128(mm_src_alpha, 3);
 
-                mm_sub_alpha = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
-                /* dst_alpha -> mm_dst_alpha (000000000000A000) */
-                mm_dst_alpha = _mm_cvtsi32_si128(dst_alpha);
-                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
-                mm_dst_alpha = _mm_srli_si128(mm_dst_alpha, 3);
-
-                /* Calc alpha first */
-
-                /* (srcA * dstA) */
-                mm_sub_alpha = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
-                /* (srcA * dstA) / 255 */
-                mm_sub_alpha = _mm_srli_epi16(_mm_mulhi_epu16(mm_sub_alpha,
-                                          _mm_set1_epi16((short)0x8081)), 7);
-                /* srcA + dstA */
-                mm_dst_alpha = _mm_add_epi16(mm_src_alpha, mm_dst_alpha);
-                /* srcA + dstA - ((srcA * dstA) / 255); */
-                mm_dst_alpha = _mm_slli_si128(_mm_sub_epi16(mm_dst_alpha,
-                                             mm_sub_alpha), 3);
-
-                /* Then Calc RGB */
-                /* 0000000000000A0A -> rgb_src_alpha */
-                rgb_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
-                /* 000000000A0A0A0A -> rgb_src_alpha */
-                rgb_src_alpha = _mm_unpacklo_epi32(rgb_src_alpha,
-                                                   rgb_src_alpha);
-
-                /* src(ARGB) -> src1 (000000000000ARGB) */
-                src1 = _mm_cvtsi32_si128(*srcp);
-                /* 000000000A0R0G0B -> src1 */
-                src1 = _mm_unpacklo_epi8(src1, mm_zero);
-
-                /* dst(ARGB) -> dst1 (000000000000ARGB) */
-                dst1 = _mm_cvtsi32_si128(*dstp);
-                /* 000000000A0R0G0B -> dst1 */
-                dst1 = _mm_unpacklo_epi8(dst1, mm_zero);
-
-                /* (srcRGB - dstRGB) */
-                sub_dst = _mm_sub_epi16(src1, dst1);
-
-                /* (srcRGB - dstRGB) * srcA */
-                sub_dst = _mm_mullo_epi16(sub_dst, rgb_src_alpha);
-
-                /* (srcRGB - dstRGB) * srcA + srcRGB */
-                sub_dst = _mm_add_epi16(sub_dst, src1);
-
-                /* (dstRGB << 8) */
-                dst1 = _mm_slli_epi16(dst1, 8);
-
-                /* ((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) */
-                sub_dst = _mm_add_epi16(sub_dst, dst1);
-
-                /* (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)*/
-                sub_dst = _mm_srli_epi16(sub_dst, 8);
-
-                /* pack everything back into a pixel */
-                sub_dst = _mm_packus_epi16(sub_dst, mm_zero);
-                sub_dst = _mm_and_si128(sub_dst, rgb_mask_128);
-                /* add alpha to RGB */
-                sub_dst = _mm_add_epi16(mm_dst_alpha, sub_dst);
-                *dstp = _mm_cvtsi128_si32(sub_dst);
-
-            }
-            ++srcp;
-            ++dstp;
-        }, n, width);
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-
-static void
-alphablit_alpha_sse2_argb_surf_alpha_big_end (SDL_BlitInfo * info)
-{
-    int             n;
-    int             width = info->width;
-    int             height = info->height;
-    Uint32          *srcp = (Uint32 *)info->s_pixels;
-    int             srcskip = info->s_skip >> 2;
-    Uint32          *dstp = (Uint32 *)info->d_pixels;
-    int             dstskip = info->d_skip >> 2;
-
-    SDL_PixelFormat *srcfmt = info->src;
-    SDL_PixelFormat *dstfmt = info->dst;
-
-    int             srcbpp = srcfmt->BytesPerPixel;
-    int             dstbpp = dstfmt->BytesPerPixel;
-
-    Uint32          dst_amask = dstfmt->Amask;
-    Uint32          src_amask = srcfmt->Amask;
-
-    int             dst_opaque = (dst_amask ? 0 : 255);
-
-    Uint32          modulateA = info->src_blanket_alpha;
-
-    Uint64          rgb_mask;
-
-    __m128i src1, dst1, sub_dst, mm_src_alpha;
-    __m128i rgb_src_alpha, mm_zero;
-    __m128i mm_dst_alpha, mm_sub_alpha, rgb_mask_128;
-
-    mm_zero = _mm_setzero_si128();
-
-    rgb_mask = 0x0000000000FFFFFF; // 0F0F0F0F
-    rgb_mask_128 = _mm_loadl_epi64((const __m128i *) & rgb_mask);
-
-
-    /* Original 'Straight Alpha' blending equation:
-       --------------------------------------------
-       dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
-         dstA = srcA + (dstA * (1-srcA))
-
-       We use something slightly different to simulate
-       SDL1, as follows:
-       dstRGB = (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)
-         dstA = srcA + dstA - ((srcA * dstA) / 255);
-                                                        */
-
-    while (height--)
-    {
-        LOOP_UNROLLED4(
-        {
-            Uint32 src_alpha = (*srcp & src_amask);
-            Uint32 dst_alpha = (*dstp & dst_amask) + dst_opaque;
-            /* modulate src_alpha - need to do it here for
-               accurate testing */
-            src_alpha = (src_alpha * modulateA) / 255;
-
-            if ((src_alpha == src_amask) || (dst_alpha == 0))
-            {
-                /* 255 src alpha or 0 dst alpha
-                   So copy src pixel over dst pixel, also copy
-                   modulated alpha */
-                *dstp = (*srcp & 0xFFFFFF00) | src_alpha;
-            }
-            else
-            {
-                /* Do the actual blend */
-                /* src_alpha -> mm_src_alpha (000000000000A000) */
-                mm_src_alpha = _mm_cvtsi32_si128(src_alpha);
-                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
-                mm_src_alpha = _mm_srli_si128(mm_src_alpha, 3);
-
-                mm_sub_alpha = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
                 /* dst_alpha -> mm_dst_alpha (000000000000A000) */
                 mm_dst_alpha = _mm_cvtsi32_si128(dst_alpha);
                 /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
@@ -2810,33 +2671,10 @@ alphablit_alpha_sse2_argb_no_surf_alpha (SDL_BlitInfo * info)
     int             n;
     int             width = info->width;
     int             height = info->height;
-    Uint32          *srcp = (Uint32 *)info->s_pixels;
     int             srcskip = info->s_skip >> 2;
-    Uint32          *dstp = (Uint32 *)info->d_pixels;
     int             dstskip = info->d_skip >> 2;
-
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
-
-    int             srcbpp = srcfmt->BytesPerPixel;
-    int             dstbpp = dstfmt->BytesPerPixel;
-
-    Uint32          dst_amask = dstfmt->Amask;
-    Uint32          src_amask = srcfmt->Amask;
-
-    int             dst_opaque = (dst_amask ? 0 : 255);
-
-    Uint64          rgb_mask;
-
-    __m128i src1, dst1, sub_dst, mm_src_alpha;
-    __m128i rgb_src_alpha, mm_zero;
-    __m128i mm_dst_alpha, mm_sub_alpha, rgb_mask_128;
-
-    mm_zero = _mm_setzero_si128();
-
-    rgb_mask = 0x0000000000FFFFFF; // 0F0F0F0F
-    rgb_mask_128 = _mm_loadl_epi64((const __m128i *) & rgb_mask);
-
 
     /* Original 'Straight Alpha' blending equation:
        --------------------------------------------
@@ -2847,69 +2685,480 @@ alphablit_alpha_sse2_argb_no_surf_alpha (SDL_BlitInfo * info)
        SDL1, as follows:
        dstRGB = (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)
          dstA = srcA + dstA - ((srcA * dstA) / 255);
-                                                        */
+    */
 
-    while (height--)
+    /* There are three paths through this blitter:
+
+        1. Two pixels at once - 64 bit edition.
+        2. Two pixels at once - 32 bit edition.
+        3. One pixel at a time.
+    */
+
+    if (((width % 2) == 0) && ((srcskip % 2) == 0) && ((dstskip % 2) == 0))
     {
-        LOOP_UNROLLED4(
+        width = width/2;
+        srcskip = srcskip/2;
+        dstskip = dstskip/2;
+
+        Uint64          *srcp = (Uint64 *)info->s_pixels;
+        Uint64          *dstp = (Uint64 *)info->d_pixels;
+
+        Uint64          src_amask = ((Uint64)srcfmt->Amask << 32) | srcfmt->Amask;
+        Uint64          dst_amask = ((Uint64)dstfmt->Amask << 32) | dstfmt->Amask;
+
+        Uint64          rgb_mask = 0x00FFFFFF00FFFFFF;
+        Uint64          offset_rgb_mask = 0xFF00FFFFFF00FFFF;
+
+        __m128i src1, dst1, temp, temp2, mm_src_alpha, mm_dst_alpha;
+        __m128i mm_alpha_mask, mm_zero, rgb_mask_128, offset_rgb_mask_128, alpha_mask_128;
+
+        mm_zero = _mm_setzero_si128();
+        mm_alpha_mask = _mm_cvtsi32_si128(0x00FF00FF);
+
+#if defined(ENV64BIT)
+        /* two pixels at a time - 64 bit version - only works when blit width
+           is an even number, and makes use of some intrinsic instructions
+           that are not available in 32 bit */
+        rgb_mask_128 = _mm_cvtsi64_si128(rgb_mask);
+        offset_rgb_mask_128 = _mm_cvtsi64_si128(offset_rgb_mask);
+        alpha_mask_128 = _mm_cvtsi64_si128(src_amask);
+
+        while (height--)
         {
-            Uint32 src_alpha = (*srcp & src_amask);
-            Uint32 dst_alpha = (*dstp & dst_amask) + dst_opaque;
-            if ((src_alpha == src_amask) || (dst_alpha == 0))
+            LOOP_UNROLLED4(
             {
-                /* 255 src alpha or 0 dst alpha
-                   So just copy src pixel over dst pixel*/
-                *dstp = *srcp;
-            }
-            else
-            {
+
+                /* load the pixels into SSE registers */
+                /* src(ARGB) -> src1 (00000000ARGBARGB) */
+                src1 = _mm_cvtsi64_si128(*srcp);
+                /* dst(ARGB) -> dst1 (00000000ARGBARGB) */
+                dst1 = _mm_cvtsi64_si128(*dstp);
+                /* src_alpha -> mm_src_alpha (00000000A000A000) */
+                mm_src_alpha = _mm_and_si128(src1, alpha_mask_128);
+                /* dst_alpha -> mm_dst_alpha (00000000A000A000) */
+                mm_dst_alpha = _mm_and_si128(dst1, alpha_mask_128);
+
+
                 /* Do the actual blend */
-                /* src_alpha -> mm_src_alpha (000000000000A000) */
-                mm_src_alpha = _mm_cvtsi32_si128(src_alpha);
-                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
-                mm_src_alpha = _mm_srli_si128(mm_src_alpha, 3);
 
-                mm_sub_alpha = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
-                /* dst_alpha -> mm_dst_alpha (000000000000A000) */
-                mm_dst_alpha = _mm_cvtsi32_si128(dst_alpha);
-                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
-                mm_dst_alpha = _mm_srli_si128(mm_dst_alpha, 3);
+                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000A000A00) */
+                mm_src_alpha = _mm_srli_si128(mm_src_alpha, 1);
 
+                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000A000A00) */
+                mm_dst_alpha = _mm_srli_si128(mm_dst_alpha, 1);
+                /* this makes sure we copy across src RGB data when dst is 0*/
+                temp2 = _mm_cmpeq_epi8(mm_dst_alpha, offset_rgb_mask_128);
                 /* Calc alpha first */
 
                 /* (srcA * dstA) */
-                mm_sub_alpha = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
+                temp = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
+
                 /* (srcA * dstA) / 255 */
-                mm_sub_alpha = _mm_srli_epi16(_mm_mulhi_epu16(mm_sub_alpha,
-                                          _mm_set1_epi16((short)0x8081)), 7);
-                /* srcA + dstA */
-                mm_dst_alpha = _mm_add_epi16(mm_src_alpha, mm_dst_alpha);
+                temp = _mm_srli_epi16(_mm_mulhi_epu16(temp,
+                                      _mm_set1_epi16((short)0x8081)), 7);
                 /* srcA + dstA - ((srcA * dstA) / 255); */
-                mm_dst_alpha = _mm_slli_si128(_mm_sub_epi16(mm_dst_alpha,
-                                             mm_sub_alpha), 3);
+                mm_dst_alpha = _mm_sub_epi16(mm_dst_alpha, temp);
+                mm_dst_alpha = _mm_add_epi16(mm_src_alpha, mm_dst_alpha);
+                mm_dst_alpha = _mm_slli_si128(mm_dst_alpha, 1);
+
+                /* this makes sure we copy across src RGB data when dst is 0*/
+                mm_src_alpha = _mm_or_si128(mm_src_alpha,temp2);
+                // Create squashed src alpha
+                mm_src_alpha = _mm_add_epi16(
+                    _mm_and_si128(_mm_srli_si128(mm_src_alpha, 2), mm_alpha_mask),
+                    _mm_and_si128(_mm_srli_si128(mm_src_alpha, 4), mm_alpha_mask));
 
                 /* Then Calc RGB */
-                /* 0000000000000A0A -> rgb_src_alpha */
-                rgb_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
-                /* 000000000A0A0A0A -> rgb_src_alpha */
-                rgb_src_alpha = _mm_unpacklo_epi32(rgb_src_alpha,
-                                                   rgb_src_alpha);
+                /* 0000000000000A0A -> mm_src_alpha */
 
-                /* src(ARGB) -> src1 (000000000000ARGB) */
-                src1 = _mm_cvtsi32_si128(*srcp);
+                mm_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
+                /* 000000000A0A0A0A -> rgb_src_alpha */
+                mm_src_alpha = _mm_unpacklo_epi32(mm_src_alpha,
+                                                  mm_src_alpha);
+
                 /* 000000000A0R0G0B -> src1 */
                 src1 = _mm_unpacklo_epi8(src1, mm_zero);
 
-                /* dst(ARGB) -> dst1 (000000000000ARGB) */
-                dst1 = _mm_cvtsi32_si128(*dstp);
+
                 /* 000000000A0R0G0B -> dst1 */
+                dst1 = _mm_unpacklo_epi8(dst1, mm_zero);
+
+                /* (srcRGB - dstRGB) */
+                temp = _mm_sub_epi16(src1, dst1);
+
+                /* (srcRGB - dstRGB) * srcA */
+                temp = _mm_mullo_epi16(temp, mm_src_alpha);
+
+                /* (srcRGB - dstRGB) * srcA + srcRGB */
+                temp = _mm_add_epi16(temp, src1);
+
+                /* (dstRGB << 8) */
+                dst1 = _mm_slli_epi16(dst1, 8);
+
+                /* ((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) */
+                temp = _mm_add_epi16(temp, dst1);
+
+                /* (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)*/
+                temp = _mm_srli_epi16(temp, 8);
+
+                /* pack everything back into a pixel */
+                temp = _mm_packus_epi16(temp, mm_zero);
+                temp = _mm_and_si128(temp, rgb_mask_128);
+                /* add alpha to RGB */
+                temp = _mm_add_epi16(mm_dst_alpha, temp);
+                *dstp = _mm_cvtsi128_si64(temp);
+
+                ++srcp;
+                ++dstp;
+            }, n, width);
+            srcp += srcskip;
+            dstp += dstskip;
+        }
+#else /* 32 bit 2 pixel path */
+
+        /* two pixels at a time - 32 bit version - only works when blit width
+           is an even number */
+        rgb_mask_128 = _mm_loadl_epi64((const __m128i *) & rgb_mask);
+        offset_rgb_mask_128 = _mm_loadl_epi64((const __m128i *) & offset_rgb_mask);
+        alpha_mask_128 = _mm_loadl_epi64((const __m128i *) & src_amask);
+
+        while (height--)
+        {
+            LOOP_UNROLLED4(
+            {
+
+                /* load the pixels into SSE registers */
+                /* src(ARGB) -> src1 (00000000ARGBARGB) */
+                src1 = _mm_loadl_epi64((const __m128i *)srcp);
+                /* dst(ARGB) -> dst1 (00000000ARGBARGB) */
+                dst1 = _mm_loadl_epi64((const __m128i *)dstp);
+                /* src_alpha -> mm_src_alpha (00000000A000A000) */
+                mm_src_alpha = _mm_and_si128(src1, alpha_mask_128);
+                /* dst_alpha -> mm_dst_alpha (00000000A000A000) */
+                mm_dst_alpha = _mm_and_si128(dst1, alpha_mask_128);
+
+
+                /* Do the actual blend */
+
+                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000A000A00) */
+                mm_src_alpha = _mm_srli_si128(mm_src_alpha, 1);
+
+                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000A000A00) */
+                mm_dst_alpha = _mm_srli_si128(mm_dst_alpha, 1);
+                /* this makes sure we copy across src RGB data when dst is 0*/
+                temp2 = _mm_cmpeq_epi8(mm_dst_alpha, offset_rgb_mask_128);
+                /* Calc alpha first */
+
+                /* (srcA * dstA) */
+                temp = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
+
+                /* (srcA * dstA) / 255 */
+                temp = _mm_srli_epi16(_mm_mulhi_epu16(temp,
+                                      _mm_set1_epi16((short)0x8081)), 7);
+                /* srcA + dstA - ((srcA * dstA) / 255); */
+                mm_dst_alpha = _mm_sub_epi16(mm_dst_alpha, temp);
+                mm_dst_alpha = _mm_add_epi16(mm_src_alpha, mm_dst_alpha);
+                mm_dst_alpha = _mm_slli_si128(mm_dst_alpha, 1);
+
+                /* this makes sure we copy across src RGB data when dst is 0*/
+                mm_src_alpha = _mm_or_si128(mm_src_alpha,temp2);
+                // Create squashed src alpha
+                mm_src_alpha = _mm_add_epi16(
+                    _mm_and_si128(_mm_srli_si128(mm_src_alpha, 2), mm_alpha_mask),
+                    _mm_and_si128(_mm_srli_si128(mm_src_alpha, 4), mm_alpha_mask));
+
+                /* Then Calc RGB */
+                /* 0000000000000A0A -> mm_src_alpha */
+
+                mm_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
+                /* 000000000A0A0A0A -> rgb_src_alpha */
+                mm_src_alpha = _mm_unpacklo_epi32(mm_src_alpha,
+                                                  mm_src_alpha);
+
+                /* 000000000A0R0G0B -> src1 */
+                src1 = _mm_unpacklo_epi8(src1, mm_zero);
+
+
+
+                /* 000000000A0R0G0B -> dst1 */
+                dst1 = _mm_unpacklo_epi8(dst1, mm_zero);
+
+                /* (srcRGB - dstRGB) */
+                temp = _mm_sub_epi16(src1, dst1);
+
+                /* (srcRGB - dstRGB) * srcA */
+                temp = _mm_mullo_epi16(temp, mm_src_alpha);
+
+                /* (srcRGB - dstRGB) * srcA + srcRGB */
+                temp = _mm_add_epi16(temp, src1);
+
+                /* (dstRGB << 8) */
+                dst1 = _mm_slli_epi16(dst1, 8);
+
+                /* ((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) */
+                temp = _mm_add_epi16(temp, dst1);
+
+                /* (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)*/
+                temp = _mm_srli_epi16(temp, 8);
+
+                /* pack everything back into a pixel */
+                temp = _mm_packus_epi16(temp, mm_zero);
+                temp = _mm_and_si128(temp, rgb_mask_128);
+                /* add alpha to RGB */
+                temp = _mm_add_epi16(mm_dst_alpha, temp);
+                *dstp = (((Uint64)_mm_cvtsi128_si32(_mm_srli_si128(temp,4))) << 32 | (Uint32)_mm_cvtsi128_si32(temp));
+
+                ++srcp;
+                ++dstp;
+            }, n, width);
+            srcp += srcskip;
+            dstp += dstskip;
+        }
+#endif /* 32 bit 2 pixel path */
+
+    }
+    else
+    {
+        /* one pixel at a time */
+
+        Uint32          *srcp = (Uint32 *)info->s_pixels;
+        Uint32          *dstp = (Uint32 *)info->d_pixels;
+
+        Uint32          dst_amask = dstfmt->Amask;
+        Uint32          src_amask = srcfmt->Amask;
+
+        __m128i mm_zero, rgb_mask_128;
+        __m128i src1, dst1, sub_dst;
+        __m128i mm_src_alpha, mm_dst_alpha, mm_sub_alpha;
+
+        mm_zero = _mm_setzero_si128();
+
+        rgb_mask_128 = _mm_cvtsi32_si128(0x00FFFFFF);
+
+        while (height--)
+        {
+            LOOP_UNROLLED4(
+            {
+                Uint32 src_alpha = (*srcp & src_amask);
+                Uint32 dst_alpha = (*dstp & dst_amask);
+                if ((src_alpha == src_amask) || (dst_alpha == 0))
+                {
+                    /* 255 src alpha or 0 dst alpha
+                       So just copy src pixel over dst pixel*/
+                    *dstp = *srcp;
+                }
+                else
+                {
+                    /* Do the actual blend */
+                    /* src_alpha -> mm_src_alpha (000000000000A000) */
+                    mm_src_alpha = _mm_cvtsi32_si128(src_alpha);
+                    /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
+                    mm_src_alpha = _mm_srli_si128(mm_src_alpha, 3);
+
+                    /* dst_alpha -> mm_dst_alpha (000000000000A000) */
+                    mm_dst_alpha = _mm_cvtsi32_si128(dst_alpha);
+                    /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
+                    mm_dst_alpha = _mm_srli_si128(mm_dst_alpha, 3);
+
+                    /* Calc alpha first */
+
+                    /* (srcA * dstA) */
+                    mm_sub_alpha = _mm_mullo_epi16(mm_src_alpha, mm_dst_alpha);
+
+
+                    /* (srcA * dstA) / 255 */
+                    mm_sub_alpha = _mm_srli_epi16(_mm_mulhi_epu16(mm_sub_alpha,
+                                              _mm_set1_epi16((short)0x8081)), 7);
+                    /* srcA + dstA - ((srcA * dstA) / 255); */
+                    mm_dst_alpha = _mm_sub_epi16(mm_dst_alpha, mm_sub_alpha);
+                    mm_dst_alpha = _mm_add_epi16(mm_src_alpha, mm_dst_alpha);
+                    mm_dst_alpha = _mm_slli_si128(mm_dst_alpha, 3);
+
+                    /* Then Calc RGB */
+                    /* 0000000000000A0A -> rgb_src_alpha */
+                    mm_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
+                    /* 000000000A0A0A0A -> rgb_src_alpha */
+                    mm_src_alpha = _mm_unpacklo_epi32(mm_src_alpha,
+                                                      mm_src_alpha);
+
+                    /* src(ARGB) -> src1 (000000000000ARGB) */
+                    src1 = _mm_cvtsi32_si128(*srcp);
+                    /* 000000000A0R0G0B -> src1 */
+                    src1 = _mm_unpacklo_epi8(src1, mm_zero);
+
+                    /* dst(ARGB) -> dst1 (000000000000ARGB) */
+                    dst1 = _mm_cvtsi32_si128(*dstp);
+                    /* 000000000A0R0G0B -> dst1 */
+                    dst1 = _mm_unpacklo_epi8(dst1, mm_zero);
+
+                    /* (srcRGB - dstRGB) */
+                    sub_dst = _mm_sub_epi16(src1, dst1);
+
+                    /* (srcRGB - dstRGB) * srcA */
+                    sub_dst = _mm_mullo_epi16(sub_dst, mm_src_alpha);
+
+                    /* (srcRGB - dstRGB) * srcA + srcRGB */
+                    sub_dst = _mm_add_epi16(sub_dst, src1);
+
+                    /* (dstRGB << 8) */
+                    dst1 = _mm_slli_epi16(dst1, 8);
+
+                    /* ((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) */
+                    sub_dst = _mm_add_epi16(sub_dst, dst1);
+
+                    /* (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)*/
+                    sub_dst = _mm_srli_epi16(sub_dst, 8);
+
+                    /* pack everything back into a pixel */
+                    sub_dst = _mm_packus_epi16(sub_dst, mm_zero);
+                    sub_dst = _mm_and_si128(sub_dst, rgb_mask_128);
+                    /* add alpha to RGB */
+                    sub_dst = _mm_add_epi16(mm_dst_alpha, sub_dst);
+                    *dstp = _mm_cvtsi128_si32(sub_dst);
+
+                }
+                ++srcp;
+                ++dstp;
+            }, n, width);
+            srcp += srcskip;
+            dstp += dstskip;
+        }
+    }
+}
+
+static void
+alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst (SDL_BlitInfo * info)
+{
+    int             n;
+    int             width = info->width;
+    int             height = info->height;
+    int             srcskip = info->s_skip >> 2;
+    int             dstskip = info->d_skip >> 2;
+
+    SDL_PixelFormat *srcfmt = info->src;
+    SDL_PixelFormat *dstfmt = info->dst;
+
+ /* There are three rough paths through this blitter:
+
+        1. Two pixels at once - 64 bit edition.
+        2. Two pixels at once - 32 bit edition.
+        3. One pixel at a time.
+ */
+    if (((width % 2) == 0) && ((srcskip % 2) == 0) && ((dstskip % 2) == 0))
+    {
+        width = width/2;
+        srcskip = srcskip/2;
+        dstskip = dstskip/2;
+
+        Uint64          *srcp = (Uint64 *)info->s_pixels;
+        Uint64          *dstp = (Uint64 *)info->d_pixels;
+
+        Uint64          src_amask = ((Uint64)srcfmt->Amask << 32) | srcfmt->Amask;
+
+        Uint64          rgb_mask = 0x00FFFFFF00FFFFFF;
+
+        __m128i src1, dst1, sub_dst, mm_src_alpha, mm_zero, mm_alpha_mask_1, mm_alpha_mask_2, mm_rgb_mask;
+
+        mm_zero = _mm_setzero_si128();
+        mm_alpha_mask_1 = _mm_cvtsi32_si128(0x000000FF);
+        mm_alpha_mask_2 = _mm_cvtsi32_si128(0x00FF0000);
+
+#if defined(ENV64BIT)
+
+        /* two pixels at a time - 64 bit version - only works when blit width
+           is an even number, and makes use of some intrinsic instructions
+           that are not available in 32 bit */
+        mm_rgb_mask = _mm_cvtsi64_si128(rgb_mask);
+        while (height--)
+        {
+            LOOP_UNROLLED4(
+            {
+                /* src(ARGB) -> src1 (00000000ARGBARGB) */
+                src1 = _mm_cvtsi64_si128(*srcp);
+
+                /* created squashed alpha -> mm_src_alpha (0000000000000A0A) */
+                mm_src_alpha = _mm_add_epi16(
+                    _mm_and_si128(_mm_srli_si128(src1, 3), mm_alpha_mask_1),
+                    _mm_and_si128(_mm_srli_si128(src1, 5), mm_alpha_mask_2));
+
+                /* Then Calc RGB */
+                /* 000000000A10A10A20A2 -> rgb_src_alpha */
+                mm_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
+                /* 0A10A10A10A10A20A20A20A2 -> rgb_src_alpha */
+                mm_src_alpha = _mm_unpacklo_epi32(mm_src_alpha, mm_src_alpha);
+
+                /* 0A0R0G0B0A0R0G0B -> src1 */
+                src1 = _mm_unpacklo_epi8(src1, mm_zero);
+
+                /* dst(ARGB) -> dst1 (00000000ARGBARGB) */
+                dst1 = _mm_cvtsi64_si128(*dstp);
+                /* 0A0R0G0B0A0R0G0B -> dst1 */
                 dst1 = _mm_unpacklo_epi8(dst1, mm_zero);
 
                 /* (srcRGB - dstRGB) */
                 sub_dst = _mm_sub_epi16(src1, dst1);
 
                 /* (srcRGB - dstRGB) * srcA */
-                sub_dst = _mm_mullo_epi16(sub_dst, rgb_src_alpha);
+                sub_dst = _mm_mullo_epi16(sub_dst, mm_src_alpha);
+
+                /* (srcRGB - dstRGB) * srcA + srcRGB */
+                sub_dst = _mm_add_epi16(sub_dst, src1);
+
+                /* (dstRGB << 8) */
+                dst1 = _mm_slli_epi16(dst1, 8);
+
+                /* ((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) */
+                sub_dst = _mm_add_epi16(sub_dst, dst1);
+
+                /* (((dstRGB << 8) + (srcRGB - dstRGB) * srcA + srcRGB) >> 8)*/
+                sub_dst = _mm_srli_epi16(sub_dst, 8);
+
+                /* pack everything back into a pixel with zeroed out alpha */
+                sub_dst = _mm_packus_epi16(sub_dst, mm_zero);
+                sub_dst = _mm_and_si128(sub_dst, mm_rgb_mask);
+                *dstp = _mm_cvtsi128_si64(sub_dst);
+
+                ++srcp;
+                ++dstp;
+            }, n, width);
+            srcp += srcskip;
+            dstp += dstskip;
+        }
+#else /* 32 bit */
+
+        /* two pixels at a time - 32 bit version - only works when blit width
+           is an even number */
+        while (height--)
+        {
+            LOOP_UNROLLED4(
+            {
+                /* src(ARGB) -> src1 (00000000ARGBARGB) */
+                src1 = _mm_loadl_epi64((const __m128i *) srcp);
+
+                /* created squashed alpha -> mm_src_alpha (0000000000000A0A) */
+                mm_src_alpha = _mm_add_epi16(
+                    _mm_and_si128(_mm_srli_si128(src1, 3), mm_alpha_mask_1),
+                    _mm_and_si128(_mm_srli_si128(src1, 5), mm_alpha_mask_2));
+
+                /* Then Calc RGB */
+                /* 000000000A10A10A20A2 -> rgb_src_alpha */
+                mm_src_alpha = _mm_unpacklo_epi16(mm_src_alpha, mm_src_alpha);
+                /* 0A10A10A10A10A20A20A20A2 -> rgb_src_alpha */
+                mm_src_alpha = _mm_unpacklo_epi32(mm_src_alpha, mm_src_alpha);
+
+                /* 0A0R0G0B0A0R0G0B -> src1 */
+                src1 = _mm_unpacklo_epi8(src1, mm_zero);
+
+                /* dst(ARGB) -> dst1 (00000000ARGBARGB) */
+                dst1 = _mm_loadl_epi64((const __m128i *) dstp);
+                /* 0A0R0G0B0A0R0G0B -> dst1 */
+                dst1 = _mm_unpacklo_epi8(dst1, mm_zero);
+
+                /* (srcRGB - dstRGB) */
+                sub_dst = _mm_sub_epi16(src1, dst1);
+
+                /* (srcRGB - dstRGB) * srcA */
+                sub_dst = _mm_mullo_epi16(sub_dst, mm_src_alpha);
 
                 /* (srcRGB - dstRGB) * srcA + srcRGB */
                 sub_dst = _mm_add_epi16(sub_dst, src1);
@@ -2925,68 +3174,42 @@ alphablit_alpha_sse2_argb_no_surf_alpha (SDL_BlitInfo * info)
 
                 /* pack everything back into a pixel */
                 sub_dst = _mm_packus_epi16(sub_dst, mm_zero);
-                sub_dst = _mm_and_si128(sub_dst, rgb_mask_128);
-                /* add alpha to RGB */
-                sub_dst = _mm_add_epi16(mm_dst_alpha, sub_dst);
-                *dstp = _mm_cvtsi128_si32(sub_dst);
+                /* reset alpha to 0 */
+                *dstp = (((Uint64)_mm_cvtsi128_si32(_mm_srli_si128(sub_dst,4))) << 32 | (Uint32)_mm_cvtsi128_si32(sub_dst)) & rgb_mask;
 
-            }
-            ++srcp;
-            ++dstp;
-        }, n, width);
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
+                ++srcp;
+                ++dstp;
+            }, n, width);
+            srcp += srcskip;
+            dstp += dstskip;
+        }
+#endif /* 32 bit */
 
-static void
-alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst (SDL_BlitInfo * info)
-{
-    int             n;
-    int             width = info->width;
-    int             height = info->height;
-    Uint32          *srcp = (Uint32 *)info->s_pixels;
-    int             srcskip = info->s_skip >> 2;
-    Uint32          *dstp = (Uint32 *)info->d_pixels;
-    int             dstskip = info->d_skip >> 2;
-
-    SDL_PixelFormat *srcfmt = info->src;
-    SDL_PixelFormat *dstfmt = info->dst;
-
-    Uint32          src_amask = srcfmt->Amask;
-
-    Uint32          rgb_mask;
-
-    __m128i src1, dst1, sub_dst, mm_src_alpha, mm_zero;
-
-    mm_zero = _mm_setzero_si128();
-
-    if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-    {
-        rgb_mask = 0x00FFFFFF;
     }
     else
     {
-        rgb_mask = 0xFFFFFF00;
-    }
+        /* one pixel at a time */
+        Uint32          *srcp = (Uint32 *)info->s_pixels;
+        Uint32          *dstp = (Uint32 *)info->d_pixels;
 
+        Uint32          src_amask = srcfmt->Amask;
 
-    while (height--)
-    {
-        LOOP_UNROLLED4(
+        Uint32          rgb_mask = 0x00FFFFFF;
+
+        __m128i src1, dst1, sub_dst, mm_src_alpha, mm_zero, mm_rgb_mask;
+
+        mm_zero = _mm_setzero_si128();
+        mm_rgb_mask = _mm_cvtsi32_si128(rgb_mask);
+
+        while (height--)
         {
-            Uint32 src_alpha = (*srcp & src_amask);
-            if ((src_alpha == src_amask))
-            {
-                *dstp = (*srcp) & rgb_mask;
-            }
-            else
+            LOOP_UNROLLED4(
             {
                 /* Do the actual blend */
-                /* src_alpha -> mm_src_alpha (000000000000A000) */
-                mm_src_alpha = _mm_cvtsi32_si128(src_alpha);
-                /* mm_src_alpha >> ashift -> rgb_src_alpha(000000000000000A) */
-                mm_src_alpha = _mm_srli_si128(mm_src_alpha, 3);
+                /* src(ARGB) -> src1 (000000000000ARGB) */
+                src1 = _mm_cvtsi32_si128(*srcp);
+                /* src1 >> ashift -> mm_src_alpha(000000000000000A) */
+                mm_src_alpha = _mm_srli_si128(src1, 3);
 
                 /* Then Calc RGB */
                 /* 0000000000000A0A -> rgb_src_alpha */
@@ -2994,8 +3217,6 @@ alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst (SDL_BlitInfo * info)
                 /* 000000000A0A0A0A -> rgb_src_alpha */
                 mm_src_alpha = _mm_unpacklo_epi32(mm_src_alpha, mm_src_alpha);
 
-                /* src(ARGB) -> src1 (000000000000ARGB) */
-                src1 = _mm_cvtsi32_si128(*srcp);
                 /* 000000000A0R0G0B -> src1 */
                 src1 = _mm_unpacklo_epi8(src1, mm_zero);
 
@@ -3024,16 +3245,18 @@ alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst (SDL_BlitInfo * info)
 
                 /* pack everything back into a pixel */
                 sub_dst = _mm_packus_epi16(sub_dst, mm_zero);
-                /* reset alpha to 255 */
-                *dstp = (_mm_cvtsi128_si32(sub_dst) & rgb_mask);
+                sub_dst = _mm_and_si128(sub_dst, mm_rgb_mask);
+                /* reset alpha to 0 */
+                *dstp = _mm_cvtsi128_si32(sub_dst);
 
-            }
-            ++srcp;
-            ++dstp;
-        }, n, width);
-        srcp += srcskip;
-        dstp += dstskip;
+                ++srcp;
+                ++dstp;
+            }, n, width);
+            srcp += srcskip;
+            dstp += dstskip;
+        }
     }
+
 }
 
 #endif /* IS_SDLv2 && (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1653,8 +1653,9 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     else
         alpha = (Uint8)alphaval;
 
-    if (alpha == 255)
+    if (alpha == 255 && (surf->format->BytesPerPixel == 1))
     {
+        /* Can't blend with a surface alpha of 255 and 8bit surfaces */
         if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0)
             return RAISE(pgExc_SDLError, SDL_GetError());
     }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1653,6 +1653,11 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
     else
         alpha = (Uint8)alphaval;
 
+    if (alpha == 255)
+    {
+        if (SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE) != 0)
+            return RAISE(pgExc_SDLError, SDL_GetError());
+    }
     pgSurface_Prep(self);
     result =
         SDL_SetSurfaceRLE(surf, (flags & PGS_RLEACCEL) ? SDL_TRUE : SDL_FALSE);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -4310,8 +4310,8 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             SDL_GetColorKey(src, &key) != 0 &&
             (dst->format->BytesPerPixel == 4 ||
              dst->format->BytesPerPixel == 2) &&
-            (SDL_ISPIXELFORMAT_ALPHA(src->format->format) ||
-             SDL_GetSurfaceAlphaMod(src, &alpha) == 0) &&
+             _PgSurface_SrcAlpha(src) &&
+            (SDL_ISPIXELFORMAT_ALPHA(src->format->format)) &&
              !pg_HasSurfaceRLE(src) && !pg_HasSurfaceRLE(dst) &&
              !(src->flags & SDL_RLEACCEL) && !(dst->flags & SDL_RLEACCEL))
     {


### PR DESCRIPTION
Noticed that some combos of surfaces were wrongly being redirected down the slow path of the new blitter when there was no need to.

This should fix that with a better test on who gets to enter the new blitter thunderdome.

Noticed it when testing:
https://github.com/pygame/pygame/issues/1618

New blitter still slightly slower in alpha to alpha case after this PR (same on other two as it's no longer being used) but is actually better in alpha+surf_alpha case.