### PR TITLE
Fix warnings, make warnings error on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,26 @@ on:
   push:
     branches: main
     paths-ignore:
-    - 'docs/**'
-    - 'examples/**'
-    - '.gitignore'
-    - 'README.rst'
-    - '.github/workflows/manylinux.yml'
-    - '.github/workflows/ubuntu-sdist.yml'
-    - '.github/workflows/format-lint.yml'
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/build.yml'
 
   pull_request:
     branches: main
     paths-ignore:
-    - 'docs/**'
-    - 'examples/**'
-    - '.gitignore'
-    - 'README.rst'
-    - '.github/workflows/manylinux.yml'
-    - '.github/workflows/ubuntu-sdist.yml'
-    - '.github/workflows/format-lint.yml'
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/build.yml'
 
 jobs:
   deps:

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,32 @@
+name: cppcheck Static Analysis
+
+# Run cppcheck on src_c changes to main branch, or any PR to main.
+on:
+  push:
+    branches: main
+    paths:
+      - 'src_c/**'
+
+  pull_request:
+    branches: main
+    paths:
+      - 'src_c/**'
+
+# TODO: Any more static checkers can be added here
+jobs:
+  run-cppcheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Install deps
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get upgrade
+          sudo apt install cppcheck
+
+      - name: Run Static Checker
+        # skip cppcheck on SDL_gfx and scrap for now
+        run: cppcheck src_c --force --enable=performance,portability,warning \
+          --suppress=*:src_c/SDL_gfx/* --suppress=*:src_c/scrap*

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -1,21 +1,19 @@
 name: python3 setup.py lint
 
-# Run CI only when a release is created, on changes to main branch, or any PR
-# to main. Do not run CI on any other branch. Also, skip any non-source changes
-# from running on CI
+# Run lint CI on changes to main branch, or any PR to main. Do not run CI on
+# any other branch. Also, skip any non-source changes from running on lint CI
 on:
-  release:
-    types: [created]
   push:
     branches: main
     paths-ignore:
       - 'docs/**'
       - 'examples/**'
       - '.gitignore'
-      - 'README.rst'
-      - '.github/workflows/build.yml'
-      - '.github/workflows/manylinux.yml'
-      - '.github/workflows/ubuntu-sdist.yml'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/format-lint.yml'
 
   pull_request:
     branches: main
@@ -23,10 +21,11 @@ on:
       - 'docs/**'
       - 'examples/**'
       - '.gitignore'
-      - 'README.rst'
-      - '.github/workflows/build.yml'
-      - '.github/workflows/manylinux.yml'
-      - '.github/workflows/ubuntu-sdist.yml'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/format-lint.yml'
 
 jobs:
   format-lint-code-check:

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -9,24 +9,26 @@ on:
   push:
     branches: main
     paths-ignore:
-    - 'docs/**'
-    - 'examples/**'
-    - '.gitignore'
-    - 'README.rst'
-    - '.github/workflows/build.yml'
-    - '.github/workflows/ubuntu-sdist.yml'
-    - '.github/workflows/format-lint.yml'
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/manylinux.yml'
 
   pull_request:
     branches: main
     paths-ignore:
-    - 'docs/**'
-    - 'examples/**'
-    - '.gitignore'
-    - 'README.rst'
-    - '.github/workflows/build.yml'
-    - '.github/workflows/ubuntu-sdist.yml'
-    - '.github/workflows/format-lint.yml'
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/manylinux.yml'
 
 jobs:
   build-manylinux:

--- a/.github/workflows/ubuntu-sdist.yml
+++ b/.github/workflows/ubuntu-sdist.yml
@@ -9,24 +9,26 @@ on:
   push:
     branches: main
     paths-ignore:
-    - 'docs/**'
-    - 'examples/**'
-    - '.gitignore'
-    - 'README.rst'
-    - '.github/workflows/build.yml'
-    - '.github/workflows/manylinux.yml'
-    - '.github/workflows/format-lint.yml'
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/ubuntu-sdist.yml'
 
   pull_request:
     branches: main
     paths-ignore:
-    - 'docs/**'
-    - 'examples/**'
-    - '.gitignore'
-    - 'README.rst'
-    - '.github/workflows/build.yml'
-    - '.github/workflows/manylinux.yml'
-    - '.github/workflows/format-lint.yml'
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/ubuntu-sdist.yml'
 
 jobs:
   build:

--- a/setup.py
+++ b/setup.py
@@ -369,22 +369,20 @@ for e in extensions:
         # some warnings are skipped here
         ("/W3", "/wd4142", "/wd4996")
         if sys.platform == "win32"
-        else ("-Wall", "-Wno-error=unknown-pragmas") # "-Wno-error=sign-compare"
+        else ("-Wall", "-Wno-error=unknown-pragmas")
     )
-
-    if "freetype" in e.name and sys.platform not in ("darwin", "win32"):
-        # TODO: fix freetype issues here
-        e.extra_compile_args.append("-Wno-error=unused-but-set-variable")
 
     if "surface" in e.name and sys.platform == "darwin":
         # skip -Werror on alphablit because sse2neon is used on arm mac
         continue
 
-    if ("mask" in e.name or "pixel" in e.name) and sys.platform == "win32":
-        # TODO fix
-        # skip -Werror on mask, pixelarray and pixelcopy because of many MSVC 
-        # static analyzer issues
-        continue
+    if "freetype" in e.name and sys.platform not in ("darwin", "win32"):
+        # TODO: fix freetype issues here
+        e.extra_compile_args.append("-Wno-error=unused-but-set-variable")
+
+    if "mask" in e.name and sys.platform == "win32":
+        # skip analyze warnings that pop up a lot in mask for now. TODO fix
+        e.extra_compile_args.extend(("/wd6385", "/wd6386"))
 
     if (
         "CI" in os.environ

--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -85,6 +85,12 @@ surf_colorspace(PyObject *self, PyObject *arg)
     int cspace;
     surfobj2 = NULL;
 
+#ifdef _MSC_VER
+    /* MSVC static analyzer false alarm: assure color is NULL-terminated by
+     * making analyzer assume it was initialised */
+    __analysis_assume(color = "inited");
+#endif
+
     /*get all the arguments*/
     if (!PyArg_ParseTuple(arg, "O!s|O!", &pgSurface_Type, &surfobj, &color,
                           &pgSurface_Type, &surfobj2))

--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -589,7 +589,7 @@ bgr32_to_rgb(const void *src, void *dst, int length, SDL_PixelFormat *format)
                 b = *s++;
                 g = *s++;
                 r = *s++;
-                *s++;
+                s++;
                 *d32++ = ((r >> rloss) << rshift) | ((g >> gloss) << gshift) |
                          ((b >> bloss) << bshift);
             }
@@ -1928,6 +1928,9 @@ Camera(pgCameraObject *self, PyObject *arg)
     }
 
     return (PyObject *)cameraobj;
+#else
+    return RAISE(PyExc_RuntimeError,
+                 "_camera backend not available on your platform");
 #endif
 }
 

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -1191,7 +1191,7 @@ _ftfont_setrender_flag(pgFontObject *self, PyObject *value, void *closure)
     const intptr_t render_flag = (intptr_t)closure;
 
     /* Generic setter; We do not know the name of the attribute */
-    DEL_ATTR_NOT_SUPPORTED_CHECK(NULL, value);
+    DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
     if (!PyBool_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "The style value must be a boolean");

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -935,7 +935,7 @@ _ftfont_repr(pgFontObject *self)
 static PyObject *
 _ftfont_getstyle_flag(pgFontObject *self, void *closure)
 {
-    const long style_flag = (long)closure;
+    const intptr_t style_flag = (intptr_t)closure;
 
     return PyBool_FromLong(self->style & (FT_UInt16)style_flag);
 }
