### PR TITLE
Update ftfont.py to fix circular dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ dist
 .vagrant
 *.egg-info/
 *.so
+Setup.bak

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Minor fork for M1 Macs. If you're having trouble using, e.g., pygame_font or the extended image library and you installed SDL2 and companion libraries with Homebrew, this might work for you.
+Minor fork for M1 Macs. If you installed SDL2 and companion libraries with Homebrew and Pygame is giving you errors when you use, i.e., pygame_font, this might work for you.
 
 .. image:: https://raw.githubusercontent.com/pygame/pygame/main/docs/pygame_logo.gif
   :width: 200

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+Minor fork for M1 Macs. If you're having trouble using, e.g., pygame_font or the extended image library and you installed SDL2 and companion libraries with Homebrew, this might work for you.
+
 .. image:: https://raw.githubusercontent.com/pygame/pygame/main/docs/pygame_logo.gif
   :width: 200
   :height: 70

--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -198,6 +198,5 @@ def main(sdl2=False):
 
 
 if __name__ == '__main__':
-    main(sdl2=True)
     print ("""This is the configuration subscript for OSX Darwin.
              Please run "config.py" for full configuration.""")

--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -160,19 +160,20 @@ def main(sdl2=False):
     ])
 
     print ('Hunting dependencies...')
-    incdirs = ['/usr/local/include']
+    incdirs = ['/usr/local/include', '/opt/homebrew/include']
     if sdl2:
-        incdirs.append('/usr/local/include/SDL2')
+        incdirs.extend(['/usr/local/include/SDL2', '/opt/homebrew/include/SDL2'])
     else:
-        incdirs.append('/usr/local/include/SDL')
+        incdirs.extend(['/usr/local/include/SDL', '/opt/homebrew/include/SDL'])
 
     incdirs.extend([
        #'/usr/X11/include',
        '/opt/local/include',
+       '/opt/homebrew/include/freetype2/freetype'
        '/opt/local/include/freetype2/freetype']
     )
     #libdirs = ['/usr/local/lib', '/usr/X11/lib', '/opt/local/lib']
-    libdirs = ['/usr/local/lib', '/opt/local/lib']
+    libdirs = ['/usr/local/lib', '/opt/local/lib', '/opt/homebrew/lib']
 
     for d in DEPS:
         if isinstance(d, (list, tuple)):
@@ -197,5 +198,6 @@ def main(sdl2=False):
 
 
 if __name__ == '__main__':
+    main(sdl2=True)
     print ("""This is the configuration subscript for OSX Darwin.
              Please run "config.py" for full configuration.""")

--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -37,6 +37,7 @@ class Dependency:
 
             for incname in incnames:
                 path = os.path.join(dir, incname)
+                path = os.path.realpath(path)
                 if os.path.isfile(path):
                     self.inc_dir = os.path.dirname(path)
                     break
@@ -44,8 +45,9 @@ class Dependency:
         for dir in libdirs:
             for name in libnames:
                 path = os.path.join(dir, name)
+                path = os.path.realpath(path)
                 if os.path.isfile(path):
-                    self.lib_dir = dir
+                    self.lib_dir = os.path.dirname(path)
                     break
         if self.lib_dir and self.inc_dir:
             print (self.name + '        '[len(self.name):] + ': found')

