### PR TITLE
Fix path dependencies

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -137,7 +137,8 @@ def main():
     origincdirs = ['/include', '/include/SDL2']
     origlibdirs = ['/lib', '/lib64', '/X11R6/lib',
                    '/lib/i386-linux-gnu', '/lib/x86_64-linux-gnu',
-                   '/lib/arm-linux-gnueabihf/', '/lib/aarch64-linux-gnu/', '/lib/powerpc64le-linux-gnu']
+                   '/lib/arm-linux-gnueabihf/', '/lib/aarch64-linux-gnu/', 
+                   '/lib/powerpc64le-linux-gnu/']
 
     if 'ORIGLIBDIRS' in os.environ and os.environ['ORIGLIBDIRS'] != "":
         origlibdirs = os.environ['ORIGLIBDIRS'].split(":")

--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -137,7 +137,7 @@ def main():
     origincdirs = ['/include', '/include/SDL2']
     origlibdirs = ['/lib', '/lib64', '/X11R6/lib',
                    '/lib/i386-linux-gnu', '/lib/x86_64-linux-gnu',
-                   '/lib/arm-linux-gnueabihf/', '/lib/aarch64-linux-gnu/']
+                   '/lib/arm-linux-gnueabihf/', '/lib/aarch64-linux-gnu/', '/lib/powerpc64le-linux-gnu']
 
     if 'ORIGLIBDIRS' in os.environ and os.environ['ORIGLIBDIRS'] != "":
         origlibdirs = os.environ['ORIGLIBDIRS'].split(":")


### PR DESCRIPTION
When working with `linux/ppc64le` architecture Pygame doesn't find several `sdl2` dependencies since they are installed  in the `/lib/powerpc64le-linux-gnu` folder