### PR TITLE
Release GIL on SDL_Quit, fix deadlock

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -474,7 +474,11 @@ _pg_quit(void)
 
     pg_is_init = 0;
 
+    /* Release the GIL here, because the timer thread cleanups should happen
+     * without deadlocking. */
+    Py_BEGIN_ALLOW_THREADS; 
     pg_atexit_quit();
+    Py_END_ALLOW_THREADS;
 }
 
 static PyObject *

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -536,8 +536,8 @@ quit(PyObject *self)
 
         Py_BEGIN_ALLOW_THREADS;
         Mix_CloseAudio();
-        Py_END_ALLOW_THREADS;
         SDL_QuitSubSystem(SDL_INIT_AUDIO);
+        Py_END_ALLOW_THREADS;
     }
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
A PR to fix #2813

The thread that is responsible for posting event timers runs in the background, and that thread needs to acquire GIL to post events. When `pygame.quit()` calls `SDL_Quit()` the GIL is held here, and the SDL function probably waits internally for the timer thread to complete and this creates a deadlock that hangs the app during `pygame.quit()`

The only fix for this is to release GIL while calling `SDL_Quit()`, hopefully this does not have any other unintended side effects, so this PR needs more testing before merging.