### PR TITLE
Simple fix to swap numpy.float type out in favour of float

### DIFF
--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -52,6 +52,7 @@ numpy_floats = []
 for type_name in "float32 float64 float96".split():
     if hasattr(numpy, type_name):
         numpy_floats.append(getattr(numpy, type_name))
+# Added below due to deprecation of numpy.float. See issue #2814
 numpy_floats.append(float)
 
 # Pixel sizes corresponding to NumPy supported integer sizes, and therefore

--- a/src_py/surfarray.py
+++ b/src_py/surfarray.py
@@ -49,9 +49,10 @@ import warnings     # will be removed in the future
 
 # float96 not available on all numpy versions.
 numpy_floats = []
-for type_name in "float float32 float64 float96".split():
+for type_name in "float32 float64 float96".split():
     if hasattr(numpy, type_name):
         numpy_floats.append(getattr(numpy, type_name))
+numpy_floats.append(float)
 
 # Pixel sizes corresponding to NumPy supported integer sizes, and therefore
 # permissible for 2D reference arrays.


### PR DESCRIPTION
This is because numpy.float is now deprecated.

See #2814 