### PR TITLE
Add a requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ setuptools
 wheel
 numpy >= 1.6.2
 requests
-Sphinx
+Sphinx==3.5.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 setuptools
 wheel
 numpy >= 1.6.2
+requests
+Sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+setuptools
+wheel
+numpy >= 1.6.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ wheel
 numpy >= 1.6.2
 requests
 Sphinx==3.5.4
+cython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-setuptools
-wheel
-numpy >= 1.6.2
-requests
-Sphinx==3.5.4
-cython
+setuptools      # needed to setup
+wheel           # needed to build wheels
+numpy >= 1.6.2  # optional in a basic pygame install, probably needed for development
+requests        # might be needed to download some stuff
+Sphinx==3.5.4   # needed to build docs
+cython          # needed to build pygame

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ setuptools      # needed to setup
 wheel           # needed to build wheels
 numpy >= 1.6.2  # optional in a basic pygame install, probably needed for development
 requests        # might be needed to download some stuff
-Sphinx==3.5.4   # needed to build docs
+Sphinx~=4.1     # needed to build docs
 cython          # needed to build pygame


### PR DESCRIPTION
Added a `requirements-dev.txt` file to the root directory to help developers to setup python packages for building `pygame`:
- `numpy` is optional for a basic pygame install, but it is probably needed for development
- `setuptools` is needed for setup.py
- `wheel` is needed for building wheels