### PR TITLE
Fix drawing of big ellipses

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1891,7 +1891,8 @@ static void
 draw_ellipse_filled(SDL_Surface *surf, int x0, int y0, int width, int height,
                     Uint32 color, int *drawn_area)
 {
-    int dx, dy, x, y, x_offset, y_offset;
+    long long dx, dy, x, y;
+    int x_offset, y_offset;
     double d1, d2;
     if (width == 1) {
         draw_line(surf, x0, y0, x0, y0 + height - 1, color, drawn_area);
@@ -1953,7 +1954,8 @@ static void
 draw_ellipse_thickness(SDL_Surface *surf, int x0, int y0, int width, int height,
                        int thickness, Uint32 color, int *drawn_area)
 {
-    int dx, dy, x, y, dx_inner, dy_inner, x_inner, y_inner, line, x_offset, y_offset;
+    long long dx, dy, dx_inner, dy_inner, x, y, x_inner, y_inner;
+    int line, x_offset, y_offset;
     double d1, d2, d1_inner, d2_inner = 0;
     x0 = x0 + width / 2;
     y0 = y0 + height / 2;

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -533,6 +533,25 @@ class DrawEllipseMixin(object):
                 for left, top in left_top:
                     not_same_size(width, height, border_width, left, top)
 
+    def test_ellipse__big_ellipse(self):
+        """ Test for big ellipse that could overflow in algorithm """
+        width = 1025
+        height = 1025
+        border = 1
+        x_value_test = int(0.4 * height)
+        y_value_test = int(0.4 * height)
+        surface = pygame.Surface((width, height))
+
+        self.draw_ellipse(surface, (255, 0, 0), (0, 0, width, height), border)
+        colored_pixels = 0
+        for y in range(height):
+            if surface.get_at((x_value_test, y)) == (255, 0, 0):
+                colored_pixels += 1
+        for x in range(width):
+            if surface.get_at((x, y_value_test)) == (255, 0, 0):
+                colored_pixels += 1
+        self.assertEqual(colored_pixels, border * 4)
+
     def test_ellipse__thick_line(self):
         """Ensures a thick lined ellipse is drawn correctly."""
         ellipse_color = pygame.Color("yellow")


### PR DESCRIPTION
This fixes #2879
Before this patch with big enough value calculation can exceed the int max value on the line 1912 and 1914 (same can be said about the function that draws ellipse with line width)
https://github.com/pygame/pygame/blob/40991f75e8b8c14a91acf43d4b16788c409abbf4/src_c/draw.c#L1912-L1914
And because of that you can end up with that weird shape (won't get into much details about why exactly do you get "rotated square")
Edge value was if the width was 1024 and height was 1024; or anything that gives you the bigger value of (width^2)*height (because that is 2^31, and int supports up to 2^31 - 1)