### PR TITLE
Better deprecation for swizzle, change up repr functions

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -45,9 +45,9 @@
 
 #include <ctype.h>
 
-
-#if (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L) && !defined(round)
-#define pg_round(d) (((d < 0) ? (ceil((d)-0.5)) : (floor((d)+0.5))))
+#if (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L) && \
+    !defined(round)
+#define pg_round(d) (((d < 0) ? (ceil((d)-0.5)) : (floor((d) + 0.5))))
 #else
 #define pg_round(d) round(d)
 #endif
@@ -190,7 +190,6 @@ pg_RGBAFromColorObj(PyObject *color, Uint8 rgba[]);
 static int
 pg_RGBAFromFuzzyColorObj(PyObject *color, Uint8 rgba[]);
 
-
 /**
  * Methods, which are bound to the pgColorObject type.
  */
@@ -205,8 +204,7 @@ static PyMethodDef _color_methods[] = {
      DOC_COLORLERP},
     {"premul_alpha", (PyCFunction)_premul_alpha, METH_NOARGS,
      DOC_COLORPREMULALPHA},
-    {"update", (PyCFunction)_color_update, METH_VARARGS,
-     DOC_COLORUPDATE},
+    {"update", (PyCFunction)_color_update, METH_VARARGS, DOC_COLORUPDATE},
     {NULL, NULL, 0, NULL}};
 
 /**
@@ -299,11 +297,9 @@ static PySequenceMethods _color_as_sequence = {
     NULL,                             /* sq_inplace_repeat */
 };
 
