### PR TITLE
Link to Patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: pygame


### PR DESCRIPTION
I noticed that @illume set up a pygame patreon recently. This commit would put a little "sponsor this project" tab on the side of the github repo, which would just serve to increase the visibility of the patreon.

[skip ci]