### PR TITLE
Fix pygame.version.SDL and pygame.version.vernum

### DIFF
--- a/buildconfig/version.py.in
+++ b/buildconfig/version.py.in
@@ -47,7 +47,7 @@ class SoftwareVersion(tuple):
         return f"{str(self.__class__.__name__)}({', '.join(fields)})"
 
     def __str__(self):
-        return f"{major}.{minor}.{patch}"
+        return f"{self.major}.{self.minor}.{self.patch}"
 
     major = property(lambda self: self[0])
     minor = property(lambda self: self[1])


### PR DESCRIPTION
On current version of pygame.version.SDL (pun intended 😅) you get the error if you write 
`print(pygame.version.SDL)`

`NameError: name 'major' is not defined`

This should fix it