### PR TITLE
Create a list of contributors

### DIFF
--- a/docs/contributors.txt
+++ b/docs/contributors.txt
@@ -1,0 +1,98 @@
+@41aaronb
+@Bottersnike
+@DGMcKenney
+@IchMageBaume
+@LambdaGoblin
+@PeanutbutterWarrior
+@Starbuck5
+@amipy
+@as15aev
+@charlesoblack
+@code-forger
+@dr0id
+@endolith
+@galexandreg
+@glennmackintosh
+@jmm0
+@jtoloff
+@khuang0312
+@leopoldwe
+@lkito
+@mcpalmer1980
+@metagriffin
+@rumia0601
+@tsadama
+@vasiljevic
+@zoldalma999
+Aaron Li (@AaronLi)
+Adam Andrews (@adamandrews1)
+Alice Lia Stapleton (@slimelia)
+Amos Bastian (@amosbastian)
+Andrey Lopukhov (@andreyx86)
+Andy Nguyen (@anguye13)
+Ankith (@ankith26)
+Bill Edwards (@AdditionalPylons)
+Bob Ippolito (@etrepum)
+Caleb Trapp (@cmtrapp02)
+Charles (@charlesej)
+Chris Williams (@williams-c)
+Christian Bender (@christianbender)
+Christian Clauss (@cclauss)
+Christoph Gohlke (@cgohlke)
+Clark Seanor (@cruxicheiros)
+Dan H (@orangudan)
+Dan Lawrence (@MyreMylar)
+Daniel Gillet (@dangillet)
+Daniel Pope (@lordmauve)
+Daniil Kuznetsov (@KuzyWoozy)
+David Lönnhager (@dlon)
+DotMars (@DotMars)
+Evan Kanter (@evank28)
+François Magimel (@Linkid)
+Gabriel Duque (@zuh0)
+Gabriel Moreira (@gabsmoreira)
+Grigoris Tsopouridis (@gtsopus)
+Grigoriy (@flaambe)
+Hobbes (@TLHobbes)
+Ian Mallett (@imallett)
+Ilia Gogotchuri (@Gogotchuri)
+Inada Naoki (@methane)
+Joe Wreschnig (@joewreschnig)
+Josip Komljenović (@MightyJosip)
+Jussi Toivola (@jtoivola)
+K Duggan (@kduggan15)
+Lenard Lindstrom (@llindstrom)
+Lorenz Quack (@donlorenzo)
+Marcus von Appen (@marcusva)
+Marius Gedminas (@mgedmin)
+Mark Hurley (@markph0204)
+Mathieu Virbel (@tito)
+Michael Farrell (@micolous)
+Michał Górny (@mgorny)
+Neil Muller (@drnlm)
+Nguyễn Gia Phong (@McSinyx)
+Nicholas Dudfield (@sublimator)
+Niels Thykier (@nthykier)
+Nihal Mittal (@codescientist703)
+Nirav Patel (@eclecticc)
+Paul V Craven (@pvcraven)
+Pedro de la Peña (@pedrodelapena)
+Peter Shinners (@PeterShinners)
+Pierre Sassoulas (@Pierre-Sassoulas)
+Prasanna Venkatesh (@hanzohasashi33)
+Radomir Dopieralski (@deshipu)
+René Dudfield (@illume)
+Scott Noyes (@snoyes)
+Sebastian Henz (@BastiHz)
+Sett (@sw00)
+Sigurður Sveinn Halldórsson (@siggisv)
+Stefano Rivera (@stefanor)
+Steven Chua (@Graphcalibur)
+Stuart Axon (@stuaxo)
+Thiago Jobson (@thiagojobson)
+Thomas Kluyver (@takluyver)
+Tommy Sparber (@tsparber)
+Travis Chang (@Reminisque)
+Vicent Martí (@vmg)
+Werner Laurensse (@ab3)
+xFly_Dragon (@husano896)


### PR DESCRIPTION
Create a list of all github contributors to pygame. Now this list only includes the people who have contibuted via github, but pygame has received much more contributions in different forms from so many other people. Things like helping people via discord, making helpful videos/books and so many other ways of helping. Sadly, this list does not mention those people, but its a good start 
:) 