### PR TITLE
Add str and RGBA tuple types to freetype/font type hints

### DIFF
--- a/buildconfig/pygame-stubs/font.pyi
+++ b/buildconfig/pygame-stubs/font.pyi
@@ -10,7 +10,7 @@ from pygame.color import Color
 from pygame.surface import Surface
 
 _ColorValue = Union[
-    Color, Tuple[int, int, int], List[int], int, Tuple[int, int, int, int]
+    Color, str, Tuple[int, int, int], List[int], int, Tuple[int, int, int, int]
 ]
 
 def init() -> None: ...

--- a/buildconfig/pygame-stubs/freetype.pyi
+++ b/buildconfig/pygame-stubs/freetype.pyi
@@ -10,7 +10,9 @@ from pygame.surface import Surface
 from pygame.color import Color
 from pygame.rect import Rect
 
-_ColorValue = Union[Color, Tuple[int, int, int], List[int], int]
+_ColorValue = Union[
+    Color, str, Tuple[int, int, int], List[int], int, Tuple[int, int, int, int]
+]
 
 def get_error() -> str: ...
 def get_version() -> Tuple[int, int, int]: ...


### PR DESCRIPTION
As per the title. Likely these were missed at some point when the font modules were updated.

Anyway it looks like these two modules use the same `pg_RGBAFromFuzzyColorObj()` function as the draw module and it has support for string colour types.

I suspect at least some, if not all of the other five modules (mask, display, gfxdraw, pixelarray & transform) that take a `_ColorValue` type hint could also have their C code updated to use this same fuzzy loader function so that the `_ColorValue` type could be consistent across all modules rather than the current split with some accepting the string colour types and some not. 