### PR TITLE
Remove most PY2/PY3 C compatibility code

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -1945,7 +1945,6 @@ MODINIT_DEFINE(_camera)
      * the module is not loaded.
      */
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "_camera",
                                          DOC_PYGAMECAMERA,
@@ -1955,7 +1954,6 @@ MODINIT_DEFINE(_camera)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     import_pygame_base();
     if (PyErr_Occurred()) {
@@ -1974,11 +1972,7 @@ MODINIT_DEFINE(_camera)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3("_camera", camera_builtins, DOC_PYGAMECAMERA);
-#endif
 
     Py_INCREF(&pgCamera_Type);
     PyModule_AddObject(module, "CameraType", (PyObject *)&pgCamera_Type);

--- a/src_c/_sdl2/touch.c
+++ b/src_c/_sdl2/touch.c
@@ -129,7 +129,6 @@ static PyMethodDef _touch_methods[] = {
 MODINIT_DEFINE(touch)
 {
     PyObject *module;
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "touch",
                                          DOC_PYGAMESDL2TOUCH,
@@ -139,19 +138,13 @@ MODINIT_DEFINE(touch)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
     import_pygame_base();
     if (PyErr_Occurred()) {
         MODINIT_ERROR;
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "touch", _touch_methods,
-                            DOC_PYGAMESDL2TOUCH);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -640,14 +640,8 @@ static PyBufferProcs proxy_bufferprocs = {
 #define PROXY_BUFFERPROCS 0
 #endif
 
-#if PY2
-#define PROXY_TPFLAGS                                                \
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC | \
-     Py_TPFLAGS_HAVE_NEWBUFFER)
-#else
 #define PROXY_TPFLAGS \
     (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC)
-#endif
 
 static PyTypeObject pgBufproxy_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) PROXY_TYPE_FULLNAME, /* tp_name */
@@ -836,7 +830,6 @@ MODINIT_DEFINE(bufferproxy)
     PyObject *apiobj;
     static void *c_api[PYGAMEAPI_BUFPROXY_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          PROXY_MODNAME,
                                          bufferproxy_doc,
@@ -846,7 +839,6 @@ MODINIT_DEFINE(bufferproxy)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis */
     import_pygame_base();
@@ -862,12 +854,7 @@ MODINIT_DEFINE(bufferproxy)
 #define bufferproxy_docs ""
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX PROXY_MODNAME, bufferproxy_methods,
-                            bufferproxy_doc);
-#endif
 
     Py_INCREF(&pgBufproxy_Type);
     if (PyModule_AddObject(module, PROXY_TYPE_NAME,

--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -47,7 +47,7 @@
     #include <linux/videodev2.h>
 #endif
 
-#if defined(__WIN32__) && PY3
+#if defined(__WIN32__)
     #define PYGAME_WINDOWS_CAMERA 1
 
     #include <mfapi.h>

--- a/src_c/cdrom.c
+++ b/src_c/cdrom.c
@@ -576,7 +576,6 @@ MODINIT_DEFINE(cdrom)
     int ecode;
     static void *c_api[PYGAMEAPI_CDROM_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "cdrom",
                                          DOC_PYGAMECDROM,
@@ -586,7 +585,6 @@ MODINIT_DEFINE(cdrom)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -602,12 +600,7 @@ MODINIT_DEFINE(cdrom)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module =
-        Py_InitModule3(MODPREFIX "cdrom", _cdrom_methods, DOC_PYGAMECDROM);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/constants.c
+++ b/src_c/constants.c
@@ -95,7 +95,6 @@ MODINIT_DEFINE(constants)
     PyObject *module;
     PyObject *all_list;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "constants",
                                          _constants_doc,
@@ -105,14 +104,8 @@ MODINIT_DEFINE(constants)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "constants", _constant_methods,
-                            _constants_doc);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2344,7 +2344,6 @@ static PyMethodDef _draw_methods[] = {
 
 MODINIT_DEFINE(draw)
 {
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "draw",
                                          DOC_PYGAMEDRAW,
@@ -2354,7 +2353,6 @@ MODINIT_DEFINE(draw)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -2377,9 +2375,5 @@ MODINIT_DEFINE(draw)
     }
 
 /* create the module */
-#if PY3
     return PyModule_Create(&_module);
-#else
-    Py_InitModule3(MODPREFIX "draw", _draw_methods, DOC_PYGAMEDRAW);
-#endif
 }

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1473,15 +1473,12 @@ pg_event_str(PyObject *self)
     PyObject *pyobj;
     char *s;
     size_t size;
-#if PY3
     PyObject *encodedobj;
-#endif
 
     strobj = PyObject_Str(e->dict);
     if (strobj == NULL) {
         return NULL;
     }
-#if PY3
     encodedobj = PyUnicode_AsUTF8String(strobj);
     Py_DECREF(strobj);
     strobj = encodedobj;
@@ -1490,9 +1487,6 @@ pg_event_str(PyObject *self)
         return NULL;
     }
     s = PyBytes_AsString(strobj);
-#else
-    s = PyString_AsString(strobj);
-#endif
     size = (11 + strlen(_pg_name_from_eventtype(e->type)) + strlen(s) +
             sizeof(e->type) * 3 + 1);
 
@@ -1618,11 +1612,7 @@ static PyTypeObject pgEvent_Type = {
     PyObject_GenericSetAttr, /* tp_setattro */
 #endif
     0, /* tp_as_buffer */
-#if PY3
     0,
-#else
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_RICHCOMPARE,
-#endif
     DOC_PYGAMEEVENTEVENT,          /* Documentation string */
     0,                             /* tp_traverse */
     0,                             /* tp_clear */
@@ -1747,13 +1737,8 @@ set_grab(PyObject *self, PyObject *arg)
     SDL_Window *win = NULL;
 #endif /* IS_SDLv2 */
 
-#if PY2
-    if (!PyArg_ParseTuple(arg, "i", &doit))
-        return NULL;
-#else
     if (!PyArg_ParseTuple(arg, "p", &doit))
         return NULL;
-#endif
     VIDEO_INIT_CHECK();
 
 #if IS_SDLv1
@@ -1956,15 +1941,9 @@ pg_event_clear(PyObject *self, PyObject *args, PyObject *kwargs)
         NULL
     };
 
-#if PY3
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|Op", kwids,
                                      &obj, &dopump))
         return NULL;
-#else
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|Oi", kwids,
-                                     &obj, &dopump))
-        return NULL;
-#endif
 
     VIDEO_INIT_CHECK();
     _pg_event_pump(dopump);
