### PR TITLE
Add test for pygame.locals

### DIFF
--- a/src_py/locals.py
+++ b/src_py/locals.py
@@ -200,6 +200,7 @@ __all__ = [
     "KMOD_RMETA",
     "KMOD_RSHIFT",
     "KMOD_SHIFT",
+    "KSCAN_AC_BACK",
     "KSCAN_0",
     "KSCAN_1",
     "KSCAN_2",

--- a/test/locals_test.py
+++ b/test/locals_test.py
@@ -1,0 +1,17 @@
+import unittest
+
+import pygame.constants
+import pygame.locals
+
+
+class LocalsTest(unittest.TestCase):
+    def test_locals_has_all_constants(self):
+        constants_set = set(pygame.constants.__all__)
+        locals_set = set(pygame.locals.__all__)
+
+        # locals should have everything that constants has
+        self.assertEqual(constants_set - locals_set, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While doing #2953 I realised that it is quite easy for someone to forget to update `pygame.locals` when they add new constants into `pygame.constants`
So I wrote a quick test to catch this issue, and also fixed a missing constant that someone in the past forgot to add