### PR TITLE
Rejigs the alpha blitter path logic to hopefully cover issue on mac

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -253,13 +253,18 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                             {
                                 alphablit_alpha_sse2_argb_surf_alpha (&info);
                             }
-                            else if (!SDL_ISPIXELFORMAT_ALPHA(dst->format->format))
-                            {
-                                alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(&info);
-                            }
                             else
                             {
-                                alphablit_alpha_sse2_argb_no_surf_alpha (&info);
+                                if (SDL_ISPIXELFORMAT_ALPHA(dst->format->format) &&
+                                    info.dst_blend != SDL_BLENDMODE_NONE)
+                                {
+                                    alphablit_alpha_sse2_argb_no_surf_alpha (&info);
+
+                                }
+                                else
+                                {
+                                    alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(&info);
+                                }
                             }
                             break;
                         }
@@ -268,15 +273,20 @@ SoftBlitPyGame (SDL_Surface * src, SDL_Rect * srcrect, SDL_Surface * dst,
                         if ((SDL_HasSSE2()) && (src != dst)){
                             if (info.src_blanket_alpha != 255)
                             {
-                                 alphablit_alpha_sse2_argb_surf_alpha (&info);
-                            }
-                            else if (!SDL_ISPIXELFORMAT_ALPHA(dst->format->format))
-                            {
-                                alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(&info);
+                                alphablit_alpha_sse2_argb_surf_alpha (&info);
                             }
                             else
                             {
-                                alphablit_alpha_sse2_argb_no_surf_alpha (&info);
+                                if (SDL_ISPIXELFORMAT_ALPHA(dst->format->format) &&
+                                    info.dst_blend != SDL_BLENDMODE_NONE)
+                                {
+                                    alphablit_alpha_sse2_argb_no_surf_alpha (&info);
+
+                                }
+                                else
+                                {
+                                    alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(&info);
+                                }
                             }
                             break;
                         }


### PR DESCRIPTION
This is an experimental, untested PR because I don't have a mac. It was reported that macs had an issue in solarwolf with the shadowed text that wasn't present in 2.0.0. I'm not sure exactly what is the underlying cause but I think rejigging the logic
this way should cover all cases that were caught in 2.0.0 without losing the recent fix. Probably. The surface unit tests pass locally at least.

Hopefully @illume can try this at some point and see if it works.