### PR TITLE
Fix list_modes

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1604,12 +1604,12 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
             mode.h = 480;
         if (SDL_BITSPERPIXEL(mode.format) != bpp)
             continue;
+        if (last_width == mode.w && last_height == mode.h && last_width != -1) {
+            continue;
+        }
         if (!(size = Py_BuildValue("(ii)", mode.w, mode.h))) {
             Py_DECREF(list);
             return NULL;
-        }
-        if (last_width == mode.w && last_height == mode.h && last_width != -1) {
-            continue;
         }
         last_width = mode.w;
         last_height = mode.h;

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1556,6 +1556,7 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
     int bpp = 0;
     int flags = PGS_FULLSCREEN;
     int display_index = 0;
+    int last_width = -1, last_height;
     PyObject *list, *size;
     int i;
 
@@ -1607,6 +1608,11 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
             Py_DECREF(list);
             return NULL;
         }
+        if (last_width == mode.w && last_height == mode.h && last_width != -1) {
+            continue;
+        }
+        last_width = mode.w;
+        last_height = mode.h;
         if (0 != PyList_Append(list, size)) {
             Py_DECREF(list);
             Py_DECREF(size);

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -446,6 +446,7 @@ class DisplayModuleTest(unittest.TestCase):
         if modes != -1:
             self.assertEqual(len(modes[0]), 2)
             self.assertEqual(type(modes[0][0]), int)
+            self.assertEqual(len(modes), len(set(modes)))
 
         modes = pygame.display.list_modes(depth=0, flags=0, display=0)
         if modes != -1:


### PR DESCRIPTION
This should fix #2469. The problem is that SDL differentiate modes on multiple criteria, while PyGame does so only based on width/height.

Before this PR on my computer:
```
l = pygame.display.list_modes()
print(l)
print(len(l))
print(len(set(l)))
```
results with:
```
[(2715, 1527), (1920, 1080), (1680, 1050), (1600, 1024), (1600, 900), (1366, 768), (1360, 768), (1280, 1024), (1280, 1024), (1280, 960), (1280, 960), (1280, 800), (1280, 800), (1280, 768), (1280, 768), (1280, 720), (1280, 720), (1152, 864), (1024, 768), (1024, 768), (800, 600), (800, 600), (720, 576), (720, 576), (720, 480), (720, 480), (640, 480), (640, 480)]
28
18
```
And after this PR I get
```
[(2715, 1527), (1920, 1080), (1680, 1050), (1600, 1024), (1600, 900), (1366, 768), (1360, 768), (1280, 1024), (1280, 960), (1280, 800), (1280, 768), (1280, 720), (1152, 864), (1024, 768), (800, 600), (720, 576), (720, 480), (640, 480)]
18
18
```