### PR TITLE
Font rwops

### DIFF
--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -25,7 +25,7 @@ accessed by passing ``None`` as the font name.
 Before pygame 2.0.3, pygame.font accepts any UCS-2 / UTF-16 character
 ('\\u0001' to '\\uFFFF'). After 2.0.3, pygame.font built with SDL_ttf
 2.0.15 accepts any valid UCS-4 / UTF-32 character 
-(like emojis, if the font has them) ('\\U00000001' to '\\UFFFFFFFF')).
+(like emojis, if the font has them) ('\\U00000001' to '\\U0010FFFF')).
 More about this in :func:`Font.render`.
 
 Before pygame 2.0.3, this character space restriction can be avoided by

--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -8,29 +8,31 @@
 
 | :sl:`pygame module for loading and rendering fonts`
 
-The font module allows for rendering TrueType fonts into a new Surface object.
-It accepts any UCS-2 character ('\u0001' to '\uFFFF'). This module is optional
-and requires SDL_ttf as a dependency. You should test that :mod:`pygame.font`
-is available and initialized before attempting to use the module.
+The font module allows for rendering TrueType fonts into Surface objects.
+This module is built on top of the SDL_ttf library, which comes with all
+normal pygame installations.
 
-Most of the work done with fonts are done by using the actual Font objects. The
-module by itself only has routines to initialize the module and create Font
-objects with ``pygame.font.Font()``.
+Most of the work done with fonts are done by using the actual Font objects.
+The module by itself only has routines to support the creation of Font objects
+with :func:`pygame.font.Font`.
 
-You can load fonts from the system by using the ``pygame.font.SysFont()``
-function. There are a few other functions to help lookup the system fonts.
+You can load fonts from the system by using the :func:`pygame.font.SysFont`
+function. There are a few other functions to help look up the system fonts.
 
-Pygame comes with a builtin default font. This can always be accessed by
-passing None as the font name.
+Pygame comes with a builtin default font, freesansbold. This can always be
+accessed by passing ``None`` as the font name.
 
-To use the :mod:`pygame.freetype` based ``pygame.ftfont`` as
-:mod:`pygame.font` define the environment variable PYGAME_FREETYPE before the
-first import of :mod:`pygame`. Module ``pygame.ftfont`` is a :mod:`pygame.font`
-compatible module that passes all but one of the font module unit tests:
-it does not have the UCS-2 limitation of the SDL_ttf based font module, so
-fails to raise an exception for a code point greater than '\uFFFF'. If
-:mod:`pygame.freetype` is unavailable then the SDL_ttf font module will be
-loaded instead.
+Before pygame 2.0.3, pygame.font accepts any UCS-2 / UTF-16 character
+('\\u0001' to '\\uFFFF'). After 2.0.3, pygame.font built with SDL_ttf
+2.0.15 accepts any valid UCS-4 / UTF-32 character 
+(like emojis, if the font has them) ('\\U00000001' to '\\UFFFFFFFF')).
+More about this in :func:`Font.render`.
+
+Before pygame 2.0.3, this character space restriction can be avoided by
+using the  :mod:`pygame.freetype` based ``pygame.ftfont`` to emulate the Font
+module. This can be used by defining the environment variable PYGAME_FREETYPE
+before the first import of :mod:`pygame`. Since the problem ``pygame.ftfont``
+solves no longer exists, it will likely be removed in the future.
 
 .. function:: init
 
@@ -141,15 +143,14 @@ loaded instead.
    | :sg:`Font(object, size) -> Font`
 
    Load a new font from a given filename or a python file object. The size is
-   the height of the font in pixels. If the filename is None the pygame default
-   font will be loaded. If a font cannot be loaded from the arguments given an
-   exception will be raised. Once the font is created the size cannot be
-   changed.
+   the height of the font in pixels. If the filename is ``None`` the pygame
+   default font will be loaded. If a font cannot be loaded from the arguments
+   given an exception will be raised. Once the font is created the size cannot
+   be changed.
 
    Font objects are mainly used to render text into new Surface objects. The
    render can emulate bold or italic features, but it is better to load from a
-   font with actual italic or bold glyphs. The rendered text can be regular
-   strings or unicode.
+   font with actual italic or bold glyphs.
 
    .. attribute:: bold
 
@@ -206,25 +207,25 @@ loaded instead.
       | :sl:`draw text on a new Surface`
       | :sg:`render(text, antialias, color, background=None) -> Surface`
 
