### PR TITLE
Stop using GL_CONTEXT_RELEASE_BEHAVIOR (crash on mac).

### DIFF
--- a/test/display_test.py
+++ b/test/display_test.py
@@ -239,76 +239,91 @@ class DisplayModuleTest(unittest.TestCase):
 
     @unittest.skipIf(
         os.environ.get("SDL_VIDEODRIVER") == "dummy",
-        'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',)
+        'OpenGL requires a non-"dummy" SDL_VIDEODRIVER',
+    )
     def test_gl_get_attribute(self):
 
-        # __doc__ (as of 2008-08-02) for pygame.display.gl_get_attribute:
+        screen = display.set_mode((0, 0), pygame.OPENGL)
 
-        #@@ -200,9 +206,65 @@ def todo_test_gl_get_attribute(self):
-        # attributes. See pygame.display.gl_set_attribute() for a list of
-        # valid flags.
-        #
-        # call set_mode with OPENGL flag
-        screen = display.set_mode((0,0), pygame.OPENGL)
-
-        # We create a list where we store the original values of the flags before setting them with a different value
-        original_values=[]
+        # We create a list where we store the original values of the
+        # flags before setting them with a different value.
+        original_values = []
 
         original_values.append(pygame.display.gl_get_attribute(pygame.GL_ALPHA_SIZE))
         original_values.append(pygame.display.gl_get_attribute(pygame.GL_DEPTH_SIZE))
         original_values.append(pygame.display.gl_get_attribute(pygame.GL_STENCIL_SIZE))
-        original_values.append(pygame.display.gl_get_attribute(pygame.GL_ACCUM_RED_SIZE))
-        original_values.append(pygame.display.gl_get_attribute(pygame.GL_ACCUM_GREEN_SIZE))
-        original_values.append(pygame.display.gl_get_attribute(pygame.GL_ACCUM_BLUE_SIZE))
-        original_values.append(pygame.display.gl_get_attribute(pygame.GL_ACCUM_ALPHA_SIZE))
-        original_values.append(pygame.display.gl_get_attribute(pygame.GL_MULTISAMPLEBUFFERS))
-        original_values.append(pygame.display.gl_get_attribute(pygame.GL_MULTISAMPLESAMPLES))
+        original_values.append(
+            pygame.display.gl_get_attribute(pygame.GL_ACCUM_RED_SIZE)
+        )
+        original_values.append(
+            pygame.display.gl_get_attribute(pygame.GL_ACCUM_GREEN_SIZE)
+        )
+        original_values.append(
+            pygame.display.gl_get_attribute(pygame.GL_ACCUM_BLUE_SIZE)
+        )
+        original_values.append(
+            pygame.display.gl_get_attribute(pygame.GL_ACCUM_ALPHA_SIZE)
+        )
+        original_values.append(
+            pygame.display.gl_get_attribute(pygame.GL_MULTISAMPLEBUFFERS)
+        )
+        original_values.append(
+            pygame.display.gl_get_attribute(pygame.GL_MULTISAMPLESAMPLES)
+        )
         original_values.append(pygame.display.gl_get_attribute(pygame.GL_STEREO))
 
-
-        if(SDL2):
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_ACCELERATED_VISUAL))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MAJOR_VERSION))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MINOR_VERSION))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_FLAGS))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_PROFILE_MASK))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_SHARE_WITH_CURRENT_CONTEXT))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_RELEASE_BEHAVIOR))
-            original_values.append(pygame.display.gl_get_attribute(pygame.GL_FRAMEBUFFER_SRGB_CAPABLE))
-
+        if SDL2:
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_ACCELERATED_VISUAL)
+            )
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MAJOR_VERSION)
+            )
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MINOR_VERSION)
+            )
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_FLAGS)
+            )
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_PROFILE_MASK)
+            )
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_SHARE_WITH_CURRENT_CONTEXT)
+            )
+            original_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_FRAMEBUFFER_SRGB_CAPABLE)
+            )
 
         # Setting the flags with values supposedly different from the original values
 
         # assign SDL1-supported values with gl_set_attribute
