### PR TITLE
Fix a few issues with draw.rect()

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -843,6 +843,7 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
     Uint8 rgba[4];
     Uint32 color;
     int t, l, b, r, width = 0, radius = 0; /* Default values. */
+    int x, y, w, h; /* Fields for the rounded rect draw to "normalize" into */
     int top_left_radius = -1, top_right_radius = -1, bottom_left_radius = -1,
         bottom_right_radius = -1;
 #if IS_SDLv2
@@ -886,12 +887,13 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
     if (width < 0) {
         return pgRect_New4(rect->x, rect->y, 0, 0);
     }
-    if (width > rect->w / 2 || width > rect->h / 2) {
-        width = MAX(rect->w / 2, rect->h / 2);
-    }
 
-    if (radius <= 0 && top_left_radius <= 0 && top_right_radius <= 0 &&
-        bottom_left_radius <= 0 && bottom_right_radius <= 0) {
+    /* If there isn't any rounded rect-ness OR the rect is really thin in one direction.
+       The "really thin in one direction" check is necessary because draw_round_rect
+       fails (draws something bad) on rects with a dimension that is 0 or 1 pixels across.*/
+    if ((radius <= 0 && top_left_radius <= 0 && top_right_radius <= 0 &&
+        bottom_left_radius <= 0 && bottom_right_radius <= 0) || 
+        abs(rect->w) < 2 || abs(rect->h) < 2) {
 #if IS_SDLv2
         if(width > 0){
             l = rect->x;
@@ -953,8 +955,29 @@ rect(PyObject *self, PyObject *args, PyObject *kwargs)
         if (!pgSurface_Lock(surfobj)) {
             return RAISE(PyExc_RuntimeError, "error locking surface");
         }
-        draw_round_rect(surf, rect->x, rect->y, rect->x + rect->w - 1,
-                        rect->y + rect->h - 1, radius, width, color,
+
+        /* Little bit to normalize the rect: this matters for the rounded
+           rects, despite not mattering for the normal rects. */
+        x = rect->x;
+        y = rect->y;
+        w = rect->w;
+        h = rect->h;
+
+        if (w < 0) {
+            x += w;
+            w = -w;
+        }
+
+        if (h < 0) {
+            y += h;
+            h = -h;
+        }
+
+        if (width > w / 2 || width > h / 2) {
+            width = MAX(w / 2, h / 2);
+        }
+
+        draw_round_rect(surf, x, y, x + w - 1, y + h - 1, radius, width, color,
                         top_left_radius, top_right_radius, bottom_left_radius,
                         bottom_right_radius, drawn_area);
         if (!pgSurface_Unlock(surfobj)) {


### PR DESCRIPTION
Fixes #2359, Fixes #2245 

In pygame 2, there is an issue where rects draw like this:
![2359ex1](https://user-images.githubusercontent.com/46412508/102707962-4bb87d00-4254-11eb-99e1-e158bfd8d9c9.png)
Or even not draw at all, if the rect has negative width or height.

I tracked this back to 2.0.0.dev8, the first version where this issue appears. (The same version as rounded rects were added).

The reason for this was this bit of code in draw.c (https://github.com/pygame/pygame/blob/main/src_c/draw.c#L908:L910):
```
    if (width > rect->w / 2 || width > rect->h / 2) {
        width = MAX(rect->w / 2, rect->h / 2);
    }
```
This bit of code really messes up the draw width of rectangles, usually evident with thin rectangles or ones with negative dimensions. (Especially with negative dimensions, since there isn't any `abs()` on it).

I tracked down the commit that added this in #1503, and I found out that this is actually for the rounded_rect function, which was merged into the normal rect draw function, usable through keyword arguments. However when the two functions were merged this code chunk got added so that it affected all rects, not just ones that were going to be drawn rounded.

So I fixed the reported issues by moving the above chunk of code into the conditional for drawing rounded rects.

But then I thought I have such a nice rect benchmark by dr0id - I should set it up to draw rounded rects.
![2359-ex2](https://user-images.githubusercontent.com/46412508/102708128-7bb45000-4255-11eb-89ff-af5300d257ac.PNG)

Turns out the rounded rect drawing was failing with negative width or negative height dimensions, so I set up some code to normalize the rects in the rounded rect draw.

The rounded rect drawing also fails on very thin rectangles. (See the normalized ones that are showing up as huge squares, like <rect(190, 433, 50, 1)>. I fixed this by only drawing a rect using the rounded rect code when it has a border_radius (or any variant) and it has a thickness on the x and y axis of 2 or more. (That threshold may seem arbitrary: but it's legit. Rects with an x/y dimension that equals 2 draw properly, those with dimensions that equal 0 or 1 draw improperly.)

Result:
![2359-ex3](https://user-images.githubusercontent.com/46412508/102708240-5e33b600-4256-11eb-802e-b99182b682bd.PNG)