-static PyMappingMethods _color_as_mapping = {
-    (lenfunc)_color_length,
-    (binaryfunc)_color_subscript,
-    (objobjargproc)_color_set_slice
-};
+static PyMappingMethods _color_as_mapping = {(lenfunc)_color_length,
+                                             (binaryfunc)_color_subscript,
+                                             (objobjargproc)_color_set_slice};
 
 static PyBufferProcs _color_as_buffer = {
 #if HAVE_OLD_BUFPROTO
@@ -326,25 +322,24 @@ static PyBufferProcs _color_as_buffer = {
 #define DEFERRED_ADDRESS(ADDR) 0
 
 static PyTypeObject pgColor_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
-    "pygame.Color",                    /* tp_name */
-    sizeof(pgColorObject),             /* tp_basicsize */
-    0,                                 /* tp_itemsize */
-    (destructor)_color_dealloc,        /* tp_dealloc */
-    0,                                 /* tp_print */
-    NULL,                              /* tp_getattr */
-    NULL,                              /* tp_setattr */
-    NULL,                              /* tp_compare */
-    (reprfunc)_color_repr,             /* tp_repr */
-    &_color_as_number,                 /* tp_as_number */
-    &_color_as_sequence,               /* tp_as_sequence */
-    &_color_as_mapping,                /* tp_as_mapping */
-    NULL,                              /* tp_hash */
-    NULL,                              /* tp_call */
-    NULL,                              /* tp_str */
-    NULL,                              /* tp_getattro */
-    NULL,                              /* tp_setattro */
-    &_color_as_buffer, /* tp_as_buffer */
+    PyVarObject_HEAD_INIT(NULL, 0) "pygame.Color", /* tp_name */
+    sizeof(pgColorObject),                         /* tp_basicsize */
+    0,                                             /* tp_itemsize */
+    (destructor)_color_dealloc,                    /* tp_dealloc */
+    0,                                             /* tp_print */
+    NULL,                                          /* tp_getattr */
+    NULL,                                          /* tp_setattr */
+    NULL,                                          /* tp_compare */
+    (reprfunc)_color_repr,                         /* tp_repr */
+    &_color_as_number,                             /* tp_as_number */
+    &_color_as_sequence,                           /* tp_as_sequence */
+    &_color_as_mapping,                            /* tp_as_mapping */
+    NULL,                                          /* tp_hash */
+    NULL,                                          /* tp_call */
+    NULL,                                          /* tp_str */
+    NULL,                                          /* tp_getattro */
+    NULL,                                          /* tp_setattro */
+    &_color_as_buffer,                             /* tp_as_buffer */
     COLOR_TPFLAGS,
     DOC_PYGAMECOLOR,       /* tp_doc */
     NULL,                  /* tp_traverse */
@@ -677,7 +672,8 @@ _color_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 static int
-_parse_color_from_text(PyObject *str_obj, Uint8 *rgba) {
+_parse_color_from_text(PyObject *str_obj, Uint8 *rgba)
+{
     /* Named color */
     PyObject *color = NULL;
     PyObject *name1 = NULL, *name2 = NULL;
@@ -706,7 +702,8 @@ _parse_color_from_text(PyObject *str_obj, Uint8 *rgba) {
             default:
                 break;
         }
-    } else if (!pg_RGBAFromObj(color, rgba)) {
+    }
+    else if (!pg_RGBAFromObj(color, rgba)) {
         PyErr_SetString(PyExc_ValueError, "invalid color");
         return -1;
     }
@@ -714,13 +711,14 @@ _parse_color_from_text(PyObject *str_obj, Uint8 *rgba) {
 }
 
 static int
-_parse_color_from_single_object(PyObject *obj, Uint8 *rgba) {
-
+_parse_color_from_single_object(PyObject *obj, Uint8 *rgba)
+{
     if (Text_Check(obj) || PyUnicode_Check(obj)) {
         if (_parse_color_from_text(obj, rgba)) {
             return -1;
         }
-    } else {
+    }
+    else {
         /* At this point color is either tuple-like or a single integer. */
         if (!pg_RGBAFromColorObj(obj, rgba)) {
             /* Color is not a valid tuple-like. */
@@ -741,7 +739,8 @@ _parse_color_from_single_object(PyObject *obj, Uint8 *rgba) {
                 rgba[1] = (Uint8)(color >> 16);
                 rgba[2] = (Uint8)(color >> 8);
                 rgba[3] = (Uint8)color;
-            } else {
+            }
+            else {
                 /* Exception already set by _get_color(). */
                 return -1;
             }
@@ -767,7 +766,8 @@ _color_init(pgColorObject *self, PyObject *args, PyObject *kwds)
         if (_parse_color_from_single_object(obj, rgba)) {
             return -1;
         }
-    } else {
+    }
+    else {
         Uint32 color = 0;
 
         /* Color(R,G,B[,A]) */
@@ -883,12 +883,12 @@ _color_lerp(pgColorObject *self, PyObject *args, PyObject *kw)
 {
     Uint8 rgba[4];
     Uint8 new_rgba[4];
-    PyObject* colobj;
+    PyObject *colobj;
     double amt;
     static char *keywords[] = {"color", "amount", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "Od", keywords,
-                                     &colobj, &amt)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "Od", keywords, &colobj,
+                                     &amt)) {
         return NULL;
     }
 
@@ -898,8 +898,7 @@ _color_lerp(pgColorObject *self, PyObject *args, PyObject *kw)
     }
 
     if (amt < 0 || amt > 1) {
-        return RAISE(PyExc_ValueError,
-                        "Argument 2 must be in range [0, 1]");
+        return RAISE(PyExc_ValueError, "Argument 2 must be in range [0, 1]");
     }
 
     new_rgba[0] = (Uint8)pg_round(self->data[0] * (1 - amt) + rgba[0] * amt);
@@ -1125,7 +1124,8 @@ _color_get_hsva(pgColorObject *color, void *closure)
     /* Clamp S, needed on some but not all FPUs */
     if (hsv[1] < 0) {
         hsv[1] = 0.f;
-    } else if (hsv[1] > 100) {
+    }
+    else if (hsv[1] > 100) {
         hsv[1] = 100.f;
     }
 
@@ -1155,7 +1155,6 @@ _color_set_hsva(pgColorObject *color, PyObject *value, void *closure)
     double hsva[4] = {0, 0, 0, 0};
     double f, p, q, t, v, s;
     int hi;
-
 
     DEL_ATTR_NOT_SUPPORTED_CHECK("hsva", value);
 
@@ -1487,7 +1486,6 @@ _color_set_i1i2i3(pgColorObject *color, PyObject *value, void *closure)
     double i1i2i3[3] = {0, 0, 0};
     double ar, ag, ab;
 
-
     DEL_ATTR_NOT_SUPPORTED_CHECK("i1i2i3", value);
 
     /* I1 */
@@ -1796,7 +1794,8 @@ _color_oct(pgColorObject *color)
 #if LONG_MAX == 2147483647
     if (tmp < LONG_MAX) {
         PyOS_snprintf(buf, sizeof(buf), "0%lo", (unsigned long)tmp);
-    } else {
+    }
+    else {
         PyOS_snprintf(buf, sizeof(buf), "0%loL", (unsigned long)tmp);
     }
     return PyString_FromString(buf);
@@ -1820,7 +1819,8 @@ _color_hex(pgColorObject *color)
 #if LONG_MAX == 2147483647
     if (tmp < LONG_MAX) {
         PyOS_snprintf(buf, sizeof(buf), "0x%lx", (unsigned long)tmp);
-    } else {
+    }
+    else {
         PyOS_snprintf(buf, sizeof(buf), "0x%lxL", (unsigned long)tmp);
     }
     return Text_FromUTF8(buf);
@@ -2026,7 +2026,7 @@ _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
 {
     if (val == NULL) {
         PyErr_SetString(PyExc_TypeError,
-            "Color object doesn't support item deletion");
+                        "Color object doesn't support item deletion");
         return -1;
     }
 #if PY2
@@ -2055,9 +2055,9 @@ _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
         }
         if (PySequence_Fast_GET_SIZE(fastitems) != slicelength) {
             PyErr_Format(PyExc_ValueError,
-                "attempting to assign sequence of length %zd "
-                "to slice of length %zd",
-                PySequence_Fast_GET_SIZE(fastitems), slicelength);
+                         "attempting to assign sequence of length %zd "
+                         "to slice of length %zd",
+                         PySequence_Fast_GET_SIZE(fastitems), slicelength);
             Py_DECREF(fastitems);
             return -1;
         }
@@ -2073,12 +2073,14 @@ _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
             }
 #endif /* PY2 */
             else {
-                PyErr_SetString(PyExc_TypeError, "color components must be integers");
+                PyErr_SetString(PyExc_TypeError,
+                                "color components must be integers");
                 Py_DECREF(fastitems);
                 return -1;
             }
             if (c < 0 || c > 255) {
-                PyErr_SetString(PyExc_ValueError, "color component must be 0-255");
+                PyErr_SetString(PyExc_ValueError,
+                                "color component must be 0-255");
                 Py_DECREF(fastitems);
                 return -1;
             }
@@ -2088,8 +2090,7 @@ _color_set_slice(pgColorObject *color, PyObject *idx, PyObject *val)
         Py_DECREF(fastitems);
         return 0;
     }
-    PyErr_SetString(PyExc_IndexError,
-        "Index must be an integer or slice");
+    PyErr_SetString(PyExc_IndexError, "Index must be an integer or slice");
     return -1;
 }
 
