### PR TITLE
Close issue #1563: wrong color with 2d surfarray

### DIFF
--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -39,6 +39,12 @@
        Color(255, 255, 255, 255) // Color(0, 64, 64, 64) == Color(0, 3, 3, 3)
        Color(255, 255, 255, 255) % Color(64, 64, 64, 0) == Color(63, 63, 63, 0)
 
+   Use ``int(color)`` to return the immutable integer value of the color,
+   usable as a ``dict`` key. This integer value differs from the mapped
+   pixel values of :meth:`Surface.get_at_mapped()`, :meth:`Surface.map_rgb()`
+   and :meth:`Surface.unmap_rgb()`. It can be passed as a ``color_value``
+   argument to :class:`Color` (useful with sets).
+
    :param int r: red value in the range of 0 to 255 inclusive
    :param int g: green value in the range of 0 to 255 inclusive
    :param int b: blue value in the range of 0 to 255 inclusive

--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -41,9 +41,10 @@
 
    Use ``int(color)`` to return the immutable integer value of the color,
    usable as a ``dict`` key. This integer value differs from the mapped
-   pixel values of :meth:`Surface.get_at_mapped()`, :meth:`Surface.map_rgb()`
-   and :meth:`Surface.unmap_rgb()`. It can be passed as a ``color_value``
-   argument to :class:`Color` (useful with sets).
+   pixel values of :meth:`pygame.Surface.get_at_mapped`,
+   :meth:`pygame.Surface.map_rgb` and :meth:`pygame.Surface.unmap_rgb`.
+   It can be passed as a ``color_value`` argument to :class:`Color`
+   (useful with sets).
 
    :param int r: red value in the range of 0 to 255 inclusive
    :param int g: green value in the range of 0 to 255 inclusive

--- a/docs/reST/ref/pixelcopy.rst
+++ b/docs/reST/ref/pixelcopy.rst
@@ -22,8 +22,8 @@ pygame handles array introspection.
 
 For 2d arrays of integer pixel values, the values are mapped to the
 pixel format of the related surface. To get the actual color of a pixel
-value use :meth:`Surface.unmap_rgb`. 2d arrays can only be used directly
-between surfaces having the same pixel layout.
+value use :meth:`pygame.Surface.unmap_rgb`. 2d arrays can only be used
+directly between surfaces having the same pixel layout.
 
 New in pygame 1.9.2.
 

--- a/docs/reST/ref/pixelcopy.rst
+++ b/docs/reST/ref/pixelcopy.rst
@@ -20,6 +20,11 @@ The array struct interface, on the other hand, is stable and works with earlier
 Python versions. So for now the array struct interface is the predominate way
 pygame handles array introspection.
 
+For 2d arrays of integer pixel values, the values are mapped to the
+pixel format of the related surface. To get the actual color of a pixel
+value use :meth:`Surface.unmap_rgb`. 2d arrays can only be used directly
+between surfaces having the same pixel layout.
+
 New in pygame 1.9.2.
 
 .. function:: surface_to_array

--- a/docs/reST/ref/surfarray.rst
+++ b/docs/reST/ref/surfarray.rst
@@ -22,6 +22,12 @@ This module can also separate the red, green, and blue color values into
 separate indices. These types of arrays are referred to as 3D arrays, and the
 last index is 0 for red, 1 for green, and 2 for blue.
 
+The pixels of a 2D array as returned by :func:`array2d` and :func:`pixels2d`
+are mapped to the specific surface. Use :meth:`Surface.unmap_rgb` to convert
+to a color, and :meth:`Surface.map_rgb` to get the surface specific pixel value
+of a color. Integer pixel values can only be used directly between surfaces
+with matching pixel layouts (see :class:`Surface`).
+
 .. function:: array2d
 
    | :sl:`Copy pixels into a 2d array`

--- a/docs/reST/ref/surfarray.rst
+++ b/docs/reST/ref/surfarray.rst
@@ -23,10 +23,10 @@ separate indices. These types of arrays are referred to as 3D arrays, and the
 last index is 0 for red, 1 for green, and 2 for blue.
 
 The pixels of a 2D array as returned by :func:`array2d` and :func:`pixels2d`
-are mapped to the specific surface. Use :meth:`Surface.unmap_rgb` to convert
-to a color, and :meth:`Surface.map_rgb` to get the surface specific pixel value
-of a color. Integer pixel values can only be used directly between surfaces
-with matching pixel layouts (see :class:`Surface`).
+are mapped to the specific surface. Use :meth:`pygame.Surface.unmap_rgb`
+to convert to a color, and :meth:`pygame.Surface.map_rgb` to get the surface
+specific pixel value of a color. Integer pixel values can only be used directly
+between surfaces with matching pixel layouts (see :class:`pygame.Surface`).
 
 .. function:: array2d
 


### PR DESCRIPTION
This issue resulted from a misunderstanding of mapped pixel values. Clarifications were made to the appropriate reference pages.