### PR TITLE
Fixes window minimum size when leaving SCALED on Windows.

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1240,6 +1240,12 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                 init_flip = 1;
             }
             else {
+                /* set min size to (1,1) to erase any previously set min size
+                 * relevant for windows leaving SCALED, which sets a min size
+                 * only relevant on Windows, I believe.
+                 * See https://github.com/pygame/pygame/issues/2327 */
+                SDL_SetWindowMinimumSize(win, 1, 1);
+
                 /* change existing window.
                  this invalidates the display surface*/
                 SDL_SetWindowTitle(win, title);

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -559,6 +559,16 @@ class DisplayModuleTest(unittest.TestCase):
             winsize[0] / surf.get_size()[0], winsize[1] / surf.get_size()[1]
         )
 
+    def test_set_mode_unscaled(self):
+        """ Ensures a window created with SCALED can become smaller. """
+        # see https://github.com/pygame/pygame/issues/2327
+
+        screen = pygame.display.set_mode((300,300), pygame.SCALED)
+        self.assertEqual(screen.get_size(), (300,300))
+
+        screen = pygame.display.set_mode((200,200))
+        self.assertEqual(screen.get_size(), (200,200))
+
     def test_screensaver_support(self):
         pygame.display.set_allow_screensaver(True)
         self.assertTrue(pygame.display.get_allow_screensaver())


### PR DESCRIPTION
Fixes #2327 

`SCALED` mode sets a minimum size for its window: the requested user size.
When leaving `SCALED` mode with another call to `display.set_mode()`, different things can happen on different operating systems.
I'm not totally sure why, but on Windows, the window size is changed on the same `SDL_Window` object. On other platforms, it ends up that a new window of a different size is created.

That's why this bug only affected Windows. Because other platforms ended up with new `SDL_Window` objects, those new objects did not carry over the minimum size set by `SCALED` in the previous call.

There isn't an "unset" minimum size, so I just changed it to set a minimum size of `(1,1)` in the relevant part of the code. I was worried about this causing an edge case with user requested `(0, 0)` sized windows, but 0-dimensions are treated as requests to use the display resolution dimension, so we're good.

The original issue has a good manual test code, for anyone who wants to test this locally.

I also added an automated test!