### PR TITLE
Remove 'import pygame._view' in packager_imports.

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -323,7 +323,6 @@ def packager_imports():
     import pygame.macosx
     import pygame.bufferproxy
     import pygame.colordict
-    import pygame._view
 
 # make Rects pickleable
 if PY_MAJOR_VERSION >= 3:


### PR DESCRIPTION
Super minor change.

This is spurred by me removing the old pygame hook on the pyinstaller repo.
Since pygame._view doesn't seem to exist anymore, this line doesn't need to exist. (trying to import it throws a ModuleNotFound)

**Edit:** ugh this doesn't need to run CI, but I don't know how to stop it once it starts.