-      This creates a new Surface with the specified text rendered on it. pygame
-      provides no way to directly draw text on an existing Surface: instead you
-      must use ``Font.render()`` to create an image (Surface) of the text, then
-      blit this image onto another Surface.
+      This creates a new Surface with the specified text rendered on it. 
+      :mod:`pygame.font` provides no way to directly draw text on an existing
+      Surface: instead you must use :func:`Font.render` to create an image
+      (Surface) of the text, then blit this image onto another Surface.
 
       The text can only be a single line: newline characters are not rendered.
       Null characters ('\x00') raise a TypeError. Both Unicode and char (byte)
       strings are accepted. For Unicode strings only UCS-2 characters
-      ('\u0001' to '\uFFFF') were previously supported and any greater unicode
-      codepoint would raise a UnicodeError. Now, characters in the UCS-4 range
-      are supported. For char strings a ``LATIN1`` encoding is assumed. The
-      antialias argument is a boolean: if true the characters will have smooth
-      edges. The color argument is the color of the text
+      ('\\u0001' to '\\uFFFF') were previously supported and any greater
+      unicode codepoint would raise a UnicodeError. Now, characters in the
+      UCS-4 range are supported. For char strings a ``LATIN1`` encoding is
+      assumed. The antialias argument is a boolean: if True the characters
+      will have smooth edges. The color argument is the color of the text
       [e.g.: (0,0,255) for blue]. The optional background argument is a color
       to use for the text background. If no background is passed the area
       outside the text will be transparent.
 
       The Surface returned will be of the dimensions required to hold the text.
-      (the same as those returned by Font.size()). If an empty string is passed
+      (the same as those returned by :func:`Font.size`). If an empty string is passed
       for the text, a blank surface will be returned that is zero pixel wide and
       the height of the font.
 
@@ -243,7 +244,7 @@ loaded instead.
       colorkey rather than (much less efficient) alpha values.
 
       If you render '\\n' an unknown char will be rendered. Usually a
-      rectangle. Instead you need to handle new lines yourself.
+      rectangle. Instead you need to handle newlines yourself.
 
       Font rendering is not thread safe: only a single thread can render text
       at any time.
@@ -262,7 +263,7 @@ loaded instead.
 
       Returns the dimensions needed to render the text. This can be used to
       help determine the positioning needed for text before it is rendered. It
-      can also be used for wordwrapping and other layout effects.
+      can also be used for word wrapping and other layout effects.
 
       Be aware that most fonts use kerning which adjusts the widths for
       specific letter pairs. For example, the width for "ae" will not always

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -725,23 +725,27 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     rw = pgRWops_FromObject(obj);
 
     if (rw == NULL && PyUnicode_Check(obj)) {
-        PyObject* font_defaultname_string = PyUnicode_FromString(font_defaultname);
+        PyObject *font_defaultname_string =
+            PyUnicode_FromString(font_defaultname);
         if (!PyUnicode_Compare(font_defaultname_string, obj)) {
-            /* clear out existing file loading error before attempt to get default font */
+            /* clear out existing file loading error before attempt to get
+             * default font */
             PyErr_Clear();
             Py_DECREF(obj);
             obj = font_resource(font_defaultname);
             if (obj == NULL) {
                 if (PyErr_Occurred() == NULL) {
                     PyErr_Format(PyExc_RuntimeError,
-                                "default font '%.1024s' not found",
-                                font_defaultname);
+                                 "default font '%.1024s' not found",
+                                 font_defaultname);
                 }
                 goto error;
             }
-            /* Unlike when the default font is loaded with None, the fontsize is not
-             * scaled down here. This was probably unintended implementation detail,
-             * but this rewritten code aims to keep the exact behavior as the old one */
+            /* Unlike when the default font is loaded with None, the fontsize
+             * is not scaled down here. This was probably unintended
+             * implementation detail,
+             * but this rewritten code aims to keep the exact behavior as the
+             * old one */
 
             rw = pgRWops_FromObject(obj);
         }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -84,24 +84,6 @@ utf_8_needs_UCS_4(const char *str)
 }
 #endif
 
-static PyObject *
-pg_open_obj(PyObject *obj, const char *mode)
-{
-    PyObject *result;
-    PyObject *open;
-    PyObject *bltins = PyImport_ImportModule("builtins");
-    if (!bltins)
-        return NULL;
-    open = PyObject_GetAttrString(bltins, "open");
-    Py_DECREF(bltins);
-    if (!open)
-        return NULL;
-
-    result = PyObject_CallFunction(open, "Os", obj, mode);
-    Py_DECREF(open);
-    return result;
-}
-
 /* Return an encoded file path, a file-like object or a NULL pointer.
  * May raise a Python error. Use PyErr_Occurred to check.
  */
@@ -704,8 +686,6 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     int fontsize;
     TTF_Font *font = NULL;
     PyObject *obj;
-    PyObject *test;
-    PyObject *oencoded = NULL;
     SDL_RWops *rw;
 
     const char *filename;
@@ -740,122 +720,51 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
             goto error;
         }
         fontsize = (int)(fontsize * .6875);