@@ -2212,7 +2213,7 @@ pg_RGBAFromColorObj(PyObject *color, Uint8 rgba[])
 }
 
 static int
-pg_RGBAFromFuzzyColorObj(PyObject * color, Uint8 rgba[])
+pg_RGBAFromFuzzyColorObj(PyObject *color, Uint8 rgba[])
 {
     return _parse_color_from_single_object(color, rgba) == 0;
 }

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -818,9 +818,9 @@ _color_dealloc(pgColorObject *color)
 static PyObject *
 _color_repr(pgColorObject *color)
 {
-    /* Max. would be(255, 255, 255, 255) */
-    char buf[21];
-    PyOS_snprintf(buf, sizeof(buf), "(%d, %d, %d, %d)", color->data[0],
+    /* Max. would be "Color(255, 255, 255, 255)" */
+    char buf[26];
+    PyOS_snprintf(buf, sizeof(buf), "Color(%d, %d, %d, %d)", color->data[0],
                   color->data[1], color->data[2], color->data[3]);
     return Text_FromUTF8(buf);
 }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -331,8 +331,6 @@ vector_elementwiseproxy_nonzero(vector_elementwiseproxy *self);
 static PyObject *
 vector_elementwise(pgVector *vec, PyObject *args);
 
-static int swizzling_enabled = 1;
-
 /********************************
  * Global helper functions
  ********************************/
@@ -1534,7 +1532,7 @@ vector_repr(pgVector *self)
     char buffer[2][STRING_BUF_SIZE];
 
     bufferIdx = 1;
-    tmp = PyOS_snprintf(buffer[0], STRING_BUF_SIZE, "<Vector%ld(", self->dim);
+    tmp = PyOS_snprintf(buffer[0], STRING_BUF_SIZE, "Vector%ld(", self->dim);
     if (!_vector_check_snprintf_success(tmp))
         return NULL;
     for (i = 0; i < self->dim - 1; ++i) {
@@ -1544,7 +1542,7 @@ vector_repr(pgVector *self)
         if (!_vector_check_snprintf_success(tmp))
             return NULL;
     }
-    tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g)>",
+    tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g)",
                         buffer[(bufferIdx + 1) % 2], self->coords[i]);
     if (!_vector_check_snprintf_success(tmp))
         return NULL;
@@ -1638,7 +1636,7 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
 
     len = PySequence_Length(attr_name);
 
-    if (len == 1 || !swizzling_enabled) {
+    if (len == 1) {
         return PyObject_GenericGetAttr((PyObject *)self, attr_name);
     }
 
@@ -1734,11 +1732,11 @@ vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val)
     int swizzle_err = SWIZZLE_ERR_NO_ERR;
     Py_ssize_t i;
 
-    /* if swizzling is disabled always default to generic implementation */
-    if (!swizzling_enabled || len == 1)
+    /* generic implementation */
+    if (len == 1)
         return PyObject_GenericSetAttr((PyObject *)self, attr_name, val);
 
-    /* if swizzling is enabled first try swizzle */
+    /* first try swizzle */
     for (i = 0; i < self->dim; ++i)
         entry_was_set[i] = 0;
 
@@ -1808,7 +1806,7 @@ vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val)
             /* this should NEVER happen and means a bug in the code */
             PyErr_SetString(PyExc_RuntimeError,
                             "Unhandled error in swizzle code. Please report "
-                            "this bug to pygame-users@seul.org");
+                            "this bug to github.com/pygame/pygame/issues");
             return -1;
     }
 }
