### PR TITLE
WIP: Tests for loading images with BytesIO.

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -676,6 +676,13 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
 
     retval = Bytes_GET_SIZE(result);
     printf("retval = size:%d: retval:%d: maxnum:%d:\n", size, retval, maxnum);
+    unsigned char * result_string = Bytes_AsString(result);
+    printf("read_data = (");
+    for(int ii=0; ii < retval; ii++) {
+        printf("%u, ", result_string[ii]);
+    }
+    printf(")\n");
+
     memcpy(ptr, Bytes_AsString(result), retval);
     retval /= size;
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -539,6 +539,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
     PyObject *result;
     Sint64 retval;
 #endif /* IS_SDLv2 */
+    printf("seek offset:%zd: whence:%d:\n", offset, pywhence);
 
     if (helper->fileno != -1) {
         printf("helper->fileno != -1\n");
@@ -583,7 +584,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
 
     if (!(offset == 0 && whence == SEEK_CUR)) /*being called only for 'tell'*/
     {
-        printf("if (!(offset == 0 && whence == SEEK_CUR))\n");
+        printf("calling pyseek offset:%zd: whence:%d:\n", offset, pywhence);
         result = PyObject_CallFunction(helper->seek, "ii", offset, pywhence);
         if (!result) {
             printf("seek error\n");
@@ -605,13 +606,13 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
 
     retval = PyLong_AsSsize_t(result);
     Py_DECREF(result);
-    printf("seek retval:%d:\n", retval);
 
 end:
 #ifdef WITH_THREAD
     PyGILState_Release(state);
 #endif /* ~WITH_THREAD*/
 
+    printf("seek retval:%d:\n", retval);
     return retval;
 }
 
@@ -633,6 +634,8 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
 #ifdef WITH_THREAD
     PyGILState_STATE state;
 #endif /* WITH_THREAD */
+
+    printf("read size:%zd: maxnum:%zd:\n", size, maxnum);
 
     // printf("_pg_rw_read top: helper->fileno:%d:\n", helper->fileno);
     if (helper->fileno != -1) {
@@ -683,6 +686,7 @@ end:
     PyGILState_Release(state);
 #endif /* WITH_THREAD */
 
+    printf("read retval:%d:\n", retval);
     return retval;
 }
 

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -613,7 +613,9 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
     PyGILState_STATE state;
 #endif /* WITH_THREAD */
 
+    // printf("_pg_rw_read top: helper->fileno:%d:\n", helper->fileno);
     if (helper->fileno != -1) {
+        printf("fileno != -1\n");
         retval = read(helper->fileno, ptr, size * maxnum);
         if (retval == -1) {
             return -1;
@@ -622,20 +624,24 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
         return retval;
     }
 
-    if (!helper->read)
+    if (!helper->read) {
+        printf("!helper->read\n");
         return -1;
+    }
 
 #ifdef WITH_THREAD
     state = PyGILState_Ensure();
 #endif /* WITH_THREAD */
     result = PyObject_CallFunction(helper->read, "i", size * maxnum);
     if (!result) {
+        printf("!result\n");
         PyErr_Print();
         retval = -1;
         goto end;
     }
 
     if (!Bytes_Check(result)) {
+        printf("!Bytes_Check(result)\n");
         Py_DECREF(result);
         PyErr_Print();
         retval = -1;
@@ -643,6 +649,7 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
     }
 
     retval = Bytes_GET_SIZE(result);
+    printf("retval = size:%d: retval:%d: maxnum:%d:\n", size, retval,);
     memcpy(ptr, Bytes_AsString(result), retval);
     retval /= size;
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -94,7 +94,8 @@ class ImageModuleTest(unittest.TestCase):
     def testLoadBytesIO(self):
         """ see if we can load a images with BytesIO.
         """
-        files = ["data/alien1.png", "data/alien1.jpg", "data/alien1.gif", "data/fist.bmp"]
+        # files = ["data/alien1.png", "data/alien1.jpg", "data/alien1.gif", "data/fist.bmp"]
+        files = ["data/alien1.jpg"]
 
         for fname in files:
             with self.subTest(fname=fname):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -91,6 +91,18 @@ class ImageModuleTest(unittest.TestCase):
         #     surf = pygame.image.load(open(os.path.join("examples", "data",
         #         "alien1.jpg"), "rb"))
 
+    def testLoadBytesIO(self):
+        """ see if we can load a images with BytesIO.
+        """
+        files = ["data/alien1.png", "data/alien1.jpg", "data/alien1.gif", "data/fist.bmp"]
+
+        for fname in files:
+            with self.subTest(fname=fname):
+                with open(example_path(fname), "rb") as f:
+                    img_bytes = f.read()
+                    img_file = io.BytesIO(img_bytes)
+                    image = pygame.image.load(img_file)
+
     def testSaveJPG(self):
         """ JPG equivalent to issue #211 - color channel swapping
 


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/1516 It's failing on windows python 32bit (works on 64bit).

PIL also has the same issue with BytesIO and jpeg. https://stackoverflow.com/questions/23587426/pil-open-method-not-working-with-bytesio

```
retval = size:1: retval:2: maxnum:2:
read_data = (0, 16, )
read retval:2:
seek offset:0: whence:1:
seek retval:6:
seek offset:14: whence:1:
calling pyseek offset:14: whence:1:
seek retval:20:
```

The return value should be 20, but on windows python 32 it is returning 14. Because on windows it passes in (14, 0) rather than (14,1).
Why it is getting a 0, even when passing in 1? No idea. Maybe some sort of function prototype size with dlls miss match kind of issue.

I could try and work around it perhaps... by creating a SDL_RWOPS_MEMORY from the memory in the BytesIO.