### PR TITLE
neon optimisations default on arm64

### DIFF
--- a/buildconfig/manylinux-build/docker_base/sdl_libs/build-sdl2-libs.sh
+++ b/buildconfig/manylinux-build/docker_base/sdl_libs/build-sdl2-libs.sh
@@ -27,8 +27,13 @@ tar xzf ${SDL2}.tar.gz
 # this is for renaming the tip.tar.gz
 # mv SDL-* ${SDL2}
 
+if [[ "$MAC_ARCH" == "arm64" ]]; then
+    # Build SDL with ARM optimisations on M1 macs
+    export M1_MAC_EXTRA_FLAGS="--enable-arm-simd --enable-arm-neon"
+fi
+
 cd $SDL2
-./configure --disable-video-vulkan $ARCHS_CONFIG_FLAG
+./configure --disable-video-vulkan $ARCHS_CONFIG_FLAG $M1_MAC_EXTRA_FLAGS
 make
 make install
 

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -25,6 +25,11 @@
 #define NO_PYGAME_C_API
 #include "_surface.h"
 
+#if !defined(PG_ENABLE_ARM_NEON) && defined(__aarch64__)
+// arm64 has neon optimisations enabled by default, even when fpu=neon is not passed 
+#define PG_ENABLE_ARM_NEON 1
+#endif
+
 /* See if we are compiled 64 bit on GCC or MSVC */
 #if _WIN32 || _WIN64
    #if _WIN64


### PR DESCRIPTION
ARM neon optimisations are default on arm64 (things like M1 mac and pi 3/4 running 64-bit OS, and not older pis and/or ones that run 32-bit OSes), so enable them in our code as well

This PR also makes neon optimised SDL builds on M1 mac