### PR TITLE
Fix playmus.py example (broken in 2.0.1)

### DIFF
--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -80,6 +80,7 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
    | :sg:`rewind() -> None`
 
    Resets playback of the current music to the beginning.
+   .. note:: rewind does not support all music file formats. This is a limitation in the SDL_mixer, which states rewind only supports ``MOD``, ``OGG``, ``MP3`` and Native MIDI files. 
 
    .. ## pygame.mixer.music.rewind ##
 

--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -80,7 +80,9 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
    | :sg:`rewind() -> None`
 
    Resets playback of the current music to the beginning.
-   .. note:: rewind does not support all music file formats. This is a limitation in the SDL_mixer, which states rewind only supports ``MOD``, ``OGG``, ``MP3`` and Native MIDI files. 
+   .. note:: rewind does not support all music file formats. This is a limitation
+             in the SDL_mixer, which states rewind only supports ``MOD``, ``OGG``,
+             ``MP3`` and Native MIDI files. 
 
    .. ## pygame.mixer.music.rewind ##
 

--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -80,9 +80,10 @@ can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
    | :sg:`rewind() -> None`
 
    Resets playback of the current music to the beginning.
-   .. note:: rewind does not support all music file formats. This is a limitation
-             in the SDL_mixer, which states rewind only supports ``MOD``, ``OGG``,
-             ``MP3`` and Native MIDI files. 
+   
+   .. note:: :func:`rewind` supports a limited number of file types (``MOD``, ``OGG``,
+             ``MP3`` and Native MIDI files). For unsupported file types use :func:`play`
+             which will restart the music if it's already playing.
 
    .. ## pygame.mixer.music.rewind ##
 

--- a/examples/playmus.py
+++ b/examples/playmus.py
@@ -57,10 +57,11 @@ class Window(object):
         self.line_height = self.ascender - self.descender
 
         self.write_lines(
-            "'q', ESCAPE or close this window to quit\n"
-            "SPACE to play/pause\n"
-            "'r' to rewind\n"
-            "'f' to faid out over 5 seconds\n",
+            "Press 'q' or 'ESCAPE' or close this window to quit\n"
+            "Press 'SPACE' to play / pause\n"
+            "Press 'r' to rewind (restart from the beginning)\n"
+            "Press 'f' to fade music out over 5 seconds\n\n"
+            "Window will quit automatically when music ends\n",
             0,
         )
 
@@ -112,7 +113,7 @@ def main(file_path):
             pg.mixer.music.play()
             win.write_lines("Playing ...\n", -1)
 
-            while pg.mixer.music.get_busy():
+            while pg.mixer.music.get_busy() or paused:
                 e = pg.event.wait()
                 if e.type == pg.KEYDOWN:
                     key = e.key

--- a/examples/playmus.py
+++ b/examples/playmus.py
@@ -46,7 +46,9 @@ class Window(object):
 
     def __init__(self, title):
         pg.display.set_caption(title)
-        self.screen.fill(pg.Color("white"))
+        self.text_color = (254, 231, 21, 255)
+        self.background_color = (16, 24, 32, 255)
+        self.screen.fill(self.background_color)
         pg.display.flip()
 
         pygame.freetype.init()
@@ -57,7 +59,7 @@ class Window(object):
         self.line_height = self.ascender - self.descender
 
         self.write_lines(
-            "Press 'q' or 'ESCAPE' or close this window to quit\n"
+            "\nPress 'q' or 'ESCAPE' or close this window to quit\n"
             "Press 'SPACE' to play / pause\n"
             "Press 'r' to rewind (restart from the beginning)\n"
             "Press 'f' to fade music out over 5 seconds\n\n"
@@ -85,10 +87,11 @@ class Window(object):
         for i, text_line in enumerate(text.split("\n"), line):
             y = i * line_height + self.ascender
             # Clear the line first.
-            self.screen.fill(pg.Color("white"), (0, i * line_height, w, line_height))
-
+            self.screen.fill(
+                self.background_color, (0, i * line_height, w, line_height)
+            )
             # Write new text.
-            self.font.render_to(self.screen, (15, y), text_line, pg.Color("blue"))
+            self.font.render_to(self.screen, (15, y), text_line, self.text_color)
         pg.display.flip()
 
 
@@ -136,9 +139,11 @@ def main(file_path):
                         # when finished get_busy() will return 0.
                     elif key in [pg.K_q, pg.K_ESCAPE]:
                         pg.mixer.music.stop()
+                        paused = False
                         # get_busy() will now return 0.
                 elif e.type == pg.QUIT:
                     pg.mixer.music.stop()
+                    paused = False
                     # get_busy() will now return 0.
             pg.time.set_timer(pg.USEREVENT, 0)
         finally:

--- a/examples/playmus.py
+++ b/examples/playmus.py
@@ -61,7 +61,7 @@ class Window(object):
         self.write_lines(
             "\nPress 'q' or 'ESCAPE' or close this window to quit\n"
             "Press 'SPACE' to play / pause\n"
-            "Press 'r' to rewind (restart from the beginning)\n"
+            "Press 'r' to rewind to the beginning (restart)\n"
             "Press 'f' to fade music out over 5 seconds\n\n"
             "Window will quit automatically when music ends\n",
             0,
@@ -130,21 +130,27 @@ def main(file_path):
                             paused = True
                             win.write_lines("Paused ...\n", -1)
                     elif key == pg.K_r:
-                        pg.mixer.music.rewind()
+                        if file_path[-3:].lower() in ("ogg", "mp3", "mod"):
+                            status = "Rewound."
+                            pg.mixer.music.rewind()
+                        else:
+                            status = "Restarted."
+                            pg.mixer.music.play()
                         if paused:
-                            win.write_lines("Rewound.", -1)
+                            pg.mixer.music.pause()
+                            win.write_lines(status, -1)
                     elif key == pg.K_f:
                         win.write_lines("Fading out ...\n", -1)
                         pg.mixer.music.fadeout(5000)
-                        # when finished get_busy() will return 0.
+                        # when finished get_busy() will return False.
                     elif key in [pg.K_q, pg.K_ESCAPE]:
-                        pg.mixer.music.stop()
                         paused = False
-                        # get_busy() will now return 0.
+                        pg.mixer.music.stop()
+                        # get_busy() will now return False.
                 elif e.type == pg.QUIT:
-                    pg.mixer.music.stop()
                     paused = False
-                    # get_busy() will now return 0.
+                    pg.mixer.music.stop()
+                    # get_busy() will now return False.
             pg.time.set_timer(pg.USEREVENT, 0)
         finally:
             pg.mixer.quit()


### PR DESCRIPTION
This PR is to fix an issue with the bundled example file playmus.py which stopped working correctly as of pygame 2.0.1 due to a change in returning False for `pygame.mixer.music.get_busy()` when music is paused (previously returned True).

Also tidied up the wording a little bit and fixed a typo.

Issue was raised [#2734 ](https://github.com/pygame/pygame/issues/2734)