### PR TITLE
Save Surfaces with palettes as indexed 8P PNG

### DIFF
--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -221,6 +221,7 @@ write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows,
             color_ptr[i].blue = palette->colors[i].b;
         }
         png_set_PLTE(png_ptr, info_ptr, color_ptr, ncolors);
+        free(color_ptr);
     }
 
     /* doing = "write info"; */

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -221,7 +221,7 @@ write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows,
             color_ptr[i].blue = palette->colors[i].b;
         }
         png_set_PLTE(png_ptr, info_ptr, color_ptr, ncolors);
-        free(color_ptr);
+        SDL_free(color_ptr);
     }
 
     /* doing = "write info"; */

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -208,12 +208,13 @@ write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows,
                  PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE,
                  PNG_FILTER_TYPE_BASE);
 
-
-    if (palette){
+    if (palette) {
+        doing = "set pallete";
         const int ncolors = palette->ncolors;
         int i;
-        if (!(color_ptr = (png_colorp)SDL_malloc(sizeof(png_colorp) * ncolors)))
-            goto fail;      
+        if (!(color_ptr =
+                  (png_colorp)SDL_malloc(sizeof(png_colorp) * ncolors)))
+            goto fail;
         for (i = 0; i < ncolors; i++) {
             color_ptr[i].red = palette->colors[i].r;
             color_ptr[i].green = palette->colors[i].g;
@@ -221,7 +222,6 @@ write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows,
         }
         png_set_PLTE(png_ptr, info_ptr, color_ptr, ncolors);
     }
-
 
     /* doing = "write info"; */
     png_write_info(png_ptr, info_ptr);
@@ -265,7 +265,7 @@ SavePNG(SDL_Surface *surface, const char *file, SDL_RWops *rw)
     SDL_Rect ss_rect;
     int r, i;
     int alpha = 0;
-    SDL_Palette* palette;    
+    SDL_Palette *palette;
     Uint8 surf_alpha = 255;
     Uint32 surf_colorkey;
     int has_colorkey = 0;
@@ -340,7 +340,7 @@ SavePNG(SDL_Surface *surface, const char *file, SDL_RWops *rw)
             ((unsigned char *)ss_surface->pixels) + i * ss_surface->pitch;
     }
 
-    if (palette){
+    if (palette) {
         r = write_png(file, rw, ss_rows, palette, surface->w, surface->h,
                       PNG_COLOR_TYPE_PALETTE, 8);
     }

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -170,11 +170,12 @@ png_flush_fn(png_structp png_ptr)
 }
 
 static int
