### PR TITLE
The enter key code is len = 1

### DIFF
--- a/examples/textinput.py
+++ b/examples/textinput.py
@@ -103,10 +103,10 @@ def main():
                     _IMETextPos = max(0, _IMETextPos - 1)
                 elif event.key == pg.K_RIGHT:
                     _IMETextPos = min(len(_IMEText), _IMETextPos + 1)
-
+                # Handle ENTER key
                 elif (
                     event.key in [pg.K_RETURN, pg.K_KP_ENTER]
-                    and len(event.unicode) == 0
+                    and len(event.unicode) == 1
                 ):
                     # Block if we have no text to append
                     if len(_IMEText) == 0:


### PR DESCRIPTION
On Win32, the ENTER key handling completely was defeated for some reason, so chatbox entering of text does not do anything since the unicode for ENTER is '\r' and is length 1, not zero. 