### PR TITLE
De-emphasize HWSURFACE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@
   :alt: pygame
 
 
-|TravisBuild| |AppVeyorBuild| |LaunchpadBuild|
-|PyPiVersion| |PyPiLicense| |Python2| |Python3| |GithubCommits|
-|LGTMAlerts| |LGTMGradePython| |LGTMGradeC| |Coverity|
+|AppVeyorBuild| |LaunchpadBuild| |PyPiVersion| |PyPiLicense| |Python2|
+|Python3| |GithubCommits| |LGTMAlerts| |LGTMGradePython| |LGTMGradeC|
+|Coverity|
 
 pygame_ is a free and open-source cross-platform library
 for the development of multimedia applications like video games using Python.
@@ -153,9 +153,6 @@ The programs in the ``examples`` subdirectory are in the public domain.
 See docs/licenses for licenses of dependencies.
 
 
-.. |TravisBuild| image:: https://travis-ci.org/pygame/pygame.svg?branch=master
-   :target: https://travis-ci.org/pygame/pygame
-
 .. |AppVeyorBuild| image:: https://ci.appveyor.com/api/projects/status/x4074ybuobsh4myx?svg=true
    :target: https://ci.appveyor.com/project/pygame/pygame
 
@@ -171,8 +168,8 @@ See docs/licenses for licenses of dependencies.
 .. |Python2| image:: https://img.shields.io/badge/python-2-blue.svg?v=1
 .. |Python3| image:: https://img.shields.io/badge/python-3-blue.svg?v=1
 
-.. |GithubCommits| image:: https://img.shields.io/github/commits-since/pygame/pygame/2.0.0.svg
-   :target: https://github.com/pygame/pygame/compare/2.0.0...main
+.. |GithubCommits| image:: https://img.shields.io/github/commits-since/pygame/pygame/2.0.1.svg
+   :target: https://github.com/pygame/pygame/compare/2.0.1...main
 
 .. |LGTMAlerts| image:: https://img.shields.io/lgtm/alerts/g/pygame/pygame.svg?logo=lgtm&logoWidth=18
    :target: https://lgtm.com/projects/g/pygame/pygame/alerts/

--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -148,26 +148,18 @@ required).
 
    The flags argument controls which type of display you want. There are
    several to choose from, and you can even combine multiple types using the
-   bitwise or operator, (the pipe "|" character). If you pass ``0`` or no flags
-   argument it will default to a software driven window. Here are the display
+   bitwise or operator, (the pipe "|" character). Here are the display
    flags you will want to choose from:
 
    ::
 
       pygame.FULLSCREEN    create a fullscreen display
-      pygame.DOUBLEBUF     recommended for HWSURFACE or OPENGL
-      pygame.HWSURFACE     hardware accelerated, only in FULLSCREEN
+      pygame.DOUBLEBUF     (obsolete in pygame 2) recommended for HWSURFACE or OPENGL
+      pygame.HWSURFACE     (obsolete in pygame 2) hardware accelerated, only in FULLSCREEN
       pygame.OPENGL        create an OpenGL-renderable display
       pygame.RESIZABLE     display window should be sizeable
       pygame.NOFRAME       display window will have no border or controls
-
-
-   Pygame 2 has the following additional flags available.
-
-   ::
-
-      pygame.SCALED        resolution depends on desktop size and scale
-                           graphics
+      pygame.SCALED        resolution depends on desktop size and scale graphics
       pygame.SHOWN         window is opened in visible mode (default)
       pygame.HIDDEN        window is opened in hidden mode
 
@@ -222,10 +214,8 @@ required).
    | :sg:`flip() -> None`
 
    This will update the contents of the entire display. If your display mode is
-   using the flags ``pygame.HWSURFACE`` and ``pygame.DOUBLEBUF``, this will
-   wait for a vertical retrace and swap the surfaces. If you are using a
-   different type of display mode, it will simply update the entire contents of
-   the surface.
+   using the flags ``pygame.HWSURFACE`` and ``pygame.DOUBLEBUF`` on pygame 1,
+   this will wait for a vertical retrace and swap the surfaces.
 
    When using an ``pygame.OPENGL`` display mode this will perform a gl buffer
    swap.
@@ -353,9 +343,7 @@ required).
    multiple display depths. If passed it will hint to which depth is a better
    match.
 
-   The most useful flags to pass will be ``pygame.HWSURFACE``,
-   ``pygame.DOUBLEBUF``, and maybe ``pygame.FULLSCREEN``. The function will
-   return 0 if these display flags cannot be set.
+   The function will return ``0`` if the passed display flags cannot be set.
 
    The display index ``0`` means the default display is used.
 

--- a/docs/reST/ref/locals.rst
+++ b/docs/reST/ref/locals.rst
@@ -16,8 +16,8 @@ pygame.locals import *``.
 Detailed descriptions of the various constants can be found throughout the
 pygame documentation. Here are the locations of some of them.
 
