### PR TITLE
Adjust shot explosion position in the aliens example

### DIFF
--- a/examples/aliens.py
+++ b/examples/aliens.py
@@ -378,7 +378,7 @@ def main(winstyle=0):
             player.kill()
 
         # See if shots hit the aliens.
-        for alien in pg.sprite.groupcollide(shots, aliens, 1, 1).keys():
+        for alien in pg.sprite.groupcollide(aliens, shots, 1, 1).keys():
             if pg.mixer:
                 boom_sound.play()
             Explosion(alien)


### PR DESCRIPTION
Currently, when a shot hits an alien, explosion will be created at the position of the shot because `groupcollide(shots, aliens, 1, 1).keys()` returns `shots`. This PR swaps the position of `shots` and `aliens` which makes explosion looks more natural.

```py
# See if shots hit the aliens.
for alien in pg.sprite.groupcollide(shots, aliens, 1, 1).keys():
    if pg.mixer:
        boom_sound.play()
   Explosion(alien)
```