### PR TITLE
text_input on by default, needed for pygame.TEXTINPUT

### DIFF
--- a/docs/reST/ref/key.rst
+++ b/docs/reST/ref/key.rst
@@ -365,11 +365,11 @@ for ``KMOD_NONE``, which should be compared using equals ``==``). For example:
 
 .. function:: start_text_input
 
-   | :sl:`start handling IME compositions`
+   | :sl:`start handling Unicode text input events`
    | :sg:`start_text_input() -> None`
 
    Start receiving ``pygame.TEXTEDITING`` and ``pygame.TEXTINPUT``
-   events to handle IME.
+   events.
 
    A ``pygame.TEXTEDITING`` event is received when an IME composition
    is started or changed. It contains the composition ``text``, ``length``,
@@ -378,7 +378,7 @@ for ``KMOD_NONE``, which should be compared using equals ``==``). For example:
    When the composition is committed (or non-IME input is received),
    a ``pygame.TEXTINPUT`` event is generated.
 
-   Normal ``pygame.TEXTINPUT`` events are not dependent on this.
+   Text input events handling is on by default.
 
    .. versionadded:: 2.0.0
 
@@ -386,13 +386,13 @@ for ``KMOD_NONE``, which should be compared using equals ``==``). For example:
 
 .. function:: stop_text_input
 
-   | :sl:`stop handling IME compositions`
+   | :sl:`stop handling Unicode text input events`
    | :sg:`stop_text_input() -> None`
 
    Stop receiving ``pygame.TEXTEDITING`` and ``pygame.TEXTINPUT``
-   events to handle IME.
+   events.
 
-   Normal ``pygame.TEXTINPUT`` events are not dependent on this.
+   Text input events handling is on by default
 
    .. versionadded:: 2.0.0
 
@@ -405,8 +405,6 @@ for ``KMOD_NONE``, which should be compared using equals ``==``). For example:
 
    This sets the rectangle used for typing with an IME.
    It controls where the candidate list will open, if supported.
-
-   Normal ``pygame.TEXTINPUT`` events are not dependent on this.
 
    .. versionadded:: 2.0.0
 


### PR DESCRIPTION
While trying the new `pygame.TEXTINPUT` events, I found some things in the docs that I thought could be improved...
The pygame docs says that "normal" pygame.TEXTINPUT events are not dependent on `start_text_input()` and `stop_text_input()`, but they are according to the SDL docs. 

> This function will start accepting Unicode text input events in the focused SDL window, and start emitting SDL_TEXTINPUT and SDL_TEXTEDITING events.

https://wiki.libsdl.org/SDL_StartTextInput

Testing shows that normal pygame.TEXTINPUT events will stop when pygame.key.stop_text_input() is called, but the whole SDL TextInput thing is on by default, so there is no need to call start_text_input() for them to work.

Everything also works in the textinput.py example file when pygame.key.start_text_input() is removed.

But I don't understand much about the advanced `TEXTEDITING` / IME stuff... perhaps there's something I missed.

Thanks 😄 