### PR TITLE
Add paths to /opt/homebrew

### DIFF
--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -158,11 +158,11 @@ def main(sdl2=False):
     ])
 
     print ('Hunting dependencies...')
-    incdirs = ['/usr/local/include']
+    incdirs = ['/usr/local/include', '/opt/homebrew/include']
     if sdl2:
-        incdirs.append('/usr/local/include/SDL2')
+        incdirs.extend(['/usr/local/include/SDL2', '/opt/homebrew/include/SDL2'])
     else:
-        incdirs.append('/usr/local/include/SDL')
+        incdirs.extend(['/usr/local/include/SDL', '/opt/homebrew/include/SDL'])
 
     incdirs.extend([
        #'/usr/X11/include',
@@ -170,7 +170,7 @@ def main(sdl2=False):
        '/opt/local/include/freetype2/freetype']
     )
     #libdirs = ['/usr/local/lib', '/usr/X11/lib', '/opt/local/lib']
-    libdirs = ['/usr/local/lib', '/opt/local/lib']
+    libdirs = ['/usr/local/lib', '/opt/local/lib', '/opt/homebrew/lib']
 
     for d in DEPS:
         if isinstance(d, (list, tuple)):


### PR DESCRIPTION
I had the issue that Font and Sound would not load on my M1 Mac, despite having installed all sdl2 libraries using homebrew. It appears that by adding the paths to where home-brew installs the libraries to the config file fixes the issue. At least, when I now install Pygame using:

```
pip install git+https://github.com/Muxelmann/pygame.git@patch-1
```

the following lines no longer raise exceptions/errors:


- `pygame.mixer.Sound(...)` used to result in the error `cannot import name 'Font' from partially initialized module 'pygame.font' (most likely due to a circular import)`
- `pygame.font.Font(...)` used to result in the error `mixer module not available (ModuleNotFoundError: No module named 'pygame.mixer')`
- `pygame.image.load(...)` used to result in the error `File is not a Windows BMP file`