-write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows, int w, int h,
-          int colortype, int bitdepth)
+write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows,
+          SDL_Palette *palette, int w, int h, int colortype, int bitdepth)
 {
     png_structp png_ptr = NULL;
     png_infop info_ptr = NULL;
+    png_colorp color_ptr = NULL;
     SDL_RWops *rwops;
     char *doing;
 
@@ -206,6 +207,21 @@ write_png(const char *file_name, SDL_RWops *rw, png_bytep *rows, int w, int h,
     png_set_IHDR(png_ptr, info_ptr, w, h, bitdepth, colortype,
                  PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE,
                  PNG_FILTER_TYPE_BASE);
+
+
+    if (palette){
+        const int ncolors = palette->ncolors;
+        int i;
+        if (!(color_ptr = (png_colorp)SDL_malloc(sizeof(png_colorp) * ncolors)))
+            goto fail;      
+        for (i = 0; i < ncolors; i++) {
+            color_ptr[i].red = palette->colors[i].r;
+            color_ptr[i].green = palette->colors[i].g;
+            color_ptr[i].blue = palette->colors[i].b;
+        }
+        png_set_PLTE(png_ptr, info_ptr, color_ptr, ncolors);
+    }
+
 
     /* doing = "write info"; */
     png_write_info(png_ptr, info_ptr);
@@ -249,7 +265,7 @@ SavePNG(SDL_Surface *surface, const char *file, SDL_RWops *rw)
     SDL_Rect ss_rect;
     int r, i;
     int alpha = 0;
-
+    SDL_Palette* palette;    
     Uint8 surf_alpha = 255;
     Uint32 surf_colorkey;
     int has_colorkey = 0;
@@ -259,6 +275,7 @@ SavePNG(SDL_Surface *surface, const char *file, SDL_RWops *rw)
     ss_size = 0;
     ss_surface = NULL;
 
+    palette = surface->format->palette;
     ss_w = surface->w;
     ss_h = surface->h;
 
@@ -323,12 +340,16 @@ SavePNG(SDL_Surface *surface, const char *file, SDL_RWops *rw)
             ((unsigned char *)ss_surface->pixels) + i * ss_surface->pitch;
     }
 
-    if (alpha) {
-        r = write_png(file, rw, ss_rows, surface->w, surface->h,
+    if (palette){
+        r = write_png(file, rw, ss_rows, palette, surface->w, surface->h,
+                      PNG_COLOR_TYPE_PALETTE, 8);
+    }
+    else if (alpha) {
+        r = write_png(file, rw, ss_rows, NULL, surface->w, surface->h,
                       PNG_COLOR_TYPE_RGB_ALPHA, 8);
     }
     else {
-        r = write_png(file, rw, ss_rows, surface->w, surface->h,
+        r = write_png(file, rw, ss_rows, NULL, surface->w, surface->h,
                       PNG_COLOR_TYPE_RGB, 8);
     }
 
@@ -583,7 +604,6 @@ SaveJPEG(SDL_Surface *surface, const char *file)
     r = write_jpeg(file, ss_rows, surface->w, surface->h, JPEG_QUALITY);
 
     free(ss_rows);
-
     if (free_ss_surface) {
         SDL_FreeSurface(ss_surface);
         ss_surface = NULL;

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -222,6 +222,43 @@ class ImageModuleTest(unittest.TestCase):
             del reader
             os.remove(f_path)
 
+    def testSavePaletteAsPNG8(self):
+        """see if we can save a png with color values in the proper channels."""
+        # Create a PNG file with known colors
+        pygame.display.init()
+
+        reddish_pixel = (215, 0, 0)
+        greenish_pixel = (0, 225, 0)
+        bluish_pixel = (0, 0, 235)
+        greyish_pixel = (115, 125, 135)
+
+        surf = pygame.Surface((1, 4), 0, 8)
+        surf.set_palette_at(0, reddish_pixel)
+        surf.set_palette_at(1, greenish_pixel)
+        surf.set_palette_at(2, bluish_pixel)
+        surf.set_palette_at(3, greyish_pixel)
+
+        f_path = tempfile.mktemp(suffix=".png")
+        pygame.image.save(surf, f_path)
+        try:
+            # Read the PNG file and verify that pygame saved it correctly
+            reader = png.Reader(filename=f_path)
+            reader.read()
+            palette = reader.palette()
+
+            # pixels is a generator
+            self.assertEqual(tuple(next(palette)), reddish_pixel)
+            self.assertEqual(tuple(next(palette)), greenish_pixel)
+            self.assertEqual(tuple(next(palette)), bluish_pixel)
+            self.assertEqual(tuple(next(palette)), greyish_pixel)
+
+        finally:
+            # Ensures proper clean up.
+            if not reader.file.closed:
+                reader.file.close()
+            del reader
+            os.remove(f_path)
+
     def test_save(self):
 
         s = pygame.Surface((10, 10))


### PR DESCRIPTION
Fix #646
- [x] first we need to write a unit test in [test/image_test.py](https://github.com/pygame/pygame/blob/master/test/image_test.py) (good first issue)
- [x] fix the issue in [src_c/imageext.c](https://github.com/pygame/pygame/blob/master/src_c/imageext.c#L254) SavePNG function. (harder)
- [X] ~~try SDL 2.0.2 using the SDL_image save function rather than our own. (harder)~~ - The SDL function doesn't work.