### PR TITLE
Optimisation (?) in cursor: Use a generator instead of a list

### DIFF
--- a/src_py/cursors.py
+++ b/src_py/cursors.py
@@ -63,7 +63,9 @@ class Cursor(object):
             self.data = tuple(args)
         elif len(args) == 4 and len(args[0]) == 2 and len(args[1]) == 2:
             self.type = "bitmap"
-            self.data = tuple(tuple(arg) for arg in args)
+            # pylint: disable=consider-using-generator
+            # See https://github.com/pygame/pygame/pull/2509 for analysis
+            self.data = tuple([tuple(arg) for arg in args])
         else:
             raise TypeError("Arguments must match a cursor specification")
 

--- a/src_py/cursors.py
+++ b/src_py/cursors.py
@@ -63,10 +63,10 @@ class Cursor(object):
             self.data = tuple(args)
         elif len(args) == 4 and len(args[0]) == 2 and len(args[1]) == 2:
             self.type = "bitmap"
-            self.data = tuple([tuple(arg) for arg in args])
+            self.data = tuple(tuple(arg) for arg in args)
         else:
             raise TypeError("Arguments must match a cursor specification")
-            
+
     def __len__(self):
         return len(self.data)
 


### PR DESCRIPTION
New suggestion by pylint ``2.7.2`` (consider-using-generator).

The decision to merge depends on what we suppose the use case would be.

Performance are worse when initializing something like:
```python
for i in range(10000000):
    diamond = Cursor(
        (16, i),
        (7, 7),
        (
            0, 0, 1, 0, 3, 128, 7, 192,
            14, 224, 28, 112, 56, 56, 112, 28,
            56, 56, 28, 112, 14, 224, 7, 192,
            3, 128, 1, 0, 0, 0, 0, 0,
        ),
        (
            1, 0, 3, 128, 7, 192, 15, 224,
            31, 240, 62, 248, 124, 124, 248, 62,
            124, 124, 62, 248, 31, 240, 15, 224,
            7, 192, 3, 128, 1, 0, 0, 0,
        ),
    )
    arrow = Cursor(
    (16, 16),
    (0, 0),
    (
        0x00, 0x00, 0x40, 0x00, 0x60, 0x00, 0x70, 0x00,
        0x78, 0x00, 0x7C, 0x00, 0x7E, 0x00, 0x7F, 0x00,
        0x7F, 0x80, 0x7C, 0x00, 0x6C, 0x00, 0x46, 0x00,
        0x06, 0x00, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00,
    ),
    (
        0x40, 0x00, 0xE0, 0x00, 0xF0, 0x00, 0xF8, 0x00,
        0xFC, 0x00, 0xFE, 0x00, 0xFF, 0x00, 0xFF, 0x80,
        0xFF, 0xC0, 0xFF, 0x80, 0xFE, 0x00, 0xEF, 0x00,
        0x4F, 0x00, 0x07, 0x80, 0x07, 0x80, 0x03, 0x00,
    ),
)
```
Result:
``tuple(tuple(arg) for arg in args)``: python3 a.py  ``19,39s`` user 0,01s system 95% cpu 20,243 total
``tuple([tuple(arg) for arg in args])``: python3 a.py  ``17,99s`` user 0,00s system 99% cpu 18,149 total

Now if we make the tuple big enough the result become better with a generator:

```

for i in range(10000):
    diamond = Cursor(
        (16, i),
        (7, 7),
        (
            0, 0, 1, 0, 3, 128, 7, 192,
            14, 224, 28, 112, 56, 56, 112, 28,
            56, 56, 28, 112, 14, 224, 7, 192,
            3, 128, 1, 0, 0, 0, 0, 0,
        ),
        (
            1, 0, 3, 128, 7, 192, 15, 224,
            31, 240, 62, 248, 124, 124, 248, 62,
            124, 124, 62, 248, 31, 240, 15, 224,
            7, 192, 3, 128, 1, 0, 0, 0,
        )*5000,
    )
    arrow = Cursor(
    (16, 16),
    (0, 0),
    (
        0x00, 0x00, 0x40, 0x00, 0x60, 0x00, 0x70, 0x00,
        0x78, 0x00, 0x7C, 0x00, 0x7E, 0x00, 0x7F, 0x00,
        0x7F, 0x80, 0x7C, 0x00, 0x6C, 0x00, 0x46, 0x00,
        0x06, 0x00, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00,
    ),
    (
        0x40, 0x00, 0xE0, 0x00, 0xF0, 0x00, 0xF8, 0x00,
        0xFC, 0x00, 0xFE, 0x00, 0xFF, 0x00, 0xFF, 0x80,
        0xFF, 0xC0, 0xFF, 0x80, 0xFE, 0x00, 0xEF, 0x00,
        0x4F, 0x00, 0x07, 0x80, 0x07, 0x80, 0x03, 0x00,
    ) * 5000,
)
```

``tuple(tuple(arg) for arg in args)``: python3 a.py  ``5,33s`` user 0,00s system 97% cpu 5,491 total
``tuple([tuple(arg) for arg in args])``: python3 a.py  ``5,59s`` user 0,01s system 96% cpu 5,777 total

I think it's more likely that we want to disable this pylint warning but I wanted the change in the MR to show the change.
