### PR TITLE
Documented pygame.image load_basic, load_extended, save_extended. image.c code cleanups.

### DIFF
--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -51,13 +51,21 @@ following formats.
 
    * ``JPEG``
 
+``JPEG`` and ``JPG`` refer to the same file format
+
 .. versionadded:: 1.8 Saving PNG and JPEG files.
 
-There are a three undocumented functions in this module, namely 
-``pygame.image.load_basic()``, ``pygame.image.load_extended()`` and ``pygame.image.save_extended()`` that are meant to be internal functions. 
-The use of these functions is not recommended, as these may get deprecated 
-or removed. Instead, use ``pygame.image.load()`` and ``pygame.image.save()`` 
-for loading and saving images, respectively.
+.. function:: load_basic
+
+   | :sl:`load new BMP image from a file (or file-like object)`
+   | :sg:`load_basic(file) -> Surface`
+
+   Load an image from a file source. You can pass either a filename or a Python
+   file-like object.
+
+   This function only supports loading "basic" image format, ie ``BMP``
+   format.
+   This function is always available, no matter how pygame was built.
 
 .. function:: load
 
@@ -82,7 +90,7 @@ for loading and saving images, respectively.
    For alpha transparency, like in .png images, use the ``convert_alpha()``
    method after loading so that the image has per pixel transparency.
 
-   Pygame may not always be built to support all image formats. At minimum it
+   pygame may not always be built to support all image formats. At minimum it
    will support uncompressed ``BMP``. If ``pygame.image.get_extended()``
    returns 'True', you should be able to load most images (including PNG, JPG
    and GIF).
@@ -94,6 +102,23 @@ for loading and saving images, respectively.
      eg. asurf = pygame.image.load(os.path.join('data', 'bla.png'))
 
    .. ## pygame.image.load ##
+
+.. function:: load_extended
+
+   | :sl:`load an image from a file (or file-like object)`
+   | :sg:`load_extended(filename) -> Surface`
+   | :sg:`load_extended(fileobj, namehint="") -> Surface`
+
+   This function is similar to ``pygame.image.load()``, except that this
+   function can only be used if pygame was built with extended image format
+   support.
+
+   From version 2.0.1, this function is always available, but raises an
+   error if extended image formats are not supported. Previously, this
+   function may or may not be available, depending on the state of
+   extended image format support.
+
+   .. versionchanged:: 2.0.1
 
 .. function:: save
 
@@ -121,6 +146,26 @@ for loading and saving images, respectively.
                        to save other formats than ``TGA`` to a file-like object.
 
    .. ## pygame.image.save ##
+
+.. function:: save_extended
+
+   | :sl:`save a png/jpg image to file (or file-like object)`
+   | :sg:`save_extended(Surface, filename) -> None`
+   | :sg:`save_extended(Surface, fileobj, namehint="") -> None`
+
+   This will save your Surface as either a ``PNG`` or ``JPEG`` image.
+
+   Incase the image is being saved to a file-like object, this function
+   uses the namehint argument to determine the format of the file being
+   saved. Saves to ``JPEG`` incase the namehint was not specified while
+   saving to file-like object.
+
+   From version 2.0.1, this function is always available, but raises an
+   error if extended image formats are not supported. Previously, this
+   function may or may not be available, depending on the state of
+   extended image format support.
+
+   .. versionchanged:: 2.0.1
 
 .. function:: get_sdl_image_version
 

--- a/src_c/doc/image_doc.h
+++ b/src_c/doc/image_doc.h
@@ -1,7 +1,10 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEIMAGE "pygame module for image transfer"
+#define DOC_PYGAMEIMAGELOADBASIC "load_basic(file) -> Surface\nload new BMP image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGELOAD "load(filename) -> Surface\nload(fileobj, namehint="") -> Surface\nload new image from a file (or file-like object)"
+#define DOC_PYGAMEIMAGELOADEXTENDED "load_extended(filename) -> Surface\nload_extended(fileobj, namehint="") -> Surface\nload an image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGESAVE "save(Surface, filename) -> None\nsave(Surface, fileobj, namehint="") -> None\nsave an image to file (or file-like object)"
+#define DOC_PYGAMEIMAGESAVEEXTENDED "save_extended(Surface, filename) -> None\nsave_extended(Surface, fileobj, namehint="") -> None\nsave a png/jpg image to file (or file-like object)"
 #define DOC_PYGAMEIMAGEGETSDLIMAGEVERSION "get_sdl_image_version() -> None\nget_sdl_image_version() -> (major, minor, patch)\nget version number of the SDL_Image library being used"
 #define DOC_PYGAMEIMAGEGETEXTENDED "get_extended() -> bool\ntest if extended image formats can be loaded"
 #define DOC_PYGAMEIMAGETOSTRING "tostring(Surface, format, flipped=False) -> string\ntransfer image to string buffer"
@@ -16,15 +19,29 @@
 pygame.image
 pygame module for image transfer
 
+pygame.image.load_basic
+ load_basic(file) -> Surface
+load new BMP image from a file (or file-like object)
+
 pygame.image.load
  load(filename) -> Surface
  load(fileobj, namehint="") -> Surface
 load new image from a file (or file-like object)
 
+pygame.image.load_extended
+ load_extended(filename) -> Surface
+ load_extended(fileobj, namehint="") -> Surface
+load an image from a file (or file-like object)
+
 pygame.image.save
  save(Surface, filename) -> None
  save(Surface, fileobj, namehint="") -> None
 save an image to file (or file-like object)
