### PR TITLE
Fix segfault in mixer.pre_init()

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -575,7 +575,7 @@ init(PyObject *self, PyObject *args, PyObject *keywds)
 
     static char *kwids[] = {"frequency", "size",       "channels",
                             "buffer",    "devicename", "allowedchanges", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "|iiiisi", kwids, &freq,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "|iiiizi", kwids, &freq,
                                      &size, &channels, &chunk, &devicename,
                                      &allowedchanges)) {
         return NULL;
@@ -614,7 +614,6 @@ pre_init(PyObject *self, PyObject *args, PyObject *keywds)
 {
     static char *kwids[] = {"frequency", "size",       "channels",
                             "buffer",    "devicename", "allowedchanges", NULL};
-    int dname_size = 0;
 
     request_frequency = 0;
     request_size = 0;
@@ -623,8 +622,8 @@ pre_init(PyObject *self, PyObject *args, PyObject *keywds)
     request_devicename = NULL;
     request_allowedchanges = -1;
     if (!PyArg_ParseTupleAndKeywords(
-            args, keywds, "|iiiiz#i", kwids, &request_frequency, &request_size,
-            &request_channels, &request_chunksize, &request_devicename, &dname_size,
+            args, keywds, "|iiiizi", kwids, &request_frequency, &request_size,
+            &request_channels, &request_chunksize, &request_devicename,
             &request_allowedchanges))
         return NULL;
     if (!request_frequency) {


### PR DESCRIPTION
Fixes #2493 

I'm not sure why this bug didn't occur on Windows.

This bug happened because the devicename parameter was using the "z#" format string, which goes into (string / NULL) and (length of string). However, it was grabbing the length of the string as an integer, rather than a Py_ssize_t, which is why it segfaulted, since that has been deprecated. (And since we defined PY_SSIZE_T_CLEAN before including Python.h).

I fixed this by changing the format string to just "z" - since the length of the string is irrelevant for our case.

I also changed the format string of mixer.init() devicename to "z" - since setting devicename = None should translate into NULL.