### PR TITLE
Add pixel format name into display info

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -334,6 +334,7 @@ pg_vidinfo_str(PyObject *self)
     int current_w = -1;
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
+    const char* pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
 
     SDL_version versioninfo;
     SDL_VERSION(&versioninfo);
@@ -344,8 +345,6 @@ pg_vidinfo_str(PyObject *self)
         current_h = info->current_h;
     }
 
-    Uint32 pixelFormatEnum = info->vfmt->format;
-    const char* surfacePixelFormatName = SDL_GetPixelFormatName(pixelFormatEnum);
 
     sprintf(str,
             "<VideoInfo(hw = %d, wm = %d,video_mem = %d\n"
@@ -366,7 +365,7 @@ pg_vidinfo_str(PyObject *self)
             info->vfmt->Gshift, info->vfmt->Bshift, info->vfmt->Ashift,
             info->vfmt->Rloss, info->vfmt->Gloss, info->vfmt->Bloss,
             info->vfmt->Aloss, current_w, current_h,
-            surfacePixelFormatName);
+            pixel_format_name);
     return PyUnicode_FromString(str);
 }
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -345,7 +345,6 @@ pg_vidinfo_str(PyObject *self)
         current_h = info->current_h;
     }
 
-
     sprintf(str,
             "<VideoInfo(hw = %d, wm = %d,video_mem = %d\n"
             "         blit_hw = %d, blit_hw_CC = %d, blit_hw_A = %d,\n"

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -334,7 +334,7 @@ pg_vidinfo_str(PyObject *self)
     int current_w = -1;
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
-    const char* pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
+    const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
 
     SDL_version versioninfo;
     SDL_VERSION(&versioninfo);
@@ -363,8 +363,7 @@ pg_vidinfo_str(PyObject *self)
             info->vfmt->Bmask, info->vfmt->Amask, info->vfmt->Rshift,
             info->vfmt->Gshift, info->vfmt->Bshift, info->vfmt->Ashift,
             info->vfmt->Rloss, info->vfmt->Gloss, info->vfmt->Bloss,
-            info->vfmt->Aloss, current_w, current_h,
-            pixel_format_name);
+            info->vfmt->Aloss, current_w, current_h, pixel_format_name);
     return PyUnicode_FromString(str);
 }
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -344,6 +344,9 @@ pg_vidinfo_str(PyObject *self)
         current_h = info->current_h;
     }
 
+    Uint32 pixelFormatEnum = info->vfmt->format;
+    const char* surfacePixelFormatName = SDL_GetPixelFormatName(pixelFormatEnum);
+
     sprintf(str,
             "<VideoInfo(hw = %d, wm = %d,video_mem = %d\n"
             "         blit_hw = %d, blit_hw_CC = %d, blit_hw_A = %d,\n"
@@ -353,6 +356,7 @@ pg_vidinfo_str(PyObject *self)
             "         shifts = (%d, %d, %d, %d),\n"
             "         losses =  (%d, %d, %d, %d),\n"
             "         current_w = %d, current_h = %d\n"
+            "         pixel_format = %s\n"
             ">\n",
             info->hw_available, info->wm_available, info->video_mem,
             info->blit_hw, info->blit_hw_CC, info->blit_hw_A, info->blit_sw,
@@ -361,7 +365,8 @@ pg_vidinfo_str(PyObject *self)
             info->vfmt->Bmask, info->vfmt->Amask, info->vfmt->Rshift,
             info->vfmt->Gshift, info->vfmt->Bshift, info->vfmt->Ashift,
             info->vfmt->Rloss, info->vfmt->Gloss, info->vfmt->Bloss,
-            info->vfmt->Aloss, current_w, current_h);
+            info->vfmt->Aloss, current_w, current_h,
+            surfacePixelFormatName);
     return PyUnicode_FromString(str);
 }
 


### PR DESCRIPTION
Helps make it easier to spot when display surfaces are different from what we are expecting. This came up from discussion of display surfaces being RGB on windows and linux, but ARGB on mac.

**Test program**:
```python
import pygame

pygame.init()
print(pygame.display.Info())
```

**Before:**
```
<VideoInfo(hw = 0, wm = 1,video_mem = 0
         blit_hw = 0, blit_hw_CC = 0, blit_hw_A = 0,
         blit_sw = 0, blit_sw_CC = 0, blit_sw_A = 0,
         bitsize  = 32, bytesize = 4,
         masks =  (16711680, 65280, 255, 0),
         shifts = (16, 8, 0, 0),
         losses =  (0, 0, 0, 8),
         current_w = 800, current_h = 600
>
```

**After:**
```
<VideoInfo(hw = 0, wm = 1,video_mem = 0
         blit_hw = 0, blit_hw_CC = 0, blit_hw_A = 0,
         blit_sw = 0, blit_sw_CC = 0, blit_sw_A = 0,
         bitsize  = 32, bytesize = 4,
         masks =  (16711680, 65280, 255, 0),
         shifts = (16, 8, 0, 0),
         losses =  (0, 0, 0, 8),
         current_w = 800, current_h = 600
         pixel_format = SDL_PIXELFORMAT_RGB888
>
```