### PR TITLE
Fix leaving fullscreen creates window at (0,0)

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1218,6 +1218,13 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                 }
             }
 
+            // SDL doesn't preserve window position in fullscreen mode
+            // However, windows coming out of fullscreen need these to go back into the correct position
+            if (sdl_flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) {
+                state->fullscreen_backup_x = x;
+                state->fullscreen_backup_y = y;
+            }
+
             if (!win) {
                 /*open window*/
                 win = SDL_CreateWindow(title, x, y, w_1, h_1, sdl_flags);
@@ -1247,13 +1254,6 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                         win, sdl_flags & (SDL_WINDOW_FULLSCREEN |
                                           SDL_WINDOW_FULLSCREEN_DESKTOP))) {
                     return RAISE(pgExc_SDLError, SDL_GetError());
-                }
-
-                // SDL doesn't preserve window position in fullscreen mode
-                // However, windows coming out of fullscreen need these to go back into the correct position
-                if (sdl_flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) {
-                    state->fullscreen_backup_x = x;
-                    state->fullscreen_backup_y = y;
                 }
 
                 assert(surface);

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1150,10 +1150,17 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 
             if (win) {
                 if (SDL_GetWindowDisplayIndex(win) == display) {
-                    //fullscreen windows don't hold window x and y as needed
+                    // fullscreen windows don't hold window x and y as needed
                     if (SDL_GetWindowFlags(win) & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) { 
                         x = state->fullscreen_backup_x;
                         y = state->fullscreen_backup_y;
+
+                        // if the program goes into fullscreen first the "saved x and y" are "undefined position"
+                        // that should be interpreted as a cue to center the window
+                        if (x == SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
+                            x = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
+                        if (y == SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
+                            y = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
                     }
                     else {
                         SDL_GetWindowPosition(win, &x, &y);
@@ -1248,13 +1255,14 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                 else if (flags & PGS_HIDDEN)
                     SDL_HideWindow(win);
 
-                SDL_SetWindowPosition(win, x, y);
                 if (0 !=
                     SDL_SetWindowFullscreen(
                         win, sdl_flags & (SDL_WINDOW_FULLSCREEN |
                                           SDL_WINDOW_FULLSCREEN_DESKTOP))) {
                     return RAISE(pgExc_SDLError, SDL_GetError());
                 }
+
+                SDL_SetWindowPosition(win, x, y);
 
                 assert(surface);
             }


### PR DESCRIPTION
Targeted to fix #2360.

Over the past day I've been investigating issue #2360.
The window created inside `set_mode()` is supposed to get its position from the last window, if it exists.
The problem is that if the last window is a fullscreen window, `SDL_GetWindowPosition()` returns (0, 0).
Perhaps in SDL1 the window position values were saved in fullscreen windows, despite not being "real" - fullscreen windows don't have a position on the screen - they are the screen.

This solution works on Windows 10 and Mac.

Further things:
- Is there a more elegant solution than adding special backup ints to be got/set in random circumstances?
- Does this work on ubuntu? Other linux distros?

