### PR TITLE
Get scrap building on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /prebuilt-x??
 /prebuilt_downloads
 
+# macOS generated files
+.DS_Store
+
 # Sphinx generated files: makeref.py
 /docs/\.buildinfo
 /docs/objects.inv

--- a/buildconfig/Setup_Darwin.in
+++ b/buildconfig/Setup_Darwin.in
@@ -1,4 +1,5 @@
 #This file defines platform specific modules for mac os x
 SCRAP =
+scrap src_c/scrap.c $(SDL) $(SCRAP) $(DEBUG)
 sdlmain_osx src_c/sdlmain_osx.m $(SDL) $(DEBUG)
 #_camera src_c/_camera.c src/camera_mac.m $(SDL) $(DEBUG)


### PR DESCRIPTION
This only builds the SDL2 clipboard based version of scrap, because scrap_mac has its own problems, but at least it upgrades `pygame.scrap` from the dreaded `pygame.MissingModule`.

It took me a long time to figure out why building scrap wasn't even being attempted, and in the end it was a one line fix.

I'm not sure why this fixes it, because I'm unfamiliar with these `.in` files, but this does fix it.

With this is in place it will also be possible to get scrap_mac.c up to speed. (Because it actually builds!)

I also added `.DS_Store` to the gitignore as a convenience for anyone committing from a mac.

Again, relevant to #1178 