@@ -2212,15 +2191,9 @@ pg_event_get(PyObject *self, PyObject *args, PyObject *kwargs)
         NULL
     };
 
-#if PY3
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OpO", kwids,
                                      &obj_evtype, &dopump, &obj_exclude))
         return NULL;
-#else
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OiO", kwids,
-                                      &obj_evtype, &dopump, &obj_exclude))
-        return NULL;
-#endif
 
     VIDEO_INIT_CHECK();
 
@@ -2254,15 +2227,9 @@ pg_event_peek(PyObject *self, PyObject *args, PyObject *kwargs)
         NULL
     };
 
-#if PY3
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|Op", kwids,
                                      &obj, &dopump))
         return NULL;
-#else
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|Oi", kwids,
-                                     &obj, &dopump))
-        return NULL;
-#endif
 
     VIDEO_INIT_CHECK();
 
@@ -2505,7 +2472,6 @@ MODINIT_DEFINE(event)
     int ecode;
     static void *c_api[PYGAMEAPI_EVENT_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "event",
                                          DOC_PYGAMEEVENT,
@@ -2515,7 +2481,6 @@ MODINIT_DEFINE(event)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -2535,12 +2500,7 @@ MODINIT_DEFINE(event)
 #endif
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module =
-        Py_InitModule3(MODPREFIX "event", _event_methods, DOC_PYGAMEEVENT);
-#endif
     dict = PyModule_GetDict(module);
 
     if (NULL == (joy_instance_map = PyDict_New())) {

--- a/src_c/fastevent.c
+++ b/src_c/fastevent.c
@@ -200,7 +200,6 @@ MODINIT_DEFINE(fastevent)
     PyObject *module, *eventmodule, *dict;
     int ecode;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "fastevent",
                                          DOC_PYGAMEFASTEVENT,
@@ -210,7 +209,6 @@ MODINIT_DEFINE(fastevent)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -225,12 +223,7 @@ MODINIT_DEFINE(fastevent)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "fastevent", _fastevent_methods,
-                            DOC_PYGAMEFASTEVENT);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -51,18 +51,13 @@
     (SDL_TTF_COMPILEDVERSION >= SDL_VERSIONNUM(X, Y, Z))
 #endif
 
-#if PY3
 #define RAISE_TEXT_TYPE_ERROR() \
     RAISE(PyExc_TypeError, "text must be a unicode or bytes");
-#else
-#define RAISE_TEXT_TYPE_ERROR() \
-    RAISE(PyExc_TypeError, "text must be a string or unicode");
-#endif
 
 /* For filtering out UCS-4 and larger characters when Python is
  * built with Py_UNICODE_WIDE.
  */
-#if PY2 && !defined(Py_UNICODE_IS_SURROGATE) || defined(PYPY_VERSION)
+#if defined(PYPY_VERSION)
 #define Py_UNICODE_IS_SURROGATE(ch) (0xD800 <= (ch) && (ch) <= 0xDFFF)
 #endif
 
@@ -139,7 +134,6 @@ font_resource(const char *filename)
         return NULL;
     }
 
