### PR TITLE
Renamed pygame.sprite.LayeredDirty.set_timing_treshold to pygame.sprite.LayeredDirty.set_timing_threshold

### DIFF
--- a/buildconfig/pygame-stubs/sprite.pyi
+++ b/buildconfig/pygame-stubs/sprite.pyi
@@ -108,6 +108,9 @@ class LayeredDirty(LayeredUpdates):
     def set_timing_treshold(
         self, time_ms: SupportsFloat
     ) -> None: ...  # This actually accept any value
+    def set_timing_threshold(
+        self, time_ms: SupportsFloat
+    ) -> None: ...  # This actually accept any value
 
 class GroupSingle(AbstractGroup):
     sprite: Sprite

--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -637,9 +637,23 @@ Sprites are not thread safe. So lock them yourself if using threads.
       Default is 1000./80 where 80 is the fps I want to switch to full screen
       mode.  This method's name is a typo and should be fixed.
 
+      DEPRECATED: Use rotate_rad_ip() instead.
+
       :raises TypeError: if ``time_ms`` is not int or float
 
       .. ## LayeredDirty.set_timing_treshold ##
+
+   .. method:: set_timing_threshold
+
+      | :sl:`sets the threshold in milliseconds`
+      | :sg:`set_timing_threshold(time_ms) -> None`
+
+      Default is 1000./80 where 80 is the fps I want to switch to full screen
+      mode.  This method's name is a typo and should be fixed.
+
+      :raises TypeError: if ``time_ms`` is not int or float
+
+      .. ## LayeredDirty.set_timing_threshold ##
 
    .. ## pygame.sprite.LayeredDirty ##
 

--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -638,8 +638,6 @@ Sprites are not thread safe. So lock them yourself if using threads.
 
       .. deprecated:: 2.1.1
 
-      :raises TypeError: if ``time_ms`` is not int or float
-
       .. ## LayeredDirty.set_timing_treshold ##
 
    .. method:: set_timing_threshold

--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -637,7 +637,7 @@ Sprites are not thread safe. So lock them yourself if using threads.
       Default is 1000./80 where 80 is the fps I want to switch to full screen
       mode.  This method's name is a typo and should be fixed.
 
-      DEPRECATED: Use rotate_rad_ip() instead.
+      DEPRECATED: Use set_timing_threshold() instead.
 
       :raises TypeError: if ``time_ms`` is not int or float
 

--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -634,10 +634,9 @@ Sprites are not thread safe. So lock them yourself if using threads.
       | :sl:`sets the threshold in milliseconds`
       | :sg:`set_timing_treshold(time_ms) -> None`
 
-      Default is 1000./80 where 80 is the fps I want to switch to full screen
-      mode.  This method's name is a typo and should be fixed.
-
       DEPRECATED: Use set_timing_threshold() instead.
+
+      .. deprecated:: 2.1.1
 
       :raises TypeError: if ``time_ms`` is not int or float
 
@@ -650,6 +649,8 @@ Sprites are not thread safe. So lock them yourself if using threads.
 
       Default is 1000./80 where 80 is the fps I want to switch to full screen
       mode.  This method's name is a typo and should be fixed.
+
+      .. versionadded:: 2.1.1
 
       :raises TypeError: if ``time_ms`` is not int or float
 

--- a/docs/reST/ref/sprite.rst
+++ b/docs/reST/ref/sprite.rst
@@ -566,7 +566,7 @@ Sprites are not thread safe. So lock them yourself if using threads.
    It uses the dirty flag technique and is therefore faster than the
    :class:`pygame.sprite.RenderUpdates` if you have many static sprites. It
    also switches automatically between dirty rect update and full screen
-   drawing, so you do no have to worry what would be faster.
+   drawing, so you do not have to worry what would be faster.
 
    Same as for the :class:`pygame.sprite.Group`. You can specify some
    additional attributes through kwargs:
@@ -645,8 +645,10 @@ Sprites are not thread safe. So lock them yourself if using threads.
       | :sl:`sets the threshold in milliseconds`
       | :sg:`set_timing_threshold(time_ms) -> None`
 
-      Default is 1000./80 where 80 is the fps I want to switch to full screen
-      mode.  This method's name is a typo and should be fixed.
+      Defaults to 1000.0 / 80.0. This means that the screen will be painted
+      using the flip method rather than the update method if the update
+      method is taking so long to update the screen that the frame rate falls
+      below 80 frames per second.
 
       .. versionadded:: 2.1.1
 

--- a/src_c/doc/sprite_doc.h
+++ b/src_c/doc/sprite_doc.h
@@ -48,6 +48,7 @@
 #define DOC_LAYEREDDIRTYGETCLIP "get_clip() -> Rect\nclip the area where to draw. Just pass None (default) to reset the clip"
 #define DOC_LAYEREDDIRTYCHANGELAYER "change_layer(sprite, new_layer) -> None\nchanges the layer of the sprite"
 #define DOC_LAYEREDDIRTYSETTIMINGTRESHOLD "set_timing_treshold(time_ms) -> None\nsets the threshold in milliseconds"
