### PR TITLE
Continue on aarch64 wheels

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build manylinux wheels
       run: |
         cd buildconfig/manylinux-build
-        make base-image-aarch64 pull pull-manylinux wheels wheels-manylinux
+        make pull pull-manylinux wheels wheels-manylinux
         cd ../..
         mkdir -p dist/
         cp buildconfig/manylinux-build/wheelhouse/*.whl dist/

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -35,10 +35,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      
     - name: Build manylinux wheels
       run: |
         cd buildconfig/manylinux-build
-        make pull pull-manylinux wheels wheels-manylinux
+        make base-image-aarch64 pull pull-manylinux wheels wheels-manylinux
         cd ../..
         mkdir -p dist/
         cp buildconfig/manylinux-build/wheelhouse/*.whl dist/

--- a/buildconfig/manylinux-build/Makefile
+++ b/buildconfig/manylinux-build/Makefile
@@ -81,5 +81,7 @@ pull-x64:
 pull-x86:
 	docker pull pygame/manylinux2010_base_i686
 
-pull: pull-x64 pull-x86
+pull-aarch64:
+	docker pull pygame/manylinux2014_base_aarch64
 
+pull: pull-x64 pull-x86 pull-aarch64

--- a/buildconfig/manylinux-build/Makefile
+++ b/buildconfig/manylinux-build/Makefile
@@ -12,8 +12,10 @@ wheels-x64:
 wheels-x86:
 	docker run --rm -v ${REPO_ROOT}:/io pygame/manylinux2010_base_i686 /io/buildconfig/manylinux-build/build-wheels.sh buildpypy
 
+wheels-aarch64:
+	docker run --rm -v ${REPO_ROOT}:/io pygame/manylinux2014_base_aarch64 /io/buildconfig/manylinux-build/build-wheels.sh
 
-wheels: wheels-x64 wheels-x86
+wheels: wheels-x64 wheels-x86 wheels-aarch64
 wheels-manylinux: wheels-manylinux-x64 wheels-manylinux-x86
 
 
@@ -34,7 +36,10 @@ base-image-x64:
 base-image-x86:
 	docker build -t pygame/manylinux2010_base_i686 -f docker_base/Dockerfile-i686 docker_base --build-arg BASE_IMAGE=manylinux2010_i686 --build-arg BASE_IMAGE2=manylinux2010_i686
 
-base-images: base-image-x64 base-image-x86
+base-image-aarch64:
+	docker build -t pygame/manylinux2014_base_aarch64 -f docker_base/Dockerfile-aarch64 docker_base --build-arg BASE_IMAGE=manylinux2014_aarch64 --build-arg BASE_IMAGE2=manylinux2014_aarch64
+	
+base-images: base-image-x64 base-image-x86 base-image-aarch64
 
 
 
@@ -54,7 +59,10 @@ push-x64:
 push-x86:
 	docker push pygame/manylinux2010_base_i686
 
-push: push-x64 push-x86
+push-aarch64:
+	docker push pygame/manylinux2014_base_aarch64
+	
+push: push-x64 push-x86 push-aarch64
 
 
 

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e -x
 
-export SUPPORTED_PYTHONS="cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
+if [ `uname -m` == "aarch64" ]; then
+   export SUPPORTED_PYTHONS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39" 
+else
+   export SUPPORTED_PYTHONS="cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39" 
+fi
 
 if [[ "$1" == "buildpypy" ]]; then
 	export SUPPORTED_PYTHONS="pp27-pypy_73 pp36-pypy36_pp73 pp37-pypy37_pp73"

--- a/buildconfig/manylinux-build/docker_base/Dockerfile-aarch64
+++ b/buildconfig/manylinux-build/docker_base/Dockerfile-aarch64
@@ -1,0 +1,75 @@
+ARG BASE_IMAGE=manylinux2014_aarch64
+FROM quay.io/pypa/$BASE_IMAGE
+ENV MAKEFLAGS="-j 4"
+
+# Set up repoforge
+COPY RPM-GPG-KEY.dag.txt /tmp/
+RUN rpm --import /tmp/RPM-GPG-KEY.dag.txt
+
+#ENV RPMFORGE_FILE "rpmforge-release-0.5.3-1.rf.src.rpm"
+#ADD "https://repoforge.cu.be/redhat/el5/en/source/rpmforge-release-0.5.3-1.rf.src.rpm" /tmp/${RPMFORGE_FILE}
+
+#RUN rpm -i /tmp/${RPMFORGE_FILE}
+
+# Install SDL and portmidi dependencies
+RUN yum install -y zlib-devel libjpeg-devel libX11-devel\
+    mesa-libGLU-devel audiofile-devel \
+    cmake java-1.7.0-openjdk-devel jpackage-utils libtiff-devel \
+    giflib-devel dbus-devel \
+    pulseaudio-libs-devel xz subversion dejavu-sans-fonts fontconfig \
+    libXcursor-devel libXi-devel libXxf86vm-devel \
+    libXrandr-devel libXinerama-devel libXcomposite-devel mesa-libGLU-devel xz
+RUN yum install -y libcap-devel libxkbcommon-devel
+
+# Build and install PNG
+ADD libpng /png_build/
+RUN ["bash", "/png_build/build-png.sh"]
+
+# Build and install WEBP
+ADD libwebp /webp_build/
+RUN ["bash", "/webp_build/build-webp.sh"]
+
+# Build and install freetype
+ADD freetype /freetype_build/
+RUN ["bash", "/freetype_build/build-freetype.sh"]
+
+# Build and install sndfile
+ADD sndfile /sndfile_build/
+RUN ["bash", "/sndfile_build/build-sndfile.sh"]
+
+# Build and install ALSA library
+ADD alsa /alsa_build/
+RUN ["bash", "/alsa_build/build-alsa.sh"]
+# Replace yum-installed libasound with the one we just compiled.
+RUN ["rm", "/lib64/libasound.so.2.0.0"]
+RUN ["ln", "-s", "/usr/lib/libasound.so.2.0.0", "/lib64/"]
+
+# Build and install pulseaudio
+ADD pulseaudio /pulseaudio_build/
+RUN ["bash", "/pulseaudio_build/build-pulseaudio.sh"]
+
+# Build and install fluidsynth
+ADD fluidsynth /fluidsynth_build/
+RUN ["bash", "/fluidsynth_build/build-fluidsynth.sh"]
+
+ADD ogg /ogg_build/
+RUN ["bash", "/ogg_build/build-ogg.sh"]
+
+# Build and install flac
+ADD flac /flac_build/
+RUN ["bash", "/flac_build/build-flac.sh"]
+
+# Build and install SDL
+ADD sdl_libs /sdl_build/
+#RUN ["bash", "/sdl_build/build-sdl-libs.sh"]
+RUN ["bash", "/sdl_build/build-sdl2-libs.sh"]
+
+ENV MAKEFLAGS=
+
+# Build and install SDL and portmidi
+ADD portmidi /portmidi_build/
+RUN ["bash", "/portmidi_build/build-portmidi.sh"]
+
+ENV base_image=$BASE_IMAGE
+RUN echo "$base_image"
+RUN echo "$BASE_IMAGE"

--- a/test/video_test.py
+++ b/test/video_test.py
@@ -1,5 +1,4 @@
 import unittest
-import platform
 import sys
 import pygame
 
@@ -12,8 +11,8 @@ if SDL2:
         default_caption = "pygame window"
 
         @unittest.skipIf(
-            ("Windows" in platform.platform() and not (sys.maxsize > 2 ** 32)),
-            "Windows 32 bit SDL 2.0.16 has an issue.",
+            not (sys.maxsize > 2 ** 32),
+            "32 bit SDL 2.0.16 has an issue.",
         )
         def test_renderer_set_viewport(self):
             """works."""


### PR DESCRIPTION
Continues on https://github.com/pygame/pygame/pull/2610 by @odidev 

This leaves building the images to another process, and just pulls them instead. Even with that, the arm64 build takes 4-5x as long (but at least not 3 hours) because of the qemu emulation.

This is still useful for releases, and maybe in the future we can split it up so the arm64 ones are done on arm hardware (either when github actions adds arm support or we use travis arm64 support). Additionally, people can make their own wheels locally if they want.

ps. this guide worked for setting up qemu on docker + ubuntu 20.04 https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
