### PR TITLE
Update snippet in demo page: ChimpLineByLine.rst

### DIFF
--- a/docs/reST/tut/ChimpLineByLine.rst
+++ b/docs/reST/tut/ChimpLineByLine.rst
@@ -107,7 +107,7 @@ look at each function individually in this section. ::
           raise SystemExit(message)
       image = image.convert()
       if colorkey is not None:
-          if colorkey is -1:
+          if colorkey == -1:
               colorkey = image.get_at((0, 0))
           image.set_colorkey(colorkey, RLEACCEL)
       return image, image.get_rect()


### PR DESCRIPTION
super minor: use `==` for int comparison in the example (I see this was already fixed in the source)