-        if (fontsize <= 1)
-            fontsize = 1;
     }
 
-    /* SDL accepts UTF8 */
-    oencoded = pg_EncodeString(obj, "UTF8", NULL, NULL);
-    if (!oencoded || oencoded == Py_None) {
-        /* got a file object, or an error */
-        Py_XDECREF(oencoded);
-        oencoded = NULL;
-        PyErr_Clear();
-        goto fileobject;
-    }
-    filename = PyBytes_AS_STRING(oencoded);
+    rw = pgRWops_FromObject(obj);
 
-    /* Try opening the path through RWops first */
-    if (filename) {
-        rw = SDL_RWFromFile(filename, "rb");
-        if (rw != NULL) {
-            Py_BEGIN_ALLOW_THREADS;
-            font = TTF_OpenFontIndexRW(rw, 1, fontsize, 0);
-            Py_END_ALLOW_THREADS;
-        }
-        else {
-            /*
-            PyErr_Format(PyExc_IOError,
-                                 "unable to read font file '%.1024s'",
-                                 filename);
-            goto error;
-            */
-
-            /* silently ignore this failure. We will try opening the path
-               with fopen (pg_open_obj) again later.
-               RWops can open assets bundled with P4A on Android, but not
-               font_resource() paths */
-        }
-        if (font != NULL)
-            goto success;
-    }
-
-    if (font == NULL) {
-        /*check if it is a valid file, else SDL_ttf segfaults*/
-        test = pg_open_obj(obj, "rb");
-        if (test == NULL) {
-            if (filename) {
-                if (strcmp(filename, font_defaultname) == 0) {
-                    PyObject *tmp;
-                    PyErr_Clear();
-                    tmp = font_resource(font_defaultname);
-                    if (tmp == NULL) {
-                        if (!PyErr_Occurred()) {
-                            PyErr_Format(PyExc_IOError,
-                                         "unable to read font file '%.1024s'",
-                                         filename);
-                        }
-                        goto error;
-                    }
-                    Py_DECREF(obj);
-                    obj = tmp;
-                    filename = PyBytes_AS_STRING(obj);
-                    test = pg_open_obj(obj, "rb");
-                }
-            }
-            if (test == NULL) {
-                if (!PyErr_Occurred()) {
-                    PyErr_Format(PyExc_IOError,
-                                 "unable to read font file '%.1024s'",
-                                 filename);
+    if (rw == NULL && PyUnicode_Check(obj)) {
+        PyObject* font_defaultname_string = PyUnicode_FromString(font_defaultname);
+        if (!PyUnicode_Compare(font_defaultname_string, obj)) {
+            /* clear out existing file loading error before attempt to get default font */
+            PyErr_Clear();
+            Py_DECREF(obj);
+            obj = font_resource(font_defaultname);
+            if (obj == NULL) {
+                if (PyErr_Occurred() == NULL) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                "default font '%.1024s' not found",
+                                font_defaultname);
                 }
                 goto error;
             }
-        }
-        {
-            PyObject *tmp;
-            if (!(tmp = PyObject_CallMethod(test, "close", NULL))) {
-                Py_DECREF(test);
-                goto error;
-            }
-            Py_DECREF(tmp);
-        }
-        Py_DECREF(test);
-        /* opened file (test) is not used for loading,
-           SDL_TTF fopens the file _again_.*/
+            /* Unlike when the default font is loaded with None, the fontsize is not
+             * scaled down here. This was probably unintended implementation detail,
+             * but this rewritten code aims to keep the exact behavior as the old one */
 
-        Py_BEGIN_ALLOW_THREADS;
-        font = TTF_OpenFont(filename, fontsize);
-        Py_END_ALLOW_THREADS;
+            rw = pgRWops_FromObject(obj);
+        }
     }
 
-fileobject:
-    if (font == NULL) {
-        rw = pgRWops_FromFileObject(obj);
-
-        if (rw == NULL) {
-            goto error;
-        }
-
-        Py_BEGIN_ALLOW_THREADS;
-        font = TTF_OpenFontIndexRW(rw, 1, fontsize, 0);
-        Py_END_ALLOW_THREADS;
-    }
-
-    if (font == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, SDL_GetError());
+    if (rw == NULL) {
         goto error;
     }
 
-success:
-    Py_XDECREF(oencoded);
+    if (fontsize <= 1)
+        fontsize = 1;
+
+    Py_BEGIN_ALLOW_THREADS;
+    font = TTF_OpenFontRW(rw, 1, fontsize);
+    Py_END_ALLOW_THREADS;
+
     Py_DECREF(obj);
     self->font = font;
     self->ttf_init_generation = current_ttf_generation;
+
     return 0;
 
 error:
-    Py_XDECREF(oencoded);
     Py_XDECREF(obj);
     return -1;
 }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -688,8 +688,6 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     PyObject *obj;
     SDL_RWops *rw;
 