-   - The :mod:`pygame.display` module contains flags like ``HWSURFACE`` used by
-     :func:`pygame.display.set_mode`.
+   - The :mod:`pygame.display` module contains flags like ``FULLSCREEN`` used
+     by :func:`pygame.display.set_mode`.
    - The :mod:`pygame.event` module contains the various event types.
    - The :mod:`pygame.key` module lists the keyboard constants and modifiers
      (``K_``\* and ``MOD_``\*) relating to the ``key`` and ``mod`` attributes of

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -26,7 +26,7 @@
 
    ::
 
-     HWSURFACE    creates the image in video memory
+     HWSURFACE    (obsolete in pygame 2) creates the image in video memory
      SRCALPHA     the pixel format will include a per-pixel alpha
 
    Both flags are only a request, and may not be possible for all displays and
@@ -707,8 +707,8 @@
       | :sg:`get_flags() -> int`
 
       Returns a set of current Surface features. Each feature is a bit in the
-      flags bitmask. Typical flags are ``HWSURFACE``, ``RLEACCEL``,
-      ``SRCALPHA``, and ``SRCCOLORKEY``.
+      flags bitmask. Typical flags are ``RLEACCEL``, ``SRCALPHA``, and
+      ``SRCCOLORKEY``.
 
       Here is a more complete list of flags. A full list can be found in
       ``SDL_video.h``
@@ -716,21 +716,11 @@
       ::
 
         SWSURFACE      0x00000000    # Surface is in system memory
-        HWSURFACE      0x00000001    # Surface is in video memory
-        ASYNCBLIT      0x00000004    # Use asynchronous blits if possible
+        HWSURFACE      0x00000001    # (obsolete in pygame 2) Surface is in video memory
+        ASYNCBLIT      0x00000004    # (obsolete in pygame 2) Use asynchronous blits if possible
 
-      Available for :func:`pygame.display.set_mode()`
-
-      ::
-
-        ANYFORMAT      0x10000000    # Allow any video depth/pixel-format
-        HWPALETTE      0x20000000    # Surface has exclusive palette
-        DOUBLEBUF      0x40000000    # Set up double-buffered video mode
-        FULLSCREEN     0x80000000    # Surface is a full screen display
-        OPENGL         0x00000002    # Create an OpenGL rendering context
-        OPENGLBLIT     0x0000000A    # OBSOLETE. Create an OpenGL rendering context and use it for blitting.
-        RESIZABLE      0x00000010    # This video mode may be resized
-        NOFRAME        0x00000020    # No window caption or edge frame
+      See :func:`pygame.display.set_mode()` for flags exclusive to the
+      display surface.
 
       Used internally (read-only)
 

--- a/docs/reST/tut/DisplayModes.rst
+++ b/docs/reST/tut/DisplayModes.rst
@@ -72,8 +72,6 @@ The default value for depth is 0.
 When given an argument of 0, *pygame* will select the best bit depth to use,
 usually the same as the system's current bit depth.
 The flags argument lets you control extra features for the display mode.
-You can create the display surface in hardware memory with the
-:any:`HWSURFACE <pygame.display.set_mode>` flag.
 Again, more information about this is found in the *pygame* reference documents.
 
 
@@ -161,18 +159,18 @@ documentation.
       >>> import pygame.display
       >>> pygame.display.init()
       >>> info = pygame.display.Info()
