### PR TITLE
clean modinit code, fix bugs, use recommended API

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -1973,9 +1973,16 @@ MODINIT_DEFINE(_camera)
 
     /* create the module */
     module = PyModule_Create(&_module);
+    if (!module) {
+        return NULL;
+    }
 
     Py_INCREF(&pgCamera_Type);
-    PyModule_AddObject(module, "CameraType", (PyObject *)&pgCamera_Type);
+    if (PyModule_AddObject(module, "CameraType", (PyObject *)&pgCamera_Type)) {
+        Py_DECREF(&pgCamera_Type);
+        Py_DECREF(module);
+        return NULL;
+    }
 
     return module;
 }

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -2205,10 +2205,9 @@ MODINIT_DEFINE(_freetype)
     FREETYPE_MOD_STATE(module)->cache_size = 0;
     FREETYPE_MOD_STATE(module)->resolution = PGFT_DEFAULT_RESOLUTION;
 
-    Py_INCREF((PyObject *)&pgFont_Type);
-    if (PyModule_AddObject(module, FONT_TYPE_NAME, (PyObject *)&pgFont_Type) ==
-        -1) {
-        Py_DECREF((PyObject *)&pgFont_Type);
+    Py_INCREF(&pgFont_Type);
+    if (PyModule_AddObject(module, FONT_TYPE_NAME, (PyObject *)&pgFont_Type)) {
+        Py_DECREF(&pgFont_Type);
         Py_DECREF(module);
         return NULL;
     }
@@ -2239,13 +2238,8 @@ MODINIT_DEFINE(_freetype)
     c_api[1] = &pgFont_New;
 
     apiobj = encapsulate_api(c_api, "freetype");
-    if (!apiobj) {
-        Py_DECREF(module);
-        return NULL;
-    }
-
-    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj) == -1) {
-        Py_DECREF(apiobj);
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2069,11 +2069,9 @@ static PyMethodDef _base_methods[] = {
 
 MODINIT_DEFINE(base)
 {
-    static int is_loaded = 0;
-    PyObject *module, *dict, *apiobj;
-    PyObject *atexit_register = NULL;
+    PyObject *module, *apiobj, *atexit;
+    PyObject *atexit_register;
     PyObject *pgExc_SDLError;
-    int ecode;
     static void *c_api[PYGAMEAPI_BASE_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -2086,59 +2084,41 @@ MODINIT_DEFINE(base)
                                          NULL,
                                          NULL};
 
-    if (!is_loaded) {
-        /* import need modules. Do this first so if there is an error
-           the module is not loaded.
-        */
-        PyObject *atexit = PyImport_ImportModule("atexit");
+    /* import need modules. Do this first so if there is an error
+        the module is not loaded.
+    */
+    atexit = PyImport_ImportModule("atexit");
+    if (!atexit) {
+        return NULL;
+    }
 
-        if (!atexit) {
-            return NULL;
-        }
-        atexit_register = PyObject_GetAttrString(atexit, "register");
-        Py_DECREF(atexit);
-        if (!atexit_register) {
-            return NULL;
-        }
+    atexit_register = PyObject_GetAttrString(atexit, "register");
+    Py_DECREF(atexit);
+    if (!atexit_register) {
+        return NULL;
     }
 
     /* create the module */
     module = PyModule_Create(&_module);
-    if (module == NULL) {
-        return NULL;
+    if (!module) {
+        goto error;
     }
-    dict = PyModule_GetDict(module);
 
     /* create the exceptions */
     pgExc_SDLError =
         PyErr_NewException("pygame.error", PyExc_RuntimeError, NULL);
-    if (pgExc_SDLError == NULL) {
-        Py_XDECREF(atexit_register);
-        Py_DECREF(module);
-        return NULL;
-    }
-    ecode = PyDict_SetItemString(dict, "error", pgExc_SDLError);
-    Py_DECREF(pgExc_SDLError);
-    if (ecode) {
-        Py_XDECREF(atexit_register);
-        Py_DECREF(module);
-        return NULL;
+    if (PyModule_AddObject(module, "error", pgExc_SDLError)) {
+        Py_XDECREF(pgExc_SDLError);
+        goto error;
     }
 
     pgExc_BufferError =
         PyErr_NewException("pygame.BufferError", PyExc_BufferError, NULL);
-
-    if (pgExc_SDLError == NULL) {
-        Py_XDECREF(atexit_register);
-        Py_DECREF(module);
-        return NULL;
-    }
-    ecode = PyDict_SetItemString(dict, "BufferError", pgExc_BufferError);
-    if (ecode) {
-        Py_DECREF(pgExc_BufferError);
-        Py_XDECREF(atexit_register);
-        Py_DECREF(module);
-        return NULL;
+    /* Because we need a reference to BufferError in the base module */
+    Py_XINCREF(pgExc_BufferError);
+    if (PyModule_AddObject(module, "BufferError", pgExc_BufferError)) {
+        Py_XDECREF(pgExc_BufferError);
+        goto error;
     }
 
     /* export the c api */
@@ -2173,62 +2153,45 @@ MODINIT_DEFINE(base)
 #endif
 
     apiobj = encapsulate_api(c_api, "base");
-    if (apiobj == NULL) {
-        Py_XDECREF(atexit_register);
-        Py_DECREF(pgExc_BufferError);
-        Py_DECREF(module);
-        return NULL;
-    }
-    ecode = PyDict_SetItemString(dict, PYGAMEAPI_LOCAL_ENTRY, apiobj);
-    Py_DECREF(apiobj);
-    if (ecode) {
-        Py_XDECREF(atexit_register);
-        Py_DECREF(pgExc_BufferError);
-        Py_DECREF(module);
-        return NULL;
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
+        goto error;
     }
 
     if (PyModule_AddIntConstant(module, "HAVE_NEWBUF", 1)) {
-        Py_XDECREF(atexit_register);
-        Py_DECREF(pgExc_BufferError);
-        Py_DECREF(module);
-        return NULL;
+        goto error;
     }
 
-    if (!is_loaded) {
-        /*some intialization*/
-        PyObject *quit = PyObject_GetAttrString(module, "quit");
-        PyObject *rval;
+    /*some intialization*/
+    PyObject *quit = PyObject_GetAttrString(module, "quit");
+    PyObject *rval;
 
-        if (quit == NULL) { /* assertion */
-            Py_DECREF(atexit_register);
-            Py_DECREF(pgExc_BufferError);
-            Py_DECREF(module);
-            return NULL;
-        }
-        rval = PyObject_CallFunctionObjArgs(atexit_register, quit, NULL);
-        Py_DECREF(atexit_register);
-        Py_DECREF(quit);
-        if (rval == NULL) {
-            Py_DECREF(module);
-            Py_DECREF(pgExc_BufferError);
-            return NULL;
-        }
-        Py_DECREF(rval);
-        Py_AtExit(pg_atexit_quit);
+    if (!quit) { /* assertion */
+        goto error;
+    }
+    rval = PyObject_CallFunctionObjArgs(atexit_register, quit, NULL);
+    Py_DECREF(atexit_register);
+    Py_DECREF(quit);
+    atexit_register = NULL;
+    if (!rval) {
+        goto error;
+    }
+    Py_DECREF(rval);
+    Py_AtExit(pg_atexit_quit);
 #ifdef HAVE_SIGNAL_H
-        pg_install_parachute();
+    pg_install_parachute();
 #endif
 
 #ifdef MS_WIN32
-        SDL_RegisterApp("pygame", 0, GetModuleHandle(NULL));
+    SDL_RegisterApp("pygame", 0, GetModuleHandle(NULL));
+#elif defined(macintosh) && !defined(__MWERKS__) && !TARGET_API_MAC_CARBON
+    SDL_InitQuickDraw(&pg_qd);
 #endif
-#if defined(macintosh)
-#if (!defined(__MWERKS__) && !TARGET_API_MAC_CARBON)
-        SDL_InitQuickDraw(&pg_qd);
-#endif
-#endif
-    }
-    is_loaded = 1;
     return module;
+
+error:
+    Py_XDECREF(pgExc_BufferError);
+    Py_XDECREF(atexit_register);
+    Py_XDECREF(module);
+    return NULL;
 }

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2184,8 +2184,6 @@ MODINIT_DEFINE(base)
 
 #ifdef MS_WIN32
     SDL_RegisterApp("pygame", 0, GetModuleHandle(NULL));
-#elif defined(macintosh) && !defined(__MWERKS__) && !TARGET_API_MAC_CARBON
-    SDL_InitQuickDraw(&pg_qd);
 #endif
     return module;
 

--- a/src_c/bufferproxy.c
+++ b/src_c/bufferproxy.c
@@ -614,8 +614,7 @@ pgBufproxy_Trip(PyObject *obj)
 
 MODINIT_DEFINE(bufferproxy)
 {
-    PyObject *module;
-    PyObject *apiobj;
+    PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_BUFPROXY_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -643,6 +642,9 @@ MODINIT_DEFINE(bufferproxy)
 
     /* create the module */
     module = PyModule_Create(&_module);
+    if (!module) {
+        return NULL;
+    }
 
     Py_INCREF(&pgBufproxy_Type);
     if (PyModule_AddObject(module, PROXY_TYPE_NAME,
@@ -659,12 +661,8 @@ MODINIT_DEFINE(bufferproxy)
     c_api[2] = pgBufproxy_GetParent;
     c_api[3] = pgBufproxy_Trip;
     apiobj = encapsulate_api(c_api, PROXY_MODNAME);
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
     if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
-        Py_DECREF(apiobj);
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -2091,9 +2091,7 @@ pg_RGBAFromFuzzyColorObj(PyObject *color, Uint8 rgba[])
 
 MODINIT_DEFINE(color)
 {
-    PyObject *colordict;
-    PyObject *module;
-    PyObject *apiobj;
+    PyObject *module = NULL, *colordict_module, *apiobj;
     static void *c_api[PYGAMEAPI_COLOR_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -2114,44 +2112,38 @@ MODINIT_DEFINE(color)
         return NULL;
     }
 
-    colordict = PyImport_ImportModule("pygame.colordict");
-    if (colordict) {
-        PyObject *_dict = PyModule_GetDict(colordict);
-        PyObject *colors = PyDict_GetItemString(_dict, "THECOLORS");
-        Py_INCREF(colors);
-        _COLORDICT = colors;
-        Py_DECREF(colordict);
+    colordict_module = PyImport_ImportModule("pygame.colordict");
+    if (!colordict_module) {
+        return NULL;
     }
-    else {
+
+    _COLORDICT = PyObject_GetAttrString(colordict_module, "THECOLORS");
+    Py_DECREF(colordict_module);
+    if (!_COLORDICT) {
         return NULL;
     }
 
     /* type preparation */
     if (PyType_Ready(&pgColor_Type) < 0) {
-        Py_DECREF(_COLORDICT);
-        return NULL;
+        goto error;
     }
 
     /* create the module */
     module = PyModule_Create(&_module);
-    if (module == NULL) {
-        Py_DECREF(_COLORDICT);
-        return NULL;
+    if (!module) {
+        goto error;
     }
     pgColor_Type.tp_getattro = PyObject_GenericGetAttr;
     Py_INCREF(&pgColor_Type);
     if (PyModule_AddObject(module, "Color", (PyObject *)&pgColor_Type)) {
         Py_DECREF(&pgColor_Type);
-        Py_DECREF(_COLORDICT);
-        Py_DECREF(module);
-        return NULL;
+        goto error;
     }
     Py_INCREF(_COLORDICT);
     if (PyModule_AddObject(module, "THECOLORS", _COLORDICT)) {
+        /* Yes, _COLORDICT is decref'd twice here and we want that */
         Py_DECREF(_COLORDICT);
-        Py_DECREF(_COLORDICT);
-        Py_DECREF(module);
-        return NULL;
+        goto error;
     }
 
     c_api[0] = &pgColor_Type;
@@ -2161,16 +2153,14 @@ MODINIT_DEFINE(color)
     c_api[4] = pg_RGBAFromFuzzyColorObj;
 
     apiobj = encapsulate_api(c_api, "color");
-    if (apiobj == NULL) {
-        Py_DECREF(_COLORDICT);
-        Py_DECREF(module);
-        return NULL;
-    }
     if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
-        Py_DECREF(apiobj);
-        Py_DECREF(_COLORDICT);
-        Py_DECREF(module);
-        return NULL;
+        Py_XDECREF(apiobj);
+        goto error;
     }
     return module;
+
+error:
+    Py_XDECREF(module);
+    Py_DECREF(_COLORDICT);
+    return NULL;
 }

--- a/src_c/constants.c
+++ b/src_c/constants.c
@@ -63,8 +63,7 @@ static PyMethodDef _constant_methods[] = {{NULL}};
 
 MODINIT_DEFINE(constants)
 {
-    PyObject *module;
-    PyObject *all_list;
+    PyObject *module, *all_list;
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "constants",
@@ -82,7 +81,11 @@ MODINIT_DEFINE(constants)
     }
 
     // Attempt to create __all__ variable for constants module
-    all_list = (PyObject *)PyList_New(0);
+    all_list = PyList_New(0);
+    if (!all_list) {
+        Py_DECREF(module);
+        return NULL;
+    }
 
     DEC_CONST(LIL_ENDIAN);
     DEC_CONST(BIG_ENDIAN);
@@ -613,7 +616,11 @@ MODINIT_DEFINE(constants)
 #define PYGAME_USEREVENT_DROPFILE 0x1000
     DEC_CONSTS(USEREVENT_DROPFILE, PYGAME_USEREVENT_DROPFILE);
 
-    PyModule_AddObject(module, "__all__", all_list);
+    if (PyModule_AddObject(module, "__all__", all_list)) {
+        Py_DECREF(all_list);
+        Py_DECREF(module);
+        return NULL;
+    }
 
     return module;
 }

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -989,17 +989,16 @@ MODINIT_DEFINE(font)
         return NULL;
     }
 
-    Py_INCREF((PyObject *)&PyFont_Type);
-    if (PyModule_AddObject(module, "FontType", (PyObject *)&PyFont_Type) ==
-        -1) {
-        Py_DECREF((PyObject *)&PyFont_Type);
+    Py_INCREF(&PyFont_Type);
+    if (PyModule_AddObject(module, "FontType", (PyObject *)&PyFont_Type)) {
+        Py_DECREF(&PyFont_Type);
         Py_DECREF(module);
         return NULL;
     }
 
-    Py_INCREF((PyObject *)&PyFont_Type);
-    if (PyModule_AddObject(module, "Font", (PyObject *)&PyFont_Type) == -1) {
-        Py_DECREF((PyObject *)&PyFont_Type);
+    Py_INCREF(&PyFont_Type);
+    if (PyModule_AddObject(module, "Font", (PyObject *)&PyFont_Type)) {
+        Py_DECREF(&PyFont_Type);
         Py_DECREF(module);
         return NULL;
     }
@@ -1017,12 +1016,8 @@ MODINIT_DEFINE(font)
     c_api[1] = PyFont_New;
     c_api[2] = &font_initialized;
     apiobj = encapsulate_api(c_api, "font");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj) == -1) {
-        Py_DECREF(apiobj);
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/gfxdraw.c
+++ b/src_c/gfxdraw.c
@@ -1095,8 +1095,6 @@ _gfx_beziercolor(PyObject *self, PyObject *args)
 
 MODINIT_DEFINE(gfxdraw)
 {
-    PyObject *module;
-
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          MODPREFIX "gfxdraw",
                                          DOC_PYGAMEGFXDRAW,
@@ -1127,11 +1125,5 @@ MODINIT_DEFINE(gfxdraw)
         return NULL;
     }
 
-    module = PyModule_Create(&_module);
-
-    if (module == NULL) {
-        return NULL;
-    }
-
-    return module;
+    return PyModule_Create(&_module);
 }

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -892,10 +892,10 @@ MODINIT_DEFINE(key)
         return NULL;
     }
 
-    Py_INCREF((PyObject *)&pgScancodeWrapper_Type);
+    Py_INCREF(&pgScancodeWrapper_Type);
     if (PyModule_AddObject(module, _PG_SCANCODEWRAPPER_TYPE_NAME,
-                           (PyObject *)&pgScancodeWrapper_Type) == -1) {
-        Py_DECREF((PyObject *)&pgScancodeWrapper_Type);
+                           (PyObject *)&pgScancodeWrapper_Type)) {
+        Py_DECREF(&pgScancodeWrapper_Type);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -2593,7 +2593,7 @@ static PyMethodDef _mask_methods[] = {
 
 MODINIT_DEFINE(mask)
 {
-    PyObject *module, *dict, *apiobj;
+    PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_MASK_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -2636,14 +2636,16 @@ MODINIT_DEFINE(mask)
     if (module == NULL) {
         return NULL;
     }
-    dict = PyModule_GetDict(module);
-    if (PyDict_SetItemString(dict, "MaskType", (PyObject *)&pgMask_Type) ==
-        -1) {
+    Py_INCREF(&pgMask_Type);
+    if (PyModule_AddObject(module, "MaskType", (PyObject *)&pgMask_Type)) {
+        Py_DECREF(&pgMask_Type);
         Py_DECREF(module);
         return NULL;
     }
 
-    if (PyDict_SetItemString(dict, "Mask", (PyObject *)&pgMask_Type) == -1) {
+    Py_INCREF(&pgMask_Type);
+    if (PyModule_AddObject(module, "Mask", (PyObject *)&pgMask_Type)) {
+        Py_DECREF(&pgMask_Type);
         Py_DECREF(module);
         return NULL;
     }
@@ -2651,12 +2653,8 @@ MODINIT_DEFINE(mask)
     /* export the c api */
     c_api[0] = &pgMask_Type;
     apiobj = encapsulate_api(c_api, "mask");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj) == -1) {
-        Py_DECREF(apiobj);
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -4126,13 +4126,8 @@ MODINIT_DEFINE(math)
     c_api[4] = pgVectorCompatible_Check;
     */
     apiobj = encapsulate_api(c_api, "math");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-
-    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj) != 0) {
-        Py_DECREF(apiobj);
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -475,8 +475,6 @@ static PyMethodDef _mouse_methods[] = {
 
 MODINIT_DEFINE(mouse)
 {
-    PyObject *module;
-
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
                                          "mouse",
                                          DOC_PYGAMEMOUSE,
@@ -500,9 +498,5 @@ MODINIT_DEFINE(mouse)
     }
 
     /* create the module */
-    module = PyModule_Create(&_module);
-    if (module == NULL) {
-        return NULL;
-    }
-    return module;
+    return PyModule_Create(&_module);
 }

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -560,23 +560,15 @@ MODINIT_DEFINE(mixer_music)
     }
     cobj = PyCapsule_New(&current_music, "pygame.music_mixer._MUSIC_POINTER",
                          NULL);
-    if (cobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    if (PyModule_AddObject(module, "_MUSIC_POINTER", cobj) < 0) {
-        Py_DECREF(cobj);
+    if (PyModule_AddObject(module, "_MUSIC_POINTER", cobj)) {
+        Py_XDECREF(cobj);
         Py_DECREF(module);
         return NULL;
     }
     cobj =
         PyCapsule_New(&queue_music, "pygame.music_mixer._QUEUE_POINTER", NULL);
-    if (cobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    if (PyModule_AddObject(module, "_QUEUE_POINTER", cobj) < 0) {
-        Py_DECREF(cobj);
+    if (PyModule_AddObject(module, "_QUEUE_POINTER", cobj)) {
+        Py_XDECREF(cobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -963,6 +963,9 @@ MODINIT_DEFINE(newbuffer)
 
     /* create the module */
     module = PyModule_Create(&_module);
+    if (!module) {
+        return NULL;
+    }
 
     Py_INCREF(&BufferMixin_Type);
     if (PyModule_AddObject(module, "BufferMixin",

--- a/src_c/pixelarray.c
+++ b/src_c/pixelarray.c
@@ -1972,12 +1972,8 @@ MODINIT_DEFINE(pixelarray)
     c_api[0] = &pgPixelArray_Type;
     c_api[1] = pgPixelArray_New;
     apiobj = encapsulate_api(c_api, "pixelarray");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
     if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
-        Py_DECREF(apiobj);
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -2057,8 +2057,7 @@ static PyMethodDef _pg_module_methods[] = {{NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(rect)
 {
-    PyObject *module, *dict, *apiobj;
-    int ecode;
+    PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_RECT_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -2088,13 +2087,16 @@ MODINIT_DEFINE(rect)
     if (module == NULL) {
         return NULL;
     }
-    dict = PyModule_GetDict(module);
 
-    if (PyDict_SetItemString(dict, "RectType", (PyObject *)&pgRect_Type)) {
+    Py_INCREF(&pgRect_Type);
+    if (PyModule_AddObject(module, "RectType", (PyObject *)&pgRect_Type)) {
+        Py_DECREF(&pgRect_Type);
         Py_DECREF(module);
         return NULL;
     }
-    if (PyDict_SetItemString(dict, "Rect", (PyObject *)&pgRect_Type)) {
+    Py_INCREF(&pgRect_Type);
+    if (PyModule_AddObject(module, "Rect", (PyObject *)&pgRect_Type)) {
+        Py_DECREF(&pgRect_Type);
         Py_DECREF(module);
         return NULL;
     }
@@ -2106,13 +2108,8 @@ MODINIT_DEFINE(rect)
     c_api[3] = pgRect_FromObject;
     c_api[4] = pgRect_Normalize;
     apiobj = encapsulate_api(c_api, "rect");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    ecode = PyDict_SetItemString(dict, PYGAMEAPI_LOCAL_ENTRY, apiobj);
-    Py_DECREF(apiobj);
-    if (ecode) {
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -806,8 +806,7 @@ static PyMethodDef _pg_module_methods[] = {
 
 MODINIT_DEFINE(rwobject)
 {
-    PyObject *module, *dict, *apiobj;
-    int ecode;
+    PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_RWOBJECT_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -825,7 +824,6 @@ MODINIT_DEFINE(rwobject)
     if (module == NULL) {
         return NULL;
     }
-    dict = PyModule_GetDict(module);
 
     /* export the c api */
     c_api[0] = pgRWops_FromObject;
@@ -836,13 +834,8 @@ MODINIT_DEFINE(rwobject)
     c_api[5] = pgRWops_ReleaseObject;
     c_api[6] = pgRWops_GetFileExtension;
     apiobj = encapsulate_api(c_api, "rwobject");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    ecode = PyDict_SetItemString(dict, PYGAMEAPI_LOCAL_ENTRY, apiobj);
-    Py_DECREF(apiobj);
-    if (ecode == -1) {
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/sdlmain_osx.m
+++ b/src_c/sdlmain_osx.m
@@ -342,8 +342,6 @@ static PyMethodDef macosx_builtins[] =
 
 MODINIT_DEFINE (sdlmain_osx)
 {
-    PyObject *module;
-
     /* create the module */
     static struct PyModuleDef _module = {
         PyModuleDef_HEAD_INIT,
@@ -363,6 +361,5 @@ MODINIT_DEFINE (sdlmain_osx)
         return NULL;
     }
 
-    module = PyModule_Create(&_module);
-    return module;
+    return PyModule_Create(&_module);
 }

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3721,8 +3721,7 @@ static PyMethodDef _surface_methods[] = {{NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(surface)
 {
-    PyObject *module, *dict, *apiobj;
-    int ecode;
+    PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_SURFACE_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -3769,14 +3768,17 @@ MODINIT_DEFINE(surface)
     if (module == NULL) {
         return NULL;
     }
-    dict = PyModule_GetDict(module);
-
-    if (PyDict_SetItemString(dict, "SurfaceType",
-                             (PyObject *)&pgSurface_Type)) {
+    Py_INCREF(&pgSurface_Type);
+    if (PyModule_AddObject(module, "SurfaceType",
+                           (PyObject *)&pgSurface_Type)) {
+        Py_DECREF(&pgSurface_Type);
         Py_DECREF(module);
         return NULL;
     }
-    if (PyDict_SetItemString(dict, "Surface", (PyObject *)&pgSurface_Type)) {
+
+    Py_INCREF(&pgSurface_Type);
+    if (PyModule_AddObject(module, "Surface", (PyObject *)&pgSurface_Type)) {
+        Py_DECREF(&pgSurface_Type);
         Py_DECREF(module);
         return NULL;
     }
@@ -3787,18 +3789,14 @@ MODINIT_DEFINE(surface)
     c_api[2] = pgSurface_Blit;
     c_api[3] = pgSurface_SetSurface;
     apiobj = encapsulate_api(c_api, "surface");
-    if (apiobj == NULL) {
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }
-    ecode = PyDict_SetItemString(dict, PYGAMEAPI_LOCAL_ENTRY, apiobj);
-    Py_DECREF(apiobj);
-    if (ecode) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    /* Py_INCREF (pgSurface_Type.tp_dict); INCREF's done in SetItemString */
-    if (PyDict_SetItemString(dict, "_dict", pgSurface_Type.tp_dict)) {
+    Py_XINCREF(pgSurface_Type.tp_dict);
+    if (PyModule_AddObject(module, "_dict", pgSurface_Type.tp_dict)) {
+        Py_XDECREF(pgSurface_Type.tp_dict);
         Py_DECREF(module);
         return NULL;
     }

--- a/src_c/surflock.c
+++ b/src_c/surflock.c
@@ -261,8 +261,7 @@ static PyMethodDef _surflock_methods[] = {{NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(surflock)
 {
-    PyObject *module, *dict, *apiobj;
-    int ecode;
+    PyObject *module, *apiobj;
     static void *c_api[PYGAMEAPI_SURFLOCK_NUMSLOTS];
 
     static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
@@ -284,7 +283,6 @@ MODINIT_DEFINE(surflock)
     if (module == NULL) {
         return NULL;
     }
-    dict = PyModule_GetDict(module);
 
     /* export the c api */
     c_api[0] = &pgLifetimeLock_Type;
@@ -296,13 +294,8 @@ MODINIT_DEFINE(surflock)
     c_api[6] = pgSurface_UnlockBy;
     c_api[7] = pgSurface_LockLifetime;
     apiobj = encapsulate_api(c_api, "surflock");
-    if (apiobj == NULL) {
-        Py_DECREF(module);
-        return NULL;
-    }
-    ecode = PyDict_SetItemString(dict, PYGAMEAPI_LOCAL_ENTRY, apiobj);
-    Py_DECREF(apiobj);
-    if (ecode) {
+    if (PyModule_AddObject(module, PYGAMEAPI_LOCAL_ENTRY, apiobj)) {
+        Py_XDECREF(apiobj);
         Py_DECREF(module);
         return NULL;
     }


### PR DESCRIPTION
PR to close #2951

Does some code cleanups around modinit code, fixing a few bugs in the process, and migrating away from `PyModule_GetDict` which is discouraged by the [docs](https://docs.python.org/3/c-api/module.html#c.PyModule_GetDict)

I originally planned to make use of newer API like `PyModule_AddObjectRef` (new in py3.10) and `PyModule_AddType` (new in py3.9) because that makes the modinit code even more elegant, but to do this we'd have to put some hacks on `pyver < 3.10` and I figured this could create problems if we ever intend to use `Py_LIMITED_API`, so I left this for now (but we can still do this when the minimum supported python version is 3.10, and this would happen in 5-6ish years)