### PR TITLE
add sysfont path for macos

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -185,7 +185,8 @@ def _parse_font_entry_darwin(name, filepath, fonts):
 
 
 def _font_finder_darwin():
-    locations = ["/Library/Fonts", "/Network/Library/Fonts", "/System/Library/Fonts"]
+    locations = ["/Library/Fonts", "/Network/Library/Fonts", "/System/Library/Fonts", 
+                 "/System/Library/Fonts/Supplemental"]
 
     username = os.getenv("USER")
     if username:


### PR DESCRIPTION
* Add new path of sysfont for MacOS as @Starbuck5 suggested. I check my system font and can not find other new paths.
* Close #2827 