-#if PY3
     tmp = PyObject_GetAttrString(result, "name");
     if (tmp != NULL) {
         PyObject *closeret;
@@ -155,24 +149,6 @@ font_resource(const char *filename)
     else if (!PyErr_ExceptionMatches(PyExc_MemoryError)) {
         PyErr_Clear();
     }
-#else
-    if (PyFile_Check(result)) {
-        PyObject *closeret;
-
-        tmp = PyFile_Name(result);
-        Py_INCREF(tmp);
-
-        if (!(closeret = PyObject_CallMethod(result, "close", NULL))) {
-            Py_DECREF(result);
-            Py_DECREF(tmp);
-            return NULL;
-        }
-        Py_DECREF(closeret);
-
-        Py_DECREF(result);
-        result = tmp;
-    }
-#endif
 
     tmp = pg_EncodeString(result, "UTF-8", NULL, NULL);
     if (tmp == NULL) {
@@ -304,11 +280,7 @@ font_set_bold(PyObject *self, PyObject *args)
 {
     TTF_Font *font = PyFont_AsFont(self);
     int val;
-#if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
-#else
-    if (!PyArg_ParseTuple(args, "i", &val))
-#endif /* PY3 */
         return NULL;
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_BOLD, val);
@@ -355,11 +327,7 @@ font_set_italic(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int val;
 
-#if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
-#else
-    if (!PyArg_ParseTuple(args, "i", &val))
-#endif /* PY3 */
         return NULL;
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_ITALIC, val);
@@ -406,11 +374,7 @@ font_set_underline(PyObject *self, PyObject *args)
     TTF_Font *font = PyFont_AsFont(self);
     int val;
 
-#if PY3
     if (!PyArg_ParseTuple(args, "p", &val))
-#else
-    if (!PyArg_ParseTuple(args, "i", &val))
-#endif /* PY3 */
         return NULL;
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_UNDERLINE, val);
@@ -430,17 +394,10 @@ font_render(PyObject *self, PyObject *args)
     SDL_Color foreg, backg;
     int just_return;
 
-#if PY3
     if (!PyArg_ParseTuple(args, "OpO|O", &text, &aa, &fg_rgba_obj,
                           &bg_rgba_obj)) {
         return NULL;
     }
-#else
-    if (!PyArg_ParseTuple(args, "OiO|O", &text, &aa, &fg_rgba_obj,
-                          &bg_rgba_obj)) {
-        return NULL;
-    }
-#endif /* PY3 */
 
     if (!pg_RGBAFromFuzzyColorObj(fg_rgba_obj, rgba)) {
         /* Exception already set for us */
@@ -1002,7 +959,6 @@ MODINIT_DEFINE(font)
     PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_FONT_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "font",
                                          DOC_PYGAMEFONT,
@@ -1012,7 +968,6 @@ MODINIT_DEFINE(font)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -1040,11 +995,7 @@ MODINIT_DEFINE(font)
     }
     PyFont_Type.tp_new = PyType_GenericNew;
 
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "font", _font_methods, DOC_PYGAMEFONT);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/freetype/ft_unicode.c
+++ b/src_c/freetype/ft_unicode.c
@@ -68,18 +68,11 @@ _encode_unicode_string(PyObject *obj, int ucs4)
     Py_ssize_t len, srclen;
     PGFT_char c;
     int i, j;
-#if PY3
     /* This Py_UCS4 src has to be freed later */
     Py_UCS4 *src = PyUnicode_AsUCS4Copy(obj);
     if (!src)
         return NULL;
     len = srclen = PyUnicode_GetLength(obj);
