### PR TITLE
Fix inconsistent-return-statement signaled by pylint

### DIFF
--- a/src_py/_camera_opencv_highgui.py
+++ b/src_py/_camera_opencv_highgui.py
@@ -60,28 +60,19 @@ class Camera:
 
     def get_surface(self, dest_surf=None):
         camera = self.camera
-
         im = highgui.cvQueryFrame(camera)
         #convert Ipl image to PIL image
-        #print type(im)
-        if im:
-            xx = opencv.adaptors.Ipl2NumPy(im)
-            #print type(xx)
-            #print xx.iscontiguous()
-            #print dir(xx)
-            #print xx.shape
-            xxx = numpy.reshape(xx, (numpy.product(xx.shape),))
-
-            if xx.shape[2] != 3:
-                raise ValueError("not sure what to do about this size")
-
-            pg_img = pygame.image.frombuffer(xxx, (xx.shape[1], xx.shape[0]), "RGB")
-
-            # if there is a destination surface given, we blit onto that.
-            if dest_surf:
-                dest_surf.blit(pg_img, (0, 0))
-            return dest_surf
-            #return pg_img
+        if not im:
+            return None
+        xx = opencv.adaptors.Ipl2NumPy(im)
+        xxx = numpy.reshape(xx, (numpy.product(xx.shape),))
+        if xx.shape[2] != 3:
+            raise ValueError("not sure what to do about this size")
+        pg_img = pygame.image.frombuffer(xxx, (xx.shape[1], xx.shape[0]), "RGB")
+        # if there is a destination surface given, we blit onto that.
+        if dest_surf:
+            dest_surf.blit(pg_img, (0, 0))
+        return dest_surf
 
 
 if __name__ == "__main__":

--- a/src_py/_camera_vidcapture.py
+++ b/src_py/_camera_vidcapture.py
@@ -98,19 +98,18 @@ class Camera:
         return self.get_surface(dest_surf)
 
     def get_surface(self, dest_surf=None):
-        """Returns a pygame Surface.
-        """
+        """Returns a pygame Surface."""
         abuffer, width, height = self.get_buffer()
-        if abuffer:
-            surf = pygame.image.frombuffer(abuffer, (width, height), "BGR")
-            surf = pygame.transform.flip(surf, 0, 1)
-
-            # if there is a destination surface given, we blit onto that.
-            if dest_surf:
-                dest_surf.blit(surf, (0, 0))
-            else:
-                dest_surf = surf
-            return dest_surf
+        if not abuffer:
+            return None
+        surf = pygame.image.frombuffer(abuffer, (width, height), "BGR")
+        surf = pygame.transform.flip(surf, 0, 1)
+        # if there is a destination surface given, we blit onto that.
+        if dest_surf:
+            dest_surf.blit(surf, (0, 0))
+        else:
+            dest_surf = surf
+        return dest_surf
 
 if __name__ == "__main__":
     import pygame.examples.camera


### PR DESCRIPTION
Ie: Either all return statements in a function should return an
expression, or none of them should.

This make the fact that functions can return None more apparent.