@@ -4013,14 +4011,18 @@ vector_elementwise(pgVector *vec, PyObject *args)
 static PyObject *
 math_enable_swizzling(pgVector *self)
 {
-    swizzling_enabled = 1;
+    if (PyErr_WarnEx(PyExc_DeprecationWarning, "pygame.math.enable_swizzling() is deprecated, functionality has been removed, and will be removed", 1) == -1) {
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 
 static PyObject *
 math_disable_swizzling(pgVector *self)
 {
-    swizzling_enabled = 0;
+    if (PyErr_WarnEx(PyExc_DeprecationWarning, "pygame.math.disable_swizzling() is deprecated, functionality has been removed, and will be removed", 1) == -1) {
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1612,7 +1612,6 @@ vector_project_onto(pgVector *self, PyObject *other)
     return (PyObject *)ret;
 }
 
-
 /* This method first tries normal attribute access. If successful we're
  * done. If not we try swizzling. Here we have 3 different outcomes:
  *  1) swizzling works. we return the result as a tuple
@@ -1678,7 +1677,7 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
             case 'w':
                 idx = 3;
 
-        swizzle_idx:
+            swizzle_idx:
                 if (idx >= self->dim) {
                     goto swizzle_failed;
                 };
@@ -1697,7 +1696,8 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
         }
         if (len == 2 || len == 3) {
             ((pgVector *)res)->coords[i] = value;
-        } else {
+        }
+        else {
             if (PyTuple_SetItem(res, i, PyFloat_FromDouble(value)) != 0)
                 goto internal_error;
         }
@@ -1978,7 +1978,7 @@ vector2_init(pgVector *self, PyObject *args, PyObject *kwds)
     return _vector2_set(self, xOrSequence, y);
 }
 
-static PyObject*
+static PyObject *
 vector2_update(pgVector *self, PyObject *args, PyObject *kwds)
 {
     PyObject *xOrSequence = NULL, *y = NULL;
@@ -2213,9 +2213,9 @@ static PyMethodDef vector2_methods[] = {
     {"magnitude_squared", (PyCFunction)vector_length_squared, METH_NOARGS,
      DOC_VECTOR2MAGNITUDESQUARED},
     {"rotate", (PyCFunction)vector2_rotate, METH_O, DOC_VECTOR2ROTATE},
-    {"rotate_ip", (PyCFunction)vector2_rotate_ip, METH_O,
-    DOC_VECTOR2ROTATEIP},
-    {"rotate_rad", (PyCFunction)vector2_rotate_rad, METH_O, DOC_VECTOR2ROTATERAD},
+    {"rotate_ip", (PyCFunction)vector2_rotate_ip, METH_O, DOC_VECTOR2ROTATEIP},
+    {"rotate_rad", (PyCFunction)vector2_rotate_rad, METH_O,
+     DOC_VECTOR2ROTATERAD},
     {"rotate_ip_rad", (PyCFunction)vector2_rotate_ip_rad, METH_O,
      DOC_VECTOR2ROTATEIPRAD},
     {"slerp", (PyCFunction)vector_slerp, METH_VARARGS, DOC_VECTOR2SLERP},
@@ -2246,8 +2246,7 @@ static PyMethodDef vector2_methods[] = {
      DOC_VECTOR2ASPOLAR},
     {"from_polar", (PyCFunction)vector2_from_polar, METH_VARARGS,
      DOC_VECTOR2FROMPOLAR},
-    {"project", (PyCFunction)vector2_project, METH_O,
-     DOC_VECTOR2PROJECT},
+    {"project", (PyCFunction)vector2_project, METH_O, DOC_VECTOR2PROJECT},
     {"__safe_for_unpickling__", (PyCFunction)vector_getsafepickle, METH_NOARGS,
      NULL},
     {"__reduce__", (PyCFunction)vector2_reduce, METH_NOARGS, NULL},
@@ -2266,10 +2265,9 @@ static PyGetSetDef vector2_getsets[] = {
  ********************************/
 
 static PyTypeObject pgVector2_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
-    "pygame.math.Vector2",                    /* tp_name */
-    sizeof(pgVector),                         /* tp_basicsize */
-    0,                                        /* tp_itemsize */
+    PyVarObject_HEAD_INIT(NULL, 0) "pygame.math.Vector2", /* tp_name */
+    sizeof(pgVector),                                     /* tp_basicsize */
+    0,                                                    /* tp_itemsize */
     /* Methods to implement standard operations */
     (destructor)vector_dealloc, /* tp_dealloc */
     0,                          /* tp_print */
@@ -2439,7 +2437,7 @@ vector3_init(pgVector *self, PyObject *args, PyObject *kwds)
     return _vector3_set(self, xOrSequence, y, z);
 }
 
-static PyObject*
+static PyObject *
 vector3_update(pgVector *self, PyObject *args, PyObject *kwds)
 {
     PyObject *xOrSequence = NULL, *y = NULL, *z = NULL;
@@ -3084,25 +3082,29 @@ static PyMethodDef vector3_methods[] = {
     {"rotate", (PyCFunction)vector3_rotate, METH_VARARGS, DOC_VECTOR3ROTATE},
     {"rotate_ip", (PyCFunction)vector3_rotate_ip, METH_VARARGS,
      DOC_VECTOR3ROTATEIP},
-    {"rotate_rad", (PyCFunction)vector3_rotate_rad, METH_VARARGS, DOC_VECTOR3ROTATERAD},
+    {"rotate_rad", (PyCFunction)vector3_rotate_rad, METH_VARARGS,
+     DOC_VECTOR3ROTATERAD},
     {"rotate_ip_rad", (PyCFunction)vector3_rotate_ip_rad, METH_VARARGS,
      DOC_VECTOR3ROTATEIPRAD},
     {"rotate_x", (PyCFunction)vector3_rotate_x, METH_O, DOC_VECTOR3ROTATEX},
     {"rotate_x_ip", (PyCFunction)vector3_rotate_x_ip, METH_O,
      DOC_VECTOR3ROTATEXIP},
-    {"rotate_x_rad", (PyCFunction)vector3_rotate_x_rad, METH_O, DOC_VECTOR3ROTATEXRAD},
+    {"rotate_x_rad", (PyCFunction)vector3_rotate_x_rad, METH_O,
+     DOC_VECTOR3ROTATEXRAD},
     {"rotate_x_ip_rad", (PyCFunction)vector3_rotate_x_ip_rad, METH_O,
      DOC_VECTOR3ROTATEXIPRAD},
     {"rotate_y", (PyCFunction)vector3_rotate_y, METH_O, DOC_VECTOR3ROTATEY},
     {"rotate_y_ip", (PyCFunction)vector3_rotate_y_ip, METH_O,
      DOC_VECTOR3ROTATEYIP},
-    {"rotate_y_rad", (PyCFunction)vector3_rotate_y_rad, METH_O, DOC_VECTOR3ROTATEYRAD},
+    {"rotate_y_rad", (PyCFunction)vector3_rotate_y_rad, METH_O,
+     DOC_VECTOR3ROTATEYRAD},
     {"rotate_y_ip_rad", (PyCFunction)vector3_rotate_y_ip_rad, METH_O,
      DOC_VECTOR3ROTATEYIPRAD},
     {"rotate_z", (PyCFunction)vector3_rotate_z, METH_O, DOC_VECTOR3ROTATEZ},
     {"rotate_z_ip", (PyCFunction)vector3_rotate_z_ip, METH_O,
      DOC_VECTOR3ROTATEZIP},
-    {"rotate_z_rad", (PyCFunction)vector3_rotate_z_rad, METH_O, DOC_VECTOR3ROTATEZRAD},
+    {"rotate_z_rad", (PyCFunction)vector3_rotate_z_rad, METH_O,
+     DOC_VECTOR3ROTATEZRAD},
     {"rotate_z_ip_rad", (PyCFunction)vector3_rotate_z_ip_rad, METH_O,
      DOC_VECTOR3ROTATEZIPRAD},
     {"slerp", (PyCFunction)vector_slerp, METH_VARARGS, DOC_VECTOR3SLERP},
@@ -3153,10 +3155,9 @@ static PyGetSetDef vector3_getsets[] = {
  ********************************/
 
 static PyTypeObject pgVector3_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
-    "pygame.math.Vector3",                    /* tp_name */
-    sizeof(pgVector),                         /* tp_basicsize */
-    0,                                        /* tp_itemsize */
+    PyVarObject_HEAD_INIT(NULL, 0) "pygame.math.Vector3", /* tp_name */
+    sizeof(pgVector),                                     /* tp_basicsize */
+    0,                                                    /* tp_itemsize */
     /* Methods to implement standard operations */
     (destructor)vector_dealloc, /* tp_dealloc */
     0,                          /* tp_print */
@@ -3181,7 +3182,7 @@ static PyTypeObject pgVector3_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
 #else
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_CHECKTYPES, /* tp_flags */
+        Py_TPFLAGS_CHECKTYPES,                  /* tp_flags */
 #endif
     /* Documentation string */
     DOC_PYGAMEMATHVECTOR3, /* tp_doc */
@@ -3273,35 +3274,34 @@ static PyMethodDef vectoriter_methods[] = {
 };
 
 static PyTypeObject pgVectorIter_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
-    "pygame.math.VectorIterator",                    /* tp_name */
-    sizeof(vectoriter),                              /* tp_basicsize */
-    0,                                               /* tp_itemsize */
-    (destructor)vectoriter_dealloc,                  /* tp_dealloc */
-    0,                                               /* tp_print */
-    0,                                               /* tp_getattr */
-    0,                                               /* tp_setattr */
-    0,                                               /* tp_compare */
-    0,                                               /* tp_repr */
-    0,                                               /* tp_as_number */
-    0,                                               /* tp_as_sequence */
-    0,                                               /* tp_as_mapping */
-    0,                                               /* tp_hash */
-    0,                                               /* tp_call */
-    0,                                               /* tp_str */
-    PyObject_GenericGetAttr,                         /* tp_getattro */
-    0,                                               /* tp_setattro */
-    0,                                               /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                              /* tp_flags */
-    0,                                               /* tp_doc */
-    0,                                               /* tp_traverse */
-    0,                                               /* tp_clear */
-    0,                                               /* tp_richcompare */
-    0,                                               /* tp_weaklistoffset */
-    PyObject_SelfIter,                               /* tp_iter */
-    (iternextfunc)vectoriter_next,                   /* tp_iternext */
-    vectoriter_methods,                              /* tp_methods */
-    0,                                               /* tp_members */
+    PyVarObject_HEAD_INIT(NULL, 0) "pygame.math.VectorIterator", /* tp_name */
+    sizeof(vectoriter),             /* tp_basicsize */
+    0,                              /* tp_itemsize */
+    (destructor)vectoriter_dealloc, /* tp_dealloc */
+    0,                              /* tp_print */
+    0,                              /* tp_getattr */
+    0,                              /* tp_setattr */
+    0,                              /* tp_compare */
+    0,                              /* tp_repr */
+    0,                              /* tp_as_number */
+    0,                              /* tp_as_sequence */
+    0,                              /* tp_as_mapping */
+    0,                              /* tp_hash */
+    0,                              /* tp_call */
+    0,                              /* tp_str */
+    PyObject_GenericGetAttr,        /* tp_getattro */
+    0,                              /* tp_setattro */
+    0,                              /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,             /* tp_flags */
+    0,                              /* tp_doc */
+    0,                              /* tp_traverse */
+    0,                              /* tp_clear */
+    0,                              /* tp_richcompare */
+    0,                              /* tp_weaklistoffset */
+    PyObject_SelfIter,              /* tp_iter */
+    (iternextfunc)vectoriter_next,  /* tp_iternext */
+    vectoriter_methods,             /* tp_methods */
+    0,                              /* tp_members */
 };
 
 static PyObject *
@@ -3921,10 +3921,10 @@ static PyNumberMethods vector_elementwiseproxy_as_number = {
 };
 
 static PyTypeObject pgVectorElementwiseProxy_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
-    "pygame.math.VectorElementwiseProxy",                    /* tp_name */
-    sizeof(vector_elementwiseproxy),                         /* tp_basicsize */
-    0,                                                       /* tp_itemsize */
+    PyVarObject_HEAD_INIT(
+        NULL, 0) "pygame.math.VectorElementwiseProxy", /* tp_name */
+    sizeof(vector_elementwiseproxy),                   /* tp_basicsize */
+    0,                                                 /* tp_itemsize */
     /* Methods to implement standard operations */
     (destructor)vector_elementwiseproxy_dealloc, /* tp_dealloc */
     0,                                           /* tp_print */
@@ -4011,7 +4011,10 @@ vector_elementwise(pgVector *vec, PyObject *args)
 static PyObject *
 math_enable_swizzling(pgVector *self)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning, "pygame.math.enable_swizzling() is deprecated, functionality has been removed, and will be removed", 1) == -1) {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "pygame.math.enable_swizzling() is deprecated, "
+                     "functionality has been removed, and will be removed",
+                     1) == -1) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -4020,7 +4023,10 @@ math_enable_swizzling(pgVector *self)
 static PyObject *
 math_disable_swizzling(pgVector *self)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning, "pygame.math.disable_swizzling() is deprecated, functionality has been removed, and will be removed", 1) == -1) {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "pygame.math.disable_swizzling() is deprecated, "
+                     "functionality has been removed, and will be removed",
+                     1) == -1) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -234,8 +234,6 @@ _vector_check_snprintf_success(int return_code);
 static PyObject *
 vector_repr(pgVector *self);
 static PyObject *
