### PR TITLE
Add python 3.6, 3.7 and 3.9 wheel build support for aarch64

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -49,6 +49,43 @@ jobs:
       with:
         path: dist/*.whl
 
+  build-aarch64:
+    name: "Build aarch64 wheel"
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      img: quay.io/pypa/manylinux2014_aarch64
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+         python-version: '3.7'    
+    - name: Build and test wheel
+      run: |
+            docker run --rm -v ${{ github.workspace }}:/io:rw --workdir=/io \
+            ${{ env.img }} \
+            bash -exc 'yum install -y sudo && \
+            export PYTHON_EXE=python3 && \
+            sudo yum install -y epel-release dnf && \
+            sudo yum-config-manager --enable epel && \
+            sudo yum install -y SDL2-devel freetype-devel libjpeg-turbo SDL2_mixer-devel portmidi-devel SDL2_ttf-devel SDL2_image-devel && \
+            sudo dnf install -y libjpeg-turbo-devel libvorbis && \
+            cd buildconfig/manylinux-build && \
+            source build-wheels.sh && \
+            cd ../.. && \
+            mkdir -p dist/ && \
+            cp buildconfig/manylinux-build/wheelhouse/*.whl dist/'
+    - name: Upload dist
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.whl
+
 #   - name: Upload binaries to Github Releases
 #     if: github.event_name == 'release'
 #     uses: svenstaro/upload-release-action@v2

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e -x
 
-export SUPPORTED_PYTHONS="cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
+if [ `uname -m` == "aarch64" ]; then
+   export SUPPORTED_PYTHONS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39" 
+else
+   export SUPPORTED_PYTHONS="cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39" 
+fi
 
 if [[ "$1" == "buildpypy" ]]; then
 	export SUPPORTED_PYTHONS="pp27-pypy_73 pp36-pypy36_pp73 pp37-pypy37_pp73"


### PR DESCRIPTION
Add python 3.6, 3.7 and 3.9 wheel build support for aarch64
@illume, Could you please review this PR?