### PR TITLE
Prepare math.enable/disable_swizzling for removal

### DIFF
--- a/buildconfig/pygame-stubs/math.pyi
+++ b/buildconfig/pygame-stubs/math.pyi
@@ -88,9 +88,6 @@ class _VectorElementwiseProxy3:
         self, power: Union[float, Vector3, _VectorElementwiseProxy3]
     ) -> Vector3: ...
 
-def enable_swizzling() -> None: ...
-def disable_swizzling() -> None: ...
-
 class Vector2:
     x: float
     y: float

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -792,32 +792,4 @@ Multiple coordinates can be set using slices or swizzling
 
    .. ## pygame.math.Vector3 ##
 
-
-.. function:: enable_swizzling
-
-   | :sl:`globally enables swizzling for vectors.`
-   | :sg:`enable_swizzling() -> None`
-
-   DEPRECATED: Not needed anymore. Will be removed in a later version.
-
-   Enables swizzling for all vectors until ``disable_swizzling()`` is called.
-   By default swizzling is disabled.
-
-   Lets you get or set multiple coordinates as one attribute, eg
-   ``vec.xyz = 1, 2, 3``.
-
-   .. ## pygame.math.enable_swizzling ##
-
-.. function:: disable_swizzling
-
-   | :sl:`globally disables swizzling for vectors.`
-   | :sg:`disable_swizzling() -> None`
-
-   DEPRECATED: Not needed anymore. Will be removed in a later version.
-
-   Disables swizzling for all vectors until ``enable_swizzling()`` is called.
-   By default swizzling is disabled.
-
-   .. ## pygame.math.disable_swizzling ##
-
 .. ## pygame.math ##

--- a/src_c/doc/math_doc.h
+++ b/src_c/doc/math_doc.h
@@ -66,8 +66,6 @@
 #define DOC_VECTOR3FROMSPHERICAL "from_spherical((r, theta, phi)) -> None\nSets x, y and z from a spherical coordinates 3-tuple."
 #define DOC_VECTOR3PROJECT "project(Vector3) -> Vector3\nprojects a vector onto another."
 #define DOC_VECTOR3UPDATE "update() -> None\nupdate(int) -> None\nupdate(float) -> None\nupdate(Vector3) -> None\nupdate(x, y, z) -> None\nupdate((x, y, z)) -> None\nSets the coordinates of the vector."
-#define DOC_PYGAMEMATHENABLESWIZZLING "enable_swizzling() -> None\nglobally enables swizzling for vectors."
-#define DOC_PYGAMEMATHDISABLESWIZZLING "disable_swizzling() -> None\nglobally disables swizzling for vectors."
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -360,13 +358,5 @@ pygame.math.Vector3.update
  update(x, y, z) -> None
  update((x, y, z)) -> None
 Sets the coordinates of the vector.
-
-pygame.math.enable_swizzling
- enable_swizzling() -> None
-globally enables swizzling for vectors.
-
-pygame.math.disable_swizzling
- disable_swizzling() -> None
-globally disables swizzling for vectors.
 
 */

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -331,8 +331,6 @@ vector_elementwiseproxy_nonzero(vector_elementwiseproxy *self);
 static PyObject *
 vector_elementwise(pgVector *vec, PyObject *args);
 
-static int swizzling_enabled = 1;
-
 /********************************
  * Global helper functions
  ********************************/
@@ -1509,13 +1507,13 @@ _vector_check_snprintf_success(int return_code)
     if (return_code < 0) {
         PyErr_SetString(PyExc_SystemError,
                         "internal snprintf call went wrong! Please report "
-                        "this to pygame-users@seul.org");
+                        "this to github.com/pygame/pygame/issues");
         return 0;
     }
     if (return_code >= STRING_BUF_SIZE) {
         PyErr_SetString(PyExc_SystemError,
                         "Internal buffer to small for snprintf! Please report "
-                        "this to pygame-users@seul.org");
+                        "this to github.com/pygame/pygame/issues");
         return 0;
     }
     return 1;
@@ -1630,7 +1628,7 @@ vector_getAttr_swizzle(pgVector *self, PyObject *attr_name)
 
     len = PySequence_Length(attr_name);
 
-    if (len == 1 || !swizzling_enabled) {
+    if (len == 1) {
         return PyObject_GenericGetAttr((PyObject *)self, attr_name);
     }
 
@@ -1718,8 +1716,7 @@ vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val)
     int swizzle_err = SWIZZLE_ERR_NO_ERR;
     Py_ssize_t i;
 
