### PR TITLE
Removes the link to the closed Discord server from GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,3 @@ contact_links:
   - name: 📚 Documentation
     url: https://www.pygame.org/docs/
     about: "If you have a question, please try the documentation first."
-  - name: ❓ Discord
-    url: https://discord.gg/r8yreB6
-    about: "If you can't find the answers you are looking for on the website, try our community Discord."


### PR DESCRIPTION
No sense having a dead link up on the GitHub issues page.