### PR TITLE
Remove ability to reference joysticks by index (breaking change)

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -55,7 +55,7 @@ their own new events with the :func:`pygame.event.Event()` function.
 The event type identifier is in between the values of ``NOEVENT`` and
 ``NUMEVENTS``. User defined events should have a value in the inclusive range
 of ``USEREVENT`` to ``NUMEVENTS - 1``. User defined events can get a custom
-event number with :func:`pygame.event.custom_type()`. 
+event number with :func:`pygame.event.custom_type()`.
 It is recommended all user events follow this system.
 
 Events support equality and inequality comparisons. Two events are equal if
@@ -78,18 +78,23 @@ specific attributes.
     MOUSEMOTION       pos, rel, buttons, touch
     MOUSEBUTTONUP     pos, button, touch
     MOUSEBUTTONDOWN   pos, button, touch
-    JOYAXISMOTION     joy (deprecated), instance_id, axis, value
-    JOYBALLMOTION     joy (deprecated), instance_id, ball, rel
-    JOYHATMOTION      joy (deprecated), instance_id, hat, value
-    JOYBUTTONUP       joy (deprecated), instance_id, button
-    JOYBUTTONDOWN     joy (deprecated), instance_id, button
+    JOYAXISMOTION     instance_id, axis, value
+    JOYBALLMOTION     instance_id, ball, rel
+    JOYHATMOTION      instance_id, hat, value
+    JOYBUTTONUP       instance_id, button
+    JOYBUTTONDOWN     instance_id, button
     VIDEORESIZE       size, w, h
     VIDEOEXPOSE       none
     USEREVENT         code
 
-.. versionchanged:: 2.0.0 The ``joy`` attribute was deprecated, ``instance_id`` was added.
+.. versionchanged:: 2.0.0 Added ``instance_id`` to joystick events.
 
 .. versionchanged:: 2.0.1 The ``unicode`` attribute was added to ``KEYUP`` event.
+
+.. versionchanged:: 2.1.1
+   Removed the ``joy`` attribute from joystick events. Use `instance_id`
+   instead; it corresponds to the identifier returned by
+   :meth:`Joystick.get_instance_id()`.
 
 You can also find a list of constants for keyboard keys
 :ref:`here <key-constants-label>`.
@@ -270,7 +275,7 @@ Most these window events do not have any attributes, except ``WINDOWMOVED``,
 
    Returns a single event from the queue. If the queue is empty this function
    will wait until one is created. From pygame 2.0.0, if a ``timeout`` argument
-   is given, the function will return an event of type ``pygame.NOEVENT`` 
+   is given, the function will return an event of type ``pygame.NOEVENT``
    if no events enter the queue in ``timeout`` milliseconds. The event is removed
    from the queue once it has been returned. While the program is waiting it will
    sleep in an idle state. This is important for programs that want to share the

--- a/docs/reST/ref/joystick.rst
+++ b/docs/reST/ref/joystick.rst
@@ -81,7 +81,7 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
    | :sl:`Returns the number of joysticks.`
    | :sg:`get_count() -> count`
 
-   Return the number of joystick devices on the system. The count will be ``0`` 
+   Return the number of joystick devices on the system. The count will be ``0``
    if there are no joysticks on the system.
 
    When you create Joystick objects using ``Joystick(id)``, you pass an integer
@@ -101,22 +101,11 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
    Once the device is initialized the pygame event queue will start receiving
    events about its input.
 
-   .. versionchanged:: 2.0.0 Joystick objects are now opened immediately on creation.
+   .. versionchanged:: 2.0.0
+      Joystick objects are now opened immediately on creation.
 
-   .. method:: init
-
-      | :sl:`initialize the Joystick`
-      | :sg:`init() -> None`
-
-      Initialize the joystick, if it has been closed. It is safe to call this
-      even if the joystick is already initialized.
-
-      .. deprecated:: 2.0.0
-
-         In future it will not be possible to reinitialise a closed Joystick
-         object. Will be removed in Pygame 2.1.
-
-      .. ## Joystick.init ##
+   .. versionchanged:: 2.1.1
+      Removed the deprecated `get_id()` method. Use `get_instance_id()` instead.
 
    .. method:: quit
 
@@ -138,20 +127,6 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
       Return True if the Joystick object is currently initialised.
 
       .. ## Joystick.get_init ##
-
-   .. method:: get_id
-
-      | :sl:`get the device index (deprecated)`
-      | :sg:`get_id() -> int`
-
-      Returns the original device index for this device. This is the same
-      value that was passed to the ``Joystick()`` constructor. This method can
-      safely be called while the Joystick is not initialized.
-
-      .. deprecated:: 2.0.0
-
-         The original device index is not useful in pygame 2. Use
-         :meth:`.get_instance_id` instead. Will be removed in Pygame 2.1.
 
    .. method:: get_instance_id() -> int
 
@@ -208,13 +183,13 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
       two for the position. Controls like rudders and throttles are treated as
       additional axes.
 