--- a/src_py/font.py
+++ b/src_py/font.py
@@ -1,0 +1,196 @@
+"""pygame module for loading and rendering fonts (freetype alternative)"""
+
+__all__ = ['Font', 'init', 'quit', 'get_default_font', 'get_init', 'SysFont',
+           "match_font", "get_fonts"]
+
+from pygame._freetype import init, Font as _Font, get_default_resolution
+from pygame._freetype import quit, get_default_font, get_init as _get_init
+from pygame._freetype import __PYGAMEinit__
+from pygame import encode_file_path
+from pygame.compat import bytes_, unicode_, as_unicode, as_bytes
+
+
+class Font(_Font):
+    """Font(filename, size) -> Font
+       Font(object, size) -> Font
+       create a new Font object from a file (freetype alternative)
+
+       This Font type differs from font.Font in that it can render glyphs
+       for Unicode code points in the supplementary planes (> 0xFFFF).
+       """
+
+    __encode_file_path = staticmethod(encode_file_path)
+    __get_default_resolution = staticmethod(get_default_resolution)
+    __default_font = encode_file_path(get_default_font())
+
+    __unull = as_unicode(r"\x00")
+    __bnull = as_bytes("\x00")
+
+    def __init__(self, file, size=-1):
+        if size <= 1:
+            size = 1
+        if isinstance(file, unicode_):
+            try:
+                bfile = self.__encode_file_path(file, ValueError)
+            except ValueError:
+                bfile = ''
+        else:
+            bfile = file
+        if isinstance(bfile, bytes_) and bfile == self.__default_font:
+            file = None
+        if file is None:
+            resolution = int(self.__get_default_resolution() * 0.6875)
+            if resolution == 0:
+                resolution = 1
+        else:
+            resolution = 0
+        super(Font, self).__init__(file, size=size, resolution=resolution)
+        self.strength = 1.0 / 12.0
+        self.kerning = False
+        self.origin = True
+        self.pad = True
+        self.ucs4 = True
+        self.underline_adjustment = 1.0
+
+    def render(self, text, antialias, color, background=None):
+        """render(text, antialias, color, background=None) -> Surface
+           draw text on a new Surface"""
+
+        if text is None:
+            text = ""
+        if (isinstance(text, unicode_) and self.__unull in text):
+            raise ValueError("A null character was found in the text")
+        if (isinstance(text, bytes_) and self.__bnull in text):
+            raise ValueError("A null character was found in the text")
+        save_antialiased = self.antialiased
+        self.antialiased = bool(antialias)
+        try:
+            s, r = super(Font, self).render(text, color, background)
+            return s
+        finally:
+            self.antialiased = save_antialiased
+
+    def set_bold(self, value):
+        """set_bold(bool) -> None
+           enable fake rendering of bold text"""
+
+        self.wide = bool(value)
+
+    def get_bold(self):
+        """get_bold() -> bool
+           check if text will be rendered bold"""
+
+        return self.wide
+
+    bold = property(get_bold, set_bold)
+
+    def set_italic(self, value):
+        """set_italic(bool) -> None
+           enable fake rendering of italic text"""
+
+        self.oblique = bool(value)
+
+    def get_italic(self):
+        """get_italic() -> bool
+           check if the text will be rendered italic"""
+
+        return self.oblique
+
+    italic = property(get_italic, set_italic)
+
+    def set_underline(self, value):
+        """set_underline(bool) -> None
+           control if text is rendered with an underline"""
+
+        self.underline = bool(value)
+
+    def get_underline(self):
+        """set_bold(bool) -> None
+           enable fake rendering of bold text"""
+
+        return self.underline
+
+    def metrics(self, text):
+        """metrics(text) -> list
+           Gets the metrics for each character in the passed string."""
+
+        return self.get_metrics(text)
+
+    def get_ascent(self):
+        """get_ascent() -> int
+           get the ascent of the font"""
+
+        return self.get_sized_ascender()
+
+    def get_descent(self):
+        """get_descent() -> int
+           get the descent of the font"""
+
+        return self.get_sized_descender()
+
+    def get_height(self):
+        """get_height() -> int
+           get the height of the font"""
+
+        return self.get_sized_ascender() - self.get_sized_descender() + 1
+
+    def get_linesize(self):
+        """get_linesize() -> int
+           get the line space of the font text"""
+
+        return self.get_sized_height()
+
+    def size(self, text):
+        """size(text) -> (width, height)
+           determine the amount of space needed to render text"""
+
+        return self.get_rect(text).size
+
+FontType = Font
+
+def get_init():
+    """get_init() -> bool
+       true if the font module is initialized"""
+
+    return _get_init()
+
+# This sysfont module import must follow the Font class declaration
+#
+# In the case that the SDL(2)_ttf pygame.font extension module is not built, pygame.ftfont is
+# used as a replacement for backwards compatibility. Since module sysfont itself imports Font
+# from pygame.font placing the import statement here prevents a circular import failure. 
+from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
+
+def SysFont(name, size, bold=0, italic=0, constructor=None):
+    """pygame.ftfont.SysFont(name, size, bold=False, italic=False, constructor=None) -> Font
+       Create a pygame Font from system font resources.
+
+       This will search the system fonts for the given font
+       name. You can also enable bold or italic styles, and
+       the appropriate system font will be selected if available.
+
+       This will always return a valid Font object, and will
+       fallback on the builtin pygame font if the given font
+       is not found.
+
+       Name can also be an iterable of font names, a string of
+       comma-separated font names, or a bytes of comma-separated
+       font names, in which case the set of names will be searched
+       in order. Pygame uses a small set of common font aliases. If the
+       specific font you ask for is not available, a reasonable
+       alternative may be used.
+
+       If optional constructor is provided, it must be a function with
+       signature constructor(fontpath, size, bold, italic) which returns
+       a Font instance. If None, a pygame.ftfont.Font object is created.
+    """
+    if constructor is None:
+        def constructor(fontpath, size, bold, italic):
+            font = Font(fontpath, size)
+            font.set_bold(bold)
+            font.set_italic(italic)
+            return font
+
+    return _SysFont(name, size, bold, italic, constructor)
+
+del _Font, get_default_resolution, encode_file_path, as_unicode, as_bytes

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -6,7 +6,6 @@ __all__ = ['Font', 'init', 'quit', 'get_default_font', 'get_init', 'SysFont',
 from pygame._freetype import init, Font as _Font, get_default_resolution
 from pygame._freetype import quit, get_default_font, get_init as _get_init
 from pygame._freetype import __PYGAMEinit__
-from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
 from pygame import encode_file_path
 from pygame.compat import bytes_, unicode_, as_unicode, as_bytes
 
@@ -155,6 +154,7 @@ def get_init():
 
     return _get_init()
 
+from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
 def SysFont(name, size, bold=0, italic=0, constructor=None):
     """pygame.ftfont.SysFont(name, size, bold=False, italic=False, constructor=None) -> Font
        Create a pygame Font from system font resources.

--- a/src_py/ftfont.py
+++ b/src_py/ftfont.py
@@ -154,7 +154,13 @@ def get_init():
 
     return _get_init()
 
+# This sysfont module import must follow the Font class declaration
+#
+# In the case that the SDL(2)_ttf pygame.font extension module is not built, pygame.ftfont is
+# used as a replacement for backwards compatibility. Since module sysfont itself imports Font
+# from pygame.font placing the import statement here prevents a circular import failure. 
 from pygame.sysfont import match_font, get_fonts, SysFont as _SysFont
+
 def SysFont(name, size, bold=0, italic=0, constructor=None):
     """pygame.ftfont.SysFont(name, size, bold=False, italic=False, constructor=None) -> Font
        Create a pygame Font from system font resources.


### PR DESCRIPTION
Moving the pygame.sysfont import to immediately before the SysFont function fixes the circular dependency issue with the font module on my M1 Mac. See https://github.com/pygame/pygame/issues/2500 for details.