### PR TITLE
fix segfault in display.update

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -242,6 +242,9 @@ required).
    instead of the entire area. If no argument is passed it updates the entire
    Surface area like ``pygame.display.flip()``.
 
+   Note that calling ``display.update(None)`` means no part of the window is
+   updated. Whereas ``display.update()`` means the whole window is updated.
+
    You can pass the function a single rectangle, or a sequence of rectangles.
    It is more efficient to pass many rectangles at once than to call update
    multiple times with single or a partial list of rectangles. If passing a

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1621,6 +1621,7 @@ pg_update(PyObject *self, PyObject *arg)
 
     if (!win)
         return RAISE(pgExc_SDLError, "Display mode not set");
+
     if (pg_renderer != NULL) {
         return pg_flip(self);
     }
@@ -1633,19 +1634,14 @@ pg_update(PyObject *self, PyObject *arg)
     if (PyTuple_Size(arg) == 0) {
         return pg_flip(self);
     }
-    else {
-        obj = PyTuple_GET_ITEM(arg, 0);
-        if (obj == Py_None)
-            gr = &temp;
-        else {
-            gr = pgRect_FromObject(arg, &temp);
-            if (gr != &temp) {
-                memcpy(&temp, gr, sizeof(temp));
-                gr = &temp;
-            }
-        }
+
+    if (PyTuple_GET_ITEM(arg, 0) == Py_None) {
+        /* This is to comply with old behaviour of the function, might be worth
+         * deprecating this in the future */
+        Py_RETURN_NONE;
     }
 
+    gr = pgRect_FromObject(arg, &temp);
     if (gr) {
         SDL_Rect sdlr;
 
@@ -1661,12 +1657,12 @@ pg_update(PyObject *self, PyObject *arg)
         if (PyTuple_Size(arg) != 1)
             return RAISE(
                 PyExc_ValueError,
-                "update requires a rectstyle or sequence of recstyles");
+                "update requires a rectstyle or sequence of rectstyles");
         seq = PyTuple_GET_ITEM(arg, 0);
         if (!seq || !PySequence_Check(seq))
             return RAISE(
                 PyExc_ValueError,
-                "update requires a rectstyle or sequence of recstyles");
+                "update requires a rectstyle or sequence of rectstyles");
 
         num = PySequence_Length(seq);
         rects = PyMem_New(SDL_Rect, num);

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -20,22 +20,6 @@ class DisplayModuleTest(unittest.TestCase):
     def tearDown(self):
         display.quit()
 
-    def test_update(self):
-        """see if pygame.display.update takes rects with negative values.
-        "|Tags:display|"
-        """
-        screen = pygame.display.set_mode((100, 100))
-        screen.fill((55, 55, 55))
-
-        r1 = pygame.Rect(0, 0, 100, 100)
-        pygame.display.update(r1)
-
-        r2 = pygame.Rect(-10, 0, 100, 100)
-        pygame.display.update(r2)
-
-        r3 = pygame.Rect(-10, 0, -100, -100)
-        pygame.display.update(r3)
-
     def test_Info(self):
         inf = pygame.display.Info()
         self.assertNotEqual(inf.current_h, -1)
@@ -642,6 +626,112 @@ class DisplayModuleTest(unittest.TestCase):
                 self.assertEqual(
                     (test_surf.get_width(), test_surf.get_height()), width_height
                 )
+
+
+class DisplayUpdateTest(unittest.TestCase):
+    def question(self, qstr):
+        """this is used in the interactive subclass."""
+
+    def setUp(self):
+        display.init()
+        self.screen = pygame.display.set_mode((500, 500))
+        self.screen.fill("black")
+        pygame.display.flip()
+        pygame.event.pump()  # so mac updates
+
+    def tearDown(self):
+        display.quit()
+
+    def test_update_negative(self):
+        """takes rects with negative values."""
+        self.screen.fill("green")
+
+        r1 = pygame.Rect(0, 0, 100, 100)
+        pygame.display.update(r1)
+
+        r2 = pygame.Rect(-10, 0, 100, 100)
+        pygame.display.update(r2)
+
+        r3 = pygame.Rect(-10, 0, -100, -100)
+        pygame.display.update(r3)
+
+        self.question("Is the screen green in (0, 0, 100, 100)?")
+
+    def test_update_sequence(self):
+        """only updates the part of the display given by the rects."""
+        self.screen.fill("green")
+        rects = [
+            pygame.Rect(0, 0, 100, 100),
+            pygame.Rect(100, 0, 100, 100),
+            pygame.Rect(200, 0, 100, 100),
+            pygame.Rect(300, 300, 100, 100),
+        ]
+        pygame.display.update(rects)
+        pygame.event.pump()  # so mac updates
+
+        self.question(f"Is the screen green in {rects}?")
+
+    def test_update_none_skipped(self):
+        """None is skipped inside sequences."""
+        self.screen.fill("green")
+        rects = (
+            None,
+            pygame.Rect(100, 0, 100, 100),
+            None,
+            pygame.Rect(200, 0, 100, 100),
+            pygame.Rect(300, 300, 100, 100),
+        )
+        pygame.display.update(rects)
+        pygame.event.pump()  # so mac updates
+
+        self.question(f"Is the screen green in {rects}?")
+
+    def test_update_none(self):
+        """does NOT update the display."""
+        self.screen.fill("green")
+        pygame.display.update(None)
+        pygame.event.pump()  # so mac updates
+        self.question(f"Is the screen black and NOT green?")
+
+    def test_update_no_args(self):
+        """does NOT update the display."""
+        self.screen.fill("green")
+        pygame.display.update()
+        pygame.event.pump()  # so mac updates
+        self.question(f"Is the WHOLE screen green?")
+
+    def test_update_args(self):
+        """updates the display using the args as a rect."""
+        self.screen.fill("green")
+        pygame.display.update(100, 100, 100, 100)
+        pygame.event.pump()  # so mac updates
+        self.question("Is the screen green in (100, 100, 100, 100)?")
+
+    def test_update_incorrect_args(self):
+        """raises a ValueError when inputs are wrong."""
+
+        with self.assertRaises(ValueError):
+            pygame.display.update(100, "asdf", 100, 100)
+
+        with self.assertRaises(ValueError):
+            pygame.display.update([100, "asdf", 100, 100])
+
+    def test_update_no_init(self):
+        """raises a pygame.error."""
+
+        pygame.display.quit()
+        with self.assertRaises(pygame.error):
+            pygame.display.update()
+
+
+class DisplayUpdateInteractiveTest(DisplayUpdateTest):
+    """Because we want these tests to run as interactive and not interactive."""
+
+    __tags__ = ["interactive"]
+
+    def question(self, qstr):
+        """since this is the interactive sublcass we ask a question."""
+        question(qstr)
 
 
 class DisplayInteractiveTest(unittest.TestCase):


### PR DESCRIPTION
A regression of the latest 2.1.1 release, display.update can segfault on some kinds of inputs