-vector_str(pgVector *self);
-static PyObject *
 vector_project_onto(pgVector *self, PyObject *other);
 
 /*
@@ -1550,32 +1548,6 @@ vector_repr(pgVector *self)
 }
 
 static PyObject *
-vector_str(pgVector *self)
-{
-    Py_ssize_t i;
-    int tmp;
-    int bufferIdx;
-    char buffer[2][STRING_BUF_SIZE];
-
-    bufferIdx = 1;
-    tmp = PyOS_snprintf(buffer[0], STRING_BUF_SIZE, "[");
-    if (!_vector_check_snprintf_success(tmp))
-        return NULL;
-    for (i = 0; i < self->dim - 1; ++i) {
-        tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g, ",
-                            buffer[(bufferIdx + 1) % 2], self->coords[i]);
-        bufferIdx++;
-        if (!_vector_check_snprintf_success(tmp))
-            return NULL;
-    }
-    tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g]",
-                        buffer[(bufferIdx + 1) % 2], self->coords[i]);
-    if (!_vector_check_snprintf_success(tmp))
-        return NULL;
-    return Text_FromUTF8(buffer[bufferIdx % 2]);
-}
-
-static PyObject *
 vector_project_onto(pgVector *self, PyObject *other)
 {
     Py_ssize_t i;
@@ -1924,7 +1896,7 @@ _vector2_set(pgVector *self, PyObject *xOrSequence, PyObject *y)
 #else
         else if (PyUnicode_Check(xOrSequence) || PyString_Check(xOrSequence)) {
 #endif
-            char *delimiter[3] = {"<Vector2(", ", ", ")>"};
+            char *delimiter[3] = {"Vector2(", ", ", ")"};
             Py_ssize_t error_code;
             error_code = _vector_coords_from_string(xOrSequence, delimiter,
                                                     self->coords, self->dim);
@@ -2282,7 +2254,7 @@ static PyTypeObject pgVector2_Type = {
     /* More standard operations (here for binary compatibility) */
     0,                                    /* tp_hash */
     0,                                    /* tp_call */