-#else /* PY2 */
-    /* This Py_UNICODE src should not be freed. This function never
-     * used to fail with NULL on python 2 */
-    const Py_UNICODE *src = PyUnicode_AS_UNICODE(obj);
-    len = srclen = PyUnicode_GET_SIZE(obj);
-#endif
 
     if (!ucs4) {
         /* Do UTF-16 surrogate pair decoding. Calculate character count
@@ -135,9 +128,7 @@ _encode_unicode_string(PyObject *obj, int ucs4)
     }
 
 end:
-#if PY3
     PyMem_Free(src);
-#endif
     if (utf32_buffer) {
         utf32_buffer->data[len] = 0;
         utf32_buffer->length = len;

--- a/src_c/freetype/ft_wrap.h
+++ b/src_c/freetype/ft_wrap.h
@@ -233,7 +233,7 @@ typedef struct {
     FT_UInt resolution;
 } _FreeTypeState;
 
-#if PY3 && !defined(PYPY_VERSION)
+#if !defined(PYPY_VERSION)
     extern struct PyModuleDef _freetypemodule;
 #   define FREETYPE_MOD_STATE(mod) ((_FreeTypeState*)PyModule_GetState(mod))
 #   define FREETYPE_STATE \

--- a/src_c/gfxdraw.c
+++ b/src_c/gfxdraw.c
@@ -1092,7 +1092,6 @@ MODINIT_DEFINE(gfxdraw)
 {
     PyObject *module;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          MODPREFIX "gfxdraw",
                                          DOC_PYGAMEGFXDRAW,
@@ -1102,7 +1101,6 @@ MODINIT_DEFINE(gfxdraw)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* import needed APIs; Do this first so if there is an error
        the module is not loaded.
@@ -1124,12 +1122,7 @@ MODINIT_DEFINE(gfxdraw)
         MODINIT_ERROR;
     }
 
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "gfxdraw", _gfxdraw_methods,
-                            DOC_PYGAMEGFXDRAW);
-#endif
 
     if (module == NULL) {
         MODINIT_ERROR;

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -1667,7 +1667,6 @@ MODINIT_DEFINE(image)
     PyObject *module;
     PyObject *extmodule;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "image",
                                          DOC_PYGAMEIMAGE,
@@ -1677,7 +1676,6 @@ MODINIT_DEFINE(image)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -1696,12 +1694,7 @@ MODINIT_DEFINE(image)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module =
-        Py_InitModule3(MODPREFIX "image", _image_methods, DOC_PYGAMEIMAGE);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -880,7 +880,6 @@ image_get_sdl_image_version(PyObject *self, PyObject *arg)
 }
 
 #ifdef WITH_THREAD
-#if PY3
 static void
 _imageext_free(void *ptr)
 {
@@ -889,16 +888,6 @@ _imageext_free(void *ptr)
         _pg_img_mutex = 0;
     }
 }
-#else /* PY2 */
-static void
-_imageext_free(void)
-{
-    if (_pg_img_mutex) {
-        SDL_DestroyMutex(_pg_img_mutex);
-        _pg_img_mutex = 0;
-    }
-}
-#endif /* PY2 */
 #endif /* WITH_THREAD */
 
 static PyMethodDef _imageext_methods[] = {
@@ -914,7 +903,6 @@ static PyMethodDef _imageext_methods[] = {
 
 MODINIT_DEFINE(imageext)
 {
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "imageext",
                                          _imageext_doc,
@@ -928,7 +916,6 @@ MODINIT_DEFINE(imageext)
 #else /* ~WITH_THREAD */
                                          0};
 #endif /* ~WITH_THREAD */
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -948,11 +935,6 @@ MODINIT_DEFINE(imageext)
     }
 
 #ifdef WITH_THREAD
-#if PY2
-    if (Py_AtExit(_imageext_free)) {
-        MODINIT_ERROR;
-    }
-#endif /* PY2 */
     _pg_img_mutex = SDL_CreateMutex();
     if (!_pg_img_mutex) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
@@ -961,9 +943,5 @@ MODINIT_DEFINE(imageext)
 #endif /* WITH_THREAD */
 
     /* create the module */
-#if PY3
     return PyModule_Create(&_module);
-#else
-    Py_InitModule3(MODPREFIX "imageext", _imageext_methods, _imageext_doc);
-#endif
 }

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -651,7 +651,6 @@ MODINIT_DEFINE(joystick)
     int ecode;
     static void *c_api[PYGAMEAPI_JOYSTICK_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "joystick",
                                          DOC_PYGAMEJOYSTICK,
@@ -661,7 +660,6 @@ MODINIT_DEFINE(joystick)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -685,11 +683,7 @@ MODINIT_DEFINE(joystick)
     Py_DECREF(module);
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3("joystick", _joystick_methods, DOC_PYGAMEJOYSTICK);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -116,12 +116,7 @@ static PyObject*
 pg_scancodewrapper_repr(pgScancodeWrapper *self)
 {
     PyObject *baserepr = PyTuple_Type.tp_repr((PyObject *)self);
-#if PY3
     PyObject *ret = Text_FromFormat(_PG_SCANCODEWRAPPER_TYPE_FULLNAME "%S", baserepr);
-#else /* PY2 */
-    PyObject *ret = Text_FromFormat(_PG_SCANCODEWRAPPER_TYPE_FULLNAME "%s",
-                                    PyString_AsString(baserepr));
-#endif /* PY2 */
     Py_DECREF(baserepr);
     return ret;
 }
@@ -862,7 +857,6 @@ MODINIT_DEFINE(key)
 {
     PyObject *module;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "key",
                                          DOC_PYGAMEKEY,
@@ -872,7 +866,6 @@ MODINIT_DEFINE(key)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -898,11 +891,7 @@ MODINIT_DEFINE(key)
 #endif /* IS_SDLv2 */
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "key", _key_methods, DOC_PYGAMEKEY);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2450,11 +2450,7 @@ mask_init(PyObject *self, PyObject *args, PyObject *kwargs)
     int w, h;
     int fill = 0; /* Default is false. */
     char *keywords[] = {"size", "fill", NULL};
-#if PY3
     const char *format = "O|p";
-#else
-    const char *format = "O|i";
-#endif
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, keywords, &size,
                                      &fill)) {
@@ -2488,7 +2484,6 @@ mask_init(PyObject *self, PyObject *args, PyObject *kwargs)
     return 0;
 }
 
