### PR TITLE
fix IME placement in SCALED mode

### DIFF
--- a/src_c/key.c
+++ b/src_c/key.c
@@ -815,16 +815,20 @@ key_set_text_input_rect(PyObject *self, PyObject *obj)
         return RAISE(PyExc_TypeError, "Invalid rect argument");
 
     if (sdlRenderer!=NULL){
-        SDL_Rect vprect;
+        SDL_Rect vprect, rect2;
+	/* new rect so we do not overwrite the input rect */
 	float scalex, scaley;
 
 	SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
 	SDL_RenderGetViewport(sdlRenderer, &vprect);
 
-	rect->x = (int)(rect->x * scalex + vprect.x);
-	rect->y = (int)(rect->y * scaley + vprect.y);
-	rect->w = (int)(rect->w * scalex);
-	rect->h = (int)(rect->h * scaley);
+	rect2.x = (int)(rect->x * scalex + vprect.x);
+	rect2.y = (int)(rect->y * scaley + vprect.y);
+	rect2.w = (int)(rect->w * scalex);
+	rect2.h = (int)(rect->h * scaley);
+
+	SDL_SetTextInputRect(&rect2);
+	Py_RETURN_NONE;
     }
 
     SDL_SetTextInputRect(rect);

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -814,21 +814,21 @@ key_set_text_input_rect(PyObject *self, PyObject *obj)
     if (!rect)
         return RAISE(PyExc_TypeError, "Invalid rect argument");
 
-    if (sdlRenderer!=NULL){
+    if (sdlRenderer != NULL) {
         SDL_Rect vprect, rect2;
-	/* new rect so we do not overwrite the input rect */
-	float scalex, scaley;
+        /* new rect so we do not overwrite the input rect */
+        float scalex, scaley;
 
-	SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
-	SDL_RenderGetViewport(sdlRenderer, &vprect);
+        SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
+        SDL_RenderGetViewport(sdlRenderer, &vprect);
 
-	rect2.x = (int)(rect->x * scalex + vprect.x);
-	rect2.y = (int)(rect->y * scaley + vprect.y);
-	rect2.w = (int)(rect->w * scalex);
-	rect2.h = (int)(rect->h * scaley);
+        rect2.x = (int)(rect->x * scalex + vprect.x);
+        rect2.y = (int)(rect->y * scaley + vprect.y);
+        rect2.w = (int)(rect->w * scalex);
+        rect2.h = (int)(rect->h * scaley);
 
-	SDL_SetTextInputRect(&rect2);
-	Py_RETURN_NONE;
+        SDL_SetTextInputRect(&rect2);
+        Py_RETURN_NONE;
     }
 
     SDL_SetTextInputRect(rect);

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -804,13 +804,31 @@ key_set_text_input_rect(PyObject *self, PyObject *obj)
     /* https://wiki.libsdl.org/SDL_SetTextInputRect */
 #if IS_SDLv2
     SDL_Rect *rect, temp;
+    SDL_Window *sdlWindow = pg_GetDefaultWindow();
+    SDL_Renderer *sdlRenderer = SDL_GetRenderer(sdlWindow);
+
     if (obj == Py_None) {
         Py_RETURN_NONE;
     }
     rect = pgRect_FromObject(obj, &temp);
     if (!rect)
         return RAISE(PyExc_TypeError, "Invalid rect argument");
+
+    if (sdlRenderer!=NULL){
+        SDL_Rect vprect;
+	float scalex, scaley;
+
+	SDL_RenderGetScale(sdlRenderer, &scalex, &scaley);
+	SDL_RenderGetViewport(sdlRenderer, &vprect);
+
+	rect->x = (int)(rect->x * scalex + vprect.x);
+	rect->y = (int)(rect->y * scaley + vprect.y);
+	rect->w = (int)(rect->w * scalex);
+	rect->h = (int)(rect->h * scaley);
+    }
+
     SDL_SetTextInputRect(rect);
+
 #endif /* IS_SDLv2 */
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
Fix IME placement in SCALED mode: IME placement with pygame.key.set_text_input_rect was based on physical screen pixels instead of scaled coordinates, now scaling is applied so the IME is in the right place regardless of window size. There is no test case because I see no good, non-interactive way of testing it, but there was a bug before.