### PR TITLE
Move to sphinx 3

### DIFF
--- a/docs/reST/conf.py
+++ b/docs/reST/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pygame'
-copyright = u'2000-2020, pygame developers'
+copyright = u'2000-2021, pygame developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/reST/ext/boilerplate.py
+++ b/docs/reST/ext/boilerplate.py
@@ -14,7 +14,7 @@ from sphinx.domains.python import PyClasslike
 from docutils.nodes import (section, literal, reference, paragraph, title,
                             document, Text, TextElement, inline,
                             table, tgroup, colspec, tbody, row, entry,
-                            whitespace_normalize_name, SkipNode)
+                            whitespace_normalize_name, SkipNode, line)
 import os
 import re
 from collections import deque
@@ -194,6 +194,7 @@ def get_target_summary(reference_node, env):
     except KeyError:
         raise GetError("reference has no refid")
 
+# Calls build_toc, which builds the seciton at the top where it lists the functions
 def add_toc(desc_node, env, section_node=None):
     """Add a table of contents to a desc node"""
 
@@ -211,6 +212,7 @@ def add_toc(desc_node, env, section_node=None):
         insert_at += 1
     content_node.insert(insert_at, toc)
 
+# Builds the section at the top of the module where it lists the functions
 def build_toc(descinfo, env):
     """Return a desc table of contents node tree"""
 
@@ -225,9 +227,9 @@ def build_toc(descinfo, env):
         max_fullname_len = max(max_fullname_len, len(fullname))
         max_summary_len = max(max_summary_len, len(summary))
         reference_node = toc_ref(fullname, refid)
-        ref_entry_node = entry('', paragraph('', '', reference_node))
-        sep_entry_node = entry('', paragraph('', separator))
-        sum_entry_node = entry('', paragraph('', summary))
+        ref_entry_node = entry('', line('', '', reference_node))
+        sep_entry_node = entry('', Text(separator, ''))
+        sum_entry_node = entry('', Text(summary, ''))
         row_node = row('', ref_entry_node, sep_entry_node, sum_entry_node)
         rows.append(row_node)
     col0_len = max_fullname_len + 2   # add error margin
@@ -255,8 +257,6 @@ def toc_ref(fullname, refid):
     return TocRef('', fullname,
                   name=name, refuri=as_refuri(refid), classes=['toc'])
 
-
-#>>===================================================
 def decorate_signatures(desc, classname):
     prefix = classname + DOT
     for child in desc.children:
@@ -264,8 +264,6 @@ def decorate_signatures(desc, classname):
             isinstance(child[0], sphinx.addnodes.desc_name)       ):
             new_desc_classname = sphinx.addnodes.desc_classname('', prefix)
             child.insert(0, new_desc_classname)
-
-#<<==================================================================
 
 def inject_template_globals(app, pagename, templatename, context, doctree):
     def lowercase_name(d):

--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -462,10 +462,6 @@ table.toc td {
     padding-right: 10px;
 }
 
-dt.module {
-    margin-bottom: 1em;
-}
-
 span.summaryline {
     font-style: italic;
 }
@@ -651,7 +647,6 @@ table.highlighttable pre {
 
 ul.simple {
     list-style-type: circle;
-    list-style-position: inside;
     margin-bottom: 1em;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -737,7 +737,7 @@ class DocsCommand(Command):
         runs the tests with default options.
         '''
         docs_help = (
-            "Building docs requires Python version 3.6 or above, and sphinx."
+            "Building docs requires Python version 3.6 or above, and sphinx 2 or above."
         )
         if not hasattr(sys, 'version_info') or sys.version_info < (3, 6):
             raise SystemExit(docs_help)


### PR DESCRIPTION
Since the beginning of time, pygame has been stuck on sphinx 1.x. But no more!

I've managed to fix **almost** every issue with upgrading to the latest versions of sphinx.

Issue 1) Bulleted lists were super wrong
![list_gone_wrong](https://user-images.githubusercontent.com/46412508/110457715-c89f0a00-807f-11eb-9d19-e0c0a7628022.PNG)
Fixed by getting rid of `list-style-position: inside;` for unordered lists in the css.

Issue 2) Spacing gone wonky
![weird_spacing](https://user-images.githubusercontent.com/46412508/110457778-d9e81680-807f-11eb-955c-de76f47f118f.PNG)
Fixed by changing `paragraph` docutils nodes to `Text` and `line` nodes. Newer docutils versions (from newer sphinx versions) put more `<p>` tags in the `paragraph` nodes, leading to the spacing problem.

Issue 3)
![comparison](https://user-images.githubusercontent.com/46412508/110458614-d2753d00-8080-11eb-89cf-1041e2986a7f.png)
I wasn't able to fix this. Left is before, using sphinx 1.8: each table header has a ":" and is inline with its contents. In the right picture, using sphinx 3.5, it doesn't do that, and I'm at a loss to why. I think it is in the css, and the generated html changed, making stylings that previously applied to it not apply anymore.

Why the effort?
Besides the general fact that being up to date on libraries is good, this also allows us to use fancy features added in sphinx 2 and 3. Like many of the features listed around [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#directive-py-method).

Other random fixes I did:
Update copyright to 2021
Removed duplicate `dt.module` css.

Final things:
The docs no longer build on sphinx 1.8.x, these changes break it. It does work on sphinx 2.x however.
The output is not 100% percent the same, but the error is small enough that I think it's acceptable. But if this doesn't get merged, at least it can guide someone else to fixing these problems in the future.

Also fixes #1298!