-#if PY3
 typedef struct {
     int numbufs;
     Py_ssize_t shape[2];
@@ -2560,7 +2555,6 @@ static PyBufferProcs pgMask_BufferProcs = {
     (releasebufferproc)pgMask_ReleaseBuffer
 };
 
-#endif /* PY3 */
 
 static PyTypeObject pgMask_Type = {
     PyVarObject_HEAD_INIT(NULL,0)
@@ -2581,13 +2575,8 @@ static PyTypeObject pgMask_Type = {
     (reprfunc)NULL,       /* tp_str */
     0L,                   /* tp_getattro */
     0L,                   /* tp_setattro */
-#if PY3
     &pgMask_BufferProcs,  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-#else /* PY2 */
-    0L,                   /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-#endif /* PY2 */
     DOC_PYGAMEMASKMASK, /* Documentation string */
     0,                  /* tp_traverse */
     0,                  /* tp_clear */
@@ -2621,7 +2610,6 @@ MODINIT_DEFINE(mask)
     PyObject *module, *dict, *apiobj;
     static void *c_api[PYGAMEAPI_MASK_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "mask",
                                          DOC_PYGAMEMASK,
@@ -2631,7 +2619,6 @@ MODINIT_DEFINE(mask)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -2659,11 +2646,7 @@ MODINIT_DEFINE(mask)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "mask", _mask_methods, DOC_PYGAMEMASK);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -454,11 +454,7 @@ get_double_from_unicode_slice(PyObject *unicode_obj, Py_ssize_t idx1,
                         "internal error while converting str slice to float");
         return -1;
     }
-#if PY3
     float_obj = PyFloat_FromString(slice);
-#else
-    float_obj = PyFloat_FromString(slice, NULL);
-#endif
     Py_DECREF(slice);
     if (float_obj == NULL)
         return 0;
@@ -1629,11 +1625,7 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
     double *coords;
     Py_ssize_t i, idx, len;
     PyObject *attr_unicode = NULL;
-#if PY2
-    Py_UNICODE *attr = NULL;
-#else
     const char *attr = NULL;
-#endif
     PyObject *res = NULL;
 
     len = PySequence_Length(attr_name);
@@ -1648,11 +1640,7 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
     attr_unicode = PyUnicode_FromObject(attr_name);
     if (attr_unicode == NULL)
         goto swizzle_failed;
-#if PY2
-    attr = PyUnicode_AsUnicode(attr_unicode);
-#else
     attr = PyUnicode_AsUTF8AndSize(attr_unicode, &len);
-#endif
     if (attr == NULL)
         goto internal_error;
     /* If we are not a swizzle, go straight to GenericGetAttr. */
@@ -1722,11 +1710,7 @@ internal_error:
 static int
 vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val)
 {
-#if PY2
-    Py_UNICODE *attr = NULL;
-#else
     const char *attr = NULL;
-#endif
     PyObject *attr_unicode;
     Py_ssize_t len = PySequence_Length(attr_name);
     double entry[VECTOR_MAX_SIZE];
@@ -1746,11 +1730,7 @@ vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val)
     attr_unicode = PyUnicode_FromObject(attr_name);
     if (attr_unicode == NULL)
         return -1;
-#if PY2
-    attr = PyUnicode_AsUnicode(attr_unicode);
-#else
     attr = PyUnicode_AsUTF8AndSize(attr_unicode, &len);
-#endif
 
     if (attr == NULL) {
         Py_DECREF(attr_unicode);
@@ -1921,11 +1901,7 @@ _vector2_set(pgVector *self, PyObject *xOrSequence, PyObject *y)
             else
                 return 0;
         }
-#if PY3
         else if (PyUnicode_Check(xOrSequence)) {
-#else
-        else if (PyUnicode_Check(xOrSequence) || PyString_Check(xOrSequence)) {
-#endif
             char *delimiter[3] = {"<Vector2(", ", ", ")>"};
             Py_ssize_t error_code;
             error_code = _vector_coords_from_string(xOrSequence, delimiter,
@@ -2292,12 +2268,7 @@ static PyTypeObject pgVector2_Type = {
     /* Functions to access object as input/output buffer */
     0, /* tp_as_buffer */
 /* Flags to define presence of optional/expanded features */
-#if PY3
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-#else
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_CHECKTYPES, /* tp_flags */
-#endif
     /* Documentation string */
     DOC_PYGAMEMATHVECTOR2, /* tp_doc */
 
@@ -2379,11 +2350,7 @@ _vector3_set(pgVector *self, PyObject *xOrSequence, PyObject *y, PyObject *z)
             else
                 return 0;
         }
-#if PY3
         else if (PyUnicode_Check(xOrSequence)) {
-#else
-        else if (PyUnicode_Check(xOrSequence) || PyString_Check(xOrSequence)) {
-#endif
             char *delimiter[4] = {"<Vector3(", ", ", ", ", ")>"};
             Py_ssize_t error_code;
             error_code = _vector_coords_from_string(xOrSequence, delimiter,
@@ -3179,12 +3146,7 @@ static PyTypeObject pgVector3_Type = {
     /* Functions to access object as input/output buffer */
     0, /* tp_as_buffer */
 /* Flags to define presence of optional/expanded features */
-#if PY3
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-#else
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_CHECKTYPES, /* tp_flags */
-#endif
     /* Documentation string */
     DOC_PYGAMEMATHVECTOR3, /* tp_doc */
 
@@ -3947,11 +3909,7 @@ static PyTypeObject pgVectorElementwiseProxy_Type = {
     /* Functions to access object as input/output buffer */
     0, /* tp_as_buffer */
 /* Flags to define presence of optional/expanded features */
-#if PY3
     Py_TPFLAGS_DEFAULT,
-#else
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_CHECKTYPES, /* tp_flags */
-#endif
     /* Documentation string */
     0, /* tp_doc */
 
@@ -4040,7 +3998,6 @@ MODINIT_DEFINE(math)
     PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_MATH_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "math",
                                          DOC_PYGAMEMATH,
@@ -4050,7 +4007,6 @@ MODINIT_DEFINE(math)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* initialize the extension types */
     if ((PyType_Ready(&pgVector2_Type) < 0) ||
@@ -4062,11 +4018,7 @@ MODINIT_DEFINE(math)
     }
 
     /* initialize the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "math", _math_methods, DOC_PYGAMEMATH);
-#endif
 
     if (module == NULL) {
         MODINIT_ERROR;

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1783,11 +1783,7 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
         rw = pgRWops_FromObject(file);
 
         if (rw == NULL) {
-#if PY3
             if (obj) {
-#else
-            if (obj && PyErr_ExceptionMatches(PyExc_TypeError)) {
-#endif
                 /* use 'buffer' as fallback for single arg */
                 PyErr_Clear();
                 goto LOAD_BUFFER;
@@ -1818,12 +1814,7 @@ sound_init(PyObject *self, PyObject *arg, PyObject *kwarg)
 
 LOAD_BUFFER:
 
-#if PY2
-    if (!chunk && buffer && /* conditional and */
-        PyObject_CheckBuffer(buffer)) {
-#else
     if (!chunk && buffer) {
-#endif
         Py_buffer view;
         int rcode;
 
@@ -1849,30 +1840,6 @@ LOAD_BUFFER:
         }
     }
 
-#if PY2
-    if (chunk == NULL && buffer != NULL) {
-        const void *buf = NULL;
-        Py_ssize_t buflen = 0;
-
-        if (PyObject_AsReadBuffer(buffer, &buf, &buflen)) {
-            if (obj != NULL) {
-                PyErr_Clear();
-            }
-            else {
-                PyErr_Format(PyExc_TypeError,
-                             "Expected object with buffer interface: got a %s",
-                             Py_TYPE(buffer)->tp_name);
-                return -1;
-            }
-        }
-        else {
-            if (_chunk_from_buf(buf, buflen, &chunk, &mem)) {
-                return -1;
-            }
-            ((pgSoundObject *)self)->mem = mem;
-        }
-    }
-#endif
 
     if (array != NULL) {
         pg_buffer pg_view;
@@ -1984,7 +1951,6 @@ MODINIT_DEFINE(mixer)
     int ecode;
     static void *c_api[PYGAMEAPI_MIXER_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "mixer",
                                          DOC_PYGAMEMIXER,
@@ -1994,7 +1960,6 @@ MODINIT_DEFINE(mixer)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -2024,12 +1989,7 @@ MODINIT_DEFINE(mixer)
 
     /* create the module */
     pgSound_Type.tp_new = &PyType_GenericNew;
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module =
-        Py_InitModule3(MODPREFIX "mixer", _mixer_methods, DOC_PYGAMEMIXER);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -482,7 +482,6 @@ MODINIT_DEFINE(mouse)
 {
     PyObject *module;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "mouse",
                                          DOC_PYGAMEMOUSE,
@@ -492,7 +491,6 @@ MODINIT_DEFINE(mouse)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -507,11 +505,7 @@ MODINIT_DEFINE(mouse)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3("mouse", _mouse_methods, DOC_PYGAMEMOUSE);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -530,7 +530,6 @@ MODINIT_DEFINE(mixer_music)
     PyObject *module;
     PyObject *cobj;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "mixer_music",
                                          DOC_PYGAMEMIXERMUSIC,
@@ -540,7 +539,6 @@ MODINIT_DEFINE(mixer_music)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -559,12 +557,7 @@ MODINIT_DEFINE(mixer_music)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "mixer_music", _music_methods,
-                            DOC_PYGAMEMIXERMUSIC);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -981,7 +981,6 @@ MODINIT_DEFINE(newbuffer)
 {
     PyObject *module;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "newbuffer",
                                          newbuffer_doc,
@@ -991,7 +990,6 @@ MODINIT_DEFINE(newbuffer)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* prepare exported types */
     if (PyType_Ready(&Py_buffer_Type) < 0) {
@@ -1004,11 +1002,7 @@ MODINIT_DEFINE(newbuffer)
 #define bufferproxy_docs ""
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3("newbuffer", 0, newbuffer_doc);
-#endif
 
     Py_INCREF(&BufferMixin_Type);
     if (PyModule_AddObject(module, "BufferMixin",

--- a/src_c/overlay.c
+++ b/src_c/overlay.c
@@ -219,7 +219,6 @@ MODINIT_DEFINE(overlay)
 {
     PyObject *module;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "overlay",
                                          NULL,
@@ -229,7 +228,6 @@ MODINIT_DEFINE(overlay)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -248,11 +246,7 @@ MODINIT_DEFINE(overlay)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule(MODPREFIX "overlay", _overlay_methods);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -202,7 +202,6 @@ static PyMethodDef _pxarray_methods[] = {
      DOC_PIXELARRAYTRANSPOSE},
     {NULL, NULL, 0, NULL}};
 
-#if PY3
 static void
 Text_ConcatAndDel(PyObject **string, PyObject *newpart)
 {
@@ -218,9 +217,6 @@ Text_ConcatAndDel(PyObject **string, PyObject *newpart)
     }
     *string = result;
 }
-#else
-#define Text_ConcatAndDel PyString_ConcatAndDel
-#endif
 
 /**
  * Getters and setters for the pgPixelArrayObject.
@@ -278,14 +274,8 @@ static PyBufferProcs _pxarray_bufferprocs = {
 
 #define PXARRAY_BUFFERPROCS &_pxarray_bufferprocs
 
-#if PY2
-#define PXARRAY_TPFLAGS                                              \
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC | \
-     Py_TPFLAGS_HAVE_NEWBUFFER)
-#else
 #define PXARRAY_TPFLAGS \
     (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC)
-#endif
 
 static PyTypeObject pgPixelArray_Type = {
     PyVarObject_HEAD_INIT(NULL,0)
@@ -1942,7 +1932,6 @@ MODINIT_DEFINE(pixelarray)
     PyObject *apiobj;
     static void *c_api[PYGAMEAPI_PIXELARRAY_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "pixelarray",
                                          NULL,
@@ -1952,7 +1941,6 @@ MODINIT_DEFINE(pixelarray)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -1976,11 +1964,7 @@ MODINIT_DEFINE(pixelarray)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "pixelarray", 0, 0);
-#endif
     if (!module) {
         MODINIT_ERROR;
     }

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -134,21 +134,12 @@ _view_kind(PyObject *obj, void *view_kind_vptr)
     _pc_view_kind_t *view_kind_ptr = (_pc_view_kind_t *)view_kind_vptr;
 
     if (PyUnicode_Check(obj)) {
-#if PY2
-        if (PyUnicode_GET_SIZE(obj) != 1) {
-            PyErr_SetString(PyExc_TypeError,
-                            "expected a length 1 string for argument 3");
-            return 0;
-        }
-        ch = *PyUnicode_AS_UNICODE(obj);
-#else
         if (PyUnicode_GET_LENGTH(obj) != 1) {
             PyErr_SetString(PyExc_TypeError,
                             "expected a length 1 string for argument 3");
             return 0;
         }
         ch = PyUnicode_READ_CHAR(obj, 0);
-#endif
     }
     else if (Bytes_Check(obj)) {
         if (Bytes_GET_SIZE(obj) != 1) {
@@ -1247,7 +1238,6 @@ static PyMethodDef _pixelcopy_methods[] = {
 
 MODINIT_DEFINE(pixelcopy)
 {
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "pixelcopy",
                                          DOC_PYGAMEPIXELCOPY,
@@ -1257,7 +1247,6 @@ MODINIT_DEFINE(pixelcopy)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -1271,9 +1260,5 @@ MODINIT_DEFINE(pixelcopy)
         MODINIT_ERROR;
     }
 
-#if PY3
     return PyModule_Create(&_module);
-#else
-    Py_InitModule3("pixelcopy", _pixelcopy_methods, DOC_PYGAMEPIXELCOPY);
-#endif
 }

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -2105,7 +2105,6 @@ MODINIT_DEFINE(rect)
     int ecode;
     static void *c_api[PYGAMEAPI_RECT_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "rect",
                                          _pg_module_doc,
@@ -2115,7 +2114,6 @@ MODINIT_DEFINE(rect)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* import needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -2130,12 +2128,7 @@ MODINIT_DEFINE(rect)
         MODINIT_ERROR;
     }
 
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module =
-        Py_InitModule3(MODPREFIX "rect", _pg_module_methods, _pg_module_doc);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -233,7 +233,6 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
                 break;
         }
 
-#if PY3
         key = PyUnicode_FromString(scrap_type);
         if (NULL == key) {
             return PyErr_Format(PyExc_ValueError,
@@ -253,12 +252,6 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
 
             Py_RETURN_NONE;
         }
-#else  /* !PY3 */
-        val = PyDict_GetItemString(scrap_dict, scrap_type);
-        if (NULL == val) {
-            Py_RETURN_NONE;
-        }
-#endif /* !PY3 */
 
         Py_INCREF(val);
         return val;
@@ -290,11 +283,7 @@ _scrap_put_scrap(PyObject *self, PyObject *args)
     char *scrap = NULL;
     char *scrap_type;
     PyObject *tmp;
-#if PY3
     static const char argfmt[] = "sy#";
-#else
-    static char argfmt[] = "st#";
-#endif
 
     PYGAME_SCRAP_INIT_CHECK();
 
@@ -390,7 +379,6 @@ static PyMethodDef scrap_builtins[] = {
 
 MODINIT_DEFINE(scrap)
 {
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "scrap",
                                          "",
@@ -400,7 +388,6 @@ MODINIT_DEFINE(scrap)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -411,9 +398,5 @@ MODINIT_DEFINE(scrap)
     }
 
     /* create the module */
-#if PY3
     return PyModule_Create(&_module);
-#else
-    Py_InitModule3(MODPREFIX "scrap", scrap_builtins, NULL);
-#endif
 }

--- a/src_c/scrap_x11.c
+++ b/src_c/scrap_x11.c
@@ -294,9 +294,7 @@ _set_targets(PyObject *data, Display *display, Window window, Atom property)
     int i;
     char *format;
     PyObject *list = PyDict_Keys(data);
-#if PY3
     PyObject *chars;
-#endif
     int amount = PyList_Size(list);
     /* All types plus the TARGETS and a TIMESTAMP atom. */
     Atom *targets = malloc((amount + 2) * sizeof(Atom));
@@ -306,19 +304,13 @@ _set_targets(PyObject *data, Display *display, Window window, Atom property)
     targets[0] = _atom_TARGETS;
     targets[1] = _atom_TIMESTAMP;
     for (i = 0; i < amount; i++) {
-#if PY3
         chars = PyUnicode_AsASCIIString(PyList_GetItem(list, i));
         if (!chars) {
             return;
         }
         format = PyBytes_AsString(chars);
-#else
-        format = PyString_AsString(PyList_GetItem(list, i));
-#endif
         targets[i + 2] = _convert_format(format);
-#if PY3
         Py_DECREF(chars);
-#endif
     }
     XChangeProperty(display, window, property, XA_ATOM, 32, PropModeReplace,
                     (unsigned char *)targets, amount + 2);
@@ -792,9 +784,7 @@ pygame_scrap_get_types(void)
 
     if (!pygame_scrap_lost()) {
         PyObject *key;
-#if PY3
         PyObject *chars;
-#endif
         Py_ssize_t pos = 0;
         int i = 0;
         PyObject *dict =
@@ -806,7 +796,6 @@ pygame_scrap_get_types(void)
 
         memset(types, 0, (size_t)(PyDict_Size(dict) + 1));
         while (PyDict_Next(dict, &pos, &key, NULL)) {
-#if PY3
             chars = PyUnicode_AsASCIIString(key);
             if (chars) {
                 types[i] = strdup(PyBytes_AsString(chars));
@@ -815,9 +804,6 @@ pygame_scrap_get_types(void)
             else {
                 types[i] = NULL;
             }
-#else
-            types[i] = strdup(PyString_AsString(key));
-#endif
             if (!types[i]) {
                 /* Could not allocate memory, free anything. */
                 int j = 0;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3952,21 +3952,12 @@ _view_kind(PyObject *obj, void *view_kind_vptr)
     SurfViewKind *view_kind_ptr = (SurfViewKind *)view_kind_vptr;
 
     if (PyUnicode_Check(obj)) {
-#if PY2
-        if (PyUnicode_GET_SIZE(obj) != 1) {
-            PyErr_SetString(PyExc_TypeError,
-                            "expected a length 1 string for argument 1");
-            return 0;
-        }
-        ch = *PyUnicode_AS_UNICODE(obj);
-#else
         if (PyUnicode_GET_LENGTH(obj) != 1) {
             PyErr_SetString(PyExc_TypeError,
                             "expected a length 1 string for argument 1");
             return 0;
         }
         ch = PyUnicode_READ_CHAR(obj, 0);
-#endif
     }
     else if (Bytes_Check(obj)) {
         if (Bytes_GET_SIZE(obj) != 1) {
@@ -4359,7 +4350,6 @@ MODINIT_DEFINE(surface)
     int ecode;
     static void *c_api[PYGAMEAPI_SURFACE_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "surface",
                                          DOC_PYGAMESURFACE,
@@ -4369,7 +4359,6 @@ MODINIT_DEFINE(surface)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -4401,12 +4390,7 @@ MODINIT_DEFINE(surface)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "surface", _surface_methods,
-                            DOC_PYGAMESURFACE);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -266,7 +266,6 @@ MODINIT_DEFINE(surflock)
     int ecode;
     static void *c_api[PYGAMEAPI_SURFLOCK_NUMSLOTS];
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "surflock",
                                          _surflock_doc,
@@ -276,19 +275,13 @@ MODINIT_DEFINE(surflock)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     if (PyType_Ready(&pgLifetimeLock_Type) < 0) {
         MODINIT_ERROR;
     }
 
     /* Create the module and add the functions */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module =
-        Py_InitModule3(MODPREFIX "surflock", _surflock_methods, _surflock_doc);
-#endif
     if (module == NULL) {
         MODINIT_ERROR;
     }

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -569,7 +569,6 @@ initpygame_time(void)
 MODINIT_DEFINE(time)
 #endif
 {
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "time",
                                          DOC_PYGAMETIME,
@@ -579,7 +578,6 @@ MODINIT_DEFINE(time)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* need to import base module, just so SDL is happy. Do this first so if
        the module is there is an error the module is not loaded.
@@ -600,9 +598,5 @@ MODINIT_DEFINE(time)
     }
 
     /* create the module */
-#if PY3
     return PyModule_Create(&_module);
-#else
-    Py_InitModule3(MODPREFIX "time", _time_methods, DOC_PYGAMETIME);
-#endif
 }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -49,12 +49,7 @@ struct _module_state {
 
 #include <SDL_cpuinfo.h>
 
-#if PY3
 #define GETSTATE(m) PY3_GETSTATE(_module_state, m)
-#else
-static struct _module_state _state = {0, 0, 0, 0, 0};
-#define GETSTATE(m) PY2_GETSTATE(_state)
-#endif
 
 #else /* if defined(SCALE_MMX_SUPPORT) */
 
@@ -2800,7 +2795,6 @@ MODINIT_DEFINE(transform)
     PyObject *module;
     struct _module_state *st;
 
-#if PY3
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "transform",
                                          DOC_PYGAMETRANSFORM,
@@ -2810,7 +2804,6 @@ MODINIT_DEFINE(transform)
                                          NULL,
                                          NULL,
                                          NULL};
-#endif
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -2833,12 +2826,7 @@ MODINIT_DEFINE(transform)
     }
 
     /* create the module */
-#if PY3
     module = PyModule_Create(&_module);
-#else
-    module = Py_InitModule3(MODPREFIX "transform", _transform_methods,
-                            DOC_PYGAMETRANSFORM);
-#endif
 
     if (module == 0) {
         MODINIT_ERROR;


### PR DESCRIPTION
This is a combination of what I can do automatically, with some manual editing around the edges.

There are still `PY2`s and `PY3`s in the codebase, and the constants are still defined, but this cuts down the amount severely, so I think it's worth merging.

Numbers:
PY3: 175 -> 24
PY2: 43 -> 5