### PR TITLE
Implement pygame.display.get_window_handles

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -3112,6 +3112,7 @@ static PyMethodDef _pg_display_methods[] = {
     {"Info", pgInfo, METH_NOARGS, DOC_PYGAMEDISPLAYINFO},
     {"get_surface", pg_get_surface, METH_NOARGS, DOC_PYGAMEDISPLAYGETSURFACE},
     {"get_window_size", pg_window_size, METH_NOARGS,
+     DOC_PYGAMEDISPLAYGETWINDOWSIZE},
     {"get_window_handles", pg_get_window_handles, METH_NOARGS,
      DOC_PYGAMEDISPLAYGETWINDOWHANDLES},
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -708,6 +708,32 @@ pg_get_wm_info(PyObject *self, PyObject *args)
     return dict;
 }
 
+
+static PyObject *
+pg_get_window_handles(PyObject *self, PyObject *args)
+{
+    PyObject * tmp;
+    PyObject * display;
+    PyObject * window;
+    PyObject * zero;
+
+    tmp = PyObject_CallFunction(self, "get_wm_info");
+    if (!tmp)
+        return NULL;
+
+    display = PyDict_GetItemString(tmp, "display");
+    if (!display)
+        display = PyDict_GetItemString(tmp, "hinstance");
+    if (!display)
+        display = Py_None;
+
+    window = PyDict_GetItemString(tmp, "window");
+    if (!display)
+        window = Py_None;
+
+    return Py_BuildValue("(OO)", display, window);
+}
+
 /* display functions */
 #if IS_SDLv2
 static PyObject *
@@ -3086,7 +3112,8 @@ static PyMethodDef _pg_display_methods[] = {
     {"Info", pgInfo, METH_NOARGS, DOC_PYGAMEDISPLAYINFO},
     {"get_surface", pg_get_surface, METH_NOARGS, DOC_PYGAMEDISPLAYGETSURFACE},
     {"get_window_size", pg_window_size, METH_NOARGS,
-     DOC_PYGAMEDISPLAYGETWINDOWSIZE},
+    {"get_window_handles", pg_get_window_handles, METH_NOARGS,
+     DOC_PYGAMEDISPLAYGETWINDOWHANDLES},
 
     {"set_mode", (PyCFunction)pg_set_mode, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDISPLAYSETMODE},

--- a/src_c/doc/display_doc.h
+++ b/src_c/doc/display_doc.h
@@ -10,6 +10,7 @@
 #define DOC_PYGAMEDISPLAYGETDRIVER "get_driver() -> name\nGet the name of the pygame display backend"
 #define DOC_PYGAMEDISPLAYINFO "Info() -> VideoInfo\nCreate a video display information object"
 #define DOC_PYGAMEDISPLAYGETWMINFO "get_wm_info() -> dict\nGet information about the current windowing system"
+#define DOC_PYGAMEDISPLAYGETWINDOWHANDLES "get_window_handles() -> tuple\nGet the platform specific window handles"
 #define DOC_PYGAMEDISPLAYLISTMODES "list_modes(depth=0, flags=pygame.FULLSCREEN, display=0) -> list\nGet list of available fullscreen modes"
 #define DOC_PYGAMEDISPLAYMODEOK "mode_ok(size, flags=0, depth=0, display=0) -> depth\nPick the best color depth for a display mode"
 #define DOC_PYGAMEDISPLAYGLGETATTRIBUTE "gl_get_attribute(flag) -> value\nGet the value for an OpenGL flag for the current display"


### PR DESCRIPTION
Hi,

First of all Thank You for this great project.
I am writing in favor of the ease of use with external libraries.

I would like to have a platform independent way to return all the handles necessary to create a vulkan surface.
Currenty this is supported by the `get_wm_info`.

I have a working code to render into a pygame window with glnext (a vulkan based renderer).

[pygame_window.py](https://github.com/glnext/glnext/blob/fdf94a4ae92552937de2ef8a8b4ddae8cf6b5887/examples/pygame_window.py)

Unfortunately this does not work out of the box if I change to Linux.
There is a "display" key available but it is wrapped into a PyCapsule and the pointer is retrievable in pure python.

I think it would be awesome to get a tuple with the necessary values on all platforms.
I think on windows it is (HINSTANCE, HWND), with X11 it is (Display, Window), on Mac it may be just a surface pointer I guess.
For the other platforms I assume the (Display, Window) pair is necessary.

I made the PR just to make an example of what sort of function I am talking about. I tried to apply the same code style as above. I did not manage to build it yet.