### PR TITLE
Add namehint argument to music.load()

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -22,11 +22,14 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
 
    | :sl:`Load a music file for playback`
    | :sg:`load(filename) -> None`
-   | :sg:`load(object) -> None`
+   | :sg:`load(fileobj, namehint="") -> None`
 
    This will load a music filename/file object and prepare it for playback. If
    a music stream is already playing it will be stopped. This does not start
    the music playing.
+
+   If you are loading from a file object, the namehint parameter can be used to specify
+   the type of music data in the object. For example: :code:`load(fileobj, "mp3")`.
 
    .. ## pygame.mixer.music.load ##
 

--- a/src_c/doc/music_doc.h
+++ b/src_c/doc/music_doc.h
@@ -1,6 +1,6 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEMIXERMUSIC "pygame module for controlling streamed audio"
-#define DOC_PYGAMEMIXERMUSICLOAD "load(filename) -> None\nload(object) -> None\nLoad a music file for playback"
+#define DOC_PYGAMEMIXERMUSICLOAD "load(filename) -> None\nload(fileobj, namehint="") -> None\nLoad a music file for playback"
 #define DOC_PYGAMEMIXERMUSICUNLOAD "unload() -> None\nUnload the currently loaded music to free up resources"
 #define DOC_PYGAMEMIXERMUSICPLAY "play(loops=0, start=0.0, fade_ms = 0) -> None\nStart the playback of the music stream"
 #define DOC_PYGAMEMIXERMUSICREWIND "rewind() -> None\nrestart music"
@@ -27,7 +27,7 @@ pygame module for controlling streamed audio
 
 pygame.mixer.music.load
  load(filename) -> None
- load(object) -> None
+ load(fileobj, namehint="") -> None
 Load a music file for playback
 
 pygame.mixer.music.unload

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -297,8 +297,10 @@ music_get_endevent(PyObject *self, PyObject *args)
 Mix_MusicType
 _get_type_from_hint(char *namehint)
 {
-    // Adjusts namehint into a mere file extension component
+    Mix_MusicType type = MUS_NONE;
     const char *dot;
+
+    // Adjusts namehint into a mere file extension component
     if (namehint != NULL) {
         dot = strrchr(namehint, '.');
         if (dot != NULL) {
@@ -309,7 +311,6 @@ _get_type_from_hint(char *namehint)
     /* Copied almost directly from SDL_mixer. Originally meant to check file extensions
     * to get a hint of what music type it should be.
     * https://github.com/libsdl-org/SDL_mixer/blob/master/src/music.c#L586-L631 */
-    Mix_MusicType type = MUS_NONE;
     if (SDL_strcasecmp(namehint, "WAV") == 0) {
         type = MUS_WAV;
     }

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -294,6 +294,71 @@ music_get_endevent(PyObject *self, PyObject *args)
     return PyInt_FromLong(endmusic_event);
 }
 
+Mix_MusicType
+_get_type_from_hint(char *namehint)
+{
+    // Adjusts namehint into a mere file extension component
+    const char *dot;
+    if (namehint != NULL) {
+        dot = strrchr(namehint, '.');
+        if (dot != NULL) {
+            namehint = dot + 1;
+        }
+    }
+
+    /* Copied almost directly from SDL_mixer. Originally meant to check file extensions
+    * to get a hint of what music type it should be.
+    * https://github.com/libsdl-org/SDL_mixer/blob/master/src/music.c#L586-L631 */
+    Mix_MusicType type = MUS_NONE;
+    if (SDL_strcasecmp(namehint, "WAV") == 0) {
+        type = MUS_WAV;
+    }
+    else if (SDL_strcasecmp(namehint, "MID") == 0 ||
+             SDL_strcasecmp(namehint, "MIDI") == 0 ||
+             SDL_strcasecmp(namehint, "KAR") == 0) {
+        type = MUS_MID;
+    }
+    else if (SDL_strcasecmp(namehint, "OGG") == 0) {
+        type = MUS_OGG;
+    }
+    else if (SDL_strcasecmp(namehint, "OPUS") == 0) {
+        type = MUS_OPUS;
+    }
+    else if (SDL_strcasecmp(namehint, "FLAC") == 0) {
+        type = MUS_FLAC;
+    }
+    else if (SDL_strcasecmp(namehint, "MPG") == 0 ||
+             SDL_strcasecmp(namehint, "MPEG") == 0 ||
+             SDL_strcasecmp(namehint, "MP3") == 0 ||
+             SDL_strcasecmp(namehint, "MAD") == 0) {
+        type = MUS_MP3;
+    }
+    else if (SDL_strcasecmp(namehint, "669") == 0 ||
+             SDL_strcasecmp(namehint, "AMF") == 0 ||
+             SDL_strcasecmp(namehint, "AMS") == 0 ||
+             SDL_strcasecmp(namehint, "DBM") == 0 ||
+             SDL_strcasecmp(namehint, "DSM") == 0 ||
+             SDL_strcasecmp(namehint, "FAR") == 0 ||
+             SDL_strcasecmp(namehint, "IT") == 0 ||
+             SDL_strcasecmp(namehint, "MED") == 0 ||
+             SDL_strcasecmp(namehint, "MDL") == 0 ||
+             SDL_strcasecmp(namehint, "MOD") == 0 ||
+             SDL_strcasecmp(namehint, "MOL") == 0 ||
+             SDL_strcasecmp(namehint, "MTM") == 0 ||
+             SDL_strcasecmp(namehint, "NST") == 0 ||
+             SDL_strcasecmp(namehint, "OKT") == 0 ||
+             SDL_strcasecmp(namehint, "PTM") == 0 ||
+             SDL_strcasecmp(namehint, "S3M") == 0 ||
+             SDL_strcasecmp(namehint, "STM") == 0 ||
+             SDL_strcasecmp(namehint, "ULT") == 0 ||
+             SDL_strcasecmp(namehint, "UMX") == 0 ||
+             SDL_strcasecmp(namehint, "WOW") == 0 ||
+             SDL_strcasecmp(namehint, "XM") == 0) {
+        type = MUS_MOD;
+    }
+    return type;
+}
+
 static PyObject *
 music_load(PyObject *self, PyObject *args)
 {
@@ -301,8 +366,9 @@ music_load(PyObject *self, PyObject *args)
     PyObject *oencoded;
     Mix_Music *new_music = NULL;
     const char *name;
+    char *namehint = NULL;
 
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
+    if (!PyArg_ParseTuple(args, "O|s", &obj, &namehint)) {
         return NULL;
     }
 
@@ -323,7 +389,10 @@ music_load(PyObject *self, PyObject *args)
 #if IS_SDLv1
             new_music = Mix_LoadMUS_RW(rw);
 #else  /* IS_SDLv2 */
-            new_music = Mix_LoadMUS_RW(rw, SDL_TRUE);
+            if (namehint)
+                new_music = Mix_LoadMUSType_RW(rw, _get_type_from_hint(namehint), SDL_TRUE);
+            else
+                new_music = Mix_LoadMUS_RW(rw, SDL_TRUE);
 #endif /* IS_SDLv2 */
         Py_END_ALLOW_THREADS
     }


### PR DESCRIPTION
Fixes #2407  (they would add namehint="mp3" to their program)

This was relatively simple to add, since there is a function `Mix_LoadMUSTypeRw()`, and since the SDL_Mixer code already had a list of file extensions to music type conversions.
