### PR TITLE
Compatibility fix for GraalPython

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -33,9 +33,12 @@
 */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+
+/* Ensure PyPy-specific code is not in use when running on GraalPython (PR #2580) */
 #if defined(GRAALVM_PYTHON) && defined(PYPY_VERSION)
 #undef PYPY_VERSION
 #endif
+
 #include <SDL.h>
 
 /* IS_SDLv1 is 1 if SDL 1.x.x, 0 otherwise */

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -33,6 +33,9 @@
 */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#if defined(GRAALVM_PYTHON) && defined(PYPY_VERSION)
+#undef PYPY_VERSION
+#endif
 #include <SDL.h>
 
 /* IS_SDLv1 is 1 if SDL 1.x.x, 0 otherwise */


### PR DESCRIPTION
[GraalPython](https://github.com/oracle/graalpython) defines [`PYPY_VERSION`](https://github.com/oracle/graalpython/blob/39e26642d7c4a9f490c19db9270753a657b97f30/graalpython/com.oracle.graal.python.cext/include/Python.h#L51) for compatibility with some other extensions. pygame seems to work fine on GraalPython, but only without PyPy-specific code. This makes sure `PYPY_VERSION` is not defined when running on GraalPython.