@@ -943,7 +943,7 @@ _ftfont_getstyle_flag(pgFontObject *self, void *closure)
 static int
 _ftfont_setstyle_flag(pgFontObject *self, PyObject *value, void *closure)
 {
-    const long style_flag = (long)closure;
+    const intptr_t style_flag = (intptr_t)closure;
 
     if (!PyBool_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "The style value must be a boolean");
@@ -1178,7 +1178,7 @@ _ftfont_getfixedsizes(pgFontObject *self, void *closure)
 static PyObject *
 _ftfont_getrender_flag(pgFontObject *self, void *closure)
 {
-    const long render_flag = (long)closure;
+    const intptr_t render_flag = (intptr_t)closure;
 
     return PyBool_FromLong(self->render_flags & (FT_UInt16)render_flag);
 }
@@ -1186,7 +1186,7 @@ _ftfont_getrender_flag(pgFontObject *self, void *closure)
 static int
 _ftfont_setrender_flag(pgFontObject *self, PyObject *value, void *closure)
 {
-    const long render_flag = (long)closure;
+    const intptr_t render_flag = (intptr_t)closure;
 
     /* Generic setter; We do not know the name of the attribute */
     DEL_ATTR_NOT_SUPPORTED_CHECK(NULL, value);

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -226,19 +226,21 @@ typedef enum {
 supported Python version. #endif */
 
 #define RAISE(x, y) (PyErr_SetString((x), (y)), NULL)
-#define DEL_ATTR_NOT_SUPPORTED_CHECK(name, value)                 \
-    do {                                                          \
-        if (!value) {                                             \
-            if (name) {                                           \
-                PyErr_Format(PyExc_AttributeError,                \
-                             "Cannot delete attribute %s", name); \
-            }                                                     \
-            else {                                                \
-                PyErr_SetString(PyExc_AttributeError,             \
-                                "Cannot delete attribute");       \
-            }                                                     \
-            return -1;                                            \
-        }                                                         \
+#define DEL_ATTR_NOT_SUPPORTED_CHECK(name, value)                            \
+    do {                                                                     \
+        if (!value) {                                                        \
+            PyErr_Format(PyExc_AttributeError, "Cannot delete attribute %s", \
+                         name);                                              \
+            return -1;                                                       \
+        }                                                                    \
+    } while (0)
+
+#define DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value)                           \
+    do {                                                                      \
+        if (!value) {                                                         \
+            PyErr_SetString(PyExc_AttributeError, "Cannot delete attribute"); \
+            return -1;                                                        \
+        }                                                                     \
     } while (0)
 
 /*

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -225,7 +225,7 @@ typedef enum {
 #error No support for PEP 3118/Py_TPFLAGS_HAVE_NEWBUFFER. Please use a
 supported Python version. #endif */
 
-#define RAISE(x, y) (PyErr_SetString((x), (y)), (PyObject *)NULL)
+#define RAISE(x, y) (PyErr_SetString((x), (y)), NULL)
 #define DEL_ATTR_NOT_SUPPORTED_CHECK(name, value)                 \
     do {                                                          \
         if (!value) {                                             \

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -210,12 +210,12 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 case 0: {
                     if (info.src_blend != SDL_BLENDMODE_NONE &&
                         src->format->Amask) {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
                         if (src->format->BytesPerPixel == 4 &&
                             dst->format->BytesPerPixel == 4 &&
                             src->format->Rmask == dst->format->Rmask &&
                             src->format->Gmask == dst->format->Gmask &&
-                            src->format->Bmask == dst->format->Bmask &&
-                            SDL_BYTEORDER == SDL_LIL_ENDIAN) {
+                            src->format->Bmask == dst->format->Bmask) {
 /* If our source and destination are the same ARGB 32bit
    format we can use SSE2 to speed up the blend */
 #if PG_ENABLE_ARM_NEON
@@ -261,6 +261,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                             }
 #endif /* __SSE2__*/
                         }
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
                         alphablit_alpha(&info);
                     }
                     else if (info.src_has_colorkey) {

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -1025,14 +1025,15 @@ blit_blend_premultiplied_sse2(SDL_BlitInfo *info)
     int dstskip = info->d_skip >> 2;
     SDL_PixelFormat *srcfmt = info->src;
     Uint32 amask = srcfmt->Amask;
-    Uint64 multmask;
+    // Uint64 multmask;
     Uint64 ones;
 
-    __m128i src1, dst1, sub_dst, mm_alpha, mm_zero, multmask_128, ones_128;
+    // __m128i multmask_128;
+    __m128i src1, dst1, sub_dst, mm_alpha, mm_zero, ones_128;
 
     mm_zero = _mm_setzero_si128();
-    multmask = 0x00FF00FF00FF00FF;  // 0F0F0F0F
-    multmask_128 = _mm_loadl_epi64((const __m128i *)&multmask);
+    // multmask = 0x00FF00FF00FF00FF;  // 0F0F0F0F
+    // multmask_128 = _mm_loadl_epi64((const __m128i *)&multmask);
     ones = 0x0001000100010001;
     ones_128 = _mm_loadl_epi64((const __m128i *)&ones);
 
@@ -2278,8 +2279,8 @@ alphablit_alpha_sse2_argb_surf_alpha(SDL_BlitInfo *info)
     SDL_PixelFormat *srcfmt = info->src;
     SDL_PixelFormat *dstfmt = info->dst;
 
-    int srcbpp = srcfmt->BytesPerPixel;
-    int dstbpp = dstfmt->BytesPerPixel;
+    // int srcbpp = srcfmt->BytesPerPixel;
+    // int dstbpp = dstfmt->BytesPerPixel;
 
     Uint32 dst_amask = dstfmt->Amask;
     Uint32 src_amask = srcfmt->Amask;
@@ -2792,20 +2793,20 @@ alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
     int srcskip = info->s_skip >> 2;
     int dstskip = info->d_skip >> 2;
 
-    SDL_PixelFormat *srcfmt = info->src;
-    SDL_PixelFormat *dstfmt = info->dst;
+    // SDL_PixelFormat *srcfmt = info->src;
+    // SDL_PixelFormat *dstfmt = info->dst;
 
     Uint64 *srcp64 = (Uint64 *)info->s_pixels;
     Uint64 *dstp64 = (Uint64 *)info->d_pixels;
 
-    Uint64 src_amask64 = ((Uint64)srcfmt->Amask << 32) | srcfmt->Amask;
+    // Uint64 src_amask64 = ((Uint64)srcfmt->Amask << 32) | srcfmt->Amask;
 
     Uint64 rgb_mask64 = 0x00FFFFFF00FFFFFF;
 
     Uint32 *srcp32 = (Uint32 *)info->s_pixels;
     Uint32 *dstp32 = (Uint32 *)info->d_pixels;
 
-    Uint32 src_amask32 = srcfmt->Amask;
+    // Uint32 src_amask32 = srcfmt->Amask;
 
     Uint32 rgb_mask32 = 0x00FFFFFF;
 

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1205,7 +1205,7 @@ pgGetArrayInterface(PyObject **dict, PyObject *obj)
     if (!PyDict_Check(inter)) {
         PyErr_Format(PyExc_ValueError,
                      "expected '__array_interface__' to return a dict: got %s",
-                     Py_TYPE(dict)->tp_name);
+                     Py_TYPE(inter)->tp_name);
         Py_DECREF(inter);
         return -1;
     }

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1171,10 +1171,20 @@ _pg_buffer_is_byteswapped(Py_buffer *view)
     if (view->format) {
         switch (view->format[0]) {
             case '<':
-                return SDL_BYTEORDER != SDL_LIL_ENDIAN;
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                /* Use macros to make static analyzer happy */
+                return 0;
+#else
+                return 1;
+#endif
             case '>':
             case '!':
-                return SDL_BYTEORDER != SDL_BIG_ENDIAN;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+                /* Use macros to make static analyzer happy */
+                return 0;
+#else
+                return 1;
+#endif
         }
     }
     return 0;

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -40,7 +40,7 @@
 #define VC_EXTRALEAN
 #include <windows.h>
 extern int
-SDL_RegisterApp(char *, Uint32, void *);
+SDL_RegisterApp(const char *, Uint32, void *);
 #endif
 
 #if defined(macintosh)
@@ -374,7 +374,7 @@ pg_get_sdl_byteorder(PyObject *self)
 static void
 _pg_quit(void)
 {
-    int num, i;
+    Py_ssize_t num, i;
     PyObject *quit, *privatefuncs, *temp;
 
     /* Put all the module names we want to quit in this array */
@@ -755,7 +755,7 @@ _pg_new_capsuleinterface(Py_buffer *view_p)
     cinter_p->inter.two = 2;
     cinter_p->inter.nd = ndim;
     cinter_p->inter.typekind = _pg_as_arrayinter_typekind(view_p);
-    cinter_p->inter.itemsize = view_p->itemsize;
+    cinter_p->inter.itemsize = (int)view_p->itemsize;
     cinter_p->inter.flags = _pg_as_arrayinter_flags(view_p);
     if (view_p->shape) {
         cinter_p->inter.shape = cinter_p->imem;
@@ -1589,7 +1589,7 @@ _pg_values_as_buffer(Py_buffer *view_p, int flags, PyObject *typestr,
                         "'shape' and 'strides' are not the same length");
         return -1;
     }
-    view_p->ndim = ndim;
+    view_p->ndim = (int)ndim;
     view_p->buf = PyLong_AsVoidPtr(PyTuple_GET_ITEM(data, 0));
     if (!view_p->buf && PyErr_Occurred()) {
         return -1;
@@ -2039,15 +2039,6 @@ pg_uninstall_parachute(void)
 
 /* bind functions to python */
 
-static PyObject *
-pg_do_segfault(PyObject *self, PyObject *args)
-{
-    // force crash
-    *((int *)1) = 45;
-    memcpy((char *)2, (char *)3, 10);
-    Py_RETURN_NONE;
-}
-
 static PyMethodDef _base_methods[] = {
     {"init", (PyCFunction)pg_init, METH_NOARGS, DOC_PYGAMEINIT},
     {"quit", (PyCFunction)pg_quit, METH_NOARGS, DOC_PYGAMEQUIT},
@@ -2063,8 +2054,6 @@ static PyMethodDef _base_methods[] = {
 
     {"get_array_interface", (PyCFunction)pg_get_array_interface, METH_O,
      "return an array struct interface as an interface dictionary"},
-
-    {"segfault", (PyCFunction)pg_do_segfault, METH_NOARGS, "crash"},
     {NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(base)

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -67,7 +67,13 @@ bitcount(BITMASK_W n)
         n = ((n >> 4) + n) & 0x0f0f0f0f0f0f0f0f;
         n += n >> 8;
         n += n >> 16;
+#ifdef _WIN32
+        /* Use explicit typecast to silence MSVC warning about large bitshift,
+         * even though this part code does not run on windows */
+        n += (long long)n >> 32;
+#else
         n += n >> 32;
+#endif
         return n & 0xff;
     }
     else {

--- a/src_c/bitmask.c
+++ b/src_c/bitmask.c
@@ -39,7 +39,8 @@
 static INLINE unsigned int
 bitcount(BITMASK_W n)
 {
-    if (BITMASK_W_LEN == (32)) {
+    const int bitmask_len = BITMASK_W_LEN;
+    if (bitmask_len == 32) {
 #ifdef GILLIES
         /* (C) Donald W. Gillies, 1992.  All rights reserved.  You may reuse
            this bitcount() function anywhere you please as long as you retain
@@ -61,7 +62,7 @@ bitcount(BITMASK_W n)
         return n & 0xff;
 #endif
     }
-    else if (BITMASK_W_LEN == (64)) {
+    else if (bitmask_len == 64) {
         n = ((n >> 1) & 0x5555555555555555) + (n & 0x5555555555555555);
         n = ((n >> 2) & 0x3333333333333333) + (n & 0x3333333333333333);
         n = ((n >> 4) + n) & 0x0f0f0f0f0f0f0f0f;

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -245,7 +245,7 @@ _proxy_zombie_get_buffer(PyObject *obj, Py_buffer *view_p, int flags)
 static PyObject *
 proxy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    PyObject *obj = 0;
+    PyObject *obj;
     getbufferproc get_buffer = (getbufferproc)pgObject_GetBuffer;
 
     if (!PyArg_ParseTuple(args, "O:Bufproxy", &obj)) {

--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -200,8 +200,8 @@ v4l2_read_raw(pgCameraObject *self);
 int
 v4l2_xioctl(int fd, int request, void *arg);
 int
-v4l2_process_image(pgCameraObject *self, const void *image,
-                   unsigned int buffer_size, SDL_Surface *surf);
+v4l2_process_image(pgCameraObject *self, const void *image, int buffer_size,
+                   SDL_Surface *surf);
 int
 v4l2_query_buffer(pgCameraObject *self);
 int

--- a/src_c/camera_v4l2.c
+++ b/src_c/camera_v4l2.c
@@ -177,8 +177,8 @@ v4l2_xioctl(int fd, int request, void *arg)
    currently two step processes. */
 /* TODO: Write single step conversions where they may actually be useful */
 int
-v4l2_process_image(pgCameraObject *self, const void *image,
-                   unsigned int buffer_size, SDL_Surface *surf)
+v4l2_process_image(pgCameraObject *self, const void *image, int buffer_size,
+                   SDL_Surface *surf)
 {
     if (!surf)
         return 0;
@@ -337,7 +337,7 @@ v4l2_process_image(pgCameraObject *self, const void *image,
 int
 v4l2_query_buffer(pgCameraObject *self)
 {
-    int i;
+    unsigned int i;
 
     for (i = 0; i < self->n_buffers; ++i) {
         struct v4l2_buffer buf;

--- a/src_c/camera_windows.c
+++ b/src_c/camera_windows.c
@@ -239,6 +239,7 @@ windows_device_from_name(WCHAR *device_name)
 {
     IMFAttributes *pAttributes = NULL;
     IMFActivate **ppDevices = NULL;
+    IMFActivate *ret_device;
     WCHAR *_device_name = NULL;
     UINT32 count = 0;
     HRESULT hr;
@@ -266,8 +267,9 @@ windows_device_from_name(WCHAR *device_name)
                     RELEASE(ppDevices[j]);
                 }
             }
+            ret_device = ppDevices[i];
             CoTaskMemFree(ppDevices);
-            return ppDevices[i];
+            return ret_device;
         }
         free(_device_name);
     }

--- a/src_c/camera_windows.c
+++ b/src_c/camera_windows.c
@@ -64,19 +64,19 @@
                  hr, line);
 
 #define CHECKHR(hr)            \
-    if FAILED (hr) {           \
+    if (FAILED(hr)) {          \
         FORMATHR(hr, __LINE__) \
         return 0;              \
     }
 
 #define HANDLEHR(hr)           \
-    if FAILED (hr) {           \
+    if (FAILED(hr)) {          \
         FORMATHR(hr, __LINE__) \
         goto cleanup;          \
     }
 
 #define T_HANDLEHR(hr)                 \
-    if FAILED (hr) {                   \
+    if (FAILED(hr)) {                  \
         self->t_error = hr;            \
         self->t_error_line = __LINE__; \
         break;                         \
@@ -92,7 +92,7 @@
 int
 _check_integrity(pgCameraObject *self)
 {
-    if FAILED (self->t_error) {
+    if (FAILED(self->t_error)) {
         /* MF_E_HW_MFT_FAILED_START_STREAMING */
         if (self->t_error == (HRESULT)-1072875772) {
             PyErr_SetString(PyExc_SystemError,
@@ -217,7 +217,7 @@ cleanup:
         RELEASE(ppDevices[i]);
     }
     CoTaskMemFree(ppDevices);
-    if FAILED (hr) {
+    if (FAILED(hr)) {
         if (devices) {
             for (int i = 0; i < (int)count; i++) {
                 free(devices[i]);
@@ -421,7 +421,7 @@ cleanup:
         }
     }
 
-    if FAILED (hr) {
+    if (FAILED(hr)) {
         if (index > 0) {
             RELEASE(native_types[index]);
         }

--- a/src_c/camera_windows.c
+++ b/src_c/camera_windows.c
@@ -725,6 +725,8 @@ windows_init_device(pgCameraObject *self)
 
     hr = MFStartup(MF_VERSION, MFSTARTUP_LITE);
     CHECKHR(hr);
+
+    return 1;
 }
 
 void

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -476,15 +476,15 @@ pg_get_wm_info(PyObject *self)
         return dict;
 
 #if defined(SDL_VIDEO_DRIVER_WINDOWS)
-    tmp = PyLong_FromLong((long)info.info.win.window);
+    tmp = PyLong_FromLongLong((long long)info.info.win.window);
     PyDict_SetItemString(dict, "window", tmp);
     Py_DECREF(tmp);
 
-    tmp = PyLong_FromLong((long)info.info.win.hdc);
+    tmp = PyLong_FromLongLong((long long)info.info.win.hdc);
     PyDict_SetItemString(dict, "hdc", tmp);
     Py_DECREF(tmp);
 
-    tmp = PyLong_FromLong((long)info.info.win.hinstance);
+    tmp = PyLong_FromLongLong((long long)info.info.win.hinstance);
     PyDict_SetItemString(dict, "hinstance", tmp);
     Py_DECREF(tmp);
 #endif
@@ -1016,9 +1016,9 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                         // if the program goes into fullscreen first the "saved
                         // x and y" are "undefined position" that should be
                         // interpreted as a cue to center the window
-                        if (x == SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
+                        if (x == (int)SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
                             x = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
-                        if (y == SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
+                        if (y == (int)SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
                             y = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
                     }
                     else {
@@ -1061,10 +1061,10 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                     h_1 = display_bounds.h;
 
                     if (((float)w_1) / (float)h_1 > aspect_ratio) {
-                        w_1 = h_1 * aspect_ratio;
+                        w_1 = (int)(h_1 * aspect_ratio);
                     }
                     else {
-                        h_1 = w_1 / aspect_ratio;
+                        h_1 = (int)(w_1 / aspect_ratio);
                     }
                 }
                 else {
@@ -1496,7 +1496,7 @@ pg_list_modes(PyObject *self, PyObject *args, PyObject *kwds)
             mode.w = 640;
         if (!mode.h)
             mode.h = 480;
-        if (SDL_BITSPERPIXEL(mode.format) != bpp)
+        if ((int)SDL_BITSPERPIXEL(mode.format) != bpp)
             continue;
         if (last_width == mode.w && last_height == mode.h &&
             last_width != -1) {
@@ -1615,7 +1615,6 @@ pg_update(PyObject *self, PyObject *arg)
     _DisplayState *state = DISPLAY_MOD_STATE(self);
     SDL_Rect *gr, temp = {0};
     int wide, high;
-    PyObject *obj;
 
     VIDEO_INIT_CHECK();
 
@@ -1723,6 +1722,7 @@ pg_set_palette(PyObject *self, PyObject *args)
         return NULL;
     if (!surface)
         return RAISE(pgExc_SDLError, "No display mode is set");
+
     Py_INCREF(surface);
     surf = pgSurface_AsSurface(surface);
     pal = surf->format->palette;
@@ -1741,7 +1741,10 @@ pg_set_palette(PyObject *self, PyObject *args)
         return RAISE(PyExc_ValueError, "Argument must be a sequence type");
     }
 
-    len = MIN(pal->ncolors, PySequence_Length(list));
+    len = (int)MIN(pal->ncolors, PySequence_Length(list));
+    if (len < 0) {
+        return NULL;
+    }
 
     colors = (SDL_Color *)malloc(len * sizeof(SDL_Color));
     if (!colors) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -866,9 +866,8 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 rect(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *rectobj = NULL;
-    PyObject *points = NULL, *poly_args = NULL, *ret = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *rectobj;
     SDL_Rect *rect = NULL, temp;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
@@ -1377,7 +1376,6 @@ static void
 drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
 {
     Uint8 *pixel, *end;
-    Uint8 *colorptr;
 
     if (x1 == x2) {
         return;
@@ -1404,13 +1402,11 @@ drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
             }
             break;
         case 3:
-            if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-                color <<= 8;
-            colorptr = (Uint8 *)&color;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+            color <<= 8;
+#endif
             for (; pixel <= end; pixel += 3) {
-                pixel[0] = colorptr[0];
-                pixel[1] = colorptr[1];
-                pixel[2] = colorptr[2];
+                memcpy(pixel, &color, 3 * sizeof(Uint8));
             }
             break;
         default: /*case 4*/

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -100,8 +100,8 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
 static PyObject *
 aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *start = NULL, *end = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *start, *end;
     SDL_Surface *surf = NULL;
     float startx, starty, endx, endy;
     int blend = 1; /* Default blend. */
@@ -178,8 +178,8 @@ aaline(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 line(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *start = NULL, *end = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *start, *end;
     SDL_Surface *surf = NULL;
     int startx, starty, endx, endy;
     Uint8 rgba[4];
@@ -246,9 +246,9 @@ line(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *closedobj = NULL;
-    PyObject *points = NULL, *item = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *closedobj;
+    PyObject *points, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint32 color;
     Uint8 rgba[4];
@@ -389,9 +389,9 @@ aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 lines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *closedobj = NULL;
-    PyObject *points = NULL, *item = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *closedobj;
+    PyObject *points, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint32 color;
     Uint8 rgba[4];
@@ -512,8 +512,8 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 arc(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *rectobj = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *rectobj;
     SDL_Rect *rect = NULL, temp;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
@@ -590,8 +590,8 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *rectobj = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *rectobj;
     SDL_Rect *rect = NULL, temp;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
@@ -657,8 +657,8 @@ ellipse(PyObject *self, PyObject *arg, PyObject *kwargs)
 static PyObject *
 circle(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
@@ -752,8 +752,8 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
-    PyObject *colorobj = NULL, *points = NULL, *item = NULL;
+    pgSurfaceObject *surfobj;
+    PyObject *colorobj, *points, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1250,15 +1250,15 @@ dict_from_event(SDL_Event *event)
 
 #ifdef WIN32
         case SDL_SYSWMEVENT:
-            _pg_insobj(
-                dict, "hwnd",
-                PyLong_FromLong((long)(event->syswm.msg->msg.win.hwnd)));
+            _pg_insobj(dict, "hwnd",
+                       PyLong_FromLongLong(
+                           (long long)(event->syswm.msg->msg.win.hwnd)));
             _pg_insobj(dict, "msg",
                        PyLong_FromLong(event->syswm.msg->msg.win.msg));
             _pg_insobj(dict, "wparam",
-                       PyLong_FromLong(event->syswm.msg->msg.win.wParam));
+                       PyLong_FromLongLong(event->syswm.msg->msg.win.wParam));
             _pg_insobj(dict, "lparam",
-                       PyLong_FromLong(event->syswm.msg->msg.win.lParam));
+                       PyLong_FromLongLong(event->syswm.msg->msg.win.lParam));
             break;
 #endif /* WIN32 */
 
@@ -1774,7 +1774,7 @@ _pg_eventtype_from_seq(PyObject *seq, int ind)
 }
 
 static PyObject *
-_pg_eventtype_as_seq(PyObject *obj, int *len)
+_pg_eventtype_as_seq(PyObject *obj, Py_ssize_t *len)
 {
     *len = 1;
     if (PySequence_Check(obj)) {
@@ -1804,7 +1804,8 @@ _pg_flush_events(Uint32 type)
 static PyObject *
 pg_event_clear(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    int loop, len, type;
+    Py_ssize_t len;
+    int loop, type;
     PyObject *seq, *obj = NULL;
     int dopump = 1;
 
@@ -1858,7 +1859,8 @@ static PyObject *
 _pg_get_all_events_except(PyObject *obj)
 {
     SDL_Event event;
-    int loop, type, len, ret;
+    Py_ssize_t len;
+    int loop, type, ret;
     PyObject *seq, *list;
 
     SDL_Event *filtered_events;
@@ -1994,8 +1996,9 @@ error:
 static PyObject *
 _pg_get_seq_events(PyObject *obj)
 {
+    Py_ssize_t len;
     SDL_Event event;
-    int loop, type, len, ret;
+    int loop, type, ret;
     PyObject *seq, *list;
 
     list = PyList_New(0);
@@ -2082,7 +2085,8 @@ static PyObject *
 pg_event_peek(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     SDL_Event event;
-    int len, type, loop, res;
+    Py_ssize_t len;
+    int type, loop, res;
     PyObject *seq, *obj = NULL;
     int dopump = 1;
 
@@ -2173,7 +2177,8 @@ pg_event_post(PyObject *self, PyObject *obj)
 static PyObject *
 pg_event_set_allowed(PyObject *self, PyObject *obj)
 {
-    int len, loop, type;
+    Py_ssize_t len;
+    int loop, type;
     PyObject *seq;
     VIDEO_INIT_CHECK();
 
@@ -2204,7 +2209,8 @@ pg_event_set_allowed(PyObject *self, PyObject *obj)
 static PyObject *
 pg_event_set_blocked(PyObject *self, PyObject *obj)
 {
-    int len, loop, type;
+    Py_ssize_t len;
+    int loop, type;
     PyObject *seq;
     VIDEO_INIT_CHECK();
 
@@ -2240,7 +2246,8 @@ pg_event_set_blocked(PyObject *self, PyObject *obj)
 static PyObject *
 pg_event_get_blocked(PyObject *self, PyObject *obj)
 {
-    int loop, type, len, isblocked = 0;
+    Py_ssize_t len;
+    int loop, type, isblocked = 0;
     PyObject *seq;
 
     VIDEO_INIT_CHECK();

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1756,7 +1756,7 @@ pg_event_wait(PyObject *self, PyObject *args, PyObject *kwargs)
 static int
 _pg_eventtype_from_seq(PyObject *seq, int ind)
 {
-    int val;
+    int val = 0;
     if (!pg_IntFromObjIndex(seq, ind, &val)) {
         PyErr_SetString(PyExc_TypeError,
                         "type sequence must contain valid event types");
@@ -1870,8 +1870,10 @@ _pg_get_all_events_except(PyObject *obj)
         return PyErr_NoMemory();
 
     list = PyList_New(0);
-    if (!list)
+    if (!list) {
+        free(filtered_events);
         return PyErr_NoMemory();
+    }
 
     seq = _pg_eventtype_as_seq(obj, &len);
     if (!seq)

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -793,22 +793,24 @@ font_init(PyFontObject *self, PyObject *args, PyObject *kwds)
         /*check if it is a valid file, else SDL_ttf segfaults*/
         test = pg_open_obj(obj, "rb");
         if (test == NULL) {
-            if (strcmp(filename, font_defaultname) == 0) {
-                PyObject *tmp;
-                PyErr_Clear();
-                tmp = font_resource(font_defaultname);
-                if (tmp == NULL) {
-                    if (!PyErr_Occurred()) {
-                        PyErr_Format(PyExc_IOError,
-                                     "unable to read font file '%.1024s'",
-                                     filename);
+            if (filename) {
+                if (strcmp(filename, font_defaultname) == 0) {
+                    PyObject *tmp;
+                    PyErr_Clear();
+                    tmp = font_resource(font_defaultname);
+                    if (tmp == NULL) {
+                        if (!PyErr_Occurred()) {
+                            PyErr_Format(PyExc_IOError,
+                                         "unable to read font file '%.1024s'",
+                                         filename);
+                        }
+                        goto error;
                     }
-                    goto error;
+                    Py_DECREF(obj);
+                    obj = tmp;
+                    filename = PyBytes_AS_STRING(obj);
+                    test = pg_open_obj(obj, "rb");
                 }
-                Py_DECREF(obj);
-                obj = tmp;
-                filename = PyBytes_AS_STRING(obj);
-                test = pg_open_obj(obj, "rb");
             }
             if (test == NULL) {
                 if (!PyErr_Occurred()) {

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -75,6 +75,7 @@ static const char resourcefunc_name[] = "getResource";
 
 /*
  */
+#if !SDL_TTF_VERSION_ATLEAST(2, 0, 15)
 static int
 utf_8_needs_UCS_4(const char *str)
 {
@@ -88,6 +89,7 @@ utf_8_needs_UCS_4(const char *str)
     }
     return 0;
 }
+#endif
 
 static PyObject *
 pg_open_obj(PyObject *obj, const char *mode)
@@ -691,7 +693,7 @@ font_dealloc(PyFontObject *self)
         if (self->ttf_init_generation != current_ttf_generation) {
             // Since TTF_Font is a private structure
             // it's impossible to access face field in a common way.
-            int **face_pp = font;
+            long **face_pp = (long **)font;
             *face_pp = NULL;
         }
         TTF_CloseFont(font);

--- a/src_c/freetype/ft_layout.c
+++ b/src_c/freetype/ft_layout.c
@@ -199,7 +199,7 @@ size_text(Layout *ftext, FreeTypeInstance *ft, TextContext *context,
             PyErr_NoMemory();
             return -1;
         }
-        ftext->buffer_size = string_length;
+        ftext->buffer_size = (int)string_length;
     }
 
     /* Retrieve the glyph indices of recognized text characters */

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -417,7 +417,6 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     FT_Pos underline_top = 0;
     FT_Fixed underline_size = 0;
     FontColor mono_fgcolor = {0, 0, 0, 1};
-    FontColor mono_bgcolor = {0, 0, 0, 0};
 
     /* build font text */
     font_text = _PGFT_LoadLayout(ft, fontobj, mode, text);
@@ -519,7 +518,6 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
             SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_BLEND);
         }
         fgcolor = &mono_fgcolor;
-        bgcolor = &mono_bgcolor;
         font_surf.render_gray = __render_glyph_GRAY_as_MONO1;
         font_surf.render_mono = __render_glyph_MONO_as_GRAY1;
         font_surf.fill = __fill_glyph_GRAY1;

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -335,6 +335,12 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
         surf_offset.y += offset.y;
     }
 
+    if (!surface->format->BytesPerPixel) {
+        // This should never happen, error to make static analyzer happy
+        PyErr_SetString(pgExc_SDLError, "Got surface of invalid format");
+        return -1;
+    }
+
     /*
      * Setup target surface struct
      */
@@ -408,8 +414,8 @@ _PGFT_Render_NewSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     unsigned width;
     unsigned height;
     FT_Vector offset;
-    FT_Pos underline_top;
-    FT_Fixed underline_size;
+    FT_Pos underline_top = 0;
+    FT_Fixed underline_size = 0;
     FontColor mono_fgcolor = {0, 0, 0, 1};
     FontColor mono_bgcolor = {0, 0, 0, 0};
 

--- a/src_c/freetype/ft_render_cb.c
+++ b/src_c/freetype/ft_render_cb.c
@@ -50,11 +50,11 @@ __render_glyph_GRAY1(int x, int y, FontSurface *surface,
      * Assumption, target buffer was filled with zeros before any rendering.
      */
 
-    for (j = 0; j < bitmap->rows; ++j) {
+    for (j = 0; j < (unsigned int)bitmap->rows; ++j) {
         src_cpy = src;
         dst_cpy = dst;
 
-        for (i = 0; i < bitmap->width; ++i) {
+        for (i = 0; i < (unsigned int)bitmap->width; ++i) {
             assert(src_cpy < src_end);
             src_byte = *src_cpy;
             if (src_byte) {
@@ -78,8 +78,8 @@ __render_glyph_MONO_as_GRAY1(int x, int y, FontSurface *surface,
     const int off_x = (x < 0) ? -x : 0;
     const int off_y = (y < 0) ? -y : 0;
 
-    const int max_x = MIN(x + bitmap->width, surface->width);
-    const int max_y = MIN(y + bitmap->rows, surface->height);
+    const int max_x = MIN(x + (int)bitmap->width, (int)surface->width);
+    const int max_y = MIN(y + (int)bitmap->rows, (int)surface->height);
 
     const int rx = MAX(0, x);
     const int ry = MAX(0, y);
@@ -138,11 +138,11 @@ __render_glyph_GRAY_as_MONO1(int x, int y, FontSurface *surface,
      * any rendering.
      */
 
-    for (j = 0; j < bitmap->rows; ++j) {
+    for (j = 0; j < (unsigned int)bitmap->rows; ++j) {
         src_cpy = src;
         dst_cpy = dst;
 
-        for (i = 0; i < bitmap->width; ++i) {
+        for (i = 0; i < (unsigned int)bitmap->width; ++i) {
             if (*src_cpy & '\200') /* Round up on 128 */ {
                 *dst_cpy = shade;
             }
@@ -237,11 +237,11 @@ __render_glyph_INT(int x, int y, FontSurface *surface, const FT_Bitmap *bitmap,
      */
 
     if (item_size == 1) {
-        for (j = 0; j < bitmap->rows; ++j) {
+        for (j = 0; j < (unsigned int)bitmap->rows; ++j) {
             src_cpy = src;
             dst_cpy = dst;
 
-            for (i = 0; i < bitmap->width; ++i) {
+            for (i = 0; i < (unsigned int)bitmap->width; ++i) {
                 src_byte = *src_cpy;
                 if (src_byte) {
                     *dst_cpy =
@@ -260,11 +260,11 @@ __render_glyph_INT(int x, int y, FontSurface *surface, const FT_Bitmap *bitmap,
         FT_Byte dst_byte;
         int b, int_offset = surface->format->Ashift / 8;
 
-        for (j = 0; j < bitmap->rows; ++j) {
+        for (j = 0; j < (unsigned int)bitmap->rows; ++j) {
             src_cpy = src;
             dst_cpy = dst;
 
-            for (i = 0; i < bitmap->width; ++i) {
+            for (i = 0; i < (unsigned int)bitmap->width; ++i) {
                 dst_byte = dst_cpy[int_offset];
                 for (b = 0; b < item_size; ++b) {
                     dst_cpy[b] = 0;
@@ -293,8 +293,8 @@ __render_glyph_MONO_as_INT(int x, int y, FontSurface *surface,
     const int off_x = (x < 0) ? -x : 0;
     const int off_y = (y < 0) ? -y : 0;
 
-    const int max_x = MIN(x + bitmap->width, surface->width);
-    const int max_y = MIN(y + bitmap->rows, surface->height);
+    const int max_x = MIN(x + (int)bitmap->width, (int)surface->width);
+    const int max_y = MIN(y + (int)bitmap->rows, (int)surface->height);
 
     const int rx = MAX(0, x);
     const int ry = MAX(0, y);
@@ -650,8 +650,8 @@ __fill_glyph_INT(FT_Fixed x, FT_Fixed y, FT_Fixed w, FT_Fixed h,
         const int off_x = (x < 0) ? -x : 0;                                   \
         const int off_y = (y < 0) ? -y : 0;                                   \
                                                                               \
-        const int max_x = MIN(x + bitmap->width, surface->width);             \
-        const int max_y = MIN(y + bitmap->rows, surface->height);             \
+        const int max_x = MIN(x + (int)bitmap->width, (int)surface->width);   \
+        const int max_y = MIN(y + (int)bitmap->rows, (int)surface->height);   \
                                                                               \
         const int rx = MAX(0, x);                                             \
         const int ry = MAX(0, y);                                             \
@@ -702,8 +702,8 @@ __fill_glyph_INT(FT_Fixed x, FT_Fixed y, FT_Fixed w, FT_Fixed h,
         const int off_x = (x < 0) ? -x : 0;                                 \
         const int off_y = (y < 0) ? -y : 0;                                 \
                                                                             \
-        const int max_x = MIN(x + bitmap->width, surface->width);           \
-        const int max_y = MIN(y + bitmap->rows, surface->height);           \
+        const int max_x = MIN(x + (int)bitmap->width, (int)surface->width); \
+        const int max_y = MIN(y + (int)bitmap->rows, (int)surface->height); \
                                                                             \
         const int rx = MAX(0, x);                                           \
         const int ry = MAX(0, y);                                           \

--- a/src_c/freetype/ft_wrap.c
+++ b/src_c/freetype/ft_wrap.c
@@ -69,8 +69,8 @@ _PGFT_SetError(FreeTypeInstance *ft, const char *error_msg, FT_Error error_id)
     }
 
     if (error_id && ft_msg && maxlen > error_msg_len - 42)
-        sprintf(ft->_error_msg, "%.*s: %.*s", maxlen - 2, error_msg,
-                maxlen - error_msg_len - 2, ft_msg);
+        sprintf(ft->_error_msg, "%.*s: %.*s", maxlen - 3, error_msg,
+                maxlen - error_msg_len - 3, ft_msg);
     else {
         strncpy(ft->_error_msg, error_msg, maxlen);
         ft->_error_msg[maxlen] = '\0'; /* in case of message truncation */
@@ -460,7 +460,7 @@ RWops_read(FT_Stream stream, unsigned long offset, unsigned char *buffer,
     if (count == 0)
         return 0;
 
-    return SDL_RWread(src, buffer, 1, (int)count);
+    return (unsigned long)SDL_RWread(src, buffer, 1, (int)count);
 }
 
 int
@@ -468,7 +468,7 @@ _PGFT_TryLoadFont_RWops(FreeTypeInstance *ft, pgFontObject *fontobj,
                         SDL_RWops *src, long font_index)
 {
     FT_Stream stream;
-    int position;
+    Sint64 position;
 
     position = SDL_RWtell(src);
     if (position < 0) {

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -69,7 +69,6 @@ static PyObject *
 image_load_basic(PyObject *self, PyObject *obj)
 {
     PyObject *final;
-    PyObject *oencoded;
     SDL_Surface *surf;
 
     SDL_RWops *rw = pgRWops_FromObject(obj);

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -484,7 +484,7 @@ image_tostring(PyObject *self, PyObject *arg)
 {
     pgSurfaceObject *surfobj;
     PyObject *string = NULL;
-    char *format, *data, *pixels;
+    char *format, *data;
     SDL_Surface *surf;
     int w, h, flipped = 0;
     Py_ssize_t len;
@@ -531,10 +531,9 @@ image_tostring(PyObject *self, PyObject *arg)
         PyBytes_AsStringAndSize(string, &data, &len);
 
         pgSurface_Lock(surfobj);
-        pixels = (char *)surf->pixels;
         for (h = 0; h < surf->h; ++h)
             memcpy(DATAROW(data, h, surf->w, surf->h, flipped),
-                   pixels + (h * surf->pitch), surf->w);
+                   (char *)surf->pixels + (h * surf->pitch), surf->w);
         pgSurface_Unlock(surfobj);
     }
     else if (!strcmp(format, "RGB")) {
@@ -546,7 +545,6 @@ image_tostring(PyObject *self, PyObject *arg)
 
         pgSurface_Lock(surfobj);
 
-        pixels = (char *)surf->pixels;
         switch (surf->format->BytesPerPixel) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
@@ -620,7 +618,6 @@ image_tostring(PyObject *self, PyObject *arg)
         PyBytes_AsStringAndSize(string, &data, &len);
 
         pgSurface_Lock(surfobj);
-        pixels = (char *)surf->pixels;
         switch (surf->format->BytesPerPixel) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
@@ -697,7 +694,6 @@ image_tostring(PyObject *self, PyObject *arg)
         PyBytes_AsStringAndSize(string, &data, &len);
 
         pgSurface_Lock(surfobj);
-        pixels = (char *)surf->pixels;
         switch (surf->format->BytesPerPixel) {
             case 1:
                 for (h = 0; h < surf->h; ++h) {
@@ -763,8 +759,6 @@ image_tostring(PyObject *self, PyObject *arg)
                          "Can only create pre-multiplied alpha strings if the "
                          "surface has per-pixel alpha");
 
-        hascolorkey = 0;
-
         string =
             PyBytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 4);
         if (!string)
@@ -772,7 +766,6 @@ image_tostring(PyObject *self, PyObject *arg)
         PyBytes_AsStringAndSize(string, &data, &len);
 
         pgSurface_Lock(surfobj);
-        pixels = (char *)surf->pixels;
         switch (surf->format->BytesPerPixel) {
             case 2:
                 for (h = 0; h < surf->h; ++h) {
@@ -856,8 +849,6 @@ image_tostring(PyObject *self, PyObject *arg)
                          "Can only create pre-multiplied alpha strings if the "
                          "surface has per-pixel alpha");
 
-        hascolorkey = 0;
-
         string =
             PyBytes_FromStringAndSize(NULL, (Py_ssize_t)surf->w * surf->h * 4);
         if (!string)
@@ -865,7 +856,6 @@ image_tostring(PyObject *self, PyObject *arg)
         PyBytes_AsStringAndSize(string, &data, &len);
 
         pgSurface_Lock(surfobj);
-        pixels = (char *)surf->pixels;
         switch (surf->format->BytesPerPixel) {
             case 2:
                 for (h = 0; h < surf->h; ++h) {

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -300,6 +300,12 @@ SavePNG(SDL_Surface *surface, const char *file, SDL_RWops *rw)
     ss_rect.h = ss_h;
     SDL_BlitSurface(surface, &ss_rect, ss_surface, NULL);
 
+#ifdef _MSC_VER
+    /* Make MSVC static analyzer happy by assuring ss_size >= 2 to supress
+     * a false analyzer report */
+    __analysis_assume(ss_size >= 2);
+#endif
+
     if (ss_size == 0) {
         ss_size = ss_h;
         ss_rows = (unsigned char **)malloc(sizeof(unsigned char *) * ss_size);
@@ -550,6 +556,12 @@ SaveJPEG(SDL_Surface *surface, const char *file)
 
         free_ss_surface = 1;
     }
+
+#ifdef _MSC_VER
+    /* Make MSVC static analyzer happy by assuring ss_size >= 2 to supress
+     * a false analyzer report */
+    __analysis_assume(ss_size >= 2);
+#endif
 
     ss_size = ss_h;
     ss_rows = (unsigned char **)malloc(sizeof(unsigned char *) * ss_size);

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -195,28 +195,29 @@ write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows, int w, int h,
     doing = "create png info struct";
     if (!(info_ptr = png_create_info_struct(png_ptr)))
         goto fail;
+
     if (setjmp(png_jmpbuf(png_ptr)))
         goto fail;
 
-    doing = "init IO";
+    /* doing = "init IO"; */
     png_set_write_fn(png_ptr, rwops, png_write_fn, png_flush_fn);
 
-    doing = "write header";
+    /* doing = "write header"; */
     png_set_IHDR(png_ptr, info_ptr, w, h, bitdepth, colortype,
                  PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE,
                  PNG_FILTER_TYPE_BASE);
 
-    doing = "write info";
+    /* doing = "write info"; */
     png_write_info(png_ptr, info_ptr);
 
-    doing = "write image";
+    /* doing = "write image"; */
     png_write_image(png_ptr, rows);
 
-    doing = "write end";
+    /* doing = "write end"; */
     png_write_end(png_ptr, NULL);
 
     if (rw == NULL) {
-        doing = "closing file";
+        doing = "close file";
         if (0 != SDL_RWclose(rwops))
             goto fail;
     }

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -266,10 +266,8 @@ joy_rumble(pgJoystickObject *self, PyObject *args, PyObject *kwargs)
 #if SDL_VERSION_ATLEAST(2, 0, 9)
 
     SDL_Joystick *joy = self->joy;
-    float low;
-    float high;
-    uint32_t duration;
-    int res;
+    double lowf, highf;
+    uint32_t low, high, duration;
 
     char *keywords[] = {
         "low_frequency",
@@ -278,8 +276,8 @@ joy_rumble(pgJoystickObject *self, PyObject *args, PyObject *kwargs)
         NULL,
     };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ffI", keywords, &low,
-                                     &high, &duration)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ddI", keywords, &lowf,
+                                     &highf, &duration)) {
         return NULL;
     }
 
@@ -288,24 +286,23 @@ joy_rumble(pgJoystickObject *self, PyObject *args, PyObject *kwargs)
         return RAISE(pgExc_SDLError, "Joystick not initialized");
     }
 
-    if (low < 0) {
-        low = 0.f;
+    if (lowf < 0) {
+        lowf = 0.0;
     }
-    else if (low > 1.f) {
-        low = 1.f;
+    else if (lowf > 1.0) {
+        lowf = 1.0;
     }
 
-    if (high < 0) {
-        high = 0.f;
+    if (highf < 0) {
+        highf = 0.f;
     }
-    else if (high > 1.f) {
-        high = 1.f;
+    else if (highf > 1.0) {
+        highf = 1.0;
     }
-    low *= 0xFFFF;
-    high *= 0xFFFF;
+    low = (Uint32)(lowf * 0xFFFF);
+    high = (Uint32)(highf * 0xFFFF);
 
-    res = SDL_JoystickRumble(joy, low, high, duration);
-    if (res == -1) {
+    if (SDL_JoystickRumble(joy, low, high, duration) == -1) {
         Py_RETURN_FALSE;
     }
     Py_RETURN_TRUE;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -266,8 +266,8 @@ mask_overlap_mask(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int x, y;
     bitmask_t *bitmask = pgMask_AsBitmap(self);
-    PyObject *maskobj = NULL;
-    pgMaskObject *output_maskobj = NULL;
+    PyObject *maskobj;
+    pgMaskObject *output_maskobj;
     PyObject *offset = NULL;
     static char *keywords[] = {"other", "offset", NULL};
 
@@ -651,7 +651,7 @@ mask_outline(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 mask_convolve(PyObject *aobj, PyObject *args, PyObject *kwargs)
 {
-    PyObject *bobj = NULL;
+    PyObject *bobj;
     PyObject *oobj = Py_None;
     bitmask_t *a = NULL, *b = NULL;
     int xoffset = 0, yoffset = 0;
@@ -830,7 +830,7 @@ static PyObject *
 mask_from_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     SDL_Surface *surf = NULL;
-    pgSurfaceObject *surfobj = NULL;
+    pgSurfaceObject *surfobj;
     pgMaskObject *maskobj = NULL;
     Uint32 colorkey;
     int threshold = 127; /* default value */
@@ -1054,7 +1054,7 @@ bitmask_threshold(bitmask_t *m, SDL_Surface *surf, SDL_Surface *surf2,
 static PyObject *
 mask_from_threshold(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
+    pgSurfaceObject *surfobj;
     pgSurfaceObject *surfobj2 = NULL;
     pgMaskObject *maskobj = NULL;
     SDL_Surface *surf = NULL, *surf2 = NULL;

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -493,7 +493,7 @@ mask_outline(PyObject *self, PyObject *args, PyObject *kwargs)
     int b[] = {0, 1, 1, 1, 0, -1, -1, -1, 0, 1, 1, 1, 0, -1};
     static char *keywords[] = {"every", NULL};
 
-    n = firstx = firsty = secx = x = 0;
+    firstx = firsty = secx = x = 0;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|i", keywords, &every)) {
         return NULL;
@@ -1371,20 +1371,22 @@ get_bounding_rects(bitmask_t *input, int *num_bounding_boxes,
         return 0;
     }
     /* a temporary image to assign labels to each bit of the mask */
-    image = (unsigned int *)malloc(sizeof(int) * w * h);
+    image = (unsigned int *)malloc(sizeof(unsigned int) * w * h);
     if (!image) {
         return -2;
     }
 
     /* allocate enough space for the maximum possible connected components */
     /* the union-find array. see wikipedia for info on union find */
-    ufind = (unsigned int *)malloc(sizeof(int) * (w / 2 + 1) * (h / 2 + 1));
+    ufind = (unsigned int *)malloc(sizeof(unsigned int) * (w / 2 + 1) *
+                                   (h / 2 + 1));
     if (!ufind) {
         free(image);
         return -2;
     }
 
-    largest = (unsigned int *)malloc(sizeof(int) * (w / 2 + 1) * (h / 2 + 1));
+    largest = (unsigned int *)malloc(sizeof(unsigned int) * (w / 2 + 1) *
+                                     (h / 2 + 1));
     if (!largest) {
         free(image);
         free(ufind);
@@ -1565,20 +1567,22 @@ get_connected_components(bitmask_t *mask, bitmask_t ***components, int min)
     }
 
     /* a temporary image to assign labels to each bit of the mask */
-    image = (unsigned int *)malloc(sizeof(int) * w * h);
+    image = (unsigned int *)malloc(sizeof(unsigned int) * w * h);
     if (!image) {
         return -2;
     }
 
     /* allocate enough space for the maximum possible connected components */
     /* the union-find array. see wikipedia for info on union find */
-    ufind = (unsigned int *)malloc(sizeof(int) * (w / 2 + 1) * (h / 2 + 1));
+    ufind = (unsigned int *)malloc(sizeof(unsigned int) * (w / 2 + 1) *
+                                   (h / 2 + 1));
     if (!ufind) {
         free(image);
         return -2;
     }
 
-    largest = (unsigned int *)malloc(sizeof(int) * (w / 2 + 1) * (h / 2 + 1));
+    largest = (unsigned int *)malloc(sizeof(unsigned int) * (w / 2 + 1) *
+                                     (h / 2 + 1));
     if (!largest) {
         free(image);
         free(ufind);
@@ -1758,19 +1762,21 @@ largest_connected_comp(bitmask_t *input, bitmask_t *output, int ccx, int ccy)
     }
 
     /* a temporary image to assign labels to each bit of the mask */
-    image = (unsigned int *)malloc(sizeof(int) * w * h);
+    image = (unsigned int *)malloc(sizeof(unsigned int) * w * h);
     if (!image) {
         return -2;
     }
     /* allocate enough space for the maximum possible connected components */
     /* the union-find array. see wikipedia for info on union find */
-    ufind = (unsigned int *)malloc(sizeof(int) * (w / 2 + 1) * (h / 2 + 1));
+    ufind = (unsigned int *)malloc(sizeof(unsigned int) * (w / 2 + 1) *
+                                   (h / 2 + 1));
     if (!ufind) {
         free(image);
         return -2;
     }
     /* an array to track the number of pixels associated with each label */
-    largest = (unsigned int *)malloc(sizeof(int) * (w / 2 + 1) * (h / 2 + 1));
+    largest = (unsigned int *)malloc(sizeof(unsigned int) * (w / 2 + 1) *
+                                     (h / 2 + 1));
     if (!largest) {
         free(image);
         free(ufind);

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2233,7 +2233,7 @@ mask_to_surface(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     if (NULL != destobj) {
-        int tempx, tempy;
+        int tempx = 0, tempy = 0;
 
         /* Destination coordinates can be extracted from:
          * - lists/tuples with 2 items

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -54,7 +54,8 @@
 
 #define VECTOR_EPSILON (1e-6)
 #define VECTOR_MAX_SIZE (4)
-#define STRING_BUF_SIZE (100)
+#define STRING_BUF_SIZE_REPR (112)
+#define STRING_BUF_SIZE_STR (103)
 #define SWIZZLE_ERR_NO_ERR 0
 #define SWIZZLE_ERR_DOUBLE_IDX 1
 #define SWIZZLE_ERR_EXTRACTION_ERR 2
@@ -230,7 +231,7 @@ vector_setAttr_swizzle(pgVector *self, PyObject *attr_name, PyObject *val);
 static PyObject *
 vector_elementwise(pgVector *self, PyObject *args);
 static int
-_vector_check_snprintf_success(int return_code);
+_vector_check_snprintf_success(int return_code, int max_size);
 static PyObject *
 vector_repr(pgVector *self);
 static PyObject *
@@ -589,7 +590,7 @@ vector_generic_math(PyObject *o1, PyObject *o2, int op)
 {
     Py_ssize_t i, dim;
     double *vec_coords;
-    double other_coords[VECTOR_MAX_SIZE];
+    double other_coords[VECTOR_MAX_SIZE] = {0};
     double tmp;
     PyObject *other;
     pgVector *vec, *ret = NULL;
@@ -1488,7 +1489,7 @@ vector_distance_squared_to(pgVector *self, PyObject *other)
 }
 
 static int
-_vector_check_snprintf_success(int return_code)
+_vector_check_snprintf_success(int return_code, int max_size)
 {
     if (return_code < 0) {
         PyErr_SetString(PyExc_SystemError,
@@ -1496,7 +1497,7 @@ _vector_check_snprintf_success(int return_code)
                         "this to github.com/pygame/pygame/issues");
         return 0;
     }
-    if (return_code >= STRING_BUF_SIZE) {
+    if (return_code >= max_size) {
         PyErr_SetString(PyExc_SystemError,
                         "Internal buffer to small for snprintf! Please report "
                         "this to github.com/pygame/pygame/issues");
@@ -1508,53 +1509,62 @@ _vector_check_snprintf_success(int return_code)
 static PyObject *
 vector_repr(pgVector *self)
 {
-    Py_ssize_t i;
+    /* The repr() of the largest possible Vector3 looks like
+     * "<Vector3({d}, {d}, {d})>" where 'd' has a maximum size of 32 bytes
+     *  so allocate a 16 + 3 * 32 == 112 byte buffer
+     */
+    char buffer[STRING_BUF_SIZE_REPR];
     int tmp;
-    int bufferIdx;
-    char buffer[2][STRING_BUF_SIZE];
 
-    bufferIdx = 1;
-    tmp = PyOS_snprintf(buffer[0], STRING_BUF_SIZE, "<Vector%ld(", self->dim);
-    if (!_vector_check_snprintf_success(tmp))
-        return NULL;
-    for (i = 0; i < self->dim - 1; ++i) {
-        tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g, ",
-                            buffer[(bufferIdx + 1) % 2], self->coords[i]);
-        bufferIdx++;
-        if (!_vector_check_snprintf_success(tmp))
-            return NULL;
+    if (self->dim == 2) {
+        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_REPR, "<Vector2(%g, %g)>",
+                            self->coords[0], self->coords[1]);
     }
-    tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g)>",
-                        buffer[(bufferIdx + 1) % 2], self->coords[i]);
-    if (!_vector_check_snprintf_success(tmp))
+    else if (self->dim == 3) {
+        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_REPR,
+                            "<Vector3(%g, %g, %g)>", self->coords[0],
+                            self->coords[1], self->coords[2]);
+    }
+    else {
+        return RAISE(
+            PyExc_NotImplementedError,
+            "repr() for Vectors of higher dimensions are not implemented yet");
+    }
+
+    if (!_vector_check_snprintf_success(tmp, STRING_BUF_SIZE_REPR))
         return NULL;
-    return PyUnicode_FromString(buffer[bufferIdx % 2]);
+
+    return PyUnicode_FromString(buffer);
 }
 
 static PyObject *
 vector_str(pgVector *self)
 {
-    Py_ssize_t i;
+    /* The str() of the largest possible Vector3 looks like
+     * "[{d}, {d}, {d}]" where 'd' has a maximum size of 32 bytes
+     *  so allocate a 7 + 3 * 32 == 103 byte buffer
+     */
+    char buffer[STRING_BUF_SIZE_STR];
     int tmp;
-    int bufferIdx;
-    char buffer[2][STRING_BUF_SIZE];
 
-    bufferIdx = 1;
-    tmp = PyOS_snprintf(buffer[0], STRING_BUF_SIZE, "[");
-    if (!_vector_check_snprintf_success(tmp))
-        return NULL;
-    for (i = 0; i < self->dim - 1; ++i) {
-        tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g, ",
-                            buffer[(bufferIdx + 1) % 2], self->coords[i]);
-        bufferIdx++;
-        if (!_vector_check_snprintf_success(tmp))
-            return NULL;
+    if (self->dim == 2) {
+        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_STR, "[%g, %g]",
+                            self->coords[0], self->coords[1]);
     }
-    tmp = PyOS_snprintf(buffer[bufferIdx % 2], STRING_BUF_SIZE, "%s%g]",
-                        buffer[(bufferIdx + 1) % 2], self->coords[i]);
-    if (!_vector_check_snprintf_success(tmp))
+    else if (self->dim == 3) {
+        tmp = PyOS_snprintf(buffer, STRING_BUF_SIZE_STR, "[%g, %g, %g]",
+                            self->coords[0], self->coords[1], self->coords[2]);
+    }
+    else {
+        return RAISE(
+            PyExc_NotImplementedError,
+            "repr() for Vectors of higher dimensions are not implemented yet");
+    }
+
+    if (!_vector_check_snprintf_success(tmp, STRING_BUF_SIZE_STR))
         return NULL;
-    return PyUnicode_FromString(buffer[bufferIdx % 2]);
+
+    return PyUnicode_FromString(buffer);
 }
 
 static PyObject *
@@ -1987,8 +1997,8 @@ _vector2_rotate_helper(double *dst_coords, const double *src_coords,
                 /* this should NEVER happen and means a bug in the code */
                 PyErr_SetString(
                     PyExc_RuntimeError,
-                    "Please report this bug in vector2_rotate_helper to the "
-                    "developers at github.com/pygame/pygame/issues");
+                    "Please report this bug in vector2_rotate_helper to "
+                    "the developers at github.com/pygame/pygame/issues");
                 return 0;
         }
     }
@@ -2503,8 +2513,8 @@ _vector3_rotate_helper(double *dst_coords, const double *src_coords,
                 /* this should NEVER happen and means a bug in the code */
                 PyErr_SetString(
                     PyExc_RuntimeError,
-                    "Please report this bug in vector3_rotate_helper to the "
-                    "developers at github.com/pygame/pygame/issues");
+                    "Please report this bug in vector3_rotate_helper to "
+                    "the developers at github.com/pygame/pygame/issues");
                 return 0;
         }
     }
@@ -2712,8 +2722,8 @@ vector3_rotate_x_ip_rad(pgVector *self, PyObject *angleObject)
     if (PyErr_WarnEx(
             PyExc_DeprecationWarning,
             "vector3_rotate_x_rad_ip() now has all the functionality of "
-            "vector3_rotate_x_ip_rad(), so vector3_rotate_x_ip_rad() will be "
-            "deprecated in pygame 2.1.1",
+            "vector3_rotate_x_ip_rad(), so vector3_rotate_x_ip_rad() will "
+            "be deprecated in pygame 2.1.1",
             1) == -1) {
         return NULL;
     }
@@ -2817,8 +2827,8 @@ vector3_rotate_y_ip_rad(pgVector *self, PyObject *angleObject)
     if (PyErr_WarnEx(
             PyExc_DeprecationWarning,
             "vector3_rotate_y_rad_ip() now has all the functionality of "
-            "vector3_rotate_y_ip_rad(), so vector3_rotate_y_ip_rad() will be "
-            "deprecated in pygame 2.1.1",
+            "vector3_rotate_y_ip_rad(), so vector3_rotate_y_ip_rad() will "
+            "be deprecated in pygame 2.1.1",
             1) == -1) {
         return NULL;
     }
@@ -2923,8 +2933,8 @@ vector3_rotate_z_ip_rad(pgVector *self, PyObject *angleObject)
     if (PyErr_WarnEx(
             PyExc_DeprecationWarning,
             "vector3_rotate_z_rad_ip() now has all the functionality of "
-            "vector3_rotate_z_ip_rad(), so vector3_rotate_z_ip_rad() will be "
-            "deprecated in pygame 2.1.1",
+            "vector3_rotate_z_ip_rad(), so vector3_rotate_z_ip_rad() will "
+            "be deprecated in pygame 2.1.1",
             1) == -1) {
         return NULL;
     }
@@ -2997,6 +3007,10 @@ vector3_cross(pgVector *self, PyObject *other)
     }
     else {
         other_coords = PyMem_New(double, self->dim);
+        if (!other_coords) {
+            return PyErr_NoMemory();
+        }
+
         if (!PySequence_AsVectorCoords(other, other_coords, 3)) {
             PyMem_Del(other_coords);
             return NULL;
@@ -3539,7 +3553,7 @@ vector_elementwiseproxy_generic_math(PyObject *o1, PyObject *o2, int op)
 {
     Py_ssize_t i, dim;
     double mod, other_value = 0.0;
-    double other_coords[VECTOR_MAX_SIZE];
+    double other_coords[VECTOR_MAX_SIZE] = {0};
     PyObject *other;
     pgVector *vec, *ret;
     if (vector_elementwiseproxy_Check(o1)) {
@@ -3670,8 +3684,8 @@ vector_elementwiseproxy_generic_math(PyObject *o1, PyObject *o2, int op)
                     return NULL;
                 }
                 mod = fmod(vec->coords[i], other_coords[i]);
-                /* note: checking mod*value < 0 is incorrect -- underflows to
-                   0 if value < sqrt(smallest nonzero double) */
+                /* note: checking mod*value < 0 is incorrect -- underflows
+                   to 0 if value < sqrt(smallest nonzero double) */
                 if (mod && ((other_coords[i] < 0) != (mod < 0))) {
                     mod += other_coords[i];
                 }
@@ -3929,10 +3943,9 @@ static PyNumberMethods vector_elementwiseproxy_as_number = {
 
     /* Added in release 2.2 */
     (binaryfunc)
-        vector_elementwiseproxy_floor_div, /* nb_floor_divide; __floor__ */
-    (binaryfunc)
-        vector_elementwiseproxy_div, /* nb_true_divide;          __truediv__ */
-    (binaryfunc)0,                   /* nb_inplace_floor_divide; __ifloor__ */
+        vector_elementwiseproxy_floor_div,   /* nb_floor_divide; __floor__ */
+    (binaryfunc)vector_elementwiseproxy_div, /* nb_true_divide; __truediv__ */
+    (binaryfunc)0, /* nb_inplace_floor_divide; __ifloor__ */
     (binaryfunc)0, /* nb_inplace_true_divide;  __itruediv__ */
 };
 
@@ -4096,11 +4109,17 @@ MODINIT_DEFINE(math)
     /*
     Py_INCREF(&pgVector4_Type);
     */
-    if ((PyModule_AddObject(module, "Vector2", (PyObject *)&pgVector2_Type) != 0) ||
-        (PyModule_AddObject(module, "Vector3", (PyObject *)&pgVector3_Type) != 0) ||
-        (PyModule_AddObject(module, "VectorElementwiseProxy", (PyObject *)&pgVectorElementwiseProxy_Type) != 0) ||
-        (PyModule_AddObject(module, "VectorIterator", (PyObject *)&pgVectorIter_Type) != 0) /*||
-        (PyModule_AddObject(module, "Vector4", (PyObject *)&pgVector4_Type) != 0)*/) {
+    if ((PyModule_AddObject(module, "Vector2", (PyObject *)&pgVector2_Type) !=
+         0) ||
+        (PyModule_AddObject(module, "Vector3", (PyObject *)&pgVector3_Type) !=
+         0) ||
+        (PyModule_AddObject(module, "VectorElementwiseProxy",
+                            (PyObject *)&pgVectorElementwiseProxy_Type) !=
+         0) ||
+        (PyModule_AddObject(module, "VectorIterator",
+                            (PyObject *)&pgVectorIter_Type) != 0) /*||
+(PyModule_AddObject(module, "Vector4", (PyObject *)&pgVector4_Type) !=
+0)*/) {
         if (!PyObject_HasAttrString(module, "Vector2"))
             Py_DECREF(&pgVector2_Type);
         if (!PyObject_HasAttrString(module, "Vector3"))

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -300,7 +300,7 @@ endsound_callback(int channel)
             PyGILState_Release(gstate);
             channelnum = Mix_PlayChannelTimed(channel, sound, 0, -1);
             if (channelnum != -1)
-                Mix_GroupChannel(channelnum, (intptr_t)sound);
+                Mix_GroupChannel(channelnum, (int)(intptr_t)sound);
         }
         else {
             PyGILState_STATE gstate = PyGILState_Ensure();
@@ -638,7 +638,7 @@ pgSound_Play(PyObject *self, PyObject *args, PyObject *kwargs)
     Mix_Volume(channelnum, 128);
 
     Py_BEGIN_ALLOW_THREADS;
-    Mix_GroupChannel(channelnum, (intptr_t)chunk);
+    Mix_GroupChannel(channelnum, (int)(intptr_t)chunk);
     Py_END_ALLOW_THREADS;
 
     return pgChannel_New(channelnum);
@@ -649,7 +649,7 @@ snd_get_num_channels(PyObject *self, PyObject *args)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     MIXER_INIT_CHECK();
-    return PyLong_FromLong(Mix_GroupCount((intptr_t)chunk));
+    return PyLong_FromLong(Mix_GroupCount((int)(intptr_t)chunk));
 }
 
 static PyObject *
@@ -663,7 +663,7 @@ snd_fadeout(PyObject *self, PyObject *args)
     MIXER_INIT_CHECK();
 
     Py_BEGIN_ALLOW_THREADS;
-    Mix_FadeOutGroup((intptr_t)chunk, _time);
+    Mix_FadeOutGroup((int)(intptr_t)chunk, _time);
     Py_END_ALLOW_THREADS;
     Py_RETURN_NONE;
 }
@@ -674,7 +674,7 @@ snd_stop(PyObject *self, PyObject *args)
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     MIXER_INIT_CHECK();
     Py_BEGIN_ALLOW_THREADS;
-    Mix_HaltGroup((intptr_t)chunk);
+    Mix_HaltGroup((int)(intptr_t)chunk);
     Py_END_ALLOW_THREADS;
     Py_RETURN_NONE;
 }
@@ -1025,7 +1025,7 @@ chan_play(PyObject *self, PyObject *args, PyObject *kwargs)
         channelnum = Mix_PlayChannelTimed(channelnum, chunk, loops, playtime);
     }
     if (channelnum != -1)
-        Mix_GroupChannel(channelnum, (intptr_t)chunk);
+        Mix_GroupChannel(channelnum, (int)(intptr_t)chunk);
     Py_END_ALLOW_THREADS;
 
     Py_XDECREF(channeldata[channelnum].sound);
@@ -1052,7 +1052,7 @@ chan_queue(PyObject *self, PyObject *args)
         Py_BEGIN_ALLOW_THREADS;
         channelnum = Mix_PlayChannelTimed(channelnum, chunk, 0, -1);
         if (channelnum != -1)
-            Mix_GroupChannel(channelnum, (intptr_t)chunk);
+            Mix_GroupChannel(channelnum, (int)(intptr_t)chunk);
         Py_END_ALLOW_THREADS;
 
         channeldata[channelnum].sound = sound;

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -716,8 +716,7 @@ snd_get_length(PyObject *self, PyObject *args)
     Mix_QuerySpec(&freq, &format, &channels);
     if (format == AUDIO_S8 || format == AUDIO_U8)
         mixerbytes = 1;
-    else if (format == AUDIO_F32 || format == AUDIO_F32LSB ||
-             format == AUDIO_F32MSB) {
+    else if (format == AUDIO_F32LSB || format == AUDIO_F32MSB) {
         mixerbytes = 4;
     }
     else

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -248,8 +248,7 @@ _set_bitmap_cursor(int w, int h, int spotx, int spoty, PyObject *xormask,
                    PyObject *andmask)
 {
     Uint8 *xordata = NULL, *anddata = NULL;
-    int xorsize, andsize, loop;
-    int val;
+    int xorsize, andsize, loop, val;
     SDL_Cursor *lastcursor, *cursor = NULL;
 
     if (!PySequence_Check(xormask) || !PySequence_Check(andmask))
@@ -258,8 +257,13 @@ _set_bitmap_cursor(int w, int h, int spotx, int spoty, PyObject *xormask,
     if (w % 8)
         return RAISE(PyExc_ValueError, "Cursor width must be divisible by 8.");
 
-    xorsize = PySequence_Length(xormask);
-    andsize = PySequence_Length(andmask);
+    xorsize = (int)PySequence_Length(xormask);
+    if (xorsize < 0)
+        return NULL;
+
+    andsize = (int)PySequence_Length(andmask);
+    if (andsize < 0)
+        return NULL;
 
     if (xorsize != w * h / 8 || andsize != w * h / 8)
         return RAISE(PyExc_ValueError,

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -269,6 +269,12 @@ _set_bitmap_cursor(int w, int h, int spotx, int spoty, PyObject *xormask,
         return RAISE(PyExc_ValueError,
                      "bitmasks must be sized width*height/8");
 
+#ifdef _MSC_VER
+    /* Suppress false analyzer report */
+    __analysis_assume(xorsize >= 2);
+    __analysis_assume(andsize >= 2);
+#endif
+
     xordata = (Uint8 *)malloc(xorsize);
     anddata = (Uint8 *)malloc(andsize);
 

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -296,7 +296,7 @@ Mix_MusicType
 _get_type_from_hint(char *namehint)
 {
     Mix_MusicType type = MUS_NONE;
-    const char *dot;
+    char *dot;
 
     // Adjusts namehint into a mere file extension component
     if (namehint != NULL) {

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -107,7 +107,8 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
     if (!current_music)
         return RAISE(pgExc_SDLError, "music not loaded");
 
-    Py_BEGIN_ALLOW_THREADS Mix_HookMusicFinished(endmusic_callback);
+    Py_BEGIN_ALLOW_THREADS;
+    Mix_HookMusicFinished(endmusic_callback);
     Mix_SetPostMix(mixmusic_callback, NULL);
     Mix_QuerySpec(&music_frequency, &music_format, &music_channels);
     music_pos = 0;
@@ -116,8 +117,9 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
     volume = Mix_VolumeMusic(-1);
     val = Mix_FadeInMusicPos(current_music, loops, fade_ms, startpos);
     Mix_VolumeMusic(volume);
-    Py_END_ALLOW_THREADS if (val == -1) return RAISE(pgExc_SDLError,
-                                                     SDL_GetError());
+    Py_END_ALLOW_THREADS;
+    if (val == -1)
+        return RAISE(pgExc_SDLError, SDL_GetError());
 
     Py_RETURN_NONE;
 }
@@ -129,11 +131,11 @@ music_get_busy(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS playing =
-        (Mix_PlayingMusic() && !Mix_PausedMusic());
-    Py_END_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
+    playing = (Mix_PlayingMusic() && !Mix_PausedMusic());
+    Py_END_ALLOW_THREADS;
 
-        return PyBool_FromLong(playing);
+    return PyBool_FromLong(playing);
 }
 
 static PyObject *
@@ -145,10 +147,9 @@ music_fadeout(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS
-        /* To prevent the queue_music from playing, free it before fading. */
-        if (queue_music)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    /* To prevent the queue_music from playing, free it before fading. */
+    if (queue_music) {
         Mix_FreeMusic(queue_music);
         queue_music = NULL;
         queue_music_loops = 0;
@@ -156,7 +157,8 @@ music_fadeout(PyObject *self, PyObject *args)
 
     Mix_FadeOutMusic(_time);
 
-    Py_END_ALLOW_THREADS Py_RETURN_NONE;
+    Py_END_ALLOW_THREADS;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -164,10 +166,9 @@ music_stop(PyObject *self, PyObject *args)
 {
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS
-        /* To prevent the queue_music from playing, free it before stopping. */
-        if (queue_music)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    /* To prevent the queue_music from playing, free it before stopping. */
+    if (queue_music) {
         Mix_FreeMusic(queue_music);
         queue_music = NULL;
         queue_music_loops = 0;
@@ -175,7 +176,8 @@ music_stop(PyObject *self, PyObject *args)
 
     Mix_HaltMusic();
 
-    Py_END_ALLOW_THREADS Py_RETURN_NONE;
+    Py_END_ALLOW_THREADS;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -203,10 +205,11 @@ music_rewind(PyObject *self, PyObject *args)
 {
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS Mix_RewindMusic();
-    Py_END_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
+    Mix_RewindMusic();
+    Py_END_ALLOW_THREADS;
 
-        Py_RETURN_NONE;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -219,10 +222,11 @@ music_set_volume(PyObject *self, PyObject *args)
 
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS Mix_VolumeMusic((int)(volume * 128));
-    Py_END_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
+    Mix_VolumeMusic((int)(volume * 128));
+    Py_END_ALLOW_THREADS;
 
-        Py_RETURN_NONE;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -247,11 +251,12 @@ music_set_pos(PyObject *self, PyObject *arg)
 
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS position_set = Mix_SetMusicPosition(pos);
-    Py_END_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
+    position_set = Mix_SetMusicPosition(pos);
+    Py_END_ALLOW_THREADS;
 
-        if (position_set == -1) return RAISE(
-            pgExc_SDLError, "set_pos unsupported for this codec");
+    if (position_set == -1)
+        return RAISE(pgExc_SDLError, "set_pos unsupported for this codec");
 
     Py_RETURN_NONE;
 }
@@ -392,12 +397,11 @@ _load_music(PyObject *obj, char *namehint)
         ext = pgRWops_GetFileExtension(rw);
     }
 
-    Py_BEGIN_ALLOW_THREADS new_music =
-        Mix_LoadMUSType_RW(rw, _get_type_from_hint(ext), SDL_TRUE);
-    Py_END_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
+    new_music = Mix_LoadMUSType_RW(rw, _get_type_from_hint(ext), SDL_TRUE);
+    Py_END_ALLOW_THREADS;
 
-        if (!new_music)
-    {
+    if (!new_music) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return NULL;
     }
@@ -423,8 +427,8 @@ music_load(PyObject *self, PyObject *args, PyObject *keywds)
     if (new_music == NULL)  // meaning it has an error to return
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS if (current_music != NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    if (current_music != NULL) {
         Mix_FreeMusic(current_music);
         current_music = NULL;
     }
@@ -433,9 +437,9 @@ music_load(PyObject *self, PyObject *args, PyObject *keywds)
         queue_music = NULL;
         queue_music_loops = 0;
     }
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
-        current_music = new_music;
+    current_music = new_music;
     Py_RETURN_NONE;
 }
 
@@ -444,8 +448,8 @@ music_unload(PyObject *self, PyObject *noarg)
 {
     MIXER_INIT_CHECK();
 
-    Py_BEGIN_ALLOW_THREADS if (current_music)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    if (current_music) {
         Mix_FreeMusic(current_music);
         current_music = NULL;
     }
@@ -454,9 +458,9 @@ music_unload(PyObject *self, PyObject *noarg)
         queue_music = NULL;
         queue_music_loops = 0;
     }
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
-        Py_RETURN_NONE;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -480,15 +484,14 @@ music_queue(PyObject *self, PyObject *args, PyObject *keywds)
     if (local_queue_music == NULL)  // meaning it has an error to return
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS
-        /* Free any existing queued music. */
-        if (queue_music != NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    /* Free any existing queued music. */
+    if (queue_music != NULL) {
         Mix_FreeMusic(queue_music);
     }
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
-        queue_music = local_queue_music;
+    queue_music = local_queue_music;
 
     Py_RETURN_NONE;
 }

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -439,7 +439,8 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
         } break;
         case 2: {
             Uint16 *px_p;
-            int ppa = (surf->flags & SDL_SRCALPHA && format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
@@ -472,7 +473,8 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
             Uint32 Boffset = 2 - (format->Bshift >> 3);
 #endif
             Uint32 pxcolor;
-            int ppa = (surf->flags & SDL_SRCALPHA && format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
@@ -502,7 +504,8 @@ _replace_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
         default: /* case 4: */
         {
             Uint32 *px_p;
-            int ppa = (surf->flags & SDL_SRCALPHA && surf->format->Amask);
+            int ppa = (SDL_ISPIXELFORMAT_ALPHA(format->format) &&
+                       surf->format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
@@ -641,7 +644,8 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
         } break;
         case 2: {
             Uint16 *px_p;
-            int ppa = (surf->flags & SDL_SRCALPHA && format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
@@ -683,7 +687,8 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
             Uint8 black_g = (Uint8)(black >> 8);
             Uint8 black_b = (Uint8)black;
             Uint32 pxcolor;
-            int ppa = (surf->flags & SDL_SRCALPHA && format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
@@ -723,7 +728,8 @@ _extract_color(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
         default: /* case 4: */
         {
             Uint32 *px_p;
-            int ppa = (surf->flags & SDL_SRCALPHA && surf->format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 pixel_p = pixelrow;
@@ -894,9 +900,10 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
         case 2: {
             Uint16 *pixel_p;
             Uint16 *other_pixel_p;
-            int ppa = (surf->flags & SDL_SRCALPHA && format->Amask);
-            int other_ppa =
-                (other_surf->flags & SDL_SRCALPHA && other_format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
+            int other_ppa = (SDL_ISPIXELFORMAT_ALPHA(other_format->format) &&
+                             other_format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 byte_p = row_p;
@@ -996,9 +1003,10 @@ _compare(pgPixelArrayObject *array, PyObject *args, PyObject *kwds)
         {
             Uint32 *pixel_p;
             Uint32 *other_pixel_p;
-            int ppa = (surf->flags & SDL_SRCALPHA && surf->format->Amask);
-            int other_ppa =
-                (other_surf->flags & SDL_SRCALPHA && other_format->Amask);
+            int ppa =
+                (SDL_ISPIXELFORMAT_ALPHA(format->format) && format->Amask);
+            int other_ppa = (SDL_ISPIXELFORMAT_ALPHA(other_format->format) &&
+                             other_format->Amask);
 
             for (y = 0; y < dim1; ++y) {
                 byte_p = row_p;

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -91,7 +91,7 @@ _get_color_from_object(PyObject *val, SDL_PixelFormat *format, Uint32 *color)
  * array.
  */
 static PyObject *
-_get_single_pixel(pgPixelArrayObject *array, Uint32 x, Uint32 y)
+_get_single_pixel(pgPixelArrayObject *array, Py_ssize_t x, Py_ssize_t y)
 {
     Uint8 *pixel_p;
     SDL_Surface *surf;

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -186,8 +186,8 @@ _view_kind(PyObject *obj, void *view_kind_vptr)
 static int
 _copy_mapped(Py_buffer *view_p, SDL_Surface *surf)
 {
-    int pixelsize = surf->format->BytesPerPixel;
-    int intsize = view_p->itemsize;
+    Uint8 pixelsize = surf->format->BytesPerPixel;
+    Py_ssize_t intsize = view_p->itemsize;
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
     char *src = (char *)surf->pixels;
 #else
@@ -466,7 +466,7 @@ array_to_surface(PyObject *self, PyObject *arg)
     SDL_Surface *surf;
     SDL_PixelFormat *format;
     int loopx, loopy;
-    int stridex, stridey, stridez = 0, stridez2 = 0, sizex, sizey;
+    Py_ssize_t stridex, stridey, stridez = 0, stridez2 = 0, sizex, sizey;
     int Rloss, Gloss, Bloss, Rshift, Gshift, Bshift;
 
     if (!PyArg_ParseTuple(arg, "O!O", &pgSurface_Type, &surfobj, &arrayobj)) {
@@ -849,22 +849,22 @@ map_array(PyObject *self, PyObject *args)
     int ndim;
     Py_intptr_t *shape;
     Py_intptr_t *tar_strides;
-    int tar_itemsize;
+    Py_ssize_t tar_itemsize;
     int tar_byte0 = 0;
     int tar_byte1 = 0;
     int tar_byte2 = 0;
     int tar_byte3 = 0;
-    int tar_padding_start;
-    int tar_padding_end;
+    Py_ssize_t tar_padding_start;
+    Py_ssize_t tar_padding_end;
     Py_intptr_t counters[PIXELCOPY_MAX_DIM];
-    int src_advances[PIXELCOPY_MAX_DIM];
-    int tar_advances[PIXELCOPY_MAX_DIM];
+    Py_ssize_t src_advances[PIXELCOPY_MAX_DIM] = {0};
+    Py_ssize_t tar_advances[PIXELCOPY_MAX_DIM] = {0};
     int dim_diff;
     int dim;
     int topdim;
     _pc_pixel_t pixel = {0};
     int pix_bytesize;
-    int i;
+    Py_ssize_t i;
 
     if (!PyArg_ParseTuple(args, "OOO!", &tar_array, &src_array,
                           &pgSurface_Type, &format_surf)) {
@@ -960,7 +960,7 @@ map_array(PyObject *self, PyObject *args)
                         "target array itemsize is too small for pixel format");
         goto fail;
     }
-    src_green = src_view_p->strides[src_ndim - 1];
+    src_green = (int)src_view_p->strides[src_ndim - 1];
     src_blue = 2 * src_green;
     switch (pix_bytesize) {
         case 1:
@@ -1152,8 +1152,8 @@ make_surface(PyObject *self, PyObject *arg)
         gmask = 0xFF << 8;
         bmask = 0xFF;
     }
-    sizex = view_p->shape[0];
-    sizey = view_p->shape[1];
+    sizex = (int)view_p->shape[0];
+    sizey = (int)view_p->shape[1];
 
     surf = SDL_CreateRGBSurface(0, sizex, sizey, bitsperpixel, rmask, gmask,
                                 bmask, 0);

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -1055,6 +1055,13 @@ map_array(PyObject *self, PyObject *args)
             /* Leave loop, moving left one index
              */
             --dim;
+            if (dim < 0) {
+                /* Should not happen, but handle case for extra safety */
+                PyErr_SetString(
+                    PyExc_RuntimeError,
+                    "internal pygame error in pixelcopy map_array");
+                goto fail;
+            }
             tar += tar_advances[dim];
             src += src_advances[dim];
             --counters[dim];

--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -836,7 +836,8 @@ map_array(PyObject *self, PyObject *args)
     pgSurfaceObject *format_surf;
     SDL_PixelFormat *format;
     pg_buffer src_pg_view;
-    Py_buffer *src_view_p = 0;
+    Py_buffer *src_view_p;
+    Uint8 is_src_alloc = 0;
     Uint8 *src;
     int src_ndim;
     Py_intptr_t src_strides[PIXELCOPY_MAX_DIM];
@@ -844,7 +845,8 @@ map_array(PyObject *self, PyObject *args)
     int src_green;
     int src_blue;
     pg_buffer tar_pg_view;
-    Py_buffer *tar_view_p = 0;
+    Py_buffer *tar_view_p;
+    Uint8 is_tar_alloc = 0;
     Uint8 *tar;
     int ndim;
     Py_intptr_t *shape;
@@ -880,6 +882,7 @@ map_array(PyObject *self, PyObject *args)
     if (pgObject_GetBuffer(tar_array, &tar_pg_view, PyBUF_RECORDS)) {
         goto fail;
     }
+    is_tar_alloc = 1;
     tar_view_p = (Py_buffer *)&tar_pg_view;
     tar = (Uint8 *)tar_view_p->buf;
     if (_validate_view_format(tar_view_p->format)) {
@@ -902,6 +905,7 @@ map_array(PyObject *self, PyObject *args)
     if (pgObject_GetBuffer(src_array, &src_pg_view, PyBUF_RECORDS_RO)) {
         goto fail;
     }
+    is_src_alloc = 1;
     src_view_p = (Py_buffer *)&src_pg_view;
     if (_validate_view_format(src_view_p->format)) {
         goto fail;
@@ -1112,10 +1116,10 @@ map_array(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 
 fail:
-    if (src_view_p) {
+    if (is_src_alloc) {
         pgBuffer_Release(&src_pg_view);
     }
-    if (tar_view_p) {
+    if (is_tar_alloc) {
         pgBuffer_Release(&tar_pg_view);
     }
     pgSurface_Unlock(format_surf);

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -200,7 +200,7 @@ pg_rect_dealloc(pgRectObject *self)
     }
 
 #ifdef PYPY_VERSION
-    if (pg_rect_freelist_num < PG_RECT_FREELIST_MAX) {
+    if (pg_rect_freelist_num < PG_RECT_FREELIST_MAX - 1) {
         pg_rect_freelist_num++;
         pg_rect_freelist[pg_rect_freelist_num] = self;
     }
@@ -368,7 +368,7 @@ pg_rect_normalize(pgRectObject *self, PyObject *args)
 static PyObject *
 pg_rect_move(pgRectObject *self, PyObject *args)
 {
-    int x, y;
+    int x = 0, y = 0;
 
     if (!pg_TwoIntsFromObj(args, &x, &y)) {
         return RAISE(PyExc_TypeError, "argument must contain two numbers");
@@ -381,7 +381,7 @@ pg_rect_move(pgRectObject *self, PyObject *args)
 static PyObject *
 pg_rect_move_ip(pgRectObject *self, PyObject *args)
 {
-    int x, y;
+    int x = 0, y = 0;
 
     if (!pg_TwoIntsFromObj(args, &x, &y)) {
         return RAISE(PyExc_TypeError, "argument must contain two numbers");
@@ -395,7 +395,7 @@ pg_rect_move_ip(pgRectObject *self, PyObject *args)
 static PyObject *
 pg_rect_inflate(pgRectObject *self, PyObject *args)
 {
-    int x, y;
+    int x = 0, y = 0;
 
     if (!pg_TwoIntsFromObj(args, &x, &y)) {
         return RAISE(PyExc_TypeError, "argument must contain two numbers");
@@ -409,7 +409,7 @@ pg_rect_inflate(pgRectObject *self, PyObject *args)
 static PyObject *
 pg_rect_inflate_ip(pgRectObject *self, PyObject *args)
 {
-    int x, y;
+    int x = 0, y = 0;
 
     if (!pg_TwoIntsFromObj(args, &x, &y)) {
         return RAISE(PyExc_TypeError, "argument must contain two numbers");
@@ -574,7 +574,7 @@ pg_rect_unionall_ip(pgRectObject *self, PyObject *args)
 static PyObject *
 pg_rect_collidepoint(pgRectObject *self, PyObject *args)
 {
-    int x, y;
+    int x = 0, y = 0;
     int inside;
 
     if (!pg_TwoIntsFromObj(args, &x, &y)) {
@@ -1167,7 +1167,7 @@ pg_rect_item(pgRectObject *self, Py_ssize_t i)
 static int
 pg_rect_ass_item(pgRectObject *self, Py_ssize_t i, PyObject *v)
 {
-    int val;
+    int val = 0;
     int *data = (int *)&self->r;
 
     if (i < 0 || i > 3) {
@@ -1264,7 +1264,7 @@ pg_rect_ass_subscript(pgRectObject *self, PyObject *op, PyObject *value)
         return pg_rect_ass_item(self, i, value);
     }
     else if (op == Py_Ellipsis) {
-        int val;
+        int val = 0;
 
         if (pg_IntFromObj(value, &val)) {
             self->r.x = val;
@@ -1314,7 +1314,7 @@ pg_rect_ass_subscript(pgRectObject *self, PyObject *op, PyObject *value)
         Py_ssize_t stop;
         Py_ssize_t step;
         Py_ssize_t slicelen;
-        int val;
+        int val = 0;
         Py_ssize_t i;
 
         if (PySlice_GetIndicesEx(op, 4, &start, &stop, &step, &slicelen)) {

--- a/src_c/rotozoom.c
+++ b/src_c/rotozoom.c
@@ -68,10 +68,10 @@ zoomSurfaceRGBA(SDL_Surface *src, SDL_Surface *dst, int smooth)
     /*
      * Allocate memory for row increments
      */
-    if ((sax = (int *)malloc((dst->w + 1) * sizeof(Uint32))) == NULL) {
+    if ((sax = (int *)malloc((dst->w + 1) * sizeof(int))) == NULL) {
         return (-1);
     }
-    if ((say = (int *)malloc((dst->h + 1) * sizeof(Uint32))) == NULL) {
+    if ((say = (int *)malloc((dst->h + 1) * sizeof(int))) == NULL) {
         free(sax);
         return (-1);
     }

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -31,6 +31,15 @@
 
 #include "doc/pygame_doc.h"
 
+#if defined(_WIN32)
+#define PG_LSEEK _lseeki64
+#elif defined(__APPLE__)
+/* Mac does not implement lseek64 */
+#define PG_LSEEK lseek
+#else
+#define PG_LSEEK lseek64
+#endif
+
 typedef struct {
     PyObject *read;
     PyObject *write;
@@ -536,7 +545,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
     PyGILState_STATE state;
 
     if (helper->fileno != -1) {
-        return lseek(helper->fileno, (long)offset, whence);
+        return PG_LSEEK(helper->fileno, offset, whence);
     }
 
     if (!helper->seek || !helper->tell)
@@ -576,7 +585,7 @@ end:
     return retval;
 #else  /* ~WITH_THREAD */
     if (helper->fileno != -1) {
-        return lseek(helper->fileno, offset, whence);
+        return PG_LSEEK(helper->fileno, offset, whence);
     }
 
     if (!helper->seek || !helper->tell)

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -536,7 +536,7 @@ _pg_rw_seek(SDL_RWops *context, Sint64 offset, int whence)
     PyGILState_STATE state;
 
     if (helper->fileno != -1) {
-        return lseek(helper->fileno, offset, whence);
+        return lseek(helper->fileno, (long)offset, whence);
     }
 
     if (!helper->seek || !helper->tell)
@@ -616,7 +616,7 @@ _pg_rw_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
 #endif /* WITH_THREAD */
 
     if (helper->fileno != -1) {
-        retval = read(helper->fileno, ptr, size * maxnum);
+        retval = read(helper->fileno, ptr, (unsigned int)(size * maxnum));
         if (retval == -1) {
             return -1;
         }

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -208,7 +208,7 @@ _scrap_get_scrap(PyObject *self, PyObject *args)
     char *scrap = NULL;
     PyObject *retval;
     char *scrap_type;
-    unsigned long count;
+    size_t count;
 
     PYGAME_SCRAP_INIT_CHECK();
 

--- a/src_c/scrap.h
+++ b/src_c/scrap.h
@@ -108,7 +108,7 @@ pygame_scrap_lost(void);
  *         0 otherwise.
  */
 extern int
-pygame_scrap_put(char *type, int srclen, char *src);
+pygame_scrap_put(char *type, Py_ssize_t srclen, char *src);
 
 /**
  * \brief Gets the current content from the clipboard.
@@ -123,7 +123,7 @@ pygame_scrap_put(char *type, int srclen, char *src);
  *         specified type was available.
  */
 extern char *
-pygame_scrap_get(char *type, unsigned long *count);
+pygame_scrap_get(char *type, size_t *count);
 
 /**
  * \brief Gets the currently available content types from the clipboard.

--- a/src_c/scrap_qnx.c
+++ b/src_c/scrap_qnx.c
@@ -72,7 +72,7 @@ pygame_scrap_lost(void)
 }
 
 int
-pygame_scrap_put(char *type, int srclen, char *src)
+pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
 {
     uint32_t format;
     int nulledlen = srclen + 1;

--- a/src_c/scrap_sdl2.c
+++ b/src_c/scrap_sdl2.c
@@ -9,11 +9,12 @@ char **pygame_scrap_types;
 int
 pygame_scrap_contains(char *type)
 {
-    return (strcmp(type, pygame_scrap_plaintext_type) == 0) && SDL_HasClipboardText();
+    return (strcmp(type, pygame_scrap_plaintext_type) == 0) &&
+           SDL_HasClipboardText();
 }
 
 char *
-pygame_scrap_get(char *type, unsigned long *count)
+pygame_scrap_get(char *type, size_t *count)
 {
     char *retval = NULL;
     char *clipboard = NULL;
@@ -38,7 +39,7 @@ pygame_scrap_get(char *type, unsigned long *count)
 char **
 pygame_scrap_get_types(void)
 {
-      if (!pygame_scrap_initialized()) {
+    if (!pygame_scrap_initialized()) {
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
         return NULL;
     }
@@ -70,13 +71,13 @@ pygame_scrap_lost(void)
 }
 
 int
-pygame_scrap_put(char *type, int srclen, char *src)
+pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
 {
     if (!pygame_scrap_initialized()) {
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");
         return 0;
     }
-    
+
     if (strcmp(type, pygame_scrap_plaintext_type) == 0) {
         if (SDL_SetClipboardText(src) == 0) {
             return 1;

--- a/src_c/scrap_win.c
+++ b/src_c/scrap_win.c
@@ -138,6 +138,11 @@ _create_dib_buffer(char *data, size_t *count)
     hdr.bfOffBits = (DWORD)(sizeof(BITMAPFILEHEADER) + bihdr->biSize +
                             bihdr->biClrUsed * sizeof(RGBQUAD));
 
+#ifdef _MSC_VER
+    /* Suppress false analyzer report */
+    __analysis_assume(*count > 0);
+#endif
+
     /* Copy both to the buffer. */
     buf = malloc(sizeof(hdr) + (*count));
     if (!buf)
@@ -208,12 +213,13 @@ pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
     hMem = GlobalAlloc((GMEM_MOVEABLE | GMEM_DDESHARE), nulledlen);
     if (hMem) {
         char *dst = GlobalLock(hMem);
-
-        memset(dst, 0, nulledlen);
-        if (format == CF_DIB || format == CF_DIBV5)
-            memcpy(dst, src + sizeof(BITMAPFILEHEADER), nulledlen - 1);
-        else
-            memcpy(dst, src, srclen);
+        if (dst) {
+            memset(dst, 0, nulledlen);
+            if (format == CF_DIB || format == CF_DIBV5)
+                memcpy(dst, src + sizeof(BITMAPFILEHEADER), nulledlen - 1);
+            else
+                memcpy(dst, src, srclen);
+        }
 
         GlobalUnlock(hMem);
         EmptyClipboard();

--- a/src_c/scrap_win.c
+++ b/src_c/scrap_win.c
@@ -73,10 +73,10 @@ _convert_internal_type(char *type)
  * \param size The size of the buffer.
  * \return The length of the format name.
  */
-static int
+static size_t
 _lookup_clipboard_format(UINT format, char *buf, int size)
 {
-    int len;
+    size_t len;
     char *cpy;
 
     memset(buf, 0, size);
@@ -118,7 +118,7 @@ _lookup_clipboard_format(UINT format, char *buf, int size)
  * \return The character buffer containing the BMP information.
  */
 static char *
-_create_dib_buffer(char *data, unsigned long *count)
+_create_dib_buffer(char *data, size_t *count)
 {
     BITMAPFILEHEADER hdr;
     LPBITMAPINFOHEADER bihdr;
@@ -184,10 +184,10 @@ pygame_scrap_lost(void)
 }
 
 int
-pygame_scrap_put(char *type, int srclen, char *src)
+pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
 {
     UINT format;
-    int nulledlen = srclen + 1;
+    Py_ssize_t nulledlen = srclen + 1;
     HANDLE hMem;
 
     if (!pygame_scrap_initialized()) {
@@ -235,7 +235,7 @@ pygame_scrap_put(char *type, int srclen, char *src)
 }
 
 char *
-pygame_scrap_get(char *type, unsigned long *count)
+pygame_scrap_get(char *type, size_t *count)
 {
     UINT format = _convert_format(type);
     char *retval = NULL;
@@ -316,7 +316,7 @@ pygame_scrap_get_types(void)
     char **tmptypes;
     int i = 0;
     int count = -1;
-    int len;
+    size_t len;
     char tmp[100] = {'\0'};
     int size = 0;
 

--- a/src_c/scrap_x11.c
+++ b/src_c/scrap_x11.c
@@ -673,7 +673,7 @@ pygame_scrap_lost(void)
 }
 
 int
-pygame_scrap_put(char *type, int srclen, char *src)
+pygame_scrap_put(char *type, Py_ssize_t srclen, char *src)
 {
     Atom clip;
     Atom cliptype;
@@ -752,7 +752,7 @@ SETSELECTIONOWNER:
 }
 
 char *
-pygame_scrap_get(char *type, unsigned long *count)
+pygame_scrap_get(char *type, size_t *count)
 {
     if (!pygame_scrap_initialized()) {
         PyErr_SetString(pgExc_SDLError, "scrap system not initialized.");

--- a/src_c/sdlmain_osx.m
+++ b/src_c/sdlmain_osx.m
@@ -116,6 +116,7 @@ _WMEnable(PyObject *self)
 }
 @end
 
+/* The below functions are unused for now, hence commented
 static void
 setApplicationMenu(void)
 {
@@ -184,6 +185,7 @@ setupWindowMenu(void)
     [windowMenu release];
     [windowMenuItem release];
 }
+*/
 
 static PyObject *
 _ScrapInit(PyObject *self)

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1143,7 +1143,7 @@ surf_set_palette(PyObject *self, PyObject *args)
         return RAISE(pgExc_SDLError,
                      "cannot set palette without pygame.display initialized");
 
-    len = MIN(pal->ncolors, PySequence_Length(list));
+    len = (int)MIN(pal->ncolors, PySequence_Length(list));
 
     for (i = 0; i < len; i++) {
         item = PySequence_GetItem(list, i);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1962,7 +1962,6 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
             bliterrornum = BLITS_ERR_SEQUENCE_REQUIRED;
             goto bliterror;
         }
-        bliterrornum = 0;
         argrect = NULL;
         special_flags = NULL;
         the_args = 0;

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1232,10 +1232,10 @@ surf_set_colorkey(pgSurfaceObject *self, PyObject *args)
     Uint8 rgba[4];
     int result;
     int hascolor = SDL_FALSE;
-    int bpp = surf->format->BytesPerPixel;
 
     if (!PyArg_ParseTuple(args, "|Oi", &rgba_obj, &flags))
         return NULL;
+
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
@@ -1263,7 +1263,7 @@ surf_set_colorkey(pgSurfaceObject *self, PyObject *args)
 
     pgSurface_Prep(self);
     result = 0;
-    if (hascolor && bpp == 1) {
+    if (hascolor && surf->format->BytesPerPixel == 1) {
         /* For an indexed surface, remove the previous colorkey first.
          */
         result = SDL_SetColorKey(surf, SDL_FALSE, color);
@@ -1475,7 +1475,9 @@ surf_convert(pgSurfaceObject *self, PyObject *args)
             newsurf = SDL_ConvertSurface(surf, src->format, 0);
         }
         else {
-            int bpp;
+            /* will be updated later, initialize to make static analyzer happy
+             */
+            int bpp = 0;
             SDL_PixelFormat format;
 
             memcpy(&format, surf->format, sizeof(format));

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1921,7 +1921,7 @@ surf_blits(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     int sx, sy;
     int the_args = 0;
 
-    PyObject *blitsequence = NULL;
+    PyObject *blitsequence;
     PyObject *iterator = NULL;
     PyObject *item = NULL;
     PyObject *special_flags = NULL;
@@ -3164,7 +3164,6 @@ _get_buffer_2D(PyObject *obj, Py_buffer *view_p, int flags)
 static int
 _get_buffer_3D(PyObject *obj, Py_buffer *view_p, int flags)
 {
-    const int lilendian = (SDL_BYTEORDER == SDL_LIL_ENDIAN);
     SDL_Surface *surface = pgSurface_AsSurface(obj);
     int pixelsize = surface->format->BytesPerPixel;
     char *startpixel = (char *)surface->pixels;
@@ -3198,23 +3197,41 @@ _get_buffer_3D(PyObject *obj, Py_buffer *view_p, int flags)
     view_p->strides[0] = pixelsize;
     view_p->strides[1] = surface->pitch;
     switch (surface->format->Rmask) {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
         case 0xffU:
-            view_p->strides[2] = lilendian ? 1 : -1;
-            startpixel += lilendian ? 0 : pixelsize - 1;
+            view_p->strides[2] = 1;
             break;
         case 0xff00U:
             assert(pixelsize == 4);
-            view_p->strides[2] = lilendian ? 1 : -1;
-            startpixel += lilendian ? 1 : pixelsize - 2;
+            view_p->strides[2] = 1;
+            startpixel += 1;
             break;
         case 0xff0000U:
-            view_p->strides[2] = lilendian ? -1 : 1;
-            startpixel += lilendian ? 2 : pixelsize - 3;
+            view_p->strides[2] = -1;
+            startpixel += 2;
             break;
         default: /* 0xff000000U */
             assert(pixelsize == 4);
-            view_p->strides[2] = lilendian ? -1 : 1;
-            startpixel += lilendian ? 3 : 0;
+            view_p->strides[2] = -1;
+            startpixel += 3;
+#else  /* SDL_BYTEORDER != SDL_LIL_ENDIAN */
+        case 0xffU:
+            view_p->strides[2] = -1;
+            startpixel += pixelsize - 1;
+            break;
+        case 0xff00U:
+            assert(pixelsize == 4);
+            view_p->strides[2] = -1;
+            startpixel += pixelsize - 2;
+            break;
+        case 0xff0000U:
+            view_p->strides[2] = 1;
+            startpixel += pixelsize - 3;
+            break;
+        default: /* 0xff000000U */
+            assert(pixelsize == 4);
+            view_p->strides[2] = 1;
+#endif /* SDL_BYTEORDER != SDL_LIL_ENDIAN */
     }
     view_p->buf = startpixel;
     Py_INCREF(obj);
@@ -3254,7 +3271,6 @@ static int
 _get_buffer_colorplane(PyObject *obj, Py_buffer *view_p, int flags, char *name,
                        Uint32 mask)
 {
-    const int lilendian = (SDL_BYTEORDER == SDL_LIL_ENDIAN);
     SDL_Surface *surface = pgSurface_AsSurface(obj);
     int pixelsize = surface->format->BytesPerPixel;
     char *startpixel = (char *)surface->pixels;
@@ -3274,21 +3290,34 @@ _get_buffer_colorplane(PyObject *obj, Py_buffer *view_p, int flags, char *name,
         return -1;
     }
     switch (mask) {
-            /* This switch statement is exhaustive over possible mask value,
-               the allowable masks for 24 bit and 32 bit surfaces */
+        /* This switch statement is exhaustive over possible mask value,
+           the allowable masks for 24 bit and 32 bit surfaces */
 
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
         case 0x000000ffU:
-            startpixel += lilendian ? 0 : pixelsize - 1;
             break;
         case 0x0000ff00U:
-            startpixel += lilendian ? 1 : pixelsize - 2;
+            startpixel += 1;
             break;
         case 0x00ff0000U:
-            startpixel += lilendian ? 2 : pixelsize - 3;
+            startpixel += 2;
             break;
         case 0xff000000U:
-            startpixel += lilendian ? 3 : 0;
+            startpixel += 3;
             break;
+#else  /* SDL_BYTEORDER != SDL_LIL_ENDIAN */
+        case 0x000000ffU:
+            startpixel += pixelsize - 1;
+            break;
+        case 0x0000ff00U:
+            startpixel += pixelsize - 2;
+            break;
+        case 0x00ff0000U:
+            startpixel += pixelsize - 3;
+            break;
+        case 0xff000000U:
+            break;
+#endif /* SDL_BYTEORDER != SDL_LIL_ENDIAN */
 
 #ifndef NDEBUG
             /* Assert this switch statement is exhaustive */

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -118,17 +118,18 @@ _pg_remove_event_timer(pgEventObject *ev)
         while (hunt->event->type != ev->type) {
             prev = hunt;
             hunt = hunt->next;
-            if (!hunt)
-                break;
+            if (!hunt) {
+                /* Reached end without finding a match, quit early */
+                SDL_UnlockMutex(timermutex);
+                return;
+            }
         }
-        if (hunt) {
-            if (prev)
-                prev->next = hunt->next;
-            else
-                pg_event_timer = hunt->next;
-            Py_DECREF(hunt->event);
-            PyMem_Del(hunt);
-        }
+        if (prev)
+            prev->next = hunt->next;
+        else
+            pg_event_timer = hunt->next;
+        Py_DECREF(hunt->event);
+        PyMem_Del(hunt);
     }
     /* Chances of it failing here are next to zero, dont do anything */
     SDL_UnlockMutex(timermutex);

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -30,14 +30,14 @@
 
 typedef struct pgEventTimer {
     struct pgEventTimer *next;
-    long timer_id;
+    intptr_t timer_id;
     pgEventObject *event;
     int repeat;
 } pgEventTimer;
 
 static pgEventTimer *pg_event_timer = NULL;
 static SDL_mutex *timermutex = NULL;
-static long pg_timer_id = 0;
+static intptr_t pg_timer_id = 0;
 
 static PyObject *
 pg_time_autoquit(PyObject *self)
@@ -76,7 +76,7 @@ pg_time_autoinit(PyObject *self)
     Py_RETURN_NONE;
 }
 
-static int
+static intptr_t
 _pg_add_event_timer(pgEventObject *ev, int repeat)
 {
     pgEventTimer *new;
@@ -135,7 +135,7 @@ _pg_remove_event_timer(pgEventObject *ev)
 }
 
 static pgEventTimer *
-_pg_get_event_on_timer(long timer_id)
+_pg_get_event_on_timer(intptr_t timer_id)
 {
     pgEventTimer *hunt;
 
@@ -165,7 +165,7 @@ timer_callback(Uint32 interval, void *param)
     SDL_Event event;
     PyGILState_STATE gstate;
 
-    evtimer = _pg_get_event_on_timer((long)param);
+    evtimer = _pg_get_event_on_timer((intptr_t)param);
     if (!evtimer)
         return 0;
 
@@ -287,7 +287,7 @@ static PyObject *
 time_set_timer(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int ticks, loops = 0;
-    long timer_id;
+    intptr_t timer_id;
     PyObject *obj;
     pgEventObject *e;
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -2465,8 +2465,6 @@ surf_average_surfaces(PyObject *self, PyObject *args, PyObject *kwargs)
 
     /* need to get the first surface to see how big it is */
 
-    loop = 0;
-
     for (loop = 0; loop < size; ++loop) {
         obj = PySequence_GetItem(list, loop);
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -357,18 +357,14 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, double sangle,
                 dy = (ay - (icos * (cy - y))) + yd;
                 for (x = 0; x < dst->w; x++) {
                     if (dx < 0 || dy < 0 || dx > xmaxval || dy > ymaxval) {
-                        dstpos[0] = ((Uint8 *)&bgcolor)[0];
-                        dstpos[1] = ((Uint8 *)&bgcolor)[1];
-                        dstpos[2] = ((Uint8 *)&bgcolor)[2];
+                        memcpy(dstpos, &bgcolor, 3 * sizeof(Uint8));
                         dstpos += 3;
                     }
                     else {
                         Uint8 *srcpos =
                             (Uint8 *)(srcpix + ((dy >> 16) * srcpitch) +
                                       ((dx >> 16) * 3));
-                        dstpos[0] = srcpos[0];
-                        dstpos[1] = srcpos[1];
-                        dstpos[2] = srcpos[2];
+                        memcpy(dstpos, srcpos, 3 * sizeof(Uint8));
                         dstpos += 3;
                     }
                     dx += icos;

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -627,7 +627,7 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
     surf = pgSurface_AsSurface(surfobj);
     if (surf->w < 1 || surf->h < 1) {
         Py_INCREF(surfobj);
-        return surfobj;
+        return (PyObject *)surfobj;
     }
 
     if (surf->format->BytesPerPixel == 0 || surf->format->BytesPerPixel > 4)
@@ -1134,7 +1134,7 @@ filter_expand_X_ONLYC(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
     int dstdiff = dstpitch - (dstwidth * 4);
     int *xidx0, *xmult0, *xmult1;
     int x, y;
-    int factorwidth = 4;
+    const int factorwidth = 4;
 
     /* Allocate memory for factors */
     xidx0 = malloc(dstwidth * 4);
@@ -2228,7 +2228,7 @@ surf_laplacian(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 int
-average_surfaces(SDL_Surface **surfaces, int num_surfaces,
+average_surfaces(SDL_Surface **surfaces, size_t num_surfaces,
                  SDL_Surface *destsurf, int palette_colors)
 {
     /*
@@ -2246,7 +2246,8 @@ average_surfaces(SDL_Surface **surfaces, int num_surfaces,
     Uint32 *the_idx;
     Uint32 the_color;
     SDL_Surface *surf;
-    int height, width, x, y, surf_idx;
+    size_t surf_idx;
+    int height, width, x, y;
 
     float div_inv;
 

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -287,8 +287,10 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, double sangle,
     int isin = (int)(sangle * 65536);
     int icos = (int)(cangle * 65536);
 
-    int ax = ((dst->w) << 15) - (int)(cangle * ((dst->w - 1) << 15));
-    int ay = ((dst->h) << 15) - (int)(sangle * ((dst->w - 1) << 15));
+    int ax =
+        ((dst->w) << 15) - (int)(cangle * (((long long)dst->w - 1) << 15));
+    int ay =
+        ((dst->h) << 15) - (int)(sangle * (((long long)dst->w - 1) << 15));
 
     int xmaxval = ((src->w) << 16) - 1;
     int ymaxval = ((src->h) << 16) - 1;
@@ -323,7 +325,7 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, double sangle,
                     else
                         *dstpos++ =
                             *(Uint16 *)(srcpix + ((dy >> 16) * srcpitch) +
-                                        (dx >> 16 << 1));
+                                        ((long long)dx >> 16 << 1));
                     dx += icos;
                     dy += isin;
                 }
@@ -341,7 +343,7 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, double sangle,
                     else
                         *dstpos++ =
                             *(Uint32 *)(srcpix + ((dy >> 16) * srcpitch) +
-                                        (dx >> 16 << 2));
+                                        ((long long)dx >> 16 << 2));
                     dx += icos;
                     dy += isin;
                 }
@@ -1136,6 +1138,12 @@ filter_expand_X_ONLYC(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch,
     int x, y;
     const int factorwidth = 4;
 
+#ifdef _MSC_VER
+    /* Make MSVC static analyzer happy by assuring dstwidth >= 2 to supress
+     * a false analyzer report */
+    __analysis_assume(dstwidth >= 2);
+#endif
+
     /* Allocate memory for factors */
     xidx0 = malloc(dstwidth * 4);
     if (xidx0 == NULL)
@@ -1482,6 +1490,12 @@ surf_set_smoothscale_backend(PyObject *self, PyObject *args, PyObject *kwargs)
     char *keywords[] = {"backend", NULL};
     const char *type;
 
+#ifdef _MSC_VER
+    /* MSVC static analyzer false alarm: assure type is NULL-terminated by
+     * making analyzer assume it was initialised */
+    __analysis_assume(type = "inited");
+#endif
+
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s", keywords, &type))
         return NULL;
 
@@ -1725,7 +1739,7 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *dest_surf_obj;
     SDL_Surface *dest_surf = NULL;
 
-    pgSurfaceObject *surf_obj = NULL;
+    pgSurfaceObject *surf_obj;
     SDL_Surface *surf = NULL;
 
     PyObject *search_color_obj;
@@ -1819,7 +1833,6 @@ surf_threshold(PyObject *self, PyObject *args, PyObject *kwds)
     }
 
     surf = pgSurface_AsSurface(surf_obj);
-
     if (NULL == surf) {
         return RAISE(PyExc_TypeError, "invalid surf argument");
     }
@@ -2702,7 +2715,7 @@ average_color(SDL_Surface *surf, int x, int y, int width, int height, Uint8 *r,
 static PyObject *
 surf_average_color(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    pgSurfaceObject *surfobj = NULL;
+    pgSurfaceObject *surfobj;
     PyObject *rectobj = NULL;
     SDL_Surface *surf;
     SDL_Rect *rect, temp;

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -622,14 +622,6 @@ class BaseModuleTest(unittest.TestCase):
 
         self.assertFalse(pygame.get_init())
 
-    def todo_test_segfault(self):
-
-        # __doc__ (as of 2008-08-02) for pygame.base.segfault:
-
-        # crash
-
-        self.fail()
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
PR to close #1316

Fixes some compiler warnings (and also skips some warnings) and make warnings error on CI

Also fixes most MSVC static analyzer warnings (all except ones in `pygame.mask`) and those too error on CI

### Some skipped warnings (todos for future)
- [ ] GCC on linux complains about `unused-but-set-variable` while compiling freetype. There is a complex macro system here that caused the warning, that seemed hard to fix so I skipped it for now
- [ ] MSVC static analyzer complains while compiling `pygame.mask` about possible buffer overflows, and I'm not sure whether it's a false report or not here, so I skipped it here for now