### PR TITLE
Correct blits typehint sequence arg to cover blit inputs

### DIFF
--- a/buildconfig/pygame-stubs/surface.pyi
+++ b/buildconfig/pygame-stubs/surface.pyi
@@ -48,7 +48,12 @@ class Surface(object):
         special_flags: int = ...,
     ) -> Rect: ...
     def blits(
-        self, sequence: Sequence[Union[Surface, Rect]], doreturn: Union[int, bool]
+        self,
+        sequence: Sequence[Union[Tuple[Surface, Rect],
+                                 Tuple[Surface, Rect, Rect],
+                                 Tuple[Surface, Rect, int],
+                                 Tuple[Surface, Rect, Rect, int]]],
+        doreturn: Union[int, bool]
     ) -> Union[List[Rect], None]: ...
     @overload
     def convert(self, surface: Surface) -> Surface: ...


### PR DESCRIPTION
Previously this typehint incorrectly asked for a Rect or a Surface in the sequence argument but each blit requires at least both. It now takes one of four tuples each of which requires a Surface and a Rect and three of which cover the permutations of the optional arguments in order.

fixes #2481 