### PR TITLE
Updates the joystick docs to include controller mappings for X360 & PS4 controllers

### DIFF
--- a/docs/reST/ref/joystick.rst
+++ b/docs/reST/ref/joystick.rst
@@ -232,6 +232,9 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
 
       The axis number must be an integer from ``0`` to ``get_numaxes() - 1``.
 
+      When using gamepads both the control sticks and the analog triggers are
+      usually reported as axes.
+
       .. ## Joystick.get_axis ##
 
    .. method:: get_numballs
@@ -327,3 +330,186 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
    Example code for joystick module.
 
 .. literalinclude:: code_examples/joystick_calls.py
+
+.. _controller-mappings:
+
+
+**Common Controller Axis Mappings**
+
+Controller mappings are drawn from the underlying SDL library which pygame uses and they differ
+between pygame 1 and pygame 2. Below are a couple of mappings for two popular game pads.
+
+
+**Pygame 2**
+
+Axis and hat mappings are listed from -1 to +1.
+
+
+**X-Box 360 Controller (name: "Xbox 360 Controller")**
+
+In pygame 2 the X360 controller mapping has 6 Axes, 11 buttons and 1 hat.
+
+* **Left Stick**::
+
+    Left -> Right   - Axis 0
+    Up   -> Down    - Axis 1
+
+* **Right Stick**::
+
+    Left -> Right   - Axis 3
+    Up   -> Down    - Axis 4
+
+* **Left Trigger**::
+
+    Out -> In       - Axis 2
+
+* **Right Trigger**::
+
+    Out -> In       - Axis 5
+
+* **Buttons**::
+
+    A Button        - Button 0
+    B Button        - Button 1
+    X Button        - Button 2
+    Y Button        - Button 3
+    Left Bumper     - Button 4
+    Right Bumper    - Button 5
+    Back Button     - Button 6
+    Start Button    - Button 7
+    L. Stick In     - Button 8
+    R. Stick In     - Button 9
+    Guide Button    - Button 10
+
+* **Hat/D-pad**::
+
+    Down -> Up      - Y Axis
+    Left -> Right   - X Axis
+
+
+**Playstation 4 Controller (name: "PS4 Controller")**
+
+In pygame 2 the PS4 controller mapping has 6 Axes and 16 buttons.
+
+* **Left Stick**::
+
+    Left -> Right   - Axis 0
+    Up   -> Down    - Axis 1
+
+* **Right Stick**::
+
+    Left -> Right   - Axis 2
+    Up   -> Down    - Axis 3
+
+* **Left Trigger**::
+
+    Out -> In       - Axis 4
+
+* **Right Trigger**::
+
+    Out -> In       - Axis 5
+
+* **Buttons**::
+
+    Cross Button    - Button 0
+    Circle Button   - Button 1
+    Square Button   - Button 2
+    Triangle Button - Button 3
+    Share Button    - Button 4
+    PS Button       - Button 5
+    Options Button  - Button 6
+    L. Stick In     - Button 7
+    R. Stick In     - Button 8
+    Left Bumper     - Button 9
+    Right Bumper    - Button 10
+    D-pad Up        - Button 11
+    D-pad Down      - Button 12
+    D-pad Left      - Button 13
+    D-pad Right     - Button 14
+    Touch Pad Click - Button 15
+
+**Pygame 1**
+
+Axis and hat mappings are listed from -1 to +1.
+
+
+**X-Box 360 Controller (name: "Controller (XBOX 360 For Windows)")**
+
+In pygame 1 the X360 controller mapping has 5 Axes, 10 buttons and 1 hat.
+
+* **Left Stick**::
+
+    Left -> Right   - Axis 0
+    Up   -> Down    - Axis 1
+
+* **Right Stick**::
+
+    Left -> Right   - Axis 4
+    Up   -> Down    - Axis 3
+
+* **Left Trigger & Right Trigger**::
+
+    RT -> LT        - Axis 2
+
+* **Buttons**::
+
+    A Button        - Button 0
+    B Button        - Button 1
+    X Button        - Button 2
+    Y Button        - Button 3
+    Left Bumper     - Button 4
+    Right Bumper    - Button 5
+    Back Button     - Button 6
+    Start Button    - Button 7
+    L. Stick In     - Button 8
+    R. Stick In     - Button 9
+
+* **Hat/D-pad**::
+
+    Down -> Up      - Y Axis
+    Left -> Right   - X Axis
+
+
+**Playstation 4 Controller (name: "Wireless Controller")**
+
+In pygame 1 the PS4 controller mapping has 6 Axes and 14 buttons and 1 hat.
+
+* **Left Stick**::
+
+    Left -> Right   - Axis 0
+    Up   -> Down    - Axis 1
+
+* **Right Stick**::
+
+    Left -> Right   - Axis 2
+    Up   -> Down    - Axis 3
+
+* **Left Trigger**::
+
+    Out -> In       - Axis 5
+
+* **Right Trigger**::
+
+    Out -> In       - Axis 4
+
+* **Buttons**::
+
+    Cross Button    - Button 0
+    Circle Button   - Button 1
+    Square Button   - Button 2
+    Triangle Button - Button 3
+    Left Bumper     - Button 4
+    Right Bumper    - Button 5
+    L. Trigger(Full)- Button 6
+    R. Trigger(Full)- Button 7
+    Share Button    - Button 8
+    Options Button  - Button 9
+    L. Stick In     - Button 10
+    R. Stick In     - Button 11
+    PS Button       - Button 12
+    Touch Pad Click - Button 13
+
+* **Hat/D-pad**::
+
+    Down -> Up      - Y Axis
+    Left -> Right   - X Axis


### PR DESCRIPTION
I added controller mappings for the X360 pad and the PS4 pad because A) they are the controllers I possess and B) I think they are two of the most popular controller models and thus most likely to be useful when setting up defaults.

Fixes #1167