### PR TITLE
Cython code modernizations

### DIFF
--- a/src_c/cython/pygame/_sdl2/audio.pxd
+++ b/src_c/cython/pygame/_sdl2/audio.pxd
@@ -1,7 +1,7 @@
-# cython: language_level=2
+# cython: language_level=3str
 #
 
-from sdl2 cimport *
+from .sdl2 cimport *
 
 cdef extern from "SDL.h" nogil:
     # https://wiki.libsdl.org/SDL_OpenAudioDevice

--- a/src_c/cython/pygame/_sdl2/audio.pyx
+++ b/src_c/cython/pygame/_sdl2/audio.pyx
@@ -41,38 +41,30 @@ AUDIO_ALLOW_FORMAT_CHANGE = _SDL_AUDIO_ALLOW_FORMAT_CHANGE
 AUDIO_ALLOW_CHANNELS_CHANGE = _SDL_AUDIO_ALLOW_CHANNELS_CHANGE
 AUDIO_ALLOW_ANY_CHANGE = _SDL_AUDIO_ALLOW_ANY_CHANGE
 
-
 # https://wiki.libsdl.org/SDL_GetNumAudioDevices
-def get_num_audio_devices(iscapture):
-    """ return the number of audio devices for playback or capture.
-
-    :param int iscapture: if 0 return devices available for playback of audio.
-                          If 1 return devices available for capture of audio.
-    :return: the number of devices available.
-    :rtype: int
-    """
-    devcount = SDL_GetNumAudioDevices(iscapture);
-    if devcount == -1:
-        raise error('Audio system not initialised')
-    return devcount
-
 # https://wiki.libsdl.org/SDL_GetAudioDeviceName
-def get_audio_device_name(index, iscapture):
-    """ A unique devicename is available for each available audio device.
+def get_audio_device_names(iscapture = False):
+    """ Returns a list of unique devicenames for each avaialable audio device.
 
-    :param int index: index of the devices from 0 to get_num_audio_devices(iscapture)
-    :param int iscapture: if 0 return devices available for playback of audio.
-                          If 1 return devices available for capture of audio.
+    :param bool iscapture: If False return devices available for playback.
+                           If True return devices available for capture.
 
-    :return: the devicename.
-    :rtype: bytes
+    :return: list of devicenames.
+    :rtype: List[string]
     """
-    cdef const char * name
-    name = SDL_GetAudioDeviceName(index, iscapture)
-    if not name:
-        raise error()
-    return name
 
+    cdef int count = SDL_GetNumAudioDevices(iscapture)
+    if count == -1:
+        raise error('Audio system not initialised')
+    
+    names = []
+    for i in range(count):
+        name = SDL_GetAudioDeviceName(i, iscapture)
+        if not name:
+            raise error()
+        names.append(name.decode('utf8'))
+
+    return names
 
 import traceback
 cdef void recording_cb(void* userdata, Uint8* stream, int len) nogil:

--- a/src_c/cython/pygame/_sdl2/controller.pxd
+++ b/src_c/cython/pygame/_sdl2/controller.pxd
@@ -1,7 +1,7 @@
-# cython: language_level=2
+# cython: language_level=3str
 #
 
-from sdl2 cimport *
+from .sdl2 cimport *
 
 #https://wiki.libsdl.org/CategoryGameController
 

--- a/src_c/cython/pygame/_sdl2/mixer.pxd
+++ b/src_c/cython/pygame/_sdl2/mixer.pxd
@@ -1,7 +1,7 @@
-# cython: language_level=2
+# cython: language_level=3str
 #
 
-from sdl2 cimport *
+from .sdl2 cimport *
 
 #https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC79
 

--- a/src_c/cython/pygame/_sdl2/sdl2.pxd
+++ b/src_c/cython/pygame/_sdl2/sdl2.pxd
@@ -1,4 +1,4 @@
-# cython: language_level=2
+# cython: language_level=3str
 #
 
 from libc.string cimport memset

--- a/src_c/cython/pygame/_sdl2/video.pxd
+++ b/src_c/cython/pygame/_sdl2/video.pxd
@@ -1,7 +1,7 @@
-# cython: language_level=2
+# cython: language_level=3str
 #
 
-from sdl2 cimport *
+from .sdl2 cimport *
 
 cdef extern from "SDL.h" nogil:
     ctypedef struct SDL_Window


### PR DESCRIPTION
Moved all _sdl2 cython to language level 3str, the default in upcoming Cython 3.0. It was an easy modernization to do, and I just did it to remove any possible python 2 related confusions in the future of developing those modules.

I also replaced the functions `pygame._sdl2.audio.get_num_audio_devices` and `pygame._sdl2.audio.get_audio_device_name` with the `pygame._sdl2.audio.get_audio_device_names` function.

To get a list of strings of the audio devices the old way, you had to do:
```py
count = pygame._sdl2.audio.get_num_audio_devices(False)
names = [pygame._sdl2.audio.get_audio_device_name(i, False).decode("utf-8") for i in range(count)]
```

Now you can just do:
```py
names = pygame._sdl2.audio.get_audio_device_names(False)
```

I hope my build time cython PR can get to a working state and be merged, so I didn't include the regenerated cython in this PR.