### PR TITLE
Fix case of CoreMIDI

### DIFF
--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -147,7 +147,7 @@ def main(sdl2=False):
 
 
     DEPS.extend([
-        FrameworkDependency('PORTTIME', 'CoreMidi.h', 'CoreMidi', 'CoreMIDI'),
+        FrameworkDependency('PORTTIME', 'CoreMIDI.h', 'CoreMIDI', 'CoreMIDI'),
         FrameworkDependency('QUICKTIME', 'QuickTime.h', 'QuickTime', 'QuickTime'),
         Dependency('PNG', 'png.h', 'libpng', ['png']),
         Dependency('JPEG', 'jpeglib.h', 'libjpeg', ['jpeg']),


### PR DESCRIPTION
This could cause build failures when using a case-sensitive filesystem.