### PR TITLE
Hide old modules and warn users (Overlay, cdrom)

### DIFF
--- a/docs/reST/index.rst
+++ b/docs/reST/index.rst
@@ -94,9 +94,6 @@ Reference
 :doc:`ref/bufferproxy`
   An array protocol view of surface pixels
 
-:doc:`ref/cdrom`
-  How to access and control the CD audio devices.
-
 :doc:`ref/color`
   Color representation.
 
@@ -144,9 +141,6 @@ Reference
 
 :doc:`ref/music`
   Play streaming music tracks.
-
-:doc:`ref/overlay`
-  Access advanced video overlays.
 
 :doc:`ref/pygame`
   Top level functions to manage pygame.

--- a/docs/reST/ref/cdrom.rst
+++ b/docs/reST/ref/cdrom.rst
@@ -8,6 +8,11 @@
 
 | :sl:`pygame module for audio cdrom control`
 
+.. warning::
+	This module is non functional in pygame 2.0 and above, unless you have manually compiled pygame with SDL1.
+	This module will not be supported in the future.
+	One alternative for python cdrom functionality is `pycdio <https://pypi.org/project/pycdio/>`_.
+	
 The cdrom module manages the ``CD`` and ``DVD`` drives on a computer. It can
 also control the playback of audio CDs. This module needs to be initialized
 before it can do anything. Each ``CD`` object you create represents a cdrom

--- a/docs/reST/ref/overlay.rst
+++ b/docs/reST/ref/overlay.rst
@@ -5,6 +5,10 @@
 
 .. currentmodule:: pygame
 
+.. warning::
+	This module is non functional in pygame 2.0 and above, unless you have manually compiled pygame with SDL1.
+	This module will not be supported in the future.
+
 .. class:: Overlay
 
    | :sl:`pygame object for video overlay graphics`

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -35,7 +35,8 @@ We render three sets of items based on how useful to most apps.
 
 #}
 {%- set basic = ['Color', 'display', 'draw', 'event', 'font', 'image', 'key', 'locals', 'mixer', 'mouse', 'music', 'pygame', 'Rect', 'Surface', 'time'] %}
-{%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'Overlay', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
+{%- set advanced = ['BufferProxy', 'freetype', 'gfxdraw', 'midi', 'PixelArray', 'pixelcopy', 'sndarray', 'surfarray', 'cursors', 'joystick', 'mask', 'math', 'sprite', 'transform'] %}
+{%- set hidden = ['Overlay', 'cdrom'] %}
 {%-   if pyg_sections %}
 	  <p class="bottom"><b>Most useful stuff</b>:
 {%      set sep = joiner(" | \n") %}
@@ -79,7 +80,7 @@ We render three sets of items based on how useful to most apps.
 {%-       if name|lower != simpledocname %}
 {%-         set uri = uri + '#' + section['refid'] %}
 {%-       endif %}
-{%-       if name not in basic and name not in advanced %}
+{%-       if name not in basic and name not in advanced and name not in hidden %}
 {{- sep() }}	    <a href="{{ uri }}">{{ name }}</a>
 {%-       endif %}
 {%-     endfor %}


### PR DESCRIPTION
This commit does two things:

1) Gets rid of links to the cdrom and Overlay docs so people won't stumble on to them in the present day and think pygame has that capability
2) Inserts a warning message at the top of the module docs that pygame 2.0+ doesn't support it, except for when compiled with SDL1, and that pygame isn't going to support those modules in the future.

This allows power users on older versions to still access the documentation online (by linking directly), but prevents new users from falling into holes where the docs are totally wrong.

