### PR TITLE
Fix pylance autocomplete

### DIFF
--- a/buildconfig/pygame-stubs/__init__.pyi
+++ b/buildconfig/pygame-stubs/__init__.pyi
@@ -69,3 +69,29 @@ def encode_file_path(
 ) -> bytes: ...
 def register_quit(callable: Callable) -> None: ...
 def __getattr__(name) -> Any: ...  # don't error on missing stubs
+
+surface = pygame.surface
+rect = pygame.rect
+color = pygame.color
+event = pygame.event
+bufferproxy = pygame.bufferproxy
+draw = pygame.draw
+display = pygame.display
+font = pygame.font
+image = pygame.image
+key = pygame.key
+mixer = pygame.mixer
+mouse = pygame.mouse
+time = pygame.time
+version = pygame.version
+cursors = pygame.cursors
+joystick = pygame.joystick
+mask = pygame.mask
+sprite = pygame.sprite
+transform = pygame.transform
+pixelarray = pygame.pixelarray
+sndarray = pygame.sndarray
+surfarray = pygame.surfarray
+math = pygame.math
+fastevent = pygame.fastevent
+scrap = pygame.scrap


### PR DESCRIPTION
Before this pr pylance autocomplete looked like this:
![image](https://user-images.githubusercontent.com/46655437/111341692-08ff1900-867a-11eb-8712-7a00bbf0d57c.png)

As seen from the image it didnt support submodules. The first suggestion should be `pygame.display`.

After the pr the autocomplete looks like this for me:
![image](https://user-images.githubusercontent.com/46655437/111342294-9b9fb800-867a-11eb-929e-8f1b4723ec07.png)

Before merging I would ask to test if it does not mess up any other tools (though shouldnt).