### PR TITLE
Fixed pygame.examples.mask crashing

### DIFF
--- a/examples/mask.py
+++ b/examples/mask.py
@@ -133,6 +133,7 @@ def main(*args):
     if len(args) == 0:
         raise ValueError("Require at least one image file name: non given")
     print("Press any key to quit")
+    pg.init()
     screen = pg.display.set_mode((640, 480))
     if any("fist.bmp" in x for x in args):
         pg.display.set_caption("Punch Nazis")


### PR DESCRIPTION
Thanks to discord user Nikorasu#2462 who pointed out that there is an error with this example that says 
```
File "pygame\examples\mask.py", line 175, in main
    pg.time.set_timer(pg.USEREVENT, 33)
pygame.error: pygame is not initialized
```
This simple fix should make the example work (tested locally)