-    (reprfunc)vector_str,                 /* tp_str */
+    (reprfunc)NULL,                       /* tp_str */
     (getattrofunc)vector_getAttr_swizzle, /* tp_getattro */
     (setattrofunc)vector_setAttr_swizzle, /* tp_setattro */
     /* Functions to access object as input/output buffer */
@@ -2380,7 +2352,7 @@ _vector3_set(pgVector *self, PyObject *xOrSequence, PyObject *y, PyObject *z)
 #else
         else if (PyUnicode_Check(xOrSequence) || PyString_Check(xOrSequence)) {
 #endif
-            char *delimiter[4] = {"<Vector3(", ", ", ", ", ")>"};
+            char *delimiter[4] = {"Vector3(", ", ", ", ", ")"};
             Py_ssize_t error_code;
             error_code = _vector_coords_from_string(xOrSequence, delimiter,
                                                     self->coords, self->dim);
@@ -3172,7 +3144,7 @@ static PyTypeObject pgVector3_Type = {
     /* More standard operations (here for binary compatibility) */
     0,                                    /* tp_hash */
     0,                                    /* tp_call */
-    (reprfunc)vector_str,                 /* tp_str */
+    (reprfunc)NULL,                       /* tp_str */
     (getattrofunc)vector_getAttr_swizzle, /* tp_getattro */
     (setattrofunc)vector_setAttr_swizzle, /* tp_setattro */
     /* Functions to access object as input/output buffer */

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -364,7 +364,6 @@ _pg_do_rects_intersect(GAME_Rect *A, GAME_Rect *B)
             MAX(A->y, A->y + A->h) > MIN(B->y, B->y + B->h));
 }
 
