### PR TITLE
Add 'None' as a type option when making freetype fonts

### DIFF
--- a/buildconfig/pygame-stubs/freetype.pyi
+++ b/buildconfig/pygame-stubs/freetype.pyi
@@ -60,7 +60,7 @@ class Font:
     resolution: int
     def __init__(
         self,
-        file: Union[str, IO],
+        file: Union[str, IO, None],
         size: Optional[float] = 0,
         font_index: Optional[int] = 0,
         resolution: Optional[int] = 0,


### PR DESCRIPTION
Noticed this was missing while writing some unit tests using the default font. It matches the pattern used in font.pyi, the behaviour
described in the docs and the actual behaviour.