### PR TITLE
Makes mixer.music.get_busy() return False when the music is paused

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -154,7 +154,11 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
    | :sg:`get_busy() -> bool`
 
    Returns True when the music stream is actively playing. When the music is
-   idle this returns False. It returns True even if the music is paused.
+   idle this returns False. In pygame 2.0.1 and above this function returns
+   False when the music is paused. In pygame 1 it returns True when the music
+   is paused.
+
+   .. versionchanged:: 2.0.1 Returns False when music paused.
 
    .. ## pygame.mixer.music.get_busy ##
 

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -115,7 +115,7 @@ music_get_busy(PyObject *self, PyObject *args)
     MIXER_INIT_CHECK();
 
     Py_BEGIN_ALLOW_THREADS
-    playing = Mix_PlayingMusic();
+    playing = (Mix_PlayingMusic() && !Mix_PausedMusic());
     Py_END_ALLOW_THREADS
 
     return PyInt_FromLong(playing);

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -288,7 +288,7 @@ class MixerMusicModuleTest(unittest.TestCase):
 
         self.fail()
 
-    def todo_test_get_busy(self):
+    def test_get_busy(self):
 
         # __doc__ (as of 2008-08-02) for pygame.mixer_music.get_busy:
 
@@ -296,7 +296,12 @@ class MixerMusicModuleTest(unittest.TestCase):
         # music is idle this returns False.
         #
 
-        self.fail()
+        self.music_load("ogg")
+        self.assertFalse(pygame.mixer.music.get_busy())
+        pygame.mixer.music.play()
+        self.assertTrue(pygame.mixer.music.get_busy())
+        pygame.mixer.music.pause()
+        self.assertFalse(pygame.mixer.music.get_busy())
 
     def todo_test_get_endevent(self):
 


### PR DESCRIPTION
Fixes #1449 