### PR TITLE
Fix weird MacOS display surf weirdness

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1302,8 +1302,10 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
         Py_DECREF(surface);
 
         /* ensure window is initially black */
-        if (init_flip)
+        if (init_flip) {
+            SDL_FillRect(surf, NULL, SDL_MapRGB(surf->format, 0, 0, 0));
             pg_flip_internal(state);
+        }
     }
 
     /*set the window icon*/


### PR DESCRIPTION
The contributors have been aware of this for a long time, but it doesn't impact normal pygame programs, so it has been low priority.

It does bite people occasionally though, so it's worth fixing.

While I was digging around display.c for something else I saw a comment `* ensure window is initially black */`. Basically, the perfect place to ensure the window is initially black.

I don't really understand the problem, display.c is very complex, but this is a very simple solution that does solve it.

One reproducible time this issue has gotten me is in testing #818

On Mac (pygame 2.0 and above probably), the example code produces
<img width="497" alt="Screen Shot 2021-11-21 at 11 56 27 PM" src="https://user-images.githubusercontent.com/46412508/142824628-cace7698-d171-4096-ac6b-94bfd30722f3.png">


But now it (correctly) produces
<img width="501" alt="Screen Shot 2021-11-21 at 11 55 21 PM" src="https://user-images.githubusercontent.com/46412508/142824663-5c8fdb25-7b79-4d0f-995d-fd7d8df3c5fa.png">

