### PR TITLE
Overhaul SysFont on Mac

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -177,7 +177,7 @@ def _add_font_paths(sub_elements, fonts):
 def _system_profiler_darwin():
     fonts = {}
     flout, _ = subprocess.Popen(
-        ' '.join(['system_profiler', '-xml', 'SPFontsDataType']),
+        ' '.join(['/usr/sbin/system_profiler', '-xml', 'SPFontsDataType']),
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -27,10 +27,6 @@ from os.path import basename, dirname, exists, join, splitext
 from pygame.font import Font
 from pygame.compat import xrange_, PY_MAJOR_VERSION, unicode_
 
-if sys.platform == 'darwin':
-    import xml.etree.ElementTree as ET
-
-
 OpenType_extensions = frozenset(('.ttf', '.ttc', '.otf'))
 Sysfonts = {}
 Sysalias = {}
@@ -137,58 +133,79 @@ def _parse_font_entry_win(name, font, fonts):
     if name.endswith(true_type_suffix):
         name = name.rstrip(true_type_suffix).rstrip()
     name = name.lower().split()
-    bold = italic = 0
+    bold = italic = False
     for mod in mods:
         if mod in name:
             name.remove(mod)
     if 'bold' in name:
         name.remove('bold')
-        bold = 1
+        bold = True
     if 'italic' in name:
         name.remove('italic')
-        italic = 1
+        italic = True
     name = ''.join(name)
     name = _simplename(name)
 
     _addfont(name, bold, italic, font, fonts)
 
 
-def _add_font_paths(sub_elements, fonts):
-    """ Gets each element, checks its tag content,
-        if wanted fetches the next value in the iterable
+def _parse_font_entry_darwin(name, filepath, fonts):
     """
-    font_name = None
-    bold = False
-    italic = False
-    for tag in sub_elements:
-        if tag.text == "_name":
-            font_file_name = next(sub_elements).text
-            font_name = splitext(font_file_name)[0]
-            if splitext(font_file_name)[1] not in OpenType_extensions:
-                break
-            bold = "bold" in font_name
-            italic = "italic" in font_name
-        if tag.text == "path" and font_name is not None:
-            font_path = next(sub_elements).text
-            _addfont(_simplename(font_name), bold, italic, font_path, fonts)
-            break
+    Parses a font entry for macOS
+
+    :param name: The filepath without extensions or directories
+    :param filepath: The full path to the font
+    :param fonts: The pygame font dictionary to add the parsed font data to.
+    """
+
+    name = _simplename(name)
+
+    mods = ("regular",)
+
+    for mod in mods:
+        if mod in name:
+            name = name.replace(mod, "")
+
+    bold = italic = False
+    if "bold" in name:
+        name = name.replace("bold", "")
+        bold = True
+    if "italic" in name:
+        name = name.replace("italic", "")
+        italic = True
+    
+    _addfont(name, bold, italic, filepath, fonts)
 
 
-def _system_profiler_darwin():
+def _font_finder_darwin():
+    locations = ["/Library/Fonts",
+                 "/Network/Library/Fonts",
+                 "/System/Library/Fonts"]
+
+    username = os.getenv("USER")
+    if username:
+        locations.append("/Users/" + username + "/Library/Fonts")
+
+    strange_root = "/System/Library/Assets/com_apple_MobileAsset_Font3"
+    if exists(strange_root):
+        strange_locations = os.listdir(strange_root)
+        for loc in strange_locations:
+            locations.append(strange_root + "/" + loc + "/AssetData")
+
     fonts = {}
-    flout, _ = subprocess.Popen(
-        ' '.join(['/usr/sbin/system_profiler', '-xml', 'SPFontsDataType']),
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True
-    ).communicate()
 
-    for font_node in ET.fromstring(flout).iterfind('./array/dict/array/dict'):
-        _add_font_paths(font_node.iter("*"), fonts)
+    for location in locations:
+        if not exists(location):
+            continue
+
+        files = os.listdir(location)
+        for file in files:
+            name, extension = splitext(file)
+            if extension in OpenType_extensions:
+                _parse_font_entry_darwin(name, join(location, file), fonts)
 
     return fonts
-
+    
 
 def initsysfonts_darwin():
     """ Read the fonts on MacOS, and OS X.
@@ -201,13 +218,9 @@ def initsysfonts_darwin():
     # disc
     elif exists('/usr/X11R6/bin/fc-list'):
         fonts = initsysfonts_unix('/usr/X11R6/bin/fc-list')
-    elif exists('/usr/sbin/system_profiler'):
-        try:
-            fonts = _system_profiler_darwin()
-        except (OSError, ValueError):
-            fonts = {}
     else:
-        fonts = {}
+        # eventually this should probably be the preferred solution
+        fonts = _font_finder_darwin() 
 
     return fonts
 


### PR DESCRIPTION
This fixes #2549 and #2553.

`system_profiler` is slowwwwwwwww
It hasn't been a problem in the past because pygame SysFont prefers to use the X11 installation that exists on MacOS to report fonts. (TIL there's an X11 install on some Macs). But newer Macs / Mac OS versions don't have this, so their users are starting to grate against the ~10 seconds `system_profiler` takes to give results.

To fix this, I wrote the `_font_finder_darwin()` function. It grabs fonts from all the locations I saw `system_profiler` grabbing fonts.

However, I discovered another problem. The fonts were not being "grouped" properly before. All the sysfont init functions return a dictionary with the format `{simple_font_name: {(bold, italic): font_file}, ...}`. But the `system_profiler` derived font names weren't being parsed properly. For example, Arial bold would be represented as a different font, not bold or italic.

It would look something like this:
```
fonts = {"arial": {(False, False): "/System/Library/Arial.ttf"}, 
         "arialbold": {(False, False): "/System/Library/Arial-Bold.ttf"}}
```

When it should look like:
```
fonts = {"arial": {(False, False): "/System/Library/Arial.ttf", (True, False): "/System/Library/Arial-Bold.ttf"}}
```

I made a "fidelity test" to demonstrate this, which you can download if you want - [fidelitytest.py.zip](https://github.com/pygame/pygame/files/6514855/fidelitytest.py.zip)

TLDR: It requests Arial and also requests Bold

The old (`system_profiler` path based) output was:
<img width="496" alt="fake" src="https://user-images.githubusercontent.com/46412508/118958722-88c59000-b916-11eb-96ae-f9d3a7091de3.png">

The new output is:      (this is the same as the X11 path output, as well)
<img width="421" alt="legit" src="https://user-images.githubusercontent.com/46412508/118958778-94b15200-b916-11eb-9e5e-aa99a11423ac.png">

This is because the old version didn't categorize the fonts properly, so the font module had to fake the bold. Whereas in the second version, it has a premade bold style to work from, making it much prettier on the eyes.

**Note for reviewers:**
Although this does "overhaul" the system, macs that were using the X11 based Sysfont will still use it, so this won't change compatibility on anyone who had a working SysFont module on MacOS. This makes this PR safer to merge than it would be otherwise.