+
+pygame.image.save_extended
+ save_extended(Surface, filename) -> None
+ save_extended(Surface, fileobj, namehint="") -> None
+save a png/jpg image to file (or file-like object)
 
 pygame.image.get_sdl_image_version
  get_sdl_image_version() -> None

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -371,7 +371,7 @@ image_get_sdl_image_version(PyObject *self)
         return PyObject_CallObject(extverobj, NULL);
 }
 
-#if PG_COMPILE_SSE4_2 && (SDL_VERSION_ATLEAST(2, 0
+#if PG_COMPILE_SSE4_2 && (SDL_VERSION_ATLEAST(2, 0, 0))
 #define SSE42_ALIGN_NEEDED 16
 #define SSE42_ALIGN __attribute__((aligned(SSE42_ALIGN_NEEDED)))
 
@@ -1671,9 +1671,9 @@ static PyMethodDef _image_methods[] = {
     
     {"save_extended", image_save_extended, METH_VARARGS, DOC_PYGAMEIMAGESAVEEXTENDED},
     {"save", image_save, METH_VARARGS, DOC_PYGAMEIMAGESAVE},
-    {"get_extended", image_get_extended, METH_NOARGS,
+    {"get_extended", (PyCFunction)image_get_extended, METH_NOARGS,
      DOC_PYGAMEIMAGEGETEXTENDED},
-    {"get_sdl_image_version", image_get_sdl_image_version, METH_NOARGS,
+    {"get_sdl_image_version", (PyCFunction)image_get_sdl_image_version, METH_NOARGS,
      DOC_PYGAMEIMAGEGETSDLIMAGEVERSION},
 
     {"tostring", image_tostring, METH_VARARGS, DOC_PYGAMEIMAGETOSTRING},

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -59,7 +59,7 @@ static PyObject *extverobj = NULL;
 
 /* define docs for undocumented (kinda deprecated) functions */
 #define DOC_PYGAMEIMAGELOADBASIC "internal function to load images, use pygame.image.load() instead of this"
-#define DOC_PYGAMEIMAGELOADAEXTENDED DOC_IMAGELOADBASIC
+#define DOC_PYGAMEIMAGELOADEXTENDED DOC_PYGAMEIMAGELOADBASIC
 #define DOC_PYGAMEIMAGESAVEEXTENDED "internal function to save images, use pygame.image.save() instead of this"
 
 static const char *

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -57,11 +57,6 @@ static PyObject *extloadobj = NULL;
 static PyObject *extsaveobj = NULL;
 static PyObject *extverobj = NULL;
 
-/* define docs for undocumented (kinda deprecated) functions */
-#define DOC_PYGAMEIMAGELOADBASIC "internal function to load images, use pygame.image.load() instead of this"
-#define DOC_PYGAMEIMAGELOADEXTENDED DOC_PYGAMEIMAGELOADBASIC
-#define DOC_PYGAMEIMAGESAVEEXTENDED "internal function to save images, use pygame.image.save() instead of this"
-
 static const char *
 find_extension(const char *fullname)
 {

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -289,8 +289,7 @@ image_save(PyObject *self, PyObject *arg)
             /* If it is .png .jpg .jpeg use the extended module. */
             /* try to get extended formats */
             ret = image_save_extended(self, arg);
-            if (ret == NULL)
-                result = -2;
+            result = (ret == NULL ? -2 : 0);
         }
         else if (oencoded == Py_None) {
             SDL_RWops *rw = pgRWops_FromFileObject(obj);

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -288,7 +288,9 @@ image_save(PyObject *self, PyObject *arg)
                 !strcasecmp(ext, "jpeg")) {
             /* If it is .png .jpg .jpeg use the extended module. */
             /* try to get extended formats */
-            return image_save_extended(self, arg);
+            ret = image_save_extended(self, arg);
+            if (ret == NULL)
+                result = -2;
         }
         else if (oencoded == Py_None) {
             SDL_RWops *rw = pgRWops_FromFileObject(obj);
@@ -353,7 +355,7 @@ image_save(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-image_get_extended(PyObject *self, PyObject *arg)
+image_get_extended(PyObject *self)
 {
     if (extverobj == NULL)
         Py_RETURN_FALSE;
@@ -362,12 +364,12 @@ image_get_extended(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-image_get_sdl_image_version(PyObject *self, PyObject *arg)
+image_get_sdl_image_version(PyObject *self)
 {
     if (extverobj == NULL)
         Py_RETURN_NONE;
     else
-        return PyObject_CallObject(extverobj, arg);
+        return PyObject_CallObject(extverobj, NULL);
 }
 
 

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -858,6 +858,7 @@ image_save_ext(PyObject *self, PyObject *arg)
     else {
         name = Bytes_AS_STRING(oencoded);
     }
+
     if (result > 0) {
         const char *ext = find_extension(name);
         if (!strcasecmp(ext, "jpeg") || !strcasecmp(ext, "jpg")) {
@@ -868,7 +869,7 @@ image_save_ext(PyObject *self, PyObject *arg)
              */
             if (rw != NULL) {
                 PyErr_SetString(pgExc_SDLError,
-                        "SDL_Image 2.0.2 or newer nedded to save "
+                        "SDL_Image 2.0.2 or newer needed to save "
                         "jpeg to a fileobject.");
                 result = -2;
             }


### PR DESCRIPTION
Documented pygame.image load_basic, load_extended, save_extended 
- fixes #1732
- image.c code cleanups, and CPython API usage fixes.

Continued on from #2226 PR.