### PR TITLE
Add parentheses to print so it works in py2 and py3

### DIFF
--- a/test/util/gen_stubs.py
+++ b/test/util/gen_stubs.py
@@ -104,8 +104,8 @@ def get_instance(type_):
 
     try:
         return helper(*arg)
-    except Exception, e:
-        raw_input("FAILED TO CREATE INSTANCE OF %s\n%s\n" 
+    except Exception as e:
+        raw_input("FAILED TO CREATE INSTANCE OF %s\n%s\n"
                   "Press Enter to continue" % (type_, e))
         return type_
 
@@ -342,19 +342,19 @@ if __name__ == "__main__":
         sys.exit(opt_parser.print_help())
 
     docs = options.docs and docs_as_dict() or {}
-    
+
     root = args and args[0] or 'pygame'
     if not root.startswith('pygame'):
         root = '%s.%s' % ('pygame', root)
 
     stubs, tested = get_stubs(root)
-            
+
     for fname in sorted(s for s in stubs.iterkeys() if s not in tested):
         if not fname.startswith(root): continue  # eg. module.Class
         test_name, stub = stubs[fname]
 
-        if options.list: print "%s," % fname
-        elif options.test_names: print test_name
-        else: print stub
+        if options.list: print("%s," % fname)
+        elif options.test_names: print(test_name)
+        else: print(stub)
 
 ################################################################################

--- a/test/util/svn_log_to_whatsnew.py
+++ b/test/util/svn_log_to_whatsnew.py
@@ -6,7 +6,9 @@ Should still edit the WHATSNEW to make it more human readable.
 
 
 """
-import sys,os,glob,textwrap
+import sys
+import textwrap
+
 lines = sys.stdin.readlines()
 
 out= []
@@ -23,38 +25,28 @@ for l in lines:
         out[-1]['date'] = parts[2].strip()
         date_parts = parts[2].strip().split("(")
         out[-1]['day_month_year'] = day, month, year = date_parts[1][:-1].split(",")[1].split()
-        
-
         out[-1]['message'] = ""
         state = "message"
     elif state == "message":
         out[-1]['message'] += l + "\n"
 
-import pprint
-#pprint.pprint(out)
-
-
 # group revisions on the same day into one block.
 previous = []
 for o in (out + [None]):
-
     if o and previous and o['day_month_year'] == previous[-1]['day_month_year']:
         previous.append(o)
         continue
     else:
-
         if not previous:
             previous.append(o)
             continue
-
         day, month, year = previous[-1]['day_month_year']
         revs = [int(p['revision']) for p in previous]
         if len(revs) == 1:
             revisions = revs[0]
         else:
             revisions = "%s-%s" % (min(revs), max(revs))
-
-        print "[SVN %s] %s %s, %s" % (revisions, month, day, year)
+        print("[SVN %s] %s %s, %s" % (revisions, month, day, year))
 
         # uniqify the messages, keep order.
         messages = [p['message'][2:] for p in previous]
@@ -62,31 +54,19 @@ for o in (out + [None]):
         for m in messages:
             if m not in unique_messages:
                 unique_messages.append(m)
-            
-
-
         for msg in reversed(unique_messages):
             #msg = p['message'][2:]
-
             for i in range(4):
                 if msg and msg[-1] == "\n":
                     msg = msg[:-1]
-
             lines = textwrap.wrap(msg, 74)
             if lines:
                 if lines[-1][-1:] != ".":
                     lines[-1] += "."
-
             for i, l in enumerate(lines):
                 if i == 0:
-                    print "    %s" % (l[:1].upper() + l[1:])
+                    print("    %s" % (l[:1].upper() + l[1:]))
                 if i != 0:
-                    print "      %s" % l
-
-        print ""
-
+                    print("      %s" % l)
+        print("")
         previous  = [o]
-
-
-
-


### PR DESCRIPTION
`print("foo")` works in both python2 and python3. `except Exception as e:` too. The python2 only syntax prevented `mypy` from running on the codebase for #1896 . 