### PR TITLE
minor bugfix, image.load load jpeg correctly

### DIFF
--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -192,6 +192,11 @@ image_load_ext(PyObject *self, PyObject *arg)
                 return PyErr_NoMemory();
             }
             strcpy(ext, cext);
+            /* SDL does not accept jpeg extension, since jpg and 
+             * jpeg are the same, do a small replacement */
+            if (ext == "jpeg") {
+                ext = "jpg";
+            }
 #ifdef WITH_THREAD
             lock_mutex = !strcasecmp(ext, "gif");
 #endif /* WITH_THREAD */


### PR DESCRIPTION
related to #1516, but does not fix that issue. Just make sure that loading images with jpeg extension should work as expected (when file-like objects are passed)

Of course, this fix will only work when the other underlying issue is solved