### PR TITLE
Change opaque surface test to use SDL_ISPIXELFORMAT_ALPHA() macro

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -243,13 +243,12 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                         src->format->Rmask == dst->format->Rmask &&
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
-                        src != dst &&
                         SDL_BYTEORDER == SDL_LIL_ENDIAN)
                     {
                     /* If our source and destination are the same ARGB 32bit
                        format we can use SSE2 to speed up the blend */
                     #if PG_ENABLE_ARM_NEON
-                        if (SDL_HasNEON() == SDL_TRUE){
+                        if ((SDL_HasNEON() == SDL_TRUE) && (src != dst)){
                             if (info.src_blanket_alpha != 255)
                             {
                                 alphablit_alpha_sse2_argb_surf_alpha (&info);
@@ -266,7 +265,7 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                         }
                     #endif /* PG_ENABLE_ARM_NEON */
                     #ifdef __SSE2__
-                        if (SDL_HasSSE2()){
+                        if ((SDL_HasSSE2()) && (src != dst)){
                             if (info.src_blanket_alpha != 255)
                             {
                                  alphablit_alpha_sse2_argb_surf_alpha (&info);

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -254,7 +254,7 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                             {
                                 alphablit_alpha_sse2_argb_surf_alpha (&info);
                             }
-                            else if (info.dst_blend == SDL_BLENDMODE_NONE)
+                            else if (!SDL_ISPIXELFORMAT_ALPHA(dst->format->format))
                             {
                                 alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(&info);
                             }
@@ -271,7 +271,7 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                             {
                                  alphablit_alpha_sse2_argb_surf_alpha (&info);
                             }
-                            else if (info.dst_blend == SDL_BLENDMODE_NONE)
+                            else if (!SDL_ISPIXELFORMAT_ALPHA(dst->format->format))
                             {
                                 alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(&info);
                             }

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1709,6 +1709,25 @@ class GeneralSurfaceTests(AssertRaisesRegexMixin, unittest.TestCase):
         # pprint(results)
         self.assertEqual(results, results_expected)
 
+    def test_opaque_destination_blit_with_set_alpha(self):
+        # no set_alpha()
+        src_surf = pygame.Surface((32, 32), pygame.SRCALPHA, 32)
+        src_surf.fill((255, 255, 255, 200))
+        dest_surf = pygame.Surface((32, 32))
+        dest_surf.fill((100, 100, 100))
+
+        dest_surf.blit(src_surf, (0, 0))
+
+        no_surf_alpha_col = dest_surf.get_at((0,0))
+
+        dest_surf.fill((100, 100, 100))
+        dest_surf.set_alpha(200)
+        dest_surf.blit(src_surf, (0, 0))
+
+        surf_alpha_col = dest_surf.get_at((0, 0))
+
+        self.assertEqual(no_surf_alpha_col, surf_alpha_col)
+
     def todo_test_convert(self):
 
         # __doc__ (as of 2008-08-02) for pygame.surface.Surface.convert:


### PR DESCRIPTION
This is because if a destination surface has no pixel alpha and surface alpha is set on it it's blend mode will no longer be SDL_BLENDMODE_NONE.

However, we still want to treat it as an opaque destination surface from the blitter's perspective because it will have 0 pixel alpha and we can't use the optimised 'no surface alpha' blitter which assumes two surfaces with pixel alpha to do it's thing.

This fixes the menu bug in FlyBoy.