### PR TITLE
Remove restriction on rendering 4-byte characters on `pygame.font`

### DIFF
--- a/src_c/font.c
+++ b/src_c/font.c
@@ -514,12 +514,12 @@ font_render(PyObject *self, PyObject *args)
             return RAISE(PyExc_ValueError,
                          "A null character was found in the text");
         }
-#if !SDL_VERSION_ATLEAST(2, 0, 15)
+#if !SDL_TTF_VERSION_ATLEAST(2, 0, 15)
         if (utf_8_needs_UCS_4(astring)) {
             Py_DECREF(bytes);
             return RAISE(PyExc_UnicodeError,
                          "A Unicode character above '\\uFFFF' was found;"
-                         " not supported with SDL version below 2.0.15");
+                         " not supported with SDL_ttf version below 2.0.15");
         }
 #endif
         if (aa) {

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -514,12 +514,6 @@ font_render(PyObject *self, PyObject *args)
             return RAISE(PyExc_ValueError,
                          "A null character was found in the text");
         }
-        if (utf_8_needs_UCS_4(astring)) {
-            Py_DECREF(bytes);
-            return RAISE(PyExc_UnicodeError,
-                         "A Unicode character above '\\uFFFF' was found;"
-                         " not supported");
-        }
         if (aa) {
             if (bg_rgba_obj == NULL) {
                 surf = TTF_RenderUTF8_Blended(font, astring, foreg);

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -514,6 +514,14 @@ font_render(PyObject *self, PyObject *args)
             return RAISE(PyExc_ValueError,
                          "A null character was found in the text");
         }
+#if !SDL_VERSION_ATLEAST(2, 0, 15)
+        if (utf_8_needs_UCS_4(astring)) {
+            Py_DECREF(bytes);
+            return RAISE(PyExc_UnicodeError,
+                         "A Unicode character above '\\uFFFF' was found;"
+                         " not supported with SDL version below 2.0.15");
+        }
+#endif
         if (aa) {
             if (bg_rgba_obj == NULL) {
                 surf = TTF_RenderUTF8_Blended(font, astring, foreg);


### PR DESCRIPTION
Some time ago, SDL_TTF gave support on rendering 4-byte characters (Which are emojis and some CJK characters). Although not documented in the official documentation, it was indeed implemented. It seems pygame hasn't removed this restriction on rendering 4-byte characters yet.

Test run:
![image](https://user-images.githubusercontent.com/44055981/122672876-f1df4280-d1f7-11eb-8144-e998cba75766.png)