-        pygame.display.gl_set_attribute(pygame.GL_ALPHA_SIZE,8)
-        pygame.display.gl_set_attribute(pygame.GL_DEPTH_SIZE,24)
-        pygame.display.gl_set_attribute(pygame.GL_STENCIL_SIZE,8)
-        pygame.display.gl_set_attribute(pygame.GL_ACCUM_RED_SIZE,16)
-        pygame.display.gl_set_attribute(pygame.GL_ACCUM_GREEN_SIZE,16)
-        pygame.display.gl_set_attribute(pygame.GL_ACCUM_BLUE_SIZE,16)
-        pygame.display.gl_set_attribute(pygame.GL_ACCUM_ALPHA_SIZE,16)
-        pygame.display.gl_set_attribute(pygame.GL_MULTISAMPLEBUFFERS,1)
-        pygame.display.gl_set_attribute(pygame.GL_MULTISAMPLESAMPLES,1)
-        pygame.display.gl_set_attribute(pygame.GL_STEREO,0)
+        pygame.display.gl_set_attribute(pygame.GL_ALPHA_SIZE, 8)
+        pygame.display.gl_set_attribute(pygame.GL_DEPTH_SIZE, 24)
+        pygame.display.gl_set_attribute(pygame.GL_STENCIL_SIZE, 8)
+        pygame.display.gl_set_attribute(pygame.GL_ACCUM_RED_SIZE, 16)
+        pygame.display.gl_set_attribute(pygame.GL_ACCUM_GREEN_SIZE, 16)
+        pygame.display.gl_set_attribute(pygame.GL_ACCUM_BLUE_SIZE, 16)
+        pygame.display.gl_set_attribute(pygame.GL_ACCUM_ALPHA_SIZE, 16)
+        pygame.display.gl_set_attribute(pygame.GL_MULTISAMPLEBUFFERS, 1)
+        pygame.display.gl_set_attribute(pygame.GL_MULTISAMPLESAMPLES, 1)
+        pygame.display.gl_set_attribute(pygame.GL_STEREO, 0)
 
         # assign SDL2-supported values with gl_set_attribute (if applicable)
-        if(SDL2):
-            pygame.display.gl_set_attribute(pygame.GL_ACCELERATED_VISUAL,0)
-            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_MAJOR_VERSION,1)
-            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_MINOR_VERSION,1)
+        if SDL2:
+            pygame.display.gl_set_attribute(pygame.GL_ACCELERATED_VISUAL, 0)
+            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_MAJOR_VERSION, 1)
+            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_MINOR_VERSION, 1)
             pygame.display.gl_set_attribute(pygame.GL_CONTEXT_FLAGS, 0)
-            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_PROFILE_MASK,0)
-            pygame.display.gl_set_attribute(pygame.GL_SHARE_WITH_CURRENT_CONTEXT,0)
-            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_RELEASE_BEHAVIOR,1)
-            pygame.display.gl_set_attribute(pygame.GL_FRAMEBUFFER_SRGB_CAPABLE,0)
+            pygame.display.gl_set_attribute(pygame.GL_CONTEXT_PROFILE_MASK, 0)
+            pygame.display.gl_set_attribute(pygame.GL_SHARE_WITH_CURRENT_CONTEXT, 0)
+            pygame.display.gl_set_attribute(pygame.GL_FRAMEBUFFER_SRGB_CAPABLE, 0)
 
         # We create a list where we store the values that we set each flag to
-        set_values=[8,24,8,16,16,16,16,1,1,0,0,1,1,0,0,0,1,0]
-
+        set_values = [8, 24, 8, 16, 16, 16, 16, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0]
 
         # We create a list where we store the values after getting them
-        get_values=[]
-
+        get_values = []
 
         get_values.append(pygame.display.gl_get_attribute(pygame.GL_ALPHA_SIZE))
         get_values.append(pygame.display.gl_get_attribute(pygame.GL_DEPTH_SIZE))
@@ -321,25 +336,34 @@ class DisplayModuleTest(unittest.TestCase):
         get_values.append(pygame.display.gl_get_attribute(pygame.GL_MULTISAMPLESAMPLES))
         get_values.append(pygame.display.gl_get_attribute(pygame.GL_STEREO))
 
-
-        if(SDL2):
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_ACCELERATED_VISUAL))
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MAJOR_VERSION))
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MINOR_VERSION))
+        if SDL2:
+            get_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_ACCELERATED_VISUAL)
+            )
+            get_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MAJOR_VERSION)
+            )
+            get_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_MINOR_VERSION)
+            )
             get_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_FLAGS))
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_PROFILE_MASK))
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_SHARE_WITH_CURRENT_CONTEXT))
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_CONTEXT_RELEASE_BEHAVIOR))
-            get_values.append(pygame.display.gl_get_attribute(pygame.GL_FRAMEBUFFER_SRGB_CAPABLE))
+            get_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_CONTEXT_PROFILE_MASK)
+            )
+            get_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_SHARE_WITH_CURRENT_CONTEXT)
+            )
+            get_values.append(
+                pygame.display.gl_get_attribute(pygame.GL_FRAMEBUFFER_SRGB_CAPABLE)
+            )
 
-
-        # We check to see if the values that we get correspond to the values that we set them to or to the original values
+        # We check to see if the values that we get correspond to the values that we set
+        # them to or to the original values.
         for i in range(len(original_values)):
-            self.assertTrue((get_values[i]==original_values[i]) or (get_values[i]==set_values[i]))
-
-        # test using dummy flag argument
-        with self.assertRaises(AttributeError):
-            pygame.display.gl_get_attribute(pygame.DUMMY)
+            self.assertTrue(
+                (get_values[i] == original_values[i])
+                or (get_values[i] == set_values[i])
+            )
 
         # test using non-flag argument
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Reformat test with black.

A quick fix, because it was raising an error on a local machine (but passing on CI).