+#define DOC_LAYEREDDIRTYSETTIMINGTHRESHOLD "set_timing_threshold(time_ms) -> None\nsets the threshold in milliseconds"
 #define DOC_PYGAMESPRITEGROUPSINGLE "GroupSingle(sprite=None) -> GroupSingle\nGroup container that holds a single sprite."
 #define DOC_PYGAMESPRITESPRITECOLLIDE "spritecollide(sprite, group, dokill, collided = None) -> Sprite_list\nFind sprites in a group that intersect another sprite."
 #define DOC_PYGAMESPRITECOLLIDERECT "collide_rect(left, right) -> bool\nCollision detection between two sprites, using rects."
@@ -254,6 +255,10 @@ changes the layer of the sprite
 
 pygame.sprite.LayeredDirty.set_timing_treshold
  set_timing_treshold(time_ms) -> None
+sets the threshold in milliseconds
+
+pygame.sprite.LayeredDirty.set_timing_threshold
+ set_timing_threshold(time_ms) -> None
 sets the threshold in milliseconds
 
 pygame.sprite.GroupSingle

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -86,6 +86,7 @@ Sprites are not thread safe, so lock them yourself if using threads.
 # specialized cases.
 
 from operator import truth
+from warnings import warn
 
 import pygame
 
@@ -1321,6 +1322,27 @@ class LayeredDirty(LayeredUpdates):
             sprite.dirty = 1
 
     def set_timing_treshold(self, time_ms):
+        """set the threshold in milliseconds
+
+        set_timing_treshold(time_ms): return None
+
+        Defaults to 1000.0 / 80.0. This means that the screen will be painted
+        using the flip method rather than the update method if the update
+        method is taking so long to update the screen that the frame rate falls
+        below 80 frames per second.
+
+        Raises TypeError if time_ms is not int or float.
+
+        """
+        warn('This function will be removed, use set_timing_threshold function instead')
+        if isinstance(time_ms, (int, float)):
+            self._time_threshold = time_ms
+        else:
+            raise TypeError(
+                f"Expected numeric value, got {time_ms.__class__.__name__} instead"
+            )
+
+    def set_timing_threshold(self, time_ms):
         """set the threshold in milliseconds
 
         set_timing_treshold(time_ms): return None

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1334,7 +1334,10 @@ class LayeredDirty(LayeredUpdates):
         Raises TypeError if time_ms is not int or float.
 
         """
-        warn("This function will be removed, use set_timing_threshold function instead",DeprecationWarning)
+        warn(
+            "This function will be removed, use set_timing_threshold function instead",
+            DeprecationWarning,
+        )
         self.set_timing_threshold(time_ms)
 
     def set_timing_threshold(self, time_ms):

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1334,7 +1334,7 @@ class LayeredDirty(LayeredUpdates):
         Raises TypeError if time_ms is not int or float.
 
         """
-        warn('This function will be removed, use set_timing_threshold function instead')
+        warn("This function will be removed, use set_timing_threshold function instead")
         self.set_timing_threshold(time_ms)
 
     def set_timing_threshold(self, time_ms):

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1335,12 +1335,7 @@ class LayeredDirty(LayeredUpdates):
 
         """
         warn('This function will be removed, use set_timing_threshold function instead')
-        if isinstance(time_ms, (int, float)):
-            self._time_threshold = time_ms
-        else:
-            raise TypeError(
-                f"Expected numeric value, got {time_ms.__class__.__name__} instead"
-            )
+        self.set_timing_threshold(time_ms)
 
     def set_timing_threshold(self, time_ms):
         """set the threshold in milliseconds

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1340,7 +1340,7 @@ class LayeredDirty(LayeredUpdates):
     def set_timing_threshold(self, time_ms):
         """set the threshold in milliseconds
 
-        set_timing_treshold(time_ms): return None
+        set_timing_threshold(time_ms): return None
 
         Defaults to 1000.0 / 80.0. This means that the screen will be painted
         using the flip method rather than the update method if the update

--- a/src_py/sprite.py
+++ b/src_py/sprite.py
@@ -1334,7 +1334,7 @@ class LayeredDirty(LayeredUpdates):
         Raises TypeError if time_ms is not int or float.
 
         """
-        warn("This function will be removed, use set_timing_threshold function instead")
+        warn("This function will be removed, use set_timing_threshold function instead",DeprecationWarning)
         self.set_timing_threshold(time_ms)
 
     def set_timing_threshold(self, time_ms):


### PR DESCRIPTION
Also added a deprecation warning in the docs and asked to use renamed one. 