### PR TITLE
Guard against MUS_OPUS not being defined on Xenial era SDL

### DIFF
--- a/src_c/music.c
+++ b/src_c/music.c
@@ -322,9 +322,11 @@ _get_type_from_hint(char *namehint)
     else if (SDL_strcasecmp(namehint, "OGG") == 0) {
         type = MUS_OGG;
     }
+#ifdef MUS_OPUS
     else if (SDL_strcasecmp(namehint, "OPUS") == 0) {
         type = MUS_OPUS;
     }
+#endif
     else if (SDL_strcasecmp(namehint, "FLAC") == 0) {
         type = MUS_FLAC;
     }


### PR DESCRIPTION
Unfortunately I didn't notice before merging, that there was a change that seems to break builds that don't include opus support.
https://travis-ci.org/github/pygame/pygame/builds/761959165#L1279

```c
src_c/music.c:326:16: error: ‘MUS_OPUS’ undeclared (first use in this function); did you mean ‘MUS_MP3’?
         type = MUS_OPUS;
                ^~~~~~~~
                MUS_MP3
```

Related: https://github.com/pygame/pygame/pull/2497