### PR TITLE
docs, tests and types for pathlib support

### DIFF
--- a/buildconfig/pygame-stubs/font.pyi
+++ b/buildconfig/pygame-stubs/font.pyi
@@ -1,5 +1,11 @@
 from typing import List, Optional, Union, Tuple, IO, Hashable, Iterable
 
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+else:
+    AnyPath = Union[Text, bytes]
+
 from pygame.color import Color
 from pygame.surface import Surface
 
@@ -30,7 +36,7 @@ class Font(object):
     italic: bool
     underline: bool
 
-    def __init__(self, name: Union[str, IO, None], size: int) -> None: ...
+    def __init__(self, name: Union[AnyPath, IO, None], size: int) -> None: ...
     def render(
         self,
         text: str,

--- a/buildconfig/pygame-stubs/freetype.pyi
+++ b/buildconfig/pygame-stubs/freetype.pyi
@@ -1,5 +1,11 @@
 from typing import Tuple, Optional, Union, List, Text, IO, Sequence, Any, Iterable
 
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+else:
+    AnyPath = Union[Text, bytes]
+
 from pygame.surface import Surface
 from pygame.color import Color
 from pygame.rect import Rect
@@ -60,7 +66,7 @@ class Font:
     resolution: int
     def __init__(
         self,
-        file: Union[str, IO, None],
+        file: Union[AnyPath, IO, None],
         size: Optional[float] = 0,
         font_index: Optional[int] = 0,
         resolution: Optional[int] = 0,

--- a/buildconfig/pygame-stubs/image.pyi
+++ b/buildconfig/pygame-stubs/image.pyi
@@ -3,13 +3,19 @@ from typing import Optional, Tuple, List, Union, IO, Literal
 from pygame.surface import Surface
 from pygame.bufferproxy import BufferProxy
 
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+else:
+    AnyPath = Union[Text, bytes]
+
 _BufferStyle = Union[BufferProxy, bytes, bytearray, memoryview]
 _to_string_format = Literal['p', 'RGB', 'RGBX', 'RGBA', 'ARGB', 'RGBA_PREMULT', 'ARGB_PREMULT']
 _from_buffer_format = Literal['p', 'RGB', 'BGR', 'RGBX', 'RGBA', 'ARGB']
 _from_string_format = Literal['p', 'RGB', 'RGBX', 'RGBA', 'ARGB']
 
-def load(filename: Union[str, IO], namehint: Optional[str] = "") -> Surface: ...
-def save(surface: Surface, filename: Union[str, IO],
+def load(filename: Union[AnyPath, IO], namehint: Optional[str] = "") -> Surface: ...
+def save(surface: Surface, filename: Union[AnyPath, IO],
         namehint: Optional[str] = "") -> None: ...
 def get_sdl_image_version() -> Union[None, Tuple[int, int, int]]: ...
 def get_extended() -> bool: ...

--- a/buildconfig/pygame-stubs/mixer.pyi
+++ b/buildconfig/pygame-stubs/mixer.pyi
@@ -1,5 +1,11 @@
 from typing import Optional, Union, Tuple, Any, overload, IO
 
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+else:
+    AnyPath = Union[Text, bytes]
+
 from pygame.event import Event
 from . import music as music
 import numpy
@@ -34,7 +40,7 @@ def get_sdl_mixer_version(linked: bool) -> Tuple[int, int, int]: ...
 
 class Sound:
     @overload
-    def __init__(self, file: IO) -> None: ...
+    def __init__(self, file: Union[AnyPath, IO]) -> None: ...
     @overload
     def __init__(self, buffer: Any) -> None: ...  # Buffer protocol is still not implemented in typing
     @overload

--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -137,6 +137,7 @@ loaded instead.
 
    | :sl:`create a new Font object from a file`
    | :sg:`Font(filename, size) -> Font`
+   | :sg:`Font(pathlib.Path, size) -> Font`
    | :sg:`Font(object, size) -> Font`
 
    Load a new font from a given filename or a python file object. The size is

--- a/docs/reST/ref/freetype.rst
+++ b/docs/reST/ref/freetype.rst
@@ -182,6 +182,7 @@ loaded. This module must be imported explicitly to be used. ::
 
    | :sl:`Create a new Font instance from a supported font file.`
    | :sg:`Font(file, size=0, font_index=0, resolution=0, ucs4=False) -> Font`
+   | :sg:`Font(pathlib.Path) -> Font`
 
    Argument *file* can be either a string representing the font's filename, a
    file-like object containing the font, or None; if None, a default,
@@ -293,7 +294,7 @@ loaded. This module must be imported explicitly to be used. ::
           (min_x, max_x, min_y, max_y, horizontal_advance_x, horizontal_advance_y)
 
       The bounding box min_x, max_x, min_y, and max_y values are returned as
-      grid-fitted pixel coordinates of type int. The advance values are 
+      grid-fitted pixel coordinates of type int. The advance values are
       float values.
 
       The calculations are done using the font's default size in points.
@@ -616,7 +617,7 @@ loaded. This module must be imported explicitly to be used. ::
       | :sg:`fixed_sizes -> int`
 
       Read only. Returns the number of point sizes for which the font contains
-      bitmap character images. If zero then the font is not a bitmap font. 
+      bitmap character images. If zero then the font is not a bitmap font.
       A scalable font may contain pre-rendered point sizes as strikes.
 
    .. attribute:: scalable

--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -55,17 +55,6 @@ following formats.
 
 .. versionadded:: 1.8 Saving PNG and JPEG files.
 
-.. function:: load_basic
-
-   | :sl:`load new BMP image from a file (or file-like object)`
-   | :sg:`load_basic(file) -> Surface`
-
-   Load an image from a file source. You can pass either a filename or a Python
-   file-like object.
-
-   This function only supports loading "basic" image format, ie ``BMP``
-   format.
-   This function is always available, no matter how pygame was built.
 
 .. function:: load
 
@@ -73,8 +62,8 @@ following formats.
    | :sg:`load(filename) -> Surface`
    | :sg:`load(fileobj, namehint="") -> Surface`
 
-   Load an image from a file source. You can pass either a filename or a Python
-   file-like object.
+   Load an image from a file source. You can pass either a filename, a Python
+   file-like object, or a pathlib.Path.
 
    Pygame will automatically determine the image type (e.g., ``GIF`` or bitmap)
    and create a new Surface object from the data. In some cases it will need to
@@ -103,23 +92,6 @@ following formats.
 
    .. ## pygame.image.load ##
 
-.. function:: load_extended
-
-   | :sl:`load an image from a file (or file-like object)`
-   | :sg:`load_extended(filename) -> Surface`
-   | :sg:`load_extended(fileobj, namehint="") -> Surface`
-
-   This function is similar to ``pygame.image.load()``, except that this
-   function can only be used if pygame was built with extended image format
-   support.
-
-   From version 2.0.1, this function is always available, but raises an
-   error if extended image formats are not supported. Previously, this
-   function may or may not be available, depending on the state of
-   extended image format support.
-
-   .. versionchanged:: 2.0.1
-
 .. function:: save
 
    | :sl:`save an image to file (or file-like object)`
@@ -129,43 +101,21 @@ following formats.
    This will save your Surface as either a ``BMP``, ``TGA``, ``PNG``, or
    ``JPEG`` image. If the filename extension is unrecognized it will default to
    ``TGA``. Both ``TGA``, and ``BMP`` file formats create uncompressed files.
-   You can pass a filename or a Python file-like object. For file-like object,
-   the image is saved to ``TGA`` format unless a namehint with a recognizable
-   extension is passed in.
-
-   .. note:: To be able to save the ``JPEG`` file format to a file-like object,
-             SDL2_Image version 2.0.2 or newer is needed.
+   You can pass a filename, a pathlib.Path or a Python file-like object.
+   For file-like object, the image is saved to ``TGA`` format unless
+   a namehint with a recognizable extension is passed in.
 
    .. note:: When saving to a file-like object, it seems that for most formats,
              the object needs to be flushed after saving to it to make loading
              from it possible.
 
    .. versionchanged:: 1.8 Saving PNG and JPEG files.
-   .. versionchanged:: 2.0.0.dev11
+   .. versionchanged:: 2.0.0
                        The ``namehint`` parameter was added to make it possible
                        to save other formats than ``TGA`` to a file-like object.
+                       Saving to a file-like object with JPEG is possible.
 
    .. ## pygame.image.save ##
-
-.. function:: save_extended
-
-   | :sl:`save a png/jpg image to file (or file-like object)`
-   | :sg:`save_extended(Surface, filename) -> None`
-   | :sg:`save_extended(Surface, fileobj, namehint="") -> None`
-
-   This will save your Surface as either a ``PNG`` or ``JPEG`` image.
-
-   Incase the image is being saved to a file-like object, this function
-   uses the namehint argument to determine the format of the file being
-   saved. Saves to ``JPEG`` incase the namehint was not specified while
-   saving to file-like object.
-
-   From version 2.0.1, this function is always available, but raises an
-   error if extended image formats are not supported. Previously, this
-   function may or may not be available, depending on the state of
-   extended image format support.
-
-   .. versionchanged:: 2.0.1
 
 .. function:: get_sdl_image_version
 
@@ -177,7 +127,7 @@ following formats.
    return the SDL_Image library's version number as a tuple of 3 integers
    ``(major, minor, patch)``. If not, then it will return ``None``.
 
-   .. versionadded:: 2.0.0.dev11
+   .. versionadded:: 2.0.0
 
    .. ## pygame.image.get_sdl_image_version ##
 
@@ -267,5 +217,60 @@ following formats.
       * ``ARGB``, 32-bit image with alpha channel first
 
    .. ## pygame.image.frombuffer ##
+
+.. function:: load_basic
+
+   | :sl:`load new BMP image from a file (or file-like object)`
+   | :sg:`load_basic(file) -> Surface`
+
+   Load an image from a file source. You can pass either a filename or a Python
+   file-like object, or a pathlib.Path.
+
+   This function only supports loading "basic" image format, ie ``BMP``
+   format.
+   This function is always available, no matter how pygame was built.
+
+   .. ## pygame.image.load_basic ##
+
+.. function:: load_extended
+
+   | :sl:`load an image from a file (or file-like object)`
+   | :sg:`load_extended(filename) -> Surface`
+   | :sg:`load_extended(fileobj, namehint="") -> Surface`
+
+   This function is similar to ``pygame.image.load()``, except that this
+   function can only be used if pygame was built with extended image format
+   support.
+
+   From version 2.0.1, this function is always available, but raises an
+   error if extended image formats are not supported. Previously, this
+   function may or may not be available, depending on the state of
+   extended image format support.
+
+   .. versionchanged:: 2.0.1
+
+   .. ## pygame.image.load_extended ##
+
+.. function:: save_extended
+
+   | :sl:`save a png/jpg image to file (or file-like object)`
+   | :sg:`save_extended(Surface, filename) -> None`
+   | :sg:`save_extended(Surface, fileobj, namehint="") -> None`
+
+   This will save your Surface as either a ``PNG`` or ``JPEG`` image.
+
+   Incase the image is being saved to a file-like object, this function
+   uses the namehint argument to determine the format of the file being
+   saved. Saves to ``JPEG`` incase the namehint was not specified while
+   saving to file-like object.
+
+   .. versionchanged:: 2.0.1
+                       This function is always available, but raises an
+                       error if extended image formats are not supported.
+                       Previously, this function may or may not be
+                       available, depending on the state of extended image
+                       format support.
+
+   .. ## pygame.image.save_extended ##
 
 .. ## pygame.image ##

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -265,6 +265,7 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    | :sl:`Create a new Sound object from a file or buffer object`
    | :sg:`Sound(filename) -> Sound`
    | :sg:`Sound(file=filename) -> Sound`
+   | :sg:`Sound(file=pathlib_path) -> Sound`
    | :sg:`Sound(buffer) -> Sound`
    | :sg:`Sound(buffer=buffer) -> Sound`
    | :sg:`Sound(object) -> Sound`
@@ -299,9 +300,9 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    audio sample size. This will not change.
 
    .. versionadded:: 1.8 ``pygame.mixer.Sound(buffer)``
-
    .. versionadded:: 1.9.2
       :class:`pygame.mixer.Sound` keyword arguments and array interface support
+   .. versionadded:: 2.0.1 pathlib.Path support on Python 3.
 
    .. method:: play
 

--- a/src_c/doc/font_doc.h
+++ b/src_c/doc/font_doc.h
@@ -7,7 +7,7 @@
 #define DOC_PYGAMEFONTGETFONTS "get_fonts() -> list of strings\nget all available fonts"
 #define DOC_PYGAMEFONTMATCHFONT "match_font(name, bold=False, italic=False) -> path\nfind a specific font on the system"
 #define DOC_PYGAMEFONTSYSFONT "SysFont(name, size, bold=False, italic=False) -> Font\ncreate a Font object from the system fonts"
-#define DOC_PYGAMEFONTFONT "Font(filename, size) -> Font\nFont(object, size) -> Font\ncreate a new Font object from a file"
+#define DOC_PYGAMEFONTFONT "Font(filename, size) -> Font\nFont(pathlib.Path, size) -> Font\nFont(object, size) -> Font\ncreate a new Font object from a file"
 #define DOC_FONTBOLD "bold -> bool\nGets or sets whether the font should be rendered in (faked) bold."
 #define DOC_FONTITALIC "italic -> bool\nGets or sets whether the font should be rendered in (faked) italics."
 #define DOC_FONTUNDERLINE "underline -> bool\nGets or sets whether the font should be rendered with an underline."
@@ -63,6 +63,7 @@ create a Font object from the system fonts
 
 pygame.font.Font
  Font(filename, size) -> Font
+ Font(pathlib.Path, size) -> Font
  Font(object, size) -> Font
 create a new Font object from a file
 

--- a/src_c/doc/freetype_doc.h
+++ b/src_c/doc/freetype_doc.h
@@ -11,7 +11,7 @@
 #define DOC_PYGAMEFREETYPESETDEFAULTRESOLUTION "set_default_resolution([resolution])\nSet the default pixel size in dots per inch for the module"
 #define DOC_PYGAMEFREETYPESYSFONT "SysFont(name, size, bold=False, italic=False) -> Font\ncreate a Font object from the system fonts"
 #define DOC_PYGAMEFREETYPEGETDEFAULTFONT "get_default_font() -> string\nGet the filename of the default font"
-#define DOC_PYGAMEFREETYPEFONT "Font(file, size=0, font_index=0, resolution=0, ucs4=False) -> Font\nCreate a new Font instance from a supported font file."
+#define DOC_PYGAMEFREETYPEFONT "Font(file, size=0, font_index=0, resolution=0, ucs4=False) -> Font\nFont(pathlib.Path) -> Font\nCreate a new Font instance from a supported font file."
 #define DOC_FONTNAME "name -> string\nProper font name."
 #define DOC_FONTPATH "path -> unicode\nFont file path"
 #define DOC_FONTSIZE "size -> float\nsize -> (float, float)\nThe default point size used in rendering"
@@ -106,6 +106,7 @@ Get the filename of the default font
 
 pygame.freetype.Font
  Font(file, size=0, font_index=0, resolution=0, ucs4=False) -> Font
+ Font(pathlib.Path) -> Font
 Create a new Font instance from a supported font file.
 
 pygame.freetype.Font.name

--- a/src_c/doc/image_doc.h
+++ b/src_c/doc/image_doc.h
@@ -1,15 +1,15 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEIMAGE "pygame module for image transfer"
-#define DOC_PYGAMEIMAGELOADBASIC "load_basic(file) -> Surface\nload new BMP image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGELOAD "load(filename) -> Surface\nload(fileobj, namehint="") -> Surface\nload new image from a file (or file-like object)"
-#define DOC_PYGAMEIMAGELOADEXTENDED "load_extended(filename) -> Surface\nload_extended(fileobj, namehint="") -> Surface\nload an image from a file (or file-like object)"
 #define DOC_PYGAMEIMAGESAVE "save(Surface, filename) -> None\nsave(Surface, fileobj, namehint="") -> None\nsave an image to file (or file-like object)"
-#define DOC_PYGAMEIMAGESAVEEXTENDED "save_extended(Surface, filename) -> None\nsave_extended(Surface, fileobj, namehint="") -> None\nsave a png/jpg image to file (or file-like object)"
 #define DOC_PYGAMEIMAGEGETSDLIMAGEVERSION "get_sdl_image_version() -> None\nget_sdl_image_version() -> (major, minor, patch)\nget version number of the SDL_Image library being used"
 #define DOC_PYGAMEIMAGEGETEXTENDED "get_extended() -> bool\ntest if extended image formats can be loaded"
 #define DOC_PYGAMEIMAGETOSTRING "tostring(Surface, format, flipped=False) -> string\ntransfer image to string buffer"
 #define DOC_PYGAMEIMAGEFROMSTRING "fromstring(string, size, format, flipped=False) -> Surface\ncreate new Surface from a string buffer"
 #define DOC_PYGAMEIMAGEFROMBUFFER "frombuffer(bytes, size, format) -> Surface\ncreate a new Surface that shares data inside a bytes buffer"
+#define DOC_PYGAMEIMAGELOADBASIC "load_basic(file) -> Surface\nload new BMP image from a file (or file-like object)"
+#define DOC_PYGAMEIMAGELOADEXTENDED "load_extended(filename) -> Surface\nload_extended(fileobj, namehint="") -> Surface\nload an image from a file (or file-like object)"
+#define DOC_PYGAMEIMAGESAVEEXTENDED "save_extended(Surface, filename) -> None\nsave_extended(Surface, fileobj, namehint="") -> None\nsave a png/jpg image to file (or file-like object)"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -19,29 +19,15 @@
 pygame.image
 pygame module for image transfer
 
-pygame.image.load_basic
- load_basic(file) -> Surface
-load new BMP image from a file (or file-like object)
-
 pygame.image.load
  load(filename) -> Surface
  load(fileobj, namehint="") -> Surface
 load new image from a file (or file-like object)
 
-pygame.image.load_extended
- load_extended(filename) -> Surface
- load_extended(fileobj, namehint="") -> Surface
-load an image from a file (or file-like object)
-
 pygame.image.save
  save(Surface, filename) -> None
  save(Surface, fileobj, namehint="") -> None
 save an image to file (or file-like object)
-
-pygame.image.save_extended
- save_extended(Surface, filename) -> None
- save_extended(Surface, fileobj, namehint="") -> None
-save a png/jpg image to file (or file-like object)
 
 pygame.image.get_sdl_image_version
  get_sdl_image_version() -> None
@@ -63,5 +49,19 @@ create new Surface from a string buffer
 pygame.image.frombuffer
  frombuffer(bytes, size, format) -> Surface
 create a new Surface that shares data inside a bytes buffer
+
+pygame.image.load_basic
+ load_basic(file) -> Surface
+load new BMP image from a file (or file-like object)
+
+pygame.image.load_extended
+ load_extended(filename) -> Surface
+ load_extended(fileobj, namehint="") -> Surface
+load an image from a file (or file-like object)
+
+pygame.image.save_extended
+ save_extended(Surface, filename) -> None
+ save_extended(Surface, fileobj, namehint="") -> None
+save a png/jpg image to file (or file-like object)
 
 */

--- a/src_c/doc/key_doc.h
+++ b/src_c/doc/key_doc.h
@@ -8,8 +8,8 @@
 #define DOC_PYGAMEKEYGETREPEAT "get_repeat() -> (delay, interval)\nsee how held keys are repeated"
 #define DOC_PYGAMEKEYNAME "name(key) -> string\nget the name of a key identifier"
 #define DOC_PYGAMEKEYKEYCODE "key_code(name=string) -> int\nget the key identifier from a key name"
-#define DOC_PYGAMEKEYSTARTTEXTINPUT "start_text_input() -> None\nstart handling IME compositions"
-#define DOC_PYGAMEKEYSTOPTEXTINPUT "stop_text_input() -> None\nstop handling IME compositions"
+#define DOC_PYGAMEKEYSTARTTEXTINPUT "start_text_input() -> None\nstart handling Unicode text input events"
+#define DOC_PYGAMEKEYSTOPTEXTINPUT "stop_text_input() -> None\nstop handling Unicode text input events"
 #define DOC_PYGAMEKEYSETTEXTINPUTRECT "set_text_input_rect(Rect) -> None\ncontrols the position of the candidate list"
 
 
@@ -56,11 +56,11 @@ get the key identifier from a key name
 
 pygame.key.start_text_input
  start_text_input() -> None
-start handling IME compositions
+start handling Unicode text input events
 
 pygame.key.stop_text_input
  stop_text_input() -> None
-stop handling IME compositions
+stop handling Unicode text input events
 
 pygame.key.set_text_input_rect
  set_text_input_rect(Rect) -> None

--- a/src_c/doc/mixer_doc.h
+++ b/src_c/doc/mixer_doc.h
@@ -14,7 +14,7 @@
 #define DOC_PYGAMEMIXERFINDCHANNEL "find_channel(force=False) -> Channel\nfind an unused channel"
 #define DOC_PYGAMEMIXERGETBUSY "get_busy() -> bool\ntest if any sound is being mixed"
 #define DOC_PYGAMEMIXERGETSDLMIXERVERSION "get_sdl_mixer_version() -> (major, minor, patch)\nget_sdl_mixer_version(linked=True) -> (major, minor, patch)\nget the mixer's SDL version"
-#define DOC_PYGAMEMIXERSOUND "Sound(filename) -> Sound\nSound(file=filename) -> Sound\nSound(buffer) -> Sound\nSound(buffer=buffer) -> Sound\nSound(object) -> Sound\nSound(file=object) -> Sound\nSound(array=object) -> Sound\nCreate a new Sound object from a file or buffer object"
+#define DOC_PYGAMEMIXERSOUND "Sound(filename) -> Sound\nSound(file=filename) -> Sound\nSound(file=pathlib_path) -> Sound\nSound(buffer) -> Sound\nSound(buffer=buffer) -> Sound\nSound(object) -> Sound\nSound(file=object) -> Sound\nSound(array=object) -> Sound\nCreate a new Sound object from a file or buffer object"
 #define DOC_SOUNDPLAY "play(loops=0, maxtime=0, fade_ms=0) -> Channel\nbegin sound playback"
 #define DOC_SOUNDSTOP "stop() -> None\nstop sound playback"
 #define DOC_SOUNDFADEOUT "fadeout(time) -> None\nstop sound playback after fading out"
@@ -106,6 +106,7 @@ get the mixer's SDL version
 pygame.mixer.Sound
  Sound(filename) -> Sound
  Sound(file=filename) -> Sound
+ Sound(file=pathlib_path) -> Sound
  Sound(buffer) -> Sound
  Sound(buffer=buffer) -> Sound
  Sound(object) -> Sound

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -5,6 +5,11 @@ import os
 import unittest
 import platform
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
+
 import pygame
 from pygame import font as pygame_font  # So font can be replaced with ftfont
 from pygame.compat import as_unicode, unicode_, as_bytes, xrange_, filesystem_errors
@@ -483,6 +488,14 @@ class FontTypeTest(unittest.TestCase):
             os.path.split(pygame.__file__)[0], pygame_font.get_default_font()
         )
         f = pygame_font.Font(font_path, 20)
+
+    @unittest.skipIf(pathlib is None, "no pathlib")
+    def test_load_from_pathlib(self):
+        font_name = pygame_font.get_default_font()
+        font_path = os.path.join(
+            os.path.split(pygame.__file__)[0], pygame_font.get_default_font()
+        )
+        f = pygame_font.Font(pathlib.Path(font_path), 20)
 
     def test_load_from_file_obj(self):
         font_name = pygame_font.get_default_font()

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -10,6 +10,11 @@ import weakref
 import gc
 import platform
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
+
 IS_PYPY = "PyPy" == platform.python_implementation()
 
 
@@ -1728,6 +1733,10 @@ class FreeTypeFontTest(unittest.TestCase):
         names = [fonts[0], fonts_b[1], fonts[2], fonts_b[3]]
         font_name_2 = ft.SysFont(names, size).name
         self.assertEqual(font_name_2, font_name)
+
+    @unittest.skipIf(pathlib is None, "no pathlib")
+    def test_pathlib(self):
+        f = ft.Font(pathlib.Path(self._fixed_path), 20)
 
 
 class FreeTypeTest(unittest.TestCase):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -13,6 +13,12 @@ import pygame, pygame.image, pygame.pkgdata
 from pygame.compat import xrange_, ord_, unicode_
 
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
+
+
 def test_magic(f, magic_hexes):
     """Tests a given file to see if the magic hex matches."""
     data = f.read(len(magic_hexes))
@@ -786,10 +792,10 @@ class ImageModuleTest(unittest.TestCase):
 
     def test_load_basic(self):
         """to see if we can load bmp from files and/or file-like objects in memory"""
-        
+
         # pygame.image.load(filename): return Surface
 
-        
+
         # test loading from a file
         s = pygame.image.load_basic(example_path("data/asprite.bmp"))
         self.assertEqual(s.get_at((0,0)),(255,255,255,255))
@@ -803,36 +809,46 @@ class ImageModuleTest(unittest.TestCase):
         self.assertEqual(surf.get_at((0, 0)), (5, 4, 5, 255))
         self.assertEqual(surf.get_height(), 32)
         self.assertEqual(surf.get_width(), 32)
-        
+
         f.close()
 
     def test_load_extended(self):
+        """can load different format images.
 
-        # __doc__ (as of 2008-08-02) for pygame.image.load_extended:
+        We test loading the following file types:
+            bmp, png, jpg, gif (non-animated), tga (uncompressed), tif, xpm, ppm, pgm.
+        All the loaded images are smaller than 32 x 32 pixels.
+        """
 
-        # pygame module for image transfer
+        filename_expected_color = [
+            ("asprite.bmp", (255, 255, 255, 255)),
+             ("laplacian.png", (10, 10, 70, 255)),
+             ("red.jpg", (254, 0, 0, 255)),
+             ("blue.gif", (0, 0, 255, 255)),
+             ("green.pcx", (0, 255, 0, 255)),
+             ("yellow.tga", (255, 255, 0, 255)),
+             ("turquoise.tif", (0, 255, 255, 255)),
+             ("purple.xpm", (255, 0, 255, 255)),
+             ("black.ppm", (0, 0, 0, 255)),
+             ("grey.pgm", (120, 120, 120, 255))
+        ]
 
-        #We test loading the following file types: bmp, png, jpg, gif (non-animated), tga (uncompressed), tif, xpm, ppm, pgm.
-        #All the loaded images are smaller than 32 x 32 pixels.
+        for filename, expected_color in filename_expected_color:
+            with self.subTest(
+                "Test loading a " + filename[-3:],
+                filename="examples/data/" + filename,
+                expected_color=expected_color
+            ):
+                surf = pygame.image.load_extended(example_path("data/" + filename))
+                self.assertEqual(surf.get_at((0, 0)), expected_color)
 
-        #The list of tests that are executed, with filename and expected color.
-        tests = [("asprite.bmp", (255, 255, 255, 255)),
-                 ("laplacian.png", (10, 10, 70, 255)),
-                 ("red.jpg", (254, 0, 0, 255)),
-                 ("blue.gif", (0, 0, 255, 255)),
-                 ("green.pcx", (0, 255, 0, 255)),
-                 ("yellow.tga", (255, 255, 0, 255)),
-                 ("turquoise.tif", (0, 255, 255, 255)),
-                 ("purple.xpm", (255, 0, 255, 255)),
-                 ("black.ppm", (0, 0, 0, 255)),
-                 ("grey.pgm", (120, 120, 120, 255))]
-
-        for test in tests:
-            #We use subTest to make sure all we go through all the tests, even if one fails.
-            with self.subTest("Test loading a " + test[0][-3:], filename="examples/data/" + test[0], expected_color=test[1]):
-                s = pygame.image.load_extended(example_path("data/" + test[0]))
-                self.assertEqual(s.get_at((0, 0)), test[1])
-        
+    @unittest.skipIf(pathlib is None, "no pathlib")
+    def test_load_pathlib(self):
+        """ works loading using a Path argument.
+        """
+        path = pathlib.Path(example_path("data/asprite.bmp"))
+        surf = pygame.image.load_extended(path)
+        self.assertEqual(surf.get_at((0, 0)), (255, 255, 255, 255))
 
     def test_save_extended(self):
         surf = pygame.Surface((5, 5))

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -284,6 +284,21 @@ class ImageModuleTest(unittest.TestCase):
             # clean up the temp file, even if test fails
             os.remove(temp_filename)
 
+    @unittest.skipIf(pathlib is None, "no pathlib")
+    def test_save_pathlib(self):
+        surf = pygame.Surface((1, 1))
+        surf.fill((23, 23, 23))
+        with tempfile.NamedTemporaryFile(suffix=".tga", delete=False) as f:
+            temp_filename = f.name
+
+        path = pathlib.Path(temp_filename)
+        try:
+            pygame.image.save(surf, path)
+            s2 = pygame.image.load(path)
+            self.assertEqual(s2.get_at((0, 0)), surf.get_at((0, 0)))
+        finally:
+            os.remove(temp_filename)
+
     def test_save__to_fileobject_w_namehint_argument(self):
         s = pygame.Surface((10, 10))
         s.fill((23, 23, 23))

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -11,6 +11,10 @@ import pygame
 from pygame import mixer
 from pygame.compat import unicode_, as_bytes, bytes_
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
 
 IS_PYPY = "PyPy" == platform.python_implementation()
 
@@ -936,6 +940,15 @@ class SoundTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
         sound = mixer.Sound(sound_obj)
 
         self.assertIsInstance(sound, mixer.Sound)
+
+    @unittest.skipIf(pathlib is None, "no pathlib")
+    def test_sound__from_pathlib(self):
+        """Ensure Sound() creation with a pathlib.Path object works."""
+        path = pathlib.Path(example_path(os.path.join("data", "house_lo.wav")))
+        sound1 = mixer.Sound(path)
+        sound2 = mixer.Sound(file=path)
+        self.assertIsInstance(sound1, mixer.Sound)
+        self.assertIsInstance(sound2, mixer.Sound)
 
     def todo_test_sound__from_buffer(self):
         """Ensure Sound() creation with a buffer works."""


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/1129

Updates some docs, tests and types for PathLike support.

- [x] test_image load/save
- [x] image.rst docs
- [x] image.pyi typing
- [x] test Sound 
- [x] mixer.pyi typing
- [x] font.pyi typing
- [x] freetype.pyi typing
