### PR TITLE
Fix issue #2543 segfault in font dealloc after reinit

### DIFF
--- a/src_c/include/pygame_font.h
+++ b/src_c/include/pygame_font.h
@@ -29,6 +29,7 @@ typedef struct {
   PyObject_HEAD
   TTF_Font* font;
   PyObject* weakreflist;
+  uint ttf_init_generation;
 } PyFontObject;
 #define PyFont_AsFont(x) (((PyFontObject*)x)->font)
 

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -206,6 +206,16 @@ class FontModuleTest(unittest.TestCase):
 
         self.assertEqual(pre_blit_corner_pixel, post_blit_corner_pixel)
 
+    def test_segfault_after_reinit(self):
+        """ Reinitialization of font module should not cause
+            segmentation fault """
+        import gc
+        font = pygame_font.Font(None, 20)
+        pygame_font.quit()
+        pygame_font.init()
+        del font
+        gc.collect()
+
     def test_quit(self):
         pygame_font.quit()
 


### PR DESCRIPTION
TTF_Quit frees all the resources allocated by freetype. However pointers to FT_Face from TTF_Font are not set to NULL after this. Therefore when font_dealloc tries to call TTF_CloseFont, FT_Done_Face is called on already freed object and segmentation fault appears.

It can be so when Font module quits and then GC is called. (test is provided)

Solution provided is a little hack for setting font->face to NULL. It will tell TTF_CloseFont that face has been already freed and all that's left is to free allocated SDL resources.

Also I had to introduce a field current_ttf_generation to the PyFontObject to understand if object passed to the font_dealloc function is being destructed after TTF_Quit.
