### PR TITLE
Fix pyinstaller hooks for Mac OS

### DIFF
--- a/src_py/__pyinstaller/hook-pygame.py
+++ b/src_py/__pyinstaller/hook-pygame.py
@@ -26,10 +26,10 @@ def _append_to_datas(file_path):
 
 # First append the font file, then based on the OS, append pygame icon file
 _append_to_datas("freesansbold.ttf")
+_append_to_datas("pygame_icon.bmp")
 if platform.system() == "Darwin":
     _append_to_datas("pygame_icon.tiff")
-else:
-    _append_to_datas("pygame_icon.bmp")
+
 
 if platform.system() == "Windows": 
     from PyInstaller.utils.hooks import collect_dynamic_libs


### PR DESCRIPTION
Just a minor fix to ensure that the default pygame icon loads with pyinstaller on Mac OS