### PR TITLE
Update to type hint (vector2) and docs (draw line)

### DIFF
--- a/buildconfig/pygame-stubs/math.pyi
+++ b/buildconfig/pygame-stubs/math.pyi
@@ -102,7 +102,7 @@ class Vector2:
     @overload
     def __init__(
         self,
-        x: Union[float, Tuple[float, float, float], List[float], Vector2] = 0,
+        x: Union[float, Tuple[float, float], List[float], Vector2] = 0,
     ) -> None: ...
     @overload
     def __init__(

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -302,7 +302,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 .. function:: line
 
    | :sl:`draw a straight line`
-   | :sg:`line(surface, color, start_pos, end_pos, width) -> Rect`
+   | :sg:`line(surface, color, start_pos, end_pos) -> Rect`
    | :sg:`line(surface, color, start_pos, end_pos, width=1) -> Rect`
 
    Draws a straight line on the given surface. There are no endcaps. For thick


### PR DESCRIPTION
This update:
- removes unrequired keyword "width" for pygame.draw.line in the docs
- corrects type hint for Vector2 (tuple should contain 2 floats not 3)