### PR TITLE
ENH: Updating TYPE_HEAD Macro to use newer API

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -1745,7 +1745,8 @@ PyObject* camera_getattr(PyObject* self, char* attrname) {
 }
 */
 PyTypeObject pgCamera_Type = {
-    TYPE_HEAD(NULL, 0) "Camera",
+    PyVarObject_HEAD_INIT(NULL,0)
+    "Camera",
     sizeof(pgCameraObject),
     0,
     camera_dealloc,

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -647,7 +647,8 @@ static PyGetSetDef _ftfont_getsets[] = {
 #define FULL_TYPE_NAME MODULE_NAME "." FONT_TYPE_NAME
 
 PyTypeObject pgFont_Type = {
-    TYPE_HEAD(0, 0) FULL_TYPE_NAME,           /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    FULL_TYPE_NAME,                           /* tp_name */
     sizeof(pgFontObject),                     /* tp_basicsize */
     0,                                        /* tp_itemsize */
     (destructor)_ftfont_dealloc,              /* tp_dealloc */

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -647,7 +647,7 @@ static PyGetSetDef _ftfont_getsets[] = {
 #define FULL_TYPE_NAME MODULE_NAME "." FONT_TYPE_NAME
 
 PyTypeObject pgFont_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
+    PyVarObject_HEAD_INIT(0,0)
     FULL_TYPE_NAME,                           /* tp_name */
     sizeof(pgFontObject),                     /* tp_basicsize */
     0,                                        /* tp_itemsize */

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -654,7 +654,8 @@ static PyBufferProcs proxy_bufferprocs = {
 #endif
 
 static PyTypeObject pgBufproxy_Type = {
-    TYPE_HEAD(NULL, 0) PROXY_TYPE_FULLNAME, /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    PROXY_TYPE_FULLNAME,                    /* tp_name */
     sizeof(pgBufproxyObject),               /* tp_basicsize */
     0,                                      /* tp_itemsize */
     (destructor)proxy_dealloc,              /* tp_dealloc */

--- a/src_c/cdrom.c
+++ b/src_c/cdrom.c
@@ -525,7 +525,8 @@ static PyMethodDef cd_methods[] = {
     {NULL, NULL, 0, NULL}};
 
 static PyTypeObject pgCD_Type = {
-    TYPE_HEAD(NULL, 0) "CD", /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "CD",                    /* name */
     sizeof(pgCDObject),      /* basic size */
     0,                       /* itemsize */
     cd_dealloc,              /* dealloc */

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -326,7 +326,8 @@ static PyBufferProcs _color_as_buffer = {
 #define DEFERRED_ADDRESS(ADDR) 0
 
 static PyTypeObject pgColor_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.Color", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.Color",                    /* tp_name */
     sizeof(pgColorObject),             /* tp_basicsize */
     0,                                 /* tp_itemsize */
     (destructor)_color_dealloc,        /* tp_dealloc */

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -399,7 +399,8 @@ pg_vidinfo_str(PyObject *self)
 }
 
 static PyTypeObject pgVidInfo_Type = {
-    TYPE_HEAD(NULL, 0) "VidInfo", /*name*/
+    PyVarObject_HEAD_INIT(NULL,0)
+    "VidInfo",                    /*name*/
     sizeof(pgVidInfoObject),      /*basic size*/
     0,                            /*itemsize*/
     pg_vidinfo_dealloc,           /*dealloc*/

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1170,7 +1170,8 @@ Unimplemented:
 }
 
 static PyTypeObject pgEvent_Type = {
-    TYPE_HEAD(NULL, 0) "Event", /*name*/
+    PyVarObject_HEAD_INIT(NULL,0)
+    "Event",                    /*name*/
     sizeof(pgEventObject),      /*basic size*/
     0,                          /*itemsize*/
     pg_event_dealloc,              /*dealloc*/

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -940,7 +940,8 @@ error:
 }
 
 static PyTypeObject PyFont_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.font.Font",
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.font.Font",
     sizeof(PyFontObject),
     0,
     (destructor)font_dealloc,

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -504,7 +504,8 @@ static PyMethodDef joy_methods[] = {
     {NULL, NULL, 0, NULL}};
 
 static PyTypeObject pgJoystick_Type = {
-    TYPE_HEAD(NULL, 0) "Joystick", /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "Joystick",                    /* name */
     sizeof(pgJoystickObject),      /* basic size */
     0,                             /* itemsize */
     joy_dealloc,                   /* dealloc */

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -127,7 +127,8 @@ pg_scancodewrapper_repr(pgScancodeWrapper *self)
 }
 
 static PyTypeObject pgScancodeWrapper_Type = {
-    TYPE_HEAD(NULL, 0) _PG_SCANCODEWRAPPER_TYPE_FULLNAME, /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    _PG_SCANCODEWRAPPER_TYPE_FULLNAME,            /* name */
     0,                                            /* basic size */
     0,                                            /* itemsize */
     0,                                            /* dealloc */

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2473,7 +2473,8 @@ static PyBufferProcs pgMask_BufferProcs = {
 #endif /* PY3 */
 
 static PyTypeObject pgMask_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.mask.Mask", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.mask.Mask",   /* tp_name */
     sizeof(pgMaskObject), /* tp_basicsize */
     0,                    /* tp_itemsize */
     mask_dealloc,         /* tp_dealloc */

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -2219,7 +2219,8 @@ static PyGetSetDef vector2_getsets[] = {
  ********************************/
 
 static PyTypeObject pgVector2_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.math.Vector2", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.math.Vector2",                    /* tp_name */
     sizeof(pgVector),                         /* tp_basicsize */
     0,                                        /* tp_itemsize */
     /* Methods to implement standard operations */
@@ -3098,7 +3099,8 @@ static PyGetSetDef vector3_getsets[] = {
  ********************************/
 
 static PyTypeObject pgVector3_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.math.Vector3", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.math.Vector3",                    /* tp_name */
     sizeof(pgVector),                         /* tp_basicsize */
     0,                                        /* tp_itemsize */
     /* Methods to implement standard operations */
@@ -3217,7 +3219,8 @@ static PyMethodDef vectoriter_methods[] = {
 };
 
 static PyTypeObject pgVectorIter_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.math.VectorIterator", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.math.VectorIterator",                    /* tp_name */
     sizeof(vectoriter),                              /* tp_basicsize */
     0,                                               /* tp_itemsize */
     (destructor)vectoriter_dealloc,                  /* tp_dealloc */
@@ -3864,7 +3867,8 @@ static PyNumberMethods vector_elementwiseproxy_as_number = {
 };
 
 static PyTypeObject pgVectorElementwiseProxy_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.math.VectorElementwiseProxy", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.math.VectorElementwiseProxy",                    /* tp_name */
     sizeof(vector_elementwiseproxy),                         /* tp_basicsize */
     0,                                                       /* tp_itemsize */
     /* Methods to implement standard operations */

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -990,7 +990,9 @@ sound_dealloc(pgSoundObject *self)
 }
 
 static PyTypeObject pgSound_Type = {
-    TYPE_HEAD(NULL, 0) "Sound", sizeof(pgSoundObject), 0,
+    PyVarObject_HEAD_INIT(NULL,0)
+    "Sound", 
+    sizeof(pgSoundObject), 0,
     (destructor)sound_dealloc, 0, 0, 0, /* setattr */
     0,                                  /* compare */
     0,                                  /* repr */
@@ -1305,7 +1307,8 @@ channel_dealloc(PyObject *self)
 }
 
 static PyTypeObject pgChannel_Type = {
-    TYPE_HEAD(NULL, 0) "Channel", /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "Channel",                    /* name */
     sizeof(pgChannelObject),      /* basic size */
     0,                            /* itemsize */
     channel_dealloc,              /* dealloc */

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -762,7 +762,8 @@ static PyNumberMethods buffer_as_number = {
     (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC)
 
 static PyTypeObject Py_buffer_Type = {
-    TYPE_HEAD(NULL, 0) BUFFER_TYPE_FULLNAME, /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    BUFFER_TYPE_FULLNAME,                    /* tp_name */
     sizeof(BufferObject),                    /* tp_basicsize */
     0,                                       /* tp_itemsize */
     (destructor)buffer_dealloc,              /* tp_dealloc */
@@ -926,7 +927,8 @@ static PyBufferProcs mixin_bufferprocs = {
 #define BUFFER_MIXIN_TYPE_FULLNAME "newbuffer.BufferMixin"
 
 static PyTypeObject BufferMixin_Type = {
-    TYPE_HEAD(NULL, 0) BUFFER_MIXIN_TYPE_FULLNAME, /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    BUFFER_MIXIN_TYPE_FULLNAME,                    /* tp_name */
     sizeof(PyObject),                              /* tp_basicsize */
     0,                                             /* tp_itemsize */
     0,                                             /* tp_dealloc */

--- a/src_c/overlay.c
+++ b/src_c/overlay.c
@@ -173,7 +173,8 @@ static PyMethodDef Overlay_methods[] = {
 };
 
 PyTypeObject PyOverlay_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.overlay",      /*tp_name*/
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.overlay",                         /*tp_name*/
     sizeof(PyGameOverlay),                    /*tp_basicsize*/
     0,                                        /*tp_itemsize*/
     (destructor)overlay_dealloc,              /*tp_dealloc*/

--- a/src_c/pgcompat.h
+++ b/src_c/pgcompat.h
@@ -33,9 +33,6 @@
 #define MODINIT_DEFINE(mod_name) PyMODINIT_FUNC PyInit_##mod_name (void)
 #define DECREF_MOD(mod) Py_DECREF (mod)
 
-/* Type header differs. */
-#define TYPE_HEAD(x,y) PyVarObject_HEAD_INIT(x,y)
-
 /* Text interface. Use unicode strings. */
 #define Text_Type PyUnicode_Type
 #define Text_Check PyUnicode_Check
@@ -93,11 +90,6 @@
 #define MODINIT_RETURN(x) return
 #define MODINIT_DEFINE(mod_name) PyMODINIT_FUNC init##mod_name (void)
 #define DECREF_MOD(mod)
-
-/* Type header differs. */
-#define TYPE_HEAD(x,y)                          \
-    PyObject_HEAD_INIT(x)                       \
-    0,
 
 /* Text interface. Use ascii strings. */
 #define Text_Type PyString_Type

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -288,7 +288,8 @@ static PyBufferProcs _pxarray_bufferprocs = {
 #endif
 
 static PyTypeObject pgPixelArray_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.PixelArray", /* tp_name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.PixelArray",                    /* tp_name */
     sizeof(pgPixelArrayObject),             /* tp_basicsize */
     0,                                      /* tp_itemsize */
     (destructor)_pxarray_dealloc,           /* tp_dealloc */

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -2037,7 +2037,8 @@ static PyGetSetDef pg_rect_getsets[] = {
 };
 
 static PyTypeObject pgRect_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.Rect", /*name*/
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.Rect",                    /*name*/
     sizeof(pgRectObject),             /*basicsize*/
     0,                                /*itemsize*/
     /* methods */

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -393,7 +393,8 @@ static struct PyMethodDef surface_methods[] = {
     {NULL, NULL, 0, NULL}};
 
 static PyTypeObject pgSurface_Type = {
-    TYPE_HEAD(NULL, 0) "pygame.Surface", /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "pygame.Surface",                    /* name */
     sizeof(pgSurfaceObject),             /* basic size */
     0,                                   /* itemsize */
     surface_dealloc,                     /* dealloc */

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -170,7 +170,8 @@ pgSurface_UnlockBy(pgSurfaceObject *surfobj, PyObject *lockobj)
 }
 
 static PyTypeObject pgLifetimeLock_Type = {
-    TYPE_HEAD(NULL, 0) "SurfLifeLock", /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "SurfLifeLock",                    /* name */
     sizeof(pgLifetimeLockObject),      /* basic size */
     0,                                 /* tp_itemsize */
     _lifelock_dealloc,                 /* tp_dealloc*/

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -410,7 +410,8 @@ clock_str(PyObject *self)
 }
 
 static PyTypeObject PyClock_Type = {
-    TYPE_HEAD(NULL, 0) "Clock", /* name */
+    PyVarObject_HEAD_INIT(NULL,0)
+    "Clock",                    /* name */
     sizeof(PyClockObject),      /* basic size */
     0,                          /* itemsize */
     clock_dealloc,              /* dealloc */


### PR DESCRIPTION
Hello,

I'm new to the PyGame community and wanted to help out. 
I followed issue #2208 to update the macro ` TYPE_HEAD` to `PYVAROBJECT_HEAD_INIT` , where the later calls the same named C-API. 

As @MyreMylar suggested, I will let the CI/CD run to see if the conditional on the macro is really needed. If it fails, I will add the conditional in another commit and try again. If it passes then I will go ahead remove the custom Macro and just use the C-API (unless someone tells me this is a bad idea).

I hope this PR ends up helping someone!

fixes #2208 

**UPDATE:**
Appveyor jobs are failing, they appear to all be in windows directories here's an [example output](https://ci.appveyor.com/project/pygame/pygame/builds/36552285/job/5mhe8huasovmm6c8):

So I will make another commit where I add the conditional. And summon the C and Python dieties that be to help.

```
building 'pygame.font' extension
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -Iprebuilt-x86/SDL2-2.0.12/include -Iprebuilt-x86/SDL2_ttf-2.0.15/include -IC:\projects\pygame\pypy2.7-v7.3.2-win32\include /Tcsrc_c/font.c /Fobuild\temp.win32-2.7\Release\src_c/font.obj /GF /Gy
font.c
src_c/font.c(942): error C2099: initializer is not a constant
src_c/font.c(942): warning C4047: 'initializing': 'Py_ssize_t' differs in levels of indirection from 'char [17]'
src_c/font.c(942): warning C4047: 'initializing': 'const char *' differs in levels of indirection from 'unsigned int'
src_c/font.c(942): warning C4047: 'initializing': 'Py_ssize_t' differs in levels of indirection from 'destructor'
src_c/font.c(942): warning C4047: 'initializing': 'PyMappingMethods *' differs in levels of indirection from 'hashfunc'
src_c/font.c(942): warning C4113: 'ternaryfunc' differs in parameter lists from 'hashfunc'
src_c/font.c(942): warning C4047: 'initializing': 'hashfunc' differs in levels of indirection from 'ternaryfunc'
src_c/font.c(942): warning C4113: 'reprfunc' differs in parameter lists from 'ternaryfunc'
src_c/font.c(942): warning C4047: 'initializing': 'PyBufferProcs *' differs in levels of indirection from 'long'
src_c/font.c(942): warning C4047: 'initializing': 'long' differs in levels of indirection from 'char [93]'
src_c/font.c(942): warning C4047: 'initializing': 'richcmpfunc' differs in levels of indirection from 'std::size_t'
src_c/font.c(942): warning C4047: 'initializing': 'iternextfunc' differs in levels of indirection from 'PyMethodDef *'
src_c/font.c(942): warning C4133: 'initializing': incompatible types - from 'PyGetSetDef *' to 'PyMemberDef *'
src_c/font.c(942): warning C4047: 'initializing': 'Py_ssize_t' differs in levels of indirection from 'initproc'
---
```


**UPDATE 2:**
Travis is failing for a reason that appears to be unrelated? 
But Appveyo succeeds. 