### PR TITLE
Pathlib support for most pygame functions

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -46,6 +46,9 @@ typedef struct {
 static const char pg_default_encoding[] = "unicode_escape";
 static const char pg_default_errors[] = "backslashreplace";
 
+#define PATHLIB "pathlib"
+#define PUREPATH "PurePath"
+
 #if IS_SDLv1
 static int
 _pg_rw_seek(SDL_RWops *, int, int);
@@ -160,15 +163,60 @@ fetch_object_methods(pgRWHelper *helper, PyObject *obj)
     return 0;
 }
 
+/* This function is meant to decode a pathlib object into its str/bytes representation.
+ * It is based on PyOS_FSPath, and defines this function on python 3.4, 3.5 */
+static PyObject *
+_trydecode_pathlibobj(PyObject *obj)
+{
+#if PY_VERSION_HEX >= 0x03060000
+    PyObject *ret = PyOS_FSPath(obj);
+    if (!ret) {
+        /* A valid object was not passed. But we do not consider it an error */
+        PyErr_Clear();
+        Py_INCREF(obj);
+        return obj;
+    }
+    return ret;
+#elif PY_VERSION_HEX >= 0x03040000
+    /* Custom implementation for back-compat */
+    int ret;
+    PyObject *pathlib, *purepath;
+
+    pathlib = PyImport_ImportModule(PATHLIB);
+    if (!pathlib)
+        return NULL;
+
+    purepath = PyObject_GetAttrString(pathlib, PUREPATH);
+    if (!purepath) {
+        Py_DECREF(pathlib);
+        return NULL;
+    }
+
+    ret = PyObject_IsInstance(obj, purepath);
+
+    Py_DECREF(pathlib);
+    Py_DECREF(purepath);
+
+    if (ret == 1)
+        return PyObject_Str(obj);
+    else if (ret == 0) {
+        Py_INCREF(obj);
+        return obj;
+    }
+    else
+        return NULL;
+#else
+    /* Pathlib module does not exist, just incref and return */
+    Py_INCREF(obj);
+    return obj;
+#endif
+}
+
 static PyObject *
 pg_EncodeString(PyObject *obj, const char *encoding, const char *errors,
                 PyObject *eclass)
 {
-    PyObject *oencoded;
-    PyObject *exc_type;
-    PyObject *exc_value;
-    PyObject *exc_trace;
-    PyObject *str;
+    PyObject *oencoded, *exc_type, *exc_value, *exc_trace, *str, *ret;
 
     if (obj == NULL) {
         /* Assume an error was raise; forward it */
@@ -180,8 +228,15 @@ pg_EncodeString(PyObject *obj, const char *encoding, const char *errors,
     if (errors == NULL) {
         errors = pg_default_errors;
     }
-    if (PyUnicode_Check(obj)) {
-        oencoded = PyUnicode_AsEncodedString(obj, encoding, errors);
+    
+    ret = _trydecode_pathlibobj(obj);
+    if (!ret)
+        return NULL;
+    
+    if (PyUnicode_Check(ret)) {
+        oencoded = PyUnicode_AsEncodedString(ret, encoding, errors);
+        Py_DECREF(ret);
+
         if (oencoded != NULL) {
             return oencoded;
         }
@@ -215,12 +270,14 @@ pg_EncodeString(PyObject *obj, const char *encoding, const char *errors,
                          " unexpected encoding error");
         }
         PyErr_Clear();
+        Py_RETURN_NONE;
     }
-    else if (Bytes_Check(obj)) {
-        Py_INCREF(obj);
-        return obj;
+    
+    if (Bytes_Check(ret)) {
+        return ret;
     }
 
+    Py_DECREF(ret);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
This PR adds Pathlib support to most pygame functions where a file is taken in as an argument. This includes pygame.image, pygame.mixer, pygame.music, pygame.font, pygame.ftfont and pygame.freetype (basically, wherever the internal function pg_EncodeString is called)
It was a relatively simple addition, yet much needed as many people have asked for this.
There was a previous attempt to do this, but that PR did not work on py 3.5. This PR makes sure it does.

Issues this PR aims to close are #1129 #1635 

Unit tests and docs coming soon :) 