### PR TITLE
Remove redundant python includes, fix compiler warnings

### DIFF
--- a/src_c/freetype.h
+++ b/src_c/freetype.h
@@ -26,7 +26,6 @@
 
 #include "pgcompat.h"
 #include "pgplatform.h"
-#include <Python.h>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -19,7 +19,6 @@
 */
 
 #include "pygame.h"
-#include <Python.h>
 
 #include "pgcompat.h"
 


### PR DESCRIPTION
Super minor PR, to hopefully fix #2613 

Since pygame header already includes `<Python.h>` re-including those is redundant. 
I am not a 100% sure that this fix works, because I believe python.h is header guarded anyways, but this PR is worth a shot