### PR TITLE
Temporarily skip test_sound_args on windows and Appveyor

### DIFF
--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -134,7 +134,7 @@ class MixerModuleTest(unittest.TestCase):
         self.assertRaises(pygame.error, mixer.get_num_channels)
 
     # TODO: FIXME: appveyor fails here sometimes.
-    @unittest.expectedFailure
+    @unittest.skipIf(sys.platform.startswith("win"), "See github issue 892.")
     def test_sound_args(self):
         def get_bytes(snd):
             return snd.get_raw()


### PR DESCRIPTION
Hotfix for #892.