### PR TITLE
backwards compatible env vars, SDL_VIDEODRIVER=windib, SDL_AUDIODRIVER=pulse or dsound 

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -245,6 +245,17 @@ pg_quit(PyObject *self, PyObject *arg)
 static PyObject *
 pg_init(PyObject *self, PyObject *args)
 {
+
+#if IS_SDLv2
+    /* Compatibility:
+        windib video driver was renamed in SDL2, and we don't want it to fail.
+    */
+    const char *drivername = SDL_getenv("SDL_VIDEODRIVER");
+    if (drivername && SDL_strncasecmp("windb", drivername, SDL_strlen(drivername) == 0)) {
+        SDL_setenv("SDL_VIDEODRIVER", "windows", 1);
+    }
+#endif
+
     if (!pgVideo_AutoInit())
         return RAISE(pgExc_SDLError, SDL_GetError());
     if (!pg_display_autoinit(NULL, NULL))

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -251,7 +251,7 @@ pg_init(PyObject *self, PyObject *args)
         windib video driver was renamed in SDL2, and we don't want it to fail.
     */
     const char *drivername = SDL_getenv("SDL_VIDEODRIVER");
-    if (drivername && SDL_strncasecmp("windb", drivername, SDL_strlen(drivername) == 0)) {
+    if (drivername && SDL_strncasecmp("windb", drivername, SDL_strlen(drivername)) == 0) {
         SDL_setenv("SDL_VIDEODRIVER", "windows", 1);
     }
 #endif

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -357,6 +357,7 @@ _init(int freq, int size, int channels, int chunk, char *devicename, int allowed
     Uint16 fmt = 0;
     int i;
     PyObject *music;
+    char *drivername;
 
     if (!freq) {
         freq = request_frequency;
@@ -455,6 +456,20 @@ _init(int freq, int size, int channels, int chunk, char *devicename, int allowed
                 channeldata[i].endevent = 0;
             }
         }
+
+#if IS_SDLv2
+        /* Compatibility:
+            pulse and dsound audio drivers were renamed in SDL2,
+            and we don't want it to fail.
+        */
+        drivername = SDL_getenv("SDL_AUDIODRIVER");
+        if (drivername && SDL_strncasecmp("pulse", drivername, SDL_strlen(drivername)) == 0) {
+            SDL_setenv("SDL_AUDIODRIVER", "pulseaudio", 1);
+        }
+        else if (drivername && SDL_strncasecmp("dsound", drivername, SDL_strlen(drivername)) == 0) {
+            SDL_setenv("SDL_AUDIODRIVER", "directsound", 1);
+        }
+#endif
 
         if (SDL_InitSubSystem(SDL_INIT_AUDIO) == -1)
             return PyInt_FromLong(0);


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/2282

Otherwise apps that use SDL_VIDEODRIVER=windib or SDL_AUDIODRIVER=pulse or dsound will fail when using SDL2.