### PR TITLE
(Freetype .render_to) Don't use -1 as error state.

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -318,23 +318,14 @@ parse_dest(PyObject *dest, int *x, int *y)
         Py_DECREF(oj);
         return -1;
     }
-    if (!pg_IntFromObj(oi, &i)){
-        i = -1;
-    }
-    Py_DECREF(oi);
-    if (i == -1 ) {
+    if (!pg_IntFromObj(oi, &i) || !pg_IntFromObj(oj, &j)){
+        Py_DECREF(oi);
         Py_DECREF(oj);
         PyErr_SetString(PyExc_TypeError, "dest expects a pair of numbers");
         return -1;
     }
-    if (!pg_IntFromObj(oj, &j)){
-        j = -1;
-    }
+    Py_DECREF(oi);
     Py_DECREF(oj);
-    if (j == -1 ) {
-        PyErr_SetString(PyExc_TypeError, "dest expects a pair of numbers");
-        return -1;
-    }
     *x = i;
     *y = j;
     return 0;


### PR DESCRIPTION
In pygame 2 and above, `-1` is rejected as a coordinate by `render_to` and `render_raw_to` because it is used internally by the `parse_dest` function in `_freetype.c` to set errors.

This actually happened to break some of my old code that I hadn't run on pygame 2 until yesterday.

Here's a simple test script. It works on 1.9.6 (and on this commit, ofc) but not on main.
```python
import pygame
import pygame.freetype

screen = pygame.display.set_mode((1280,720))

clock = pygame.time.Clock()

pygame.freetype.init()

# just an easy way to get default pygame font
font = pygame.freetype.SysFont("", size=64) 

while True:
    screen.fill((255,0,0))

    # they don't both have to be `-1`
    font.render_to(screen, (-1,-1), "WOW")
    
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            pygame.quit()
            raise SystemExit

    pygame.display.flip()

    clock.tick(144)
```