### PR TITLE
Fix display.list_modes()

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1595,7 +1595,7 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
     int bpp = 0;
     int flags = PGS_FULLSCREEN;
     int display_index = 0;
-    int last_width = -1, last_height;
+    int last_width = -1, last_height = -1;
     PyObject *list, *size;
     int i;
 


### PR DESCRIPTION
This actually has no end result, because the first time last_height gets used it will be initialized, but this PR is about fixing compiler warning (#2601)