### PR TITLE
Fixes scrap on Windows.

### DIFF
--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -37,8 +37,6 @@
 
 #include "doc/scrap_doc.h"
 
-
-
 /**
  * Indicates, whether pygame.scrap was initialized or not.
  */
@@ -66,7 +64,7 @@ static PyObject *
 _scrap_set_mode(PyObject *self, PyObject *args);
 
 /* Determine what type of clipboard we are using */
-#if IS_SDLv2
+#if IS_SDLv2 && !defined(__WIN32__)
 #define SDL2_SCRAP
 #include "scrap_sdl2.c"
 

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -20,22 +20,20 @@
 */
 
 /* Handle clipboard text and data in arbitrary formats */
-#include "pgcompat.h"
-
 #include <limits.h>
 #include <stdio.h>
-
-#include "pgcompat.h"
 
 #include "SDL.h"
 
 #include "SDL_syswm.h"
 
-#include "scrap.h"
-
 #include "pygame.h"
 
+#include "pgcompat.h"
+
 #include "doc/scrap_doc.h"
+
+#include "scrap.h"
 
 /**
  * Indicates, whether pygame.scrap was initialized or not.
@@ -293,7 +291,7 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
 static PyObject *
 _scrap_put_scrap(PyObject *self, PyObject *args)
 {
-    int scraplen;
+    Py_ssize_t scraplen;
     char *scrap = NULL;
     char *scrap_type;
     PyObject *tmp;

--- a/src_c/scrap_win.c
+++ b/src_c/scrap_win.c
@@ -25,7 +25,7 @@
 #define CF_DIBV5 17
 #endif
 
-static HWND handle;
+static HWND window_handle;
 #define MAX_CHUNK_SIZE INT_MAX
 
 static UINT _format_MIME_PLAIN;
@@ -164,13 +164,13 @@ pygame_scrap_init(void)
 #if IS_SDLv1
     if (SDL_GetWMInfo(&info)) {
         /* Save the information for later use */
-        handle = info.window;
+        window_handle = info.window;
         retval = 1;
     }
 #else
     if (SDL_GetWindowWMInfo(pg_GetDefaultWindow(), &info)) {
         /* Save the information for later use */
-        handle = info.info.win.window;
+        window_handle = info.info.win.window;
         retval = 1;
     }
 #endif
@@ -189,7 +189,7 @@ pygame_scrap_lost(void)
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
         return 0;
     }
-    return (GetClipboardOwner() != handle);
+    return (GetClipboardOwner() != window_handle);
 }
 
 int
@@ -208,7 +208,7 @@ pygame_scrap_put(char *type, int srclen, char *src)
     if (format == -1)
         format = _convert_format(type);
 
-    if (!OpenClipboard(handle))
+    if (!OpenClipboard(window_handle))
         return 0; /* Could not open the clipboard. */
 
     if (format == CF_DIB || format == CF_DIBV5)
@@ -257,7 +257,7 @@ pygame_scrap_get(char *type, unsigned long *count)
     if (!pygame_scrap_lost())
         return Bytes_AsString(PyDict_GetItemString(_clipdata, type));
 
-    if (!OpenClipboard(handle))
+    if (!OpenClipboard(window_handle))
         return NULL;
 
     if (!IsClipboardFormatAvailable(format)) {
@@ -329,7 +329,7 @@ pygame_scrap_get_types(void)
     char tmp[100] = {'\0'};
     int size = 0;
 
-    if (!OpenClipboard(handle))
+    if (!OpenClipboard(window_handle))
         return NULL;
 
     size = CountClipboardFormats();

--- a/src_c/scrap_win.c
+++ b/src_c/scrap_win.c
@@ -25,7 +25,7 @@
 #define CF_DIBV5 17
 #endif
 
-static HWND SDL_Window;
+static HWND handle;
 #define MAX_CHUNK_SIZE INT_MAX
 
 static UINT _format_MIME_PLAIN;
@@ -160,11 +160,21 @@ pygame_scrap_init(void)
     SDL_SetError("SDL is not running on known window manager");
 
     SDL_VERSION(&info.version);
+
+#if IS_SDLv1
     if (SDL_GetWMInfo(&info)) {
         /* Save the information for later use */
-        SDL_Window = info.window;
+        handle = info.window;
         retval = 1;
     }
+#else
+    if (SDL_GetWindowWMInfo(pg_GetDefaultWindow(), &info)) {
+        /* Save the information for later use */
+        handle = info.info.win.window;
+        retval = 1;
+    }
+#endif
+
     if (retval)
         _scrapinitialized = 1;
 
@@ -179,7 +189,7 @@ pygame_scrap_lost(void)
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
         return 0;
     }
-    return (GetClipboardOwner() != SDL_Window);
+    return (GetClipboardOwner() != handle);
 }
 
 int
@@ -198,7 +208,7 @@ pygame_scrap_put(char *type, int srclen, char *src)
     if (format == -1)
         format = _convert_format(type);
 
-    if (!OpenClipboard(SDL_Window))
+    if (!OpenClipboard(handle))
         return 0; /* Could not open the clipboard. */
 
     if (format == CF_DIB || format == CF_DIBV5)
@@ -247,7 +257,7 @@ pygame_scrap_get(char *type, unsigned long *count)
     if (!pygame_scrap_lost())
         return Bytes_AsString(PyDict_GetItemString(_clipdata, type));
 
-    if (!OpenClipboard(SDL_Window))
+    if (!OpenClipboard(handle))
         return NULL;
 
     if (!IsClipboardFormatAvailable(format)) {
@@ -319,7 +329,7 @@ pygame_scrap_get_types(void)
     char tmp[100] = {'\0'};
     int size = 0;
 
-    if (!OpenClipboard(SDL_Window))
+    if (!OpenClipboard(handle))
         return NULL;
 
     size = CountClipboardFormats();


### PR DESCRIPTION
**Why was it broken?**

The way to grab a window HWND changed in SDL2.
Also I don't think the compiler liked that the HWND was named SDL_Window, which is now a type name.

Additionally, the order of the `#includes` at the top meant that PY_SSIZE_T_CLEAN wasn't defined properly before python was included, which meant every call to `scrap.put` was printing a deprecation warning. To fix this, I also changed `scraplen` in `scrap.c` to a `Py_ssize_t` as requested. I don't believe this will affect Python 2.7 compatibility because the PEP for this, 353, was implemented in 2.5.

**Other scrap stuff:**

I couldn't get scrap building on my mac, even for pygame 1.9.6. Whatever I do `pygame.scrap` is `MissingModule`.