### PR TITLE
update mixer/music docs, unskip mp3 tests

### DIFF
--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -24,7 +24,9 @@ Sound object, it will return immediately while the sound continues to play. A
 single Sound object can also be actively played back multiple times.
 
 The mixer also has a special streaming channel. This is for music playback and
-is accessed through the :mod:`pygame.mixer.music` module.
+is accessed through the :mod:`pygame.mixer.music` module. Consider using this
+module for playing long running music. Unlike mixer module, the music module
+streams the music from the files without loading music at once into memory.
 
 The mixer module must be initialized like other pygame modules, but it has some
 extra conditions. The ``pygame.mixer.init()`` function takes several optional

--- a/docs/reST/ref/music.rst
+++ b/docs/reST/ref/music.rst
@@ -15,8 +15,10 @@ The difference between the music playback and regular Sound playback is that
 the music is streamed, and never actually loaded all at once. The mixer system
 only supports a single music stream at once.
 
-Be aware that ``MP3`` support is limited. On some systems an unsupported format
-can crash the program, ``e.g``. Debian Linux. Consider using ``OGG`` instead.
+On older pygame versions, ``MP3`` support was limited under Mac and Linux. This
+changed in pygame ``v2.0.2`` which got improved MP3 support. Consider using
+``OGG`` file format for music as that can give slightly better compression than
+MP3 in most cases.
 
 .. function:: load
 

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -26,9 +26,6 @@ class MixerMusicModuleTest(unittest.TestCase):
         if pygame.mixer.get_init() is None:
             pygame.mixer.init()
 
-    @unittest.skipIf(
-        "Darwin" in platform.system(), "SDL2_mixer not loading mp3 on travisci"
-    )
     def test_load_mp3(self):
         "|tags:music|"
         self.music_load("mp3")
@@ -124,9 +121,6 @@ class MixerMusicModuleTest(unittest.TestCase):
         finally:
             os.remove(tmppath)
 
-    @unittest.skipIf(
-        "Darwin" in platform.system(), "SDL2_mixer issue with mp3 files on Travis CI"
-    )
     def test_queue_mp3(self):
         """Ensures queue() accepts mp3 files.
 
@@ -224,8 +218,10 @@ class MixerMusicModuleTest(unittest.TestCase):
 
         self.fail()
 
-    @unittest.skipIf(os.environ.get("SDL_AUDIODRIVER")  == 'disk',
-                     'disk audio driver "playback" writing to disk is slow')
+    @unittest.skipIf(
+        os.environ.get("SDL_AUDIODRIVER") == "disk",
+        'disk audio driver "playback" writing to disk is slow',
+    )
     def test_play__start_time(self):
 
         pygame.display.init()


### PR DESCRIPTION
Minor PR, updates the docs to mention better MP3 support in latest pygame version, clarifies that `pygame.mixer` loads music at once (to close #2505) and also removes test skips on MP3 file loading