### PR TITLE
Add github actions, disable travis builds except arm64

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ on:
     - '.github/workflows/sdl1-sdist.yml'
 
 jobs:
-  build:
+  build-macos:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,87 @@
+name: MacOS
+
+# Run CI only when a release is created, on changes to main branch, or any PR 
+# to main. Do not run CI on any other branch. Also, skip any non-source changes 
+# from running on CI
+on:
+  release:
+    types: [created]
+  push:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/linux.yml'
+    - '.github/workflows/windows.yml'
+    - '.github/workflows/sdl1-sdist.yml'
+  pull_request:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/manylinux.yml'
+    - '.github/workflows/windows.yml'
+    - '.github/workflows/sdl1-sdist.yml'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # if a particular matrix build fails, don't skip the rest
+      matrix:
+        # TODO: when Github actions supports M1 Mac, add `macos-11.0` to this
+        os: [macos-10.15]
+        pyversion: ['pypy-3.7', 'pypy-2.7', '2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+    
+    - name: Set up Python ${{ matrix.pyversion }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.pyversion }}
+
+    - name: Install deps
+      run: |
+        brew install sdl2 sdl2_image sdl2_mixer sdl2_net sdl2_ttf libpng zlib freetype portmidi openblas
+        python -m pip install -U pip
+        python -m pip install -U wheel requests
+        OPENBLAS="$(brew --prefix openblas)" python -m pip install -U numpy
+
+    - name: Build the wheel and install it
+      run: |
+        python setup.py build -j4 bdist_wheel
+        python -m pip install --ignore-installed --pre --no-index --find-links=dist/ pygame
+    
+    - name: Run tests
+      env:
+        SDL_VIDEODRIVER: "dummy"
+        SDL_AUDIODRIVER: "disk"
+      run: python -m pygame.tests -v --exclude opengl,timing --time_out 300
+
+    # We upload the generated files under github actions assets
+    - name: Upload dist
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.whl
+
+#   - name: Upload binaries to Github Releases
+#     if: github.event_name == 'release'
+#     uses: svenstaro/upload-release-action@v2
+#     with:
+#       repo_token: ${{ secrets.GITHUB_TOKEN }}
+#       file: dist/*.whl
+#       tag: ${{ github.ref }}
+#
+#   - name: Upload binaries to PyPI
+#     if: github.event_name == 'release'
+#     env:
+#      TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#      TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#     run: |
+#       python3 -m pip install twine
+#       twine upload dist/*.whl

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -1,0 +1,67 @@
+name: ManyLinux
+
+# Run CI only when a release is created, on changes to main branch, or any PR 
+# to main. Do not run CI on any other branch. Also, skip any non-source changes 
+# from running on CI
+on:
+  release:
+    types: [created]
+  push:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/macos.yml'
+    - '.github/workflows/windows.yml'
+    - '.github/workflows/sdl1-sdist.yml'
+  pull_request:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/macos.yml'
+    - '.github/workflows/windows.yml'
+    - '.github/workflows/sdl1-sdist.yml'
+
+# TODO: Parallelize this build
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - name: Build manylinux wheels
+      run: |
+        cd buildconfig/manylinux-build
+        make pull pull-manylinux wheels wheels-manylinux
+        cd ../..
+        mkdir -p dist/
+        cp buildconfig/manylinux-build/wheelhouse/*.whl dist/
+
+    # We upload the generated files under github actions assets
+    - name: Upload dist
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.whl
+
+#   - name: Upload binaries to Github Releases
+#     if: github.event_name == 'release'
+#     uses: svenstaro/upload-release-action@v2
+#     with:
+#       repo_token: ${{ secrets.GITHUB_TOKEN }}
+#       file: dist/*.whl
+#       tag: ${{ github.ref }}
+#
+#   - name: Upload binaries to PyPI
+#     if: github.event_name == 'release'
+#     env:
+#      TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#      TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#     run: |
+#       python3 -m pip install twine
+#       twine upload dist/*.whl

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -29,7 +29,7 @@ on:
 
 # TODO: Parallelize this build
 jobs:
-  build:
+  build-manylinux:
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/sdl1-sdist.yml
+++ b/.github/workflows/sdl1-sdist.yml
@@ -1,0 +1,98 @@
+name: SDL1-sdist
+
+# Run CI only when a release is created, on changes to main branch, or any PR 
+# to main. Do not run CI on any other branch. Also, skip any non-source changes 
+# from running on CI
+on:
+  release:
+    types: [created]
+  push:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/macos.yml'
+    - '.github/workflows/windows.yml'
+    - '.github/workflows/manylinux.yml'
+  pull_request:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/macos.yml'
+    - '.github/workflows/windows.yml'
+    - '.github/workflows/manylinux.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - name: Install deps
+      run: |
+        sudo apt-get install python3-dev python3-setuptools python3-numpy python3-opengl libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libsdl1.2-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev libtiff5-dev libx11-6 libx11-dev fluid-soundfont-gm timgm6mb-soundfont xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fontconfig fonts-freefont-ttf libfreetype6-dev
+        python3 -m pip install -U pip
+        python3 -m pip install -U wheel requests
+
+    - name: Make sdist
+      run: |
+        python3 setup.py -config -auto -sdl1
+        python3 setup.py sdist
+
+    - name: Extract sdist for testing
+      run: |
+        import tarfile
+        import os
+        import glob
+        
+        for i in glob.iglob("dist/pygame-*.tar.gz"):
+          with tarfile.open(i, 'r:gz') as tar:
+            tar.extractall()
+          break
+
+        for dir in os.listdir(os.getcwd()):
+          if dir.startswith("pygame-"):
+            os.rename(dir, "pygame-sdist")
+            break
+      shell: python
+
+    - name: Install SDL1 pygame from sdist
+      run: |
+        python3 setup.py -config -auto -sdl1
+        python3 setup.py build -j4 install --user
+      working-directory: ./pygame-sdist
+
+    - name: Run tests
+      env:
+        SDL_VIDEODRIVER: "dummy"
+        SDL_AUDIODRIVER: "disk"
+      run: python3 -m pygame.tests -v --exclude opengl,timing --time_out 300
+
+    # We upload the generated files under github actions assets
+    - name: Upload sdist
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+
+#   - name: Upload binaries to Github Releases
+#     if: github.event_name == 'release'
+#     uses: svenstaro/upload-release-action@v2
+#     with:
+#       repo_token: ${{ secrets.GITHUB_TOKEN }}
+#       file: dist/*.tar.gz
+#       tag: ${{ github.ref }}
+#
+#   - name: Upload binaries to PyPI
+#     if: github.event_name == 'release'
+#     env:
+#      TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#      TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#     run: |
+#       python3 -m pip install twine
+#       twine upload dist/*.tar.gz

--- a/.github/workflows/sdl1-sdist.yml
+++ b/.github/workflows/sdl1-sdist.yml
@@ -28,7 +28,7 @@ on:
     - '.github/workflows/manylinux.yml'
 
 jobs:
-  build:
+  build-sdl1-sdist:
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,11 +33,11 @@ jobs:
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       # PyPy 7.3.3 has only win32 builds available (python 2.7, 3.6, and 3.7)
-      # PyPy 7.3.4 does not have 32-bit builds, only 64-bit ones (python 2.7 and 3.7)
+      # PyPy 7.3.4 does not have 32-bit builds, only 64-bit ones (python 3.7)
       # So we build with 7.3.3 for 32-bit builds, and 7.3.4 for 64-bit builds
       matrix:
         # pyversion: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7']
-        pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-2.7-v7.3.4', 'pypy-3.7-v7.3.4']
+        pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-3.7-v7.3.4']
         arch: ['x64', 'x86']
         
         exclude:
@@ -47,8 +47,6 @@ jobs:
             arch: 'x64'
           - pyversion: 'pypy-3.7-v7.3.3'
             arch: 'x64'
-          - pyversion: 'pypy-2.7-v7.3.4'
-            arch: 'x86'
           - pyversion: 'pypy-3.7-v7.3.4'
             arch: 'x86'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,11 +33,10 @@ jobs:
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       # PyPy 7.3.3 has only win32 builds available (python 2.7, 3.6, and 3.7)
-      # PyPy 7.3.4 does not have 32-bit builds, only 64-bit ones (python 3.7)
-      # So we build with 7.3.3 for 32-bit builds, and 7.3.4 for 64-bit builds
+      # PyPy 7.3.4 and above does not have 32-bit builds, only 64-bit ones (python 3.7)
+      # So we build with 7.3.3 for 32-bit builds, and 7.3.4+ for 64-bit builds
       matrix:
-        # pyversion: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7']
-        pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-3.7-v7.3.4']
+        pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-3.7']
         arch: ['x64', 'x86']
         
         exclude:
@@ -47,7 +46,7 @@ jobs:
             arch: 'x64'
           - pyversion: 'pypy-3.7-v7.3.3'
             arch: 'x64'
-          - pyversion: 'pypy-3.7-v7.3.4'
+          - pyversion: 'pypy-3.7'
             arch: 'x86'
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ on:
     - '.github/workflows/sdl1-sdist.yml'
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,7 +36,9 @@ jobs:
       # PyPy 7.3.4 and above does not have 32-bit builds, only 64-bit ones (python 3.7)
       # So we build with 7.3.3 for 32-bit builds, and 7.3.4+ for 64-bit builds
       matrix:
-        pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-3.7']
+        # pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-3.7']
+        # disable all but one to save resources, since they are covered by appveyor windows builds.
+        pyversion: ['3.5']
         arch: ['x64', 'x86']
         
         exclude:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,19 +32,25 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
+      # PyPy 7.3.3 has only win32 builds available (python 2.7, 3.6, and 3.7)
+      # PyPy 7.3.4 does not have 32-bit builds, only 64-bit ones (python 2.7 and 3.7)
+      # So we build with 7.3.3 for 32-bit builds, and 7.3.4 for 64-bit builds
       matrix:
         # pyversion: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7']
-        pyversion: ['3.5']
+        pyversion: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7-v7.3.3', 'pypy-3.6-v7.3.3', 'pypy-3.7-v7.3.3', 'pypy-2.7-v7.3.4', 'pypy-3.7-v7.3.4']
         arch: ['x64', 'x86']
-        # excludes x64 builds on pypy windows for now, remove this block when PyPy has better
-        # x64 support on windows
-        # exclude:
-        # - pyversion: 'pypy-2.7'
-        #   arch: 'x64'
-        # - pyversion: 'pypy-3.6'
-        #   arch: 'x64'
-        # - pyversion: 'pypy-3.7'
-        #   arch: 'x64'
+        
+        exclude:
+          - pyversion: 'pypy-2.7-v7.3.3'
+            arch: 'x64'
+          - pyversion: 'pypy-3.6-v7.3.3'
+            arch: 'x64'
+          - pyversion: 'pypy-3.7-v7.3.3'
+            arch: 'x64'
+          - pyversion: 'pypy-2.7-v7.3.4'
+            arch: 'x86'
+          - pyversion: 'pypy-3.7-v7.3.4'
+            arch: 'x86'
 
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,108 @@
+name: Windows
+
+# Run CI only when a release is created, on changes to main branch, or any PR 
+# to main. Do not run CI on any other branch. Also, skip any non-source changes 
+# from running on CI
+on:
+  release:
+    types: [created]
+  push:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/manylinux.yml'
+    - '.github/workflows/macos.yml'
+    - '.github/workflows/sdl1-sdist.yml'
+  pull_request:
+    branches: main
+    paths-ignore:
+    - 'docs/**'
+    - 'examples/**'
+    - '.gitignore'
+    - 'README.rst'
+    - '.github/workflows/manylinux.yml'
+    - '.github/workflows/macos.yml'
+    - '.github/workflows/sdl1-sdist.yml'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false  # if a particular matrix build fails, don't skip the rest
+      matrix:
+        # pyversion: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7']
+        pyversion: ['3.5']
+        arch: ['x64', 'x86']
+        # excludes x64 builds on pypy windows for now, remove this block when PyPy has better
+        # x64 support on windows
+        # exclude:
+        # - pyversion: 'pypy-2.7'
+        #   arch: 'x64'
+        # - pyversion: 'pypy-3.6'
+        #   arch: 'x64'
+        # - pyversion: 'pypy-3.7'
+        #   arch: 'x64'
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    # python 2.7 needs special treatment because it needs an old compiler to work
+    # https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi
+    # https://web.archive.org/web/20210106040224/https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi
+    # - name: Setup MSBuild with MSVC v9.0
+    #   if: matrix.pyversion == '2.7'
+    #   run: |
+    #     Invoke-WebRequest https://github.com/GeoNode/geonode-win-installer/raw/ffb76c7cbf1d6b4970c6c25f79c3c7682a3aa035/VCForPython27.msi -OutFile C:\VCForPython27.msi
+    #     msiexec.exe /i "C:\VCForPython27.msi" /qn ALLUSERS=1
+
+    # - name: Setup MSBuild with MSVC latest version
+    #   if: matrix.pyversion != '2.7'
+    #   uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Set up Python ${{ matrix.pyversion }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.pyversion }}
+        architecture: ${{ matrix.arch }}
+
+    - name: Install deps
+      run: |
+        python -m pip install -U pip
+        python -m pip install -U wheel requests numpy
+
+    - name: Build the wheel and install it
+      run: |
+        python setup.py build -j4 bdist_wheel
+        python -m pip install --ignore-installed --pre --no-index --find-links=dist/ pygame
+
+    - name: Run tests
+      env:
+        SDL_VIDEODRIVER: "dummy"
+        SDL_AUDIODRIVER: "disk"
+      run: python -m pygame.tests -v --exclude opengl,timing --time_out 300
+
+    # We upload the generated files under github actions assets
+    - name: Upload dist
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.whl
+
+#   - name: Upload binaries to Github Releases
+#     if: github.event_name == 'release'
+#     uses: svenstaro/upload-release-action@v2
+#     with:
+#       repo_token: ${{ secrets.GITHUB_TOKEN }}
+#       file: dist/*.whl
+#       tag: ${{ github.ref }}
+#
+#   - name: Upload binaries to PyPI
+#     if: github.event_name == 'release'
+#     env:
+#      TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#      TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#     run: |
+#       python3 -m pip install twine
+#       twine upload dist/*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ if: type != push OR branch = master OR branch = main OR branch =~ /^\d+\.\d+(\.\
 
 jobs:
   include:
-    - python: 3.6
-      name: SDL 1.2
-      env:
-        - WHICH_SDL_BUILD=-sdl1
+    # - python: 3.6
+    #   name: SDL 1.2
+    #   env:
+    #     - WHICH_SDL_BUILD=-sdl1
 
     # enable ppc64le closer to release, it is slow.
     # - os: linux-ppc64le
@@ -44,41 +44,44 @@ jobs:
     # - os: linux
     #   python: 3.7
     #   arch: s390x
-    - os: linux
-      python: 3.7
-      name: manylinux x86/amd64 python 2.7, 3.4-3.9.
-      env:
-        - MANYLINUX_WHL=yes
-        - UPLOAD_WHL_PYPI=yes
-        - GITHUB_UPLOAD=yes
-        - PYTHON_EXE=python3
-      services:
-        - docker
-    - os: osx
-      language: shell
-      env:
-        - GITHUB_UPLOAD=yes
-        - UPLOAD_WHL_PYPI=yes
-      cache:
-        directories:
-          - $HOME/.conan/data
+    # - os: linux
+    #   python: 3.7
+    #   name: manylinux x86/amd64 python 2.7, 3.4-3.9.
+    #   env:
+    #     - MANYLINUX_WHL=yes
+    #     - UPLOAD_WHL_PYPI=yes
+    #     - GITHUB_UPLOAD=yes
+    #     - PYTHON_EXE=python3
+    #   services:
+    #     - docker
+    # - os: osx
+    #   language: shell
+    #   env:
+    #     - GITHUB_UPLOAD=yes
+    #     - UPLOAD_WHL_PYPI=yes
+    #   cache:
+    #     directories:
+    #       - $HOME/.conan/data
 
     # only run this on tag posts. We need two mac builds for mac wheels when doing pypy.
-    - os: osx
-      name: mac pypy only
-      if: tag ~= /^\d+\.\d+(\.\d+)?(.\S*)?$/
-      language: shell
-      env:
-        - GITHUB_UPLOAD=yes
-        - UPLOAD_WHL_PYPI=yes
-        - PYPYONLY=yes
-      cache:
-        directories:
-          - $HOME/.conan/data
+    # - os: osx
+    #   name: mac pypy only
+    #   if: tag ~= /^\d+\.\d+(\.\d+)?(.\S*)?$/
+    #   language: shell
+    #   env:
+    #     - GITHUB_UPLOAD=yes
+    #     - UPLOAD_WHL_PYPI=yes
+    #     - PYPYONLY=yes
+    #   cache:
+    #     directories:
+    #       - $HOME/.conan/data
 
   # allow_failures:
   #   - arch: s390x
     # - python: pypy
+
+  allow_failures:
+    - arch: arm64
 
 before_install:
   - |

--- a/src_c/SDL_gfx/SDL_gfxPrimitives.c
+++ b/src_c/SDL_gfx/SDL_gfxPrimitives.c
@@ -3971,8 +3971,11 @@ int ellipseRGBA(SDL_Surface * dst, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uin
 
 /* ----- AA Ellipse */
 
