### PR TITLE
Fix typo in display.set_gamma() that causes it to fail.

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -2189,7 +2189,7 @@ pg_set_gamma(PyObject *self, PyObject *arg)
         return PyErr_NoMemory();
     SDL_CalculateGammaRamp(r, gamma_ramp);
     SDL_CalculateGammaRamp(g, gamma_ramp + 256);
-    SDL_CalculateGammaRamp(b, gamma_ramp + 256);
+    SDL_CalculateGammaRamp(b, gamma_ramp + 512);
     if (win) {
         result = SDL_SetWindowGammaRamp(win, gamma_ramp, gamma_ramp + 256,
                                         gamma_ramp + 512);


### PR DESCRIPTION
Bug reported [on Stackoverflow](https://stackoverflow.com/questions/63326377/set-gamma-with-pygame-2-0-x).

Relevant Docs: [pygame.display.set_gamma](https://www.pygame.org/docs/ref/display.html#pygame.display.set_gamma)

Unlike the SO user, on my end, `display.set_gamma()` always returned `False`. But this does fix it for me.