### PR TITLE
Drop PyLong_FromUnicode, removed in python 3.10 [skip ci]

### DIFF
--- a/src_c/pgcompat.h
+++ b/src_c/pgcompat.h
@@ -12,7 +12,6 @@
 /* Define some aliases for the removed PyInt_* functions */
 #define PyInt_Check(op) PyLong_Check(op)
 #define PyInt_FromString PyLong_FromString
-#define PyInt_FromUnicode PyLong_FromUnicode
 #define PyInt_FromLong PyLong_FromLong
 #define PyInt_FromSize_t PyLong_FromSize_t
 #define PyInt_FromSsize_t PyLong_FromSsize_t


### PR DESCRIPTION
PyLong_FromUnicode will be removed in python 3.10 (which is coming soon).
So we should drop it as well.
See
https://docs.python.org/3.10/whatsnew/3.10.html#id4
