### PR TITLE
pygame.docs: remove warning in docs generation due to a  reference to…

### DIFF
--- a/docs/reST/c_api.rst
+++ b/docs/reST/c_api.rst
@@ -8,7 +8,6 @@ pygame C API
    c_api/slots.rst
    c_api/base.rst
    c_api/bufferproxy.rst
-   c_api/cdrom.rst
    c_api/color.rst
    c_api/display.rst
    c_api/event.rst


### PR DESCRIPTION
… deleted cdrom.rst file