### PR TITLE
Sets SDL Hint for hidden mouse cursor at window edges when full screen

### DIFF
--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -160,7 +160,7 @@ mouse_get_pressed(PyObject *self, PyObject *args, PyObject *kwargs)
     PyTuple_SET_ITEM(tuple, 0, PyBool_FromLong((state & SDL_BUTTON_LMASK) != 0));
     PyTuple_SET_ITEM(tuple, 1, PyBool_FromLong((state & SDL_BUTTON_MMASK) != 0));
     PyTuple_SET_ITEM(tuple, 2, PyBool_FromLong((state & SDL_BUTTON_RMASK) != 0));
-    
+
     if (num_buttons == 5) {
         PyTuple_SET_ITEM(tuple, 3, PyBool_FromLong((state & SDL_BUTTON_X1MASK) != 0));
         PyTuple_SET_ITEM(tuple, 4, PyBool_FromLong((state & SDL_BUTTON_X2MASK) != 0));
@@ -176,6 +176,7 @@ mouse_set_visible(PyObject *self, PyObject *args)
     #if IS_SDLv2
         int mode;
         SDL_Window *win = NULL;
+        Uint32 window_flags = 0;
     #endif
 
     if (!PyArg_ParseTuple(args, "i", &toggle))
@@ -190,6 +191,18 @@ mouse_set_visible(PyObject *self, PyObject *args)
                 SDL_SetRelativeMouseMode(1);
             } else {
                 SDL_SetRelativeMouseMode(0);
+            }
+            window_flags = SDL_GetWindowFlags(win);
+            if (!toggle && (window_flags & SDL_WINDOW_FULLSCREEN_DESKTOP ||
+                            window_flags & SDL_WINDOW_FULLSCREEN))
+            {
+                SDL_SetHint(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN,
+                            "0");
+            }
+            else
+            {
+                SDL_SetHint(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN,
+                            "1");
             }
         }
     #endif


### PR DESCRIPTION
It's SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN. Set it to 0 while we are fullscreen with a hidden mouse cursor, and back to '1' otherwise.

fixes #1479 

Test Case (must have windows desktop scaled to something other than 100%):
```python
import pygame

pygame.init()
window_surface = pygame.display.set_mode((1920, 1080), flags=pygame.FULLSCREEN | pygame.SCALED)

background = pygame.Surface((1920, 1080))
background.fill(pygame.Color('#fb8691'))

fake_cursor = pygame.Surface((32, 32))
fake_cursor.fill(pygame.Color('#88CA99'))

pygame.mouse.set_visible(False)
while True:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            pygame.quit()
        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
            pygame.quit()

    window_surface.blit(background, (0, 0))

    window_surface.blit(fake_cursor, pygame.mouse.get_pos())
    pygame.display.update()
```

You may also want to set the screen resolution to your normal monitor resolution. Anyway with that in place when I move the cursor to the edges of the screen and push at the edges the mouse cursor will flicker in and out of visibility.