-      The ``pygame.JOYAXISMOTION`` events will be in the range from ``-1.0`` 
-      to ``1.0``. A value of ``0.0`` means the axis is centered. Gamepad devices 
-      will usually be ``-1``, ``0``, or ``1`` with no values in between. Older 
-      analog joystick axes will not always use the full ``-1`` to ``1`` range, 
-      and the centered value will be some area around ``0``. 
-      
-      Analog joysticks usually have a bit of noise in their axis, which will 
+      The ``pygame.JOYAXISMOTION`` events will be in the range from ``-1.0``
+      to ``1.0``. A value of ``0.0`` means the axis is centered. Gamepad devices
+      will usually be ``-1``, ``0``, or ``1`` with no values in between. Older
+      analog joystick axes will not always use the full ``-1`` to ``1`` range,
+      and the centered value will be some area around ``0``.
+
+      Analog joysticks usually have a bit of noise in their axis, which will
       generate a lot of rapid small motion events.
 
       .. ## Joystick.get_numaxes ##
@@ -225,9 +200,9 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
       | :sg:`get_axis(axis_number) -> float`
 
       Returns the current position of a joystick axis. The value will range
-      from ``-1`` to ``1`` with a value of ``0`` being centered. You may want 
-      to take into account some tolerance to handle jitter, and joystick drift 
-      may keep the joystick from centering at ``0`` or using the full range of 
+      from ``-1`` to ``1`` with a value of ``0`` being centered. You may want
+      to take into account some tolerance to handle jitter, and joystick drift
+      may keep the joystick from centering at ``0`` or using the full range of
       position values.
 
       The axis number must be an integer from ``0`` to ``get_numaxes() - 1``.
@@ -295,8 +270,8 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
       input.
 
       The ``pygame.JOYHATMOTION`` event is generated when the hat changes
-      position. The ``position`` attribute for the event contains a pair of 
-      values that are either ``-1``, ``0``, or ``1``. A position of ``(0, 0)`` 
+      position. The ``position`` attribute for the event contains a pair of
+      values that are either ``-1``, ``0``, or ``1``. A position of ``(0, 0)``
       means the hat is centered.
 
       .. ## Joystick.get_numhats ##
@@ -309,10 +284,10 @@ So call one of pygame.event.get, pygame.event.wait, or pygame.event.pump regular
       Returns the current position of a position hat. The position is given as
       two values representing the ``x`` and ``y`` position for the hat. ``(0, 0)``
       means centered. A value of ``-1`` means left/down and a value of ``1`` means
-      right/up: so ``(-1, 0)`` means left; ``(1, 0)`` means right; ``(0, 1)`` means 
+      right/up: so ``(-1, 0)`` means left; ``(1, 0)`` means right; ``(0, 1)`` means
       up; ``(1, 1)`` means upper-right; etc.
 
-      This value is digital, ``i.e.``, each coordinate can be ``-1``, ``0`` or ``1`` 
+      This value is digital, ``i.e.``, each coordinate can be ``-1``, ``0`` or ``1``
       but never in-between.
 
       The hat number must be between ``0`` and ``get_numhats() - 1``.

--- a/src_c/doc/joystick_doc.h
+++ b/src_c/doc/joystick_doc.h
@@ -1,6 +1,6 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEJOYSTICK "Pygame module for interacting with joysticks, gamepads, and trackballs."
-#define DOC_PYGAMEJOYSTICKINIT "init() -> None\nInitialize the joystick module."
+#define DOC_PYGAMEJOYSTICKINIT "init() -> None\nNo-op, retained for backwards compatibility."
 #define DOC_PYGAMEJOYSTICKQUIT "quit() -> None\nUninitialize the joystick module."
 #define DOC_PYGAMEJOYSTICKGETINIT "get_init() -> bool\nReturns True if the joystick module is initialized."
 #define DOC_PYGAMEJOYSTICKGETCOUNT "get_count() -> count\nReturns the number of joysticks."
@@ -8,7 +8,6 @@
 #define DOC_JOYSTICKINIT "init() -> None\ninitialize the Joystick"
 #define DOC_JOYSTICKQUIT "quit() -> None\nuninitialize the Joystick"
 #define DOC_JOYSTICKGETINIT "get_init() -> bool\ncheck if the Joystick is initialized"
-#define DOC_JOYSTICKGETID "get_id() -> int\nget the device index (deprecated)"
 #define DOC_JOYSTICKGETINSTANCEID "get_instance_id() -> int\nget the joystick instance id"
 #define DOC_JOYSTICKGETGUID "get_guid() -> str\nget the joystick GUID"
 #define DOC_JOYSTICKGETPOWERLEVEL "get_power_level() -> str\nget the approximate power status of the device"
@@ -63,10 +62,6 @@ uninitialize the Joystick
 pygame.joystick.Joystick.get_init
  get_init() -> bool
 check if the Joystick is initialized
-
-pygame.joystick.Joystick.get_id
- get_id() -> int
-get the device index (deprecated)
 
 pygame.joystick.Joystick.get_instance_id
  get_instance_id() -> int


### PR DESCRIPTION
This removes the compatibility hacks that enabled SDL1-style joystick device indexes to work under SDL2.

This is a deliberate breaking change which will force users to use the (correct) SDL2 API i.e. switch to instance IDs and abandon device indexes.

SDL2 does not use indexes at any point after initialising a device. This is because hotplugging events remap the device indexes. Instead SDL2 provides unique instance IDs. The hacks we added allowed us to synthesise a `.joy` attribute that behaves like a device index, based on the instance ID.

But: these hacks do break if joystick devices are added or removed. You can have multiple connected devices that have the same device index, making it impossible to distinguish events. This bug affects any game using PyGame/SDL2 but with the SDL1-compatible API.

Removing the hacks forces users to adopt correct utilisation of the API and therefore eliminates these bugs.