-    /* if swizzling is disabled always default to generic implementation */
-    if (!swizzling_enabled || len == 1)
+    if (len == 1)
         return PyObject_GenericSetAttr((PyObject *)self, attr_name, val);
 
     /* if swizzling is enabled first try swizzle */
@@ -1788,7 +1785,7 @@ vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val)
             /* this should NEVER happen and means a bug in the code */
             PyErr_SetString(PyExc_RuntimeError,
                             "Unhandled error in swizzle code. Please report "
-                            "this bug to pygame-users@seul.org");
+                            "this bug to github.com/pygame/pygame/issues");
             return -1;
     }
 }
@@ -2005,7 +2002,7 @@ _vector2_rotate_helper(double *dst_coords, const double *src_coords,
                 PyErr_SetString(
                     PyExc_RuntimeError,
                     "Please report this bug in vector2_rotate_helper to the "
-                    "developers at pygame-users@seul.org");
+                    "developers at github.com/pygame/pygame/issues");
                 return 0;
         }
     }
@@ -2506,7 +2503,7 @@ _vector3_rotate_helper(double *dst_coords, const double *src_coords,
                 PyErr_SetString(
                     PyExc_RuntimeError,
                     "Please report this bug in vector3_rotate_helper to the "
-                    "developers at pygame-users@seul.org");
+                    "developers at github.com/pygame/pygame/issues");
                 return 0;
         }
     }
@@ -3971,22 +3968,34 @@ vector_elementwise(pgVector *vec, PyObject *args)
 static PyObject *
 math_enable_swizzling(pgVector *self)
 {
-    swizzling_enabled = 1;
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "pygame.math.enable_swizzling() is deprecated, "
+                     "and its functionality is removed. This function will be "
+                     "removed in a later version.",
+                     1) == -1) {
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 
 static PyObject *
 math_disable_swizzling(pgVector *self)
 {
-    swizzling_enabled = 0;
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "pygame.math.disable_swizzling() is deprecated, "
+                     "and its functionality is removed. This function will be "
+                     "removed in a later version.",
+                     1) == -1) {
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 
 static PyMethodDef _math_methods[] = {
     {"enable_swizzling", (PyCFunction)math_enable_swizzling, METH_NOARGS,
-     "enables swizzling."},
+     "Deprecated, will be removed in a future version"},
     {"disable_swizzling", (PyCFunction)math_disable_swizzling, METH_NOARGS,
-     "disables swizzling."},
+     "Deprecated, will be removed in a future version."},
     {NULL, NULL, 0, NULL}};
 
 /****************************

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -12,7 +12,6 @@ IS_PYPY = "PyPy" == platform.python_implementation()
 
 class Vector2TypeTest(unittest.TestCase):
     def setUp(self):
-        pygame.math.enable_swizzling()
         self.zeroVec = Vector2()
         self.e1 = Vector2(1, 0)
         self.e2 = Vector2(0, 1)
@@ -24,9 +23,6 @@ class Vector2TypeTest(unittest.TestCase):
         self.v2 = Vector2(self.t2)
         self.s1 = 5.6
         self.s2 = 7.8
-
-    def tearDown(self):
-        pygame.math.enable_swizzling()
 
     def testConstructionDefault(self):
         v = Vector2()
@@ -481,13 +477,6 @@ class Vector2TypeTest(unittest.TestCase):
         self.assertNotEqual(v, Vector2((5, 1)))
 
     def test_swizzle(self):
-        self.assertTrue(hasattr(pygame.math, "enable_swizzling"))
-        self.assertTrue(hasattr(pygame.math, "disable_swizzling"))
-        # swizzling not disabled by default
-        pygame.math.disable_swizzling()
-        self.assertRaises(AttributeError, lambda: self.v1.yx)
-        pygame.math.enable_swizzling()
-
         self.assertEqual(self.v1.yx, (self.v1.y, self.v1.x))
         self.assertEqual(
             self.v1.xxyyxy,
@@ -1740,13 +1729,6 @@ class Vector3TypeTest(unittest.TestCase):
         )
 
     def test_swizzle(self):
-        self.assertTrue(hasattr(pygame.math, "enable_swizzling"))
-        self.assertTrue(hasattr(pygame.math, "disable_swizzling"))
-        # swizzling enabled by default
-        pygame.math.disable_swizzling()
-        self.assertRaises(AttributeError, lambda: self.v1.yx)
-        pygame.math.enable_swizzling()
-
         self.assertEqual(self.v1.yxz, (self.v1.y, self.v1.x, self.v1.z))
         self.assertEqual(
             self.v1.xxyyzzxyz,


### PR DESCRIPTION
This is done by #2686, but since it will take a bit to merge, I thought it would be a good idea to make a separate pr, so this can be merged in quicker.