-
 static PyObject *
 pg_rect_normalize(pgRectObject *self, PyObject *args)
 {
@@ -430,7 +429,8 @@ pg_rect_inflate_ip(pgRectObject *self, PyObject *args)
 }
 
 static PyObject *
-pg_rect_update(pgRectObject* self, PyObject* args) {
+pg_rect_update(pgRectObject *self, PyObject *args)
+{
     GAME_Rect temp;
     GAME_Rect *argrect = pgRect_FromObject(args, &temp);
 
@@ -515,7 +515,7 @@ pg_rect_unionall(pgRectObject *self, PyObject *args)
         if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
             Py_XDECREF(obj);
             return RAISE(PyExc_TypeError,
-                  "Argument must be a sequence of rectstyle objects.");
+                         "Argument must be a sequence of rectstyle objects.");
         }
         l = MIN(l, argrect->x);
         t = MIN(t, argrect->y);
@@ -562,7 +562,7 @@ pg_rect_unionall_ip(pgRectObject *self, PyObject *args)
         if (!obj || !(argrect = pgRect_FromObject(obj, &temp))) {
             Py_XDECREF(obj);
             return RAISE(PyExc_TypeError,
-                  "Argument must be a sequence of rectstyle objects.");
+                         "Argument must be a sequence of rectstyle objects.");
         }
         l = MIN(l, argrect->x);
         t = MIN(t, argrect->y);
@@ -787,9 +787,9 @@ pg_rect_collidedictall(pgRectObject *self, PyObject *args)
                 return NULL;
             }
             if (0 != PyList_Append(ret, num)) {
-               Py_DECREF(ret);
-               Py_DECREF(num);
-               return NULL; /* Exception already set. */
+                Py_DECREF(ret);
+                Py_DECREF(num);
+                return NULL; /* Exception already set. */
             }
             Py_DECREF(num);
         }