-      >>> print info
-      <VideoInfo(hw = 1, wm = 1,video_mem = 27354
-                 blit_hw = 1, blit_hw_CC = 1, blit_hw_A = 0,
-                 blit_sw = 1, blit_sw_CC = 1, blit_sw_A = 0,
-                 bitsize  = 32, bytesize = 4,
-                 masks =  (16711680, 65280, 255, 0),
-                 shifts = (16, 8, 0, 0),
-                 losses =  (0, 0, 0, 8)>
+      >>> print(info)
+      <VideoInfo(hw = 0, wm = 1,video_mem = 0
+              blit_hw = 0, blit_hw_CC = 0, blit_hw_A = 0,
+              blit_sw = 0, blit_sw_CC = 0, blit_sw_A = 0,
+              bitsize  = 32, bytesize = 4,
+              masks =  (16711680, 65280, 255, 0),
+              shifts = (16, 8, 0, 0),
+              losses =  (0, 0, 0, 8),
+              current_w = 1920, current_h = 1080
+      >
 
 You can test all these flags as simply members of the VidInfo object.
-The different blit flags tell if hardware acceleration is supported when
-blitting from the various types of surfaces to a hardware surface.
 
 
 Examples
@@ -187,13 +185,13 @@ They should help you get an idea of how to go about setting your display mode. :
   >>> #give me the biggest 16-bit display available
   >>> modes = pygame.display.list_modes(16)
   >>> if not modes:
-  ...     print '16-bit not supported'
+  ...     print('16-bit not supported')
   ... else:
-  ...     print 'Found Resolution:', modes[0]
+  ...     print('Found Resolution:', modes[0])
   ...     pygame.display.set_mode(modes[0], FULLSCREEN, 16)
 
   >>> #need an 8-bit surface, nothing else will do
   >>> if pygame.display.mode_ok((800, 600), 0, 8) != 8:
-  ...     print 'Can only work with an 8-bit display, sorry'
+  ...     print('Can only work with an 8-bit display, sorry')
   ... else:
   ...     pygame.display.set_mode((800, 600), 0, 8)

--- a/docs/reST/tut/newbieguide.rst
+++ b/docs/reST/tut/newbieguide.rst
@@ -184,6 +184,8 @@ There is NO rule six.
 Hardware surfaces are more trouble than they're worth.
 ------------------------------------------------------
 
+**Especially in pygame 2, because HWSURFACE now does nothing**
+
 If you've been looking at the various flags you can use with
 ``pygame.display.set_mode()``, you may have thought like this: `Hey,
 HWSURFACE! Well, I want that -- who doesn't like hardware acceleration. Ooo...

--- a/src_c/doc/transform_doc.h
+++ b/src_c/doc/transform_doc.h
@@ -6,7 +6,7 @@
 #define DOC_PYGAMETRANSFORMROTOZOOM "rotozoom(surface, angle, scale) -> Surface\nfiltered scale and rotation"
 #define DOC_PYGAMETRANSFORMSCALE2X "scale2x(surface, dest_surface=None) -> Surface\nspecialized image doubler"
 #define DOC_PYGAMETRANSFORMSMOOTHSCALE "smoothscale(surface, size, dest_surface=None) -> Surface\nscale a surface to an arbitrary size smoothly"
-#define DOC_PYGAMETRANSFORMGETSMOOTHSCALEBACKEND "get_smoothscale_backend() -> String\nreturn smoothscale filter version in use: 'GENERIC', 'MMX', or 'SSE'"
+#define DOC_PYGAMETRANSFORMGETSMOOTHSCALEBACKEND "get_smoothscale_backend() -> string\nreturn smoothscale filter version in use: 'GENERIC', 'MMX', or 'SSE'"
 #define DOC_PYGAMETRANSFORMSETSMOOTHSCALEBACKEND "set_smoothscale_backend(backend) -> None\nset smoothscale filter version to one of: 'GENERIC', 'MMX', or 'SSE'"
 #define DOC_PYGAMETRANSFORMCHOP "chop(surface, rect) -> Surface\ngets a copy of an image with an interior area removed"
 #define DOC_PYGAMETRANSFORMLAPLACIAN "laplacian(surface, dest_surface=None) -> Surface\nfind edges in a surface"
@@ -47,7 +47,7 @@ pygame.transform.smoothscale
 scale a surface to an arbitrary size smoothly
 
 pygame.transform.get_smoothscale_backend
- get_smoothscale_backend() -> String
+ get_smoothscale_backend() -> string
 return smoothscale filter version in use: 'GENERIC', 'MMX', or 'SSE'
 
 pygame.transform.set_smoothscale_backend

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -590,7 +590,7 @@ surface_str(PyObject *self)
                            surf->format->BitsPerPixel,
                            (surf->flags & SDL_HWSURFACE) ? "HW" : "SW");
 #else  /* IS_SDLv2 */
-    return Text_FromFormat("<Surface(%dx%dx%d)>", surf->w, surf->h,
+    return Text_FromFormat("<Surface(%dx%dx%d)> SW", surf->w, surf->h,
                            surf->format->BitsPerPixel);
 #endif /* IS_SDLv2 */
 }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -590,7 +590,7 @@ surface_str(PyObject *self)
                            surf->format->BitsPerPixel,
                            (surf->flags & SDL_HWSURFACE) ? "HW" : "SW");
 #else  /* IS_SDLv2 */
-    return Text_FromFormat("<Surface(%dx%dx%d SW)>", surf->w, surf->h,
+    return Text_FromFormat("<Surface(%dx%dx%d)>", surf->w, surf->h,
                            surf->format->BitsPerPixel);
 #endif /* IS_SDLv2 */
 }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -590,7 +590,7 @@ surface_str(PyObject *self)
                            surf->format->BitsPerPixel,
                            (surf->flags & SDL_HWSURFACE) ? "HW" : "SW");
 #else  /* IS_SDLv2 */
-    return Text_FromFormat("<Surface(%dx%dx%d)> SW", surf->w, surf->h,
+    return Text_FromFormat("<Surface(%dx%dx%d SW)>", surf->w, surf->h,
                            surf->format->BitsPerPixel);
 #endif /* IS_SDLv2 */
 }


### PR DESCRIPTION
This PR:
- Marks display flags ``HWSURFACE``, ``DOUBLEBUF``, and ``ASYNCBLIT`` obsolete on pygame 2. ([proof that they actually are](https://github.com/pygame/pygame/blob/main/src_c/_pygame.h#L58-L77))
- Removes several small references to them in other documentation / tutorials.
- ~Removes the ``SW`` in the surface repr, because all surfaces are software surfaces now.~ (The tests would have to get changed, and then it would be SDL1/SDL2 conditional, and that's too much trouble)
- Realize `transform_doc.h` change that was missed by my transform keywords PR 
- Remove Travis build from README, switch to "commits since 2.0.1" rather than "since 2.0.0".