### PR TITLE
Fix jiggling problem in pygame.transform.rotate()

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -297,15 +297,15 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, int icos, int isin)
     // and suppose the coordinate ends up being (12.6, 19.3) in the src image,
     // then we truncate to (12, 19) in order to retrieve the pixel that covers
     // [12, 13) x [19, 20), equivalently find the nearest centre (12.5, 19.5)
-    tx = 1 - x2; // = 0.5 - x2, in 31:1 fixed point
+    tx = 1 - x2;  // = 0.5 - x2, in 31:1 fixed point
 
     switch (src->format->BytesPerPixel) {
         case 1:
             for (i = 0; i < y2; ++i) {
                 Uint8 *dstpos = (Uint8 *)dstrow;
-                ty = (i << 1) + 1 - y2; // = y - y2, in 31:1 fixed point
-                dx = x0 + ((tx * icos - ty * isin + 1) >> 1); // in 16:16
-                dy = y0 + ((tx * isin + ty * icos + 1) >> 1); // in 16:16
+                ty = (i << 1) + 1 - y2;  // = y - y2, in 31:1 fixed point
+                dx = x0 + ((tx * icos - ty * isin + 1) >> 1);  // in 16:16
+                dy = y0 + ((tx * isin + ty * icos + 1) >> 1);  // in 16:16
                 for (j = 0; j < x2; ++j) {
                     if (dx < 0 || dy < 0 || dx >= x1 || dy >= y1)
                         *dstpos++ = bgcolor;
@@ -322,9 +322,9 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, int icos, int isin)
         case 2:
             for (i = 0; i < y2; ++i) {
                 Uint16 *dstpos = (Uint16 *)dstrow;
-                ty = (i << 1) + 1 - y2; // = y - y2, in 31:1 fixed point
-                dx = x0 + ((tx * icos - ty * isin + 1) >> 1); // in 16:16
-                dy = y0 + ((tx * isin + ty * icos + 1) >> 1); // in 16:16
+                ty = (i << 1) + 1 - y2;  // = y - y2, in 31:1 fixed point
+                dx = x0 + ((tx * icos - ty * isin + 1) >> 1);  // in 16:16
+                dy = y0 + ((tx * isin + ty * icos + 1) >> 1);  // in 16:16
                 for (j = 0; j < x2; ++j) {
                     if (dx < 0 || dy < 0 || dx >= x1 || dy >= y1)
                         *dstpos++ = bgcolor;
@@ -341,9 +341,9 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, int icos, int isin)
         case 4:
             for (i = 0; i < y2; ++i) {
                 Uint32 *dstpos = (Uint32 *)dstrow;
-                ty = (i << 1) + 1 - y2; // = y - y2, in 31:1 fixed point
-                dx = x0 + ((tx * icos - ty * isin + 1) >> 1); // in 16:16
-                dy = y0 + ((tx * isin + ty * icos + 1) >> 1); // in 16:16
+                ty = (i << 1) + 1 - y2;  // = y - y2, in 31:1 fixed point
+                dx = x0 + ((tx * icos - ty * isin + 1) >> 1);  // in 16:16
+                dy = y0 + ((tx * isin + ty * icos + 1) >> 1);  // in 16:16
                 for (j = 0; j < x2; ++j) {
                     if (dx < 0 || dy < 0 || dx >= x1 || dy >= y1)
                         *dstpos++ = bgcolor;
@@ -360,9 +360,9 @@ rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor, int icos, int isin)
         default: /*case 3:*/
             for (i = 0; i < y2; ++i) {
                 Uint8 *dstpos = (Uint8 *)dstrow;
-                ty = (i << 1) + 1 - y2; // = y - y2, in 31:1 fixed point
-                dx = x0 + ((tx * icos - ty * isin + 1) >> 1); // in 16:16
-                dy = y0 + ((tx * isin + ty * icos + 1) >> 1); // in 16:16
+                ty = (i << 1) + 1 - y2;  // = y - y2, in 31:1 fixed point
+                dx = x0 + ((tx * icos - ty * isin + 1) >> 1);  // in 16:16
+                dy = y0 + ((tx * isin + ty * icos + 1) >> 1);  // in 16:16
                 for (j = 0; j < x2; ++j) {
                     if (dx < 0 || dy < 0 || dx >= x1 || dy >= y1) {
                         dstpos[0] = ((Uint8 *)&bgcolor)[0];
@@ -669,8 +669,8 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     radangle = angle * .01745329251994329;
-    icos = (int)round(ldexp(cos(radangle), 16)); // in 16:16 fixed point
-    isin = (int)round(ldexp(sin(radangle), 16)); // in 16:16 fixed point
+    icos = (int)round(ldexp(cos(radangle), 16));  // in 16:16 fixed point
+    isin = (int)round(ldexp(sin(radangle), 16));  // in 16:16 fixed point
 
     // find (x0, y0) = rotation centre in 31:1 fixed point (units of one-half)
     // => corners (x0, y0), (-x0, y0), (-x0, -y0), (x0, -y0) relative to centre
@@ -686,16 +686,14 @@ surf_rotate(PyObject *self, PyObject *args, PyObject *kwargs)
     // max of all the x coordinates gives right side x relative to centre
     // max of all the y coordinates gives top side y relative to centre
     // then round to a multiple of one-half (can lose a small amount of image)
-    xc = (x0 * icos + 1) >> 1; // in 16:16 fixed point
-    yc = (y0 * icos + 1) >> 1; // in 16:16 fixed point
-    xs = (x0 * isin + 1) >> 1; // in 16:16 fixed point
-    ys = (y0 * isin + 1) >> 1; // in 16:16 fixed point
-    nxmax = (
-        MAX(MAX(MAX(xc - ys, -xc - ys), -xc + ys), xc + ys) + 0x4000
-    ) >> 15;
-    nymax = (
-        MAX(MAX(MAX(xs + yc, -xs + yc), -xs - yc), xs - yc) + 0x4000
-    ) >> 15;
+    xc = (x0 * icos + 1) >> 1;  // in 16:16 fixed point
+    yc = (y0 * icos + 1) >> 1;  // in 16:16 fixed point
+    xs = (x0 * isin + 1) >> 1;  // in 16:16 fixed point
+    ys = (y0 * isin + 1) >> 1;  // in 16:16 fixed point
+    nxmax =
+        (MAX(MAX(MAX(xc - ys, -xc - ys), -xc + ys), xc + ys) + 0x4000) >> 15;
+    nymax =
+        (MAX(MAX(MAX(xs + yc, -xs + yc), -xs - yc), xs - yc) + 0x4000) >> 15;
 
     // now (nxmax, nymax) = half the resulting image size in 31:1 fixed point
     // (i.e. in units of one-half) or the full resulting image size in integer,


### PR DESCRIPTION
### Issue

My son has been working on a game with an overhead-view playfield. He has drawn some characters in overhead view, and what we are trying to do is to call `pygame.transform.rotate()` to make the character face in the correct direction, and then draw onto the screen surface with `Surface.blit()`. We are calculating the (x, y) position of the blit using code similar to this:
```
screen.blit(rotated_image, math.floor(x - rotated_image.get_width() / 2), math.floor(y - rotated_image.get_height() / 2))
```
So basically the idea is to examine the size of the image returned from `pygame.transform.rotate()` and use this to centre the image over the (x, y) which is supposed to represent the current centre of the character.

The problem is that this does not yield a smoothly rotating character. As a test we made the character rotate by 1 degree every game tick, and what we see is the character seems to jiggle slightly to the left/right and up/down at various times in its rotation.

### Cause

Examining the code of `pygame.transform.rotate()` in `src_c/transform.c` I can more or less see the problem: the original code does not seem to have good control over rounding vs truncation and whether the rotation would be performed about the centre of a pixel or the boundary line between pixels.

I must say I do not want to be too critical of the original code, as there could be subtleties of the code which I am not appreciating, but as there are few comments I did not spend too long trying to analyze what it did before. Instead I went with an experimental approach to see if rewriting the code would fix the issue, and it did seem to.

### Proposed fix

I rmodified both the code which determines the size of the rotated image, in the function `surf_rotate()`, and also the inner loop code that generates the pixels of the rotated image, in the function `rotate()`. The modified code is following almost the same procedure as the original but with some slight refinements and more comments.

As I have a slightly different way of thinking about the mathematics than the original author, I renamed some of the variables, for instance `cx` seemed to mean `cos(angle) * x` and I renamed it to `xc` to mean `x * cos(angle)`. I also introduced a number of new variables for clarity (some optimization would be possible but I felt it not worth messing up the code).

On a side note, the previous code used 16-bit fixed point arithmetic in the inner loop for speed, but floating point arithmetic in other calculations such as deciding the width and height of the output image. For consistency I decided to change it to 16-bit fixed point arithmetic always. So if there is a tiny distortion then this will also be reflected in the sizing of the output image. This means that `sangle` changes to `isin` and `cangle` changes to `icos` everywhere. I also sneakily swapped the order of the last 2 parameters to the `rotate()` function to `icos, isin` instead of `sangle, cangle`.

### Half-pixel issues

After thinking carefully about how it needs to work, I came to the conclusion that in order for a rotated image to be able to be blitted onto something interchangeably with the original image, the rotation centre has to be the exact centre of both the original and rotated images.

This implies that if a dimension is odd (e.g. width is 201) then the rotation centre is the centre of the middle pixel (e.g. the pixel with x = 100) whereas if a dimension is even (e.g. with is 200) then it's the boundary between the 2 middle pixels (e.g. the pixels with x = 99 and x = 100).

It's also important that if the rotation centre was at the centre of a pixel (rather than a boundary) in the original image then it needs to be at the centre of a pixel (rather than a boundary) in the rotated image, and vice versa. This applies separately in the horizontal and vertical dimensions.

So it's rather strange when you think about it: suppose I have an image of 201 x 100 and then I rotate it 90 degrees, I'd expect to get a new image of 100 x 201. But this will not be able to maintain a consistent centre when drawn into a playfield, because I cannot draw the 100 x 201 image at a half-pixel offset to have it centred with respect to where the 201 x 100 image used to be. So the right way in my opinion is to return a new 101 x 200 (or 99 x 202 or similar) image for in this example.

Perhaps in the future we could have a way of passing a subpixel offset into the rotate function, or a more advanced rotate function. But this would be too hard to explain to my son, and in any case we are caching the rotated image until the next time the player changes direction, so we don't want to have the subpixel offset of player's current position built into it.

### Discussion

If people think the issue of a 201 x 100 image being rotated 90 degrees not returning a 100 x 201 image is a dealbreaker, then I am open to ideas like a new function name or more advanced API with subpixel level control. But at any rate we need a solution of some sort, because his game was not working well without this fix and now it's much smoother.

Edit: Thinking about it some more, I realize that we probably need a Boolean flag or flags to send into the rotate() function that would force the x or y dimension to be odd or even in the output image. And if the flag were not sent and defaulted to None, then it would size the image in a similar way to the original code. This would also avoid breakage for existing games. Thoughts? Note I haven't implemented this yet, so the PR might not be suitable to merge at the present time.

### Sample animations and code

Here is an animation without the fix: 
https://user-images.githubusercontent.com/21211188/146869618-6309a64b-7934-4111-9be4-3be229fab8d5.mp4

Here is an animation with the fix:
https://user-images.githubusercontent.com/21211188/146869652-c1a06d85-ab45-4faa-bea0-81be530e67be.mp4

The animations were produced with the following utility that I call `make_webp.py` that I whipped up for sample purposes:
```
#!/usr/bin/env python3

import PIL.Image
import PIL.ImageDraw
import pygame
import pygame.image
import pygame.transform
import sys

if len(sys.argv) < 6:
  print(f'usage: {sys.argv[0]:s} in.png deg_(start,stop,step) out_size_(x,y) bg_color_(r,g,b) out.webp')
  sys.exit(1)
in_png = sys.argv[1]
[deg_start, deg_stop, deg_step] = [float(i) for i in sys.argv[2].split(',')]
[out_size_x, out_size_y] = [int(i) for i in sys.argv[3].split(',')]
[bg_color_r, bg_color_g, bg_color_b] = [int(i) for i in sys.argv[4].split(',')]
out_webp = sys.argv[5]

in_image = pygame.image.load(in_png)

frames = []
deg = deg_start
while deg < deg_stop:
  rotated_image = pygame.transform.rotate(in_image, deg)

  out_image = pygame.surface.Surface((out_size_x, out_size_y), depth = 24)
  out_image.fill((bg_color_r, bg_color_g, bg_color_b))
  out_image.blit(
    rotated_image,
    (
      (out_size_x - rotated_image.get_width()) // 2,
      (out_size_y - rotated_image.get_height()) // 2
    )
  )

  frames.append(
    PIL.Image.frombytes(
      'RGB',
      (out_size_x, out_size_y),
      pygame.image.tostring(out_image, 'RGB')
    )
  )

  deg += deg_step

frames[0].save(
  out_webp,
  format = 'webp',
  append_images = frames[1:],
  save_all = True,
  duration = 100,
  loop = 0
)
```

To reproduce, here is the source image drawn by my son:
![person](https://user-images.githubusercontent.com/21211188/146869794-0d8df16f-c17f-479f-819f-a248d8dff94c.png)

And the command line used to generate the animations was:
```
./make_webp.py person.png 0,360,1 300,300 128,128,128 out.webp
```