### PR TITLE
Adds keyword argument to mixer.find_channel()

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -220,9 +220,6 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    inactive channels and the force argument is ``True``, this will find the
    Channel with the longest running Sound and return it.
 
-   If the mixer has reserved channels from ``pygame.mixer.set_reserved()`` then
-   those channels will not be returned here.
-
    .. ## pygame.mixer.find_channel ##
 
 .. function:: get_busy

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1018,7 +1018,7 @@ sound_dealloc(pgSoundObject *self)
 
 static PyTypeObject pgSound_Type = {
     PyVarObject_HEAD_INIT(NULL,0)
-    "Sound", 
+    "Sound",
     sizeof(pgSoundObject), 0,
     (destructor)sound_dealloc, 0, 0, 0, /* setattr */
     0,                                  /* compare */
@@ -1448,11 +1448,14 @@ Channel(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mixer_find_channel(PyObject *self, PyObject *args)
+mixer_find_channel(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int chan, force = 0;
-    if (!PyArg_ParseTuple(args, "|i", &force))
+    static char *keywords[] = {"force", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|i", keywords, &force)) {
         return NULL;
+    }
 
     MIXER_INIT_CHECK();
 
@@ -1954,7 +1957,8 @@ static PyMethodDef _mixer_methods[] = {
 
     {"get_busy", (PyCFunction)get_busy, METH_NOARGS, DOC_PYGAMEMIXERGETBUSY},
     {"Channel", Channel, METH_VARARGS, DOC_PYGAMEMIXERCHANNEL},
-    {"find_channel", mixer_find_channel, METH_VARARGS,
+    {"find_channel", (PyCFunction)mixer_find_channel,
+     METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEMIXERFINDCHANNEL},
     {"fadeout", mixer_fadeout, METH_VARARGS, DOC_PYGAMEMIXERFADEOUT},
     {"stop", (PyCFunction)mixer_stop, METH_NOARGS, DOC_PYGAMEMIXERSTOP},

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -490,23 +490,48 @@ class MixerModuleTest(unittest.TestCase):
 
         self.fail()
 
-    def todo_test_find_channel(self):
-
+    def test_find_channel(self):
         # __doc__ (as of 2008-08-02) for pygame.mixer.find_channel:
 
         # pygame.mixer.find_channel(force=False): return Channel
         # find an unused channel
-        #
-        # This will find and return an inactive Channel object. If there are
-        # no inactive Channels this function will return None. If there are no
-        # inactive channels and the force argument is True, this will find the
-        # Channel with the longest running Sound and return it.
-        #
-        # If the mixer has reserved channels from pygame.mixer.set_reserved()
-        # then those channels will not be returned here.
-        #
+        mixer.init()
 
-        self.fail()
+        filename = example_path(os.path.join("data", "house_lo.wav"))
+        sound = mixer.Sound(file=filename)
+
+        num_channels = mixer.get_num_channels()
+
+        if num_channels > 0:
+            found_channel = mixer.find_channel()
+            self.assertIsNotNone(found_channel)
+
+            # try playing on all channels
+            channels = []
+            for channel_id in range(0, num_channels):
+                channel = mixer.Channel(channel_id)
+                channel.play(sound)
+                channels.append(channel)
+
+            # should fail without being forceful
+            found_channel = mixer.find_channel()
+            self.assertIsNone(found_channel)
+
+            # try forcing without keyword
+            found_channel = mixer.find_channel(True)
+            self.assertIsNotNone(found_channel)
+
+            # try forcing with keyword
+            found_channel = mixer.find_channel(force=True)
+            self.assertIsNotNone(found_channel)
+
+            for channel in channels:
+                channel.stop()
+            found_channel = mixer.find_channel()
+            self.assertIsNotNone(found_channel)
+
+
+
 
     def todo_test_get_busy(self):
 


### PR DESCRIPTION
Also adds a test and fixes an incorrect assertion in the docs that this function is affected by `mixer.set_reserved()`. It is not as can be seen in the docs here:.

https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_43.html

> The following functions are affected by this setting:
>4.3.3 Mix_PlayChannel
>4.3.4 Mix_PlayChannelTimed
>4.3.5 Mix_FadeInChannel
>4.3.6 Mix_FadeInChannelTimed

Note that `Mix_GroupAvailable()` the function we use in `mixer.find_channel()` is not among them. Reserving a channel only affects passing in -1 to playback functions.

fixes #2489