### PR TITLE
Fix for paused music and get_pos()

### DIFF
--- a/src_c/music.c
+++ b/src_c/music.c
@@ -194,6 +194,8 @@ music_unpause(PyObject *self, PyObject *args)
     MIXER_INIT_CHECK();
 
     Mix_ResumeMusic();
+    /* need to set pos_time for the adjusted time spent paused*/
+    music_pos_time = SDL_GetTicks();
     Py_RETURN_NONE;
 }
 
@@ -365,7 +367,7 @@ _get_type_from_hint(char *namehint)
     return type;
 }
 
-Mix_Music * 
+Mix_Music *
 _load_music(PyObject *obj, char *namehint) {
     Mix_Music *new_music = NULL;
     char* ext = NULL;
@@ -383,7 +385,7 @@ _load_music(PyObject *obj, char *namehint) {
         Py_XDECREF(_type);
         Py_XDECREF(_traceback);
         return NULL;
-    } 
+    }
     if (namehint) {
         ext = namehint;
     } else {
@@ -398,7 +400,7 @@ _load_music(PyObject *obj, char *namehint) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return NULL;
     }
-    
+
     return new_music;
 }
 
@@ -471,7 +473,7 @@ music_queue(PyObject *self, PyObject *args, PyObject *keywds)
     MIXER_INIT_CHECK();
 
     queue_music_loops = loops;
-    
+
     local_queue_music = _load_music(obj, namehint);
     if (local_queue_music == NULL) // meaning it has an error to return
         return NULL;

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -4,6 +4,7 @@ import os
 import sys
 import platform
 import unittest
+import time
 
 from pygame.tests.test_utils import example_path
 import pygame
@@ -177,6 +178,26 @@ class MixerMusicModuleTest(unittest.TestCase):
         """Ensures queue() correctly handles invalid filenames."""
         with self.assertRaises(pygame.error):
             pygame.mixer.music.queue("")
+
+    def test_music_pause__unpause(self):
+        """Ensure music has the correct position immediately after unpausing
+
+        |tags:music|
+        """
+        filename = example_path(os.path.join("data", "house_lo.mp3"))
+        pygame.mixer.music.load(filename)
+        pygame.mixer.music.play()
+
+        # Wait 0.5s, then pause
+        time.sleep(0.5)
+        pygame.mixer.music.pause()
+        # Wait 0.5s, get position, unpause, then get position again
+        time.sleep(0.5)
+        before_unpause = pygame.mixer.music.get_pos()
+        pygame.mixer.music.unpause()
+        after_unpause = pygame.mixer.music.get_pos()
+
+        self.assertEqual(before_unpause, after_unpause)
 
     def todo_test_stop(self):
 

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -189,10 +189,10 @@ class MixerMusicModuleTest(unittest.TestCase):
         pygame.mixer.music.play()
 
         # Wait 0.5s, then pause
-        time.sleep(0.5)
+        time.sleep(0.05)
         pygame.mixer.music.pause()
         # Wait 0.5s, get position, unpause, then get position again
-        time.sleep(0.5)
+        time.sleep(0.05)
         before_unpause = pygame.mixer.music.get_pos()
         pygame.mixer.music.unpause()
         after_unpause = pygame.mixer.music.get_pos()

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -188,10 +188,10 @@ class MixerMusicModuleTest(unittest.TestCase):
         pygame.mixer.music.load(filename)
         pygame.mixer.music.play()
 
-        # Wait 0.5s, then pause
+        # Wait 0.05s, then pause
         time.sleep(0.05)
         pygame.mixer.music.pause()
-        # Wait 0.5s, get position, unpause, then get position again
+        # Wait 0.05s, get position, unpause, then get position again
         time.sleep(0.05)
         before_unpause = pygame.mixer.music.get_pos()
         pygame.mixer.music.unpause()


### PR DESCRIPTION
Setting music_pos_time after an unpause to adjust for time spent in a pause for get_pos()

fixes this issue: [https://github.com/pygame/pygame/issues/2786](https://github.com/pygame/pygame/issues/2786)

The test script did need to be modified to allow for:
assert before_unpause <= after_unpause
instead of 
assert before_unpause < after_unpause

This is because the after_unpause is created so quickly that the song has not progressed yet and they are the same value. 