### PR TITLE
Improve sysfont on windows

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -113,7 +113,10 @@ def initsysfonts_win32():
         if not dirname(font):
             font = join(fontdir, font)
 
-        _parse_font_entry_win(name, font, fonts)
+        # Some are named A & B, both names should be processed separately
+        # Ex: the main Cambria file is marked as "Cambria & Cambria Math"
+        for name in name.split("&"):
+            _parse_font_entry_win(name, font, fonts)
 
     return fonts
 
@@ -303,6 +306,7 @@ def create_aliases():
          'georgia', 'cambria', 'constantia', 'dejavuserif',
          'liberationserif'),
         ('wingdings', 'wingbats'),
+        ('comicsansms', 'comicsans'),
     )
     for alias_set in alias_groups:
         for name in alias_set:


### PR DESCRIPTION
Yesterday I was reminded of my adventures digging around in Mac sysfont, so I was inspired to see if there were any obvious problems with Windows sysfont.

I went into `sysfont.py` and told it to print out the constructed font dictionary.

Check out the entries for Cambria:
```py
    "cambriacambriamath": {(False, False): "C:\\WINDOWS\\Fonts\\cambria.ttc"},
    "cambria": {
        (True, False): "C:\\WINDOWS\\Fonts\\cambriab.ttf",
        (True, True): "C:\\WINDOWS\\Fonts\\cambriaz.ttf",
        (False, True): "C:\\WINDOWS\\Fonts\\cambriai.ttf",
    },
```
The tuples represent (bold, italic), and as you can see, it doesn't detect a nonbold and nonitalic variant of Cambria. However, it does find something named "cambriacambriamath."

That's weird. When I print out the names before they are parsed, it is actually finding something named "Cambria & Cambria Math." There's also several other fonts that have this problem, Cambria is just the most famous one.

This problem is fixed with a simple `str.split("&")`, since those names should just be parsed separately.

When I implemented that, the entries became this:
```py
    "cambria": {
        (False, False): "C:\\WINDOWS\\Fonts\\cambria.ttc",
        (True, False): "C:\\WINDOWS\\Fonts\\cambriab.ttf",
        (True, True): "C:\\WINDOWS\\Fonts\\cambriaz.ttf",
        (False, True): "C:\\WINDOWS\\Fonts\\cambriai.ttf",
    },
    "cambriamath": {(False, False): "C:\\WINDOWS\\Fonts\\cambria.ttc"},
```

Before, if you requested "Cambria," pygame would silently give out Cambria bold.
![before](https://user-images.githubusercontent.com/46412508/126018762-01786bdd-a8ee-4a6d-9274-10769e10cea9.PNG)

Now, Cambria is Cambria
![after](https://user-images.githubusercontent.com/46412508/126019070-bdeaa29d-c898-4cf4-b471-b2441e3b0f3d.PNG)

(Of course you can still request bold from SysFont and it will hook you up, at least for Cambria)

I also noticed that SysFont wouldn't give out Comic Sans unless you entered "Comic Sans MS," which is technically the name of the font. So I added an alias to the alias group system that "comicsansms" and "comicsans" are related.