@@ -2037,10 +2037,9 @@ static PyGetSetDef pg_rect_getsets[] = {
 };
 
 static PyTypeObject pgRect_Type = {
-    PyVarObject_HEAD_INIT(NULL,0)
-    "pygame.Rect",                    /*name*/
-    sizeof(pgRectObject),             /*basicsize*/
-    0,                                /*itemsize*/
+    PyVarObject_HEAD_INIT(NULL, 0) "pygame.Rect", /*name*/
+    sizeof(pgRectObject),                         /*basicsize*/
+    0,                                            /*itemsize*/
     /* methods */
     (destructor)pg_rect_dealloc, /*dealloc*/
     (printfunc)NULL,             /*print*/

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1443,7 +1443,7 @@ pg_rect_repr(pgRectObject *self)
 {
     char string[256];
 
-    sprintf(string, "<rect(%d, %d, %d, %d)>", self->r.x, self->r.y, self->r.w,
+    sprintf(string, "Rect(%d, %d, %d, %d)", self->r.x, self->r.y, self->r.w,
             self->r.h);
     return Text_FromUTF8(string);
 }

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -497,7 +497,7 @@ class ColorTypeTest(unittest.TestCase):
 
     def test_repr(self):
         c = pygame.Color(68, 38, 26, 69)
-        t = "(68, 38, 26, 69)"
+        t = "Color(68, 38, 26, 69)"
         self.assertEqual(repr(c), t)
 
     def test_add(self):

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -261,11 +261,11 @@ class Vector2TypeTest(unittest.TestCase):
 
     def testStr(self):
         v = Vector2(1.2, 3.4)
-        self.assertEqual(str(v), "[1.2, 3.4]")
+        self.assertEqual(str(v), "Vector2(1.2, 3.4)")
 
     def testRepr(self):
         v = Vector2(1.2, 3.4)
-        self.assertEqual(v.__repr__(), "<Vector2(1.2, 3.4)>")
+        self.assertEqual(v.__repr__(), "Vector2(1.2, 3.4)")
         self.assertEqual(v, Vector2(v.__repr__()))
 
     def testIter(self):
@@ -1343,11 +1343,11 @@ class Vector3TypeTest(unittest.TestCase):
 
     def testStr(self):
         v = Vector3(1.2, 3.4, 5.6)
-        self.assertEqual(str(v), "[1.2, 3.4, 5.6]")
+        self.assertEqual(str(v), "Vector3(1.2, 3.4, 5.6)")
 
     def testRepr(self):
         v = Vector3(1.2, 3.4, -9.6)
-        self.assertEqual(v.__repr__(), "<Vector3(1.2, 3.4, -9.6)>")
+        self.assertEqual(v.__repr__(), "Vector3(1.2, 3.4, -9.6)")
         self.assertEqual(v, Vector3(v.__repr__()))
 
     def testIter(self):

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -13,7 +13,6 @@ PY3 = sys.version_info.major == 3
 
 class Vector2TypeTest(unittest.TestCase):
     def setUp(self):
-        pygame.math.enable_swizzling()
         self.zeroVec = Vector2()
         self.e1 = Vector2(1, 0)
         self.e2 = Vector2(0, 1)
@@ -25,9 +24,6 @@ class Vector2TypeTest(unittest.TestCase):
         self.v2 = Vector2(self.t2)
         self.s1 = 5.6
         self.s2 = 7.8
-
-    def tearDown(self):
-        pygame.math.enable_swizzling()
 
     def testConstructionDefault(self):
         v = Vector2()
@@ -485,13 +481,6 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertNotEqual(v, Vector2((5, 1)))
 
     def test_swizzle(self):
-        self.assertTrue(hasattr(pygame.math, "enable_swizzling"))
-        self.assertTrue(hasattr(pygame.math, "disable_swizzling"))
-        # swizzling not disabled by default
-        pygame.math.disable_swizzling()
-        self.assertRaises(AttributeError, lambda: self.v1.yx)
-        pygame.math.enable_swizzling()
-
         self.assertEqual(self.v1.yx, (self.v1.y, self.v1.x))
         self.assertEqual(
             self.v1.xxyyxy,
@@ -1747,13 +1736,6 @@ class Vector3TypeTest(unittest.TestCase):
         )
 
     def test_swizzle(self):
-        self.assertTrue(hasattr(pygame.math, "enable_swizzling"))
-        self.assertTrue(hasattr(pygame.math, "disable_swizzling"))
-        # swizzling enabled by default
-        pygame.math.disable_swizzling()
-        self.assertRaises(AttributeError, lambda: self.v1.yx)
-        pygame.math.enable_swizzling()
-
         self.assertEqual(self.v1.yxz, (self.v1.y, self.v1.x, self.v1.z))
         self.assertEqual(
             self.v1.xxyyzzxyz,


### PR DESCRIPTION
This PR does 2 separate things:

### Thing 1

Prepares the `math.enable_swizzling()` and `math.disable_swizzling()` for removal. I removed the functionality of the functions, and made them emit deprecation warnings. I also removed calls to those functions from the tests.

### Thing 2

According to the [python datamodel docs](https://docs.python.org/3.8/reference/datamodel.html#object.__repr__) for __repr__

> If at all possible, this should look like a valid Python expression that could be used to recreate an object with the same value (given an appropriate environment). If this is not possible, a string of the form <...some useful description...> should be returned.

So, the `<...>` syntax used by most pygame repr functions is not quite correct. Don't get me wrong, some pygame classes definitely should use it, such as `pygame.Surface`, which cannot be recreated with the data printed out.

I went through the pygame classes and identified places where I thought the repr function could lose the brackets or be otherwise improved.

`<rect(1, 2, 3, 4)>` -> `Rect(1, 2, 3, 4)`

`<Vector2(1, 2)>` -> `Vector2(1, 2)`

`<Vector3(1, 2, 3)>` -> `Vector3(1, 2, 3)`

`(255, 0, 120, 255)` -> `Color(255, 0, 120, 255)`

I also removed the Vector `str()` functionality, because Vectors should be represented as Vectors.
```
>>> str(pygame.Vector2(1,2))
'[1, 2]'
```
Not as lists!

The Vector test suite has a test where it puts the output of `__repr__()` back into a Vector constructor, and it works. There's an undocumented way to construct a Vector using a string. So I had to change that undocumented way to accept the new string format rather than the old one.

I'm not sure why this functionality exists. The only thing I could think of is for pickling, but the Vector classes each have a reduce() method to handle that. It seems useless and undocumented, although it is tested for, and so I would like to remove it. I left it in for this PR though, because I'm not sure if it has a use, and I want to keep this PR simpler to review.

I wanted to do `clang-format` on the files, but I put it as a separate commit so it would be easier to see changes by clicking on the other two commits.

Other math.c things that could be improved: the vectors have an undocumented `epsilon` attribute, the code has a bunch of commented out buffer protocol stuff that hasn't been touched since at least 2012, so that should just be deleted.