-    const char *filename;
-
     self->font = NULL;
     if (!PyArg_ParseTuple(args, "Oi", &obj, &fontsize)) {
         return -1;

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -37,13 +37,6 @@
 
 #include "structmember.h"
 
-/* Require SDL_ttf 2.0.6 or later for rwops support */
-#ifdef TTF_MAJOR_VERSION
-#define FONT_HAVE_RWOPS 1
-#else
-#define FONT_HAVE_RWOPS 0
-#endif
-
 #ifndef SDL_TTF_VERSION_ATLEAST
 #define SDL_TTF_COMPILEDVERSION                                  \
     SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, \
@@ -762,7 +755,6 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     }
     filename = PyBytes_AS_STRING(oencoded);
 
-#if FONT_HAVE_RWOPS
     /* Try opening the path through RWops first */
     if (filename) {
         rw = SDL_RWFromFile(filename, "rb");
@@ -787,7 +779,6 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
         if (font != NULL)
             goto success;
     }
-#endif
 
     if (font == NULL) {
         /*check if it is a valid file, else SDL_ttf segfaults*/
@@ -840,7 +831,6 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
 
 fileobject:
     if (font == NULL) {
-#if FONT_HAVE_RWOPS
         rw = pgRWops_FromFileObject(obj);
 
         if (rw == NULL) {
@@ -850,11 +840,6 @@ fileobject:
         Py_BEGIN_ALLOW_THREADS;
         font = TTF_OpenFontIndexRW(rw, 1, fontsize, 0);
         Py_END_ALLOW_THREADS;
-#else
-        PyErr_SetString(PyExc_NotImplementedError,
-                        "nonstring fonts require SDL_ttf-2.0.6");
-        goto error;
-#endif
     }
 
     if (font == NULL) {

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -725,9 +725,7 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
     rw = pgRWops_FromObject(obj);
 
     if (rw == NULL && PyUnicode_Check(obj)) {
-        PyObject *font_defaultname_string =
-            PyUnicode_FromString(font_defaultname);
-        if (!PyUnicode_Compare(font_defaultname_string, obj)) {
+        if (!PyUnicode_CompareWithASCIIString(obj, font_defaultname)) {
             /* clear out existing file loading error before attempt to get
              * default font */
             PyErr_Clear();

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -469,7 +469,7 @@ class FontTypeTest(unittest.TestCase):
 
         pygame_font.init()
         self.assertRaises(
-            FileNotFoundError, pygame_font.Font, str("some-fictional-font.ttf"), 20
+            FileNotFoundError, pygame_font.Font, "some-fictional-font.ttf", 20
         )
 
     def test_load_from_file(self):


### PR DESCRIPTION
This PR is a bugfix, and enhancement, and code cleanup.

Code cleanup: It follows #2695's quest to simplify pygame resource loaders by rewriting `font_init` to use higher level pygame rwobject constructs. This about halves the lines of code in `font_init`.

Enhancement: the higher level loading systems allow for better error messages from #2694. I also prettied up the docs, cleaning up some misleading statements and putting some more restructured text function linking in there.

Bugfix: despite the pygame default font + pyinstaller issue being officially fixed, people have still been running into it. Ankith and I neglected to test `--onefile` executables, and the issue persisted there. This fixes it, tested both with and without onefile.


Fun fact!
Pygame will load freesansbold.ttf if the user passes `None` or `"freesansbold.ttf"`. 
But if the user passes `"freesansbold.ttf"`, pygame actually looks locally first, then loads the default font if it can't find something called `"freesansbold.ttf"` locally.

Here's my testing file if anyone wants to use it.
```py
import sys
import pygame

pygame.init()

screen = pygame.display.set_mode((400, 200))

clock = pygame.time.Clock()

num = 0
if len(sys.argv) > 1:
    num = int(sys.argv[1])

# loads default font
if num == 0:
    font = pygame.font.Font(None, 100)

# loads a font file
if num == 1:
    font = pygame.font.Font("Oswald-Regular.ttf", 100)

# looks in current dir, if it can't find it, loads default font
# HOWEVER, does not scale the default font down like None does
if num == 2:
    font = pygame.font.Font("freesansbold.ttf", 100)

# loads a weird IO object
if num == 3:
    font = pygame.font.Font(open("Oswald-Regular.ttf", "rb"), 100)

# fails to load a font file
if num == 4:
    font = pygame.font.Font("not-your-font.ttf", 100)

im = font.render("Hello", True, "black")
print(im)

while True:
    screen.fill("purple")
    screen.blit(im, (0,0))

    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            pygame.quit()
            raise SystemExit

    pygame.display.flip()
    
    clock.tick(144)
```