-/* Windows targets do not have lrint, so provide a local inline version */
+/* Visual Studio 2015 and above define the lrint intristic function, but for
+ * compatibility with older windows compilers, we need to define it ourselves
+ */
 #if defined(_MSC_VER)
+#if _MSC_VER < 1900
 /* Detect 64bit and use intrinsic version */
 #ifdef _M_X64
 #include <emmintrin.h>
@@ -4008,6 +4011,7 @@ lrint (double flt)
 #pragma warning(pop)
 #else
 #error lrint needed for MSVC on non X86/AMD64/ARM targets.
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Continued on from [PR by Ankith](https://github.com/pygame/pygame/pull/2507) (Mostly this is by Ankith, with a few tweaks).


- windows python 2 build fails because someone at MS removed compiler-for-py2 download. We use appveyor for these instead.
- Disabled all windows python except 3.5. We use appveyor for others instead.
- windows, pypy stopped distributing 32bit builds, and now does 64bit only. We use appveyor for these.
- release uploads are disabled for now
- all builds on Travis are disabled, except arm64 (which is allowed to fail).
- gave the jobs different names like `build-windows`, rather than all of them being `build`.

There's more discussion below, and further work possible... but this is good for now.

With everything passing here, we will move to requiring github actions to pass before allowing a merge.

Closes issue: https://github.com/pygame/pygame/issues/2300