### PR TITLE
Add `pygame.get_preferred_locales`

### DIFF
--- a/buildconfig/stubs/pygame/context.pyi
+++ b/buildconfig/stubs/pygame/context.pyi
@@ -3,9 +3,9 @@ from typing import List, Optional
 from typing_extensions import TypedDict
 
 # dict at runtime, TypedDict exists solely for the typechecking benefits
-class Locale(TypedDict):
+class _Locale(TypedDict):
     language: str
     country: Optional[str]
 
 def get_pref_path(org: str, app: str) -> str: ...
-def get_pref_locales() -> List[Locale]: ...
+def get_pref_locales() -> List[_Locale]: ...

--- a/buildconfig/stubs/pygame/context.pyi
+++ b/buildconfig/stubs/pygame/context.pyi
@@ -1,1 +1,11 @@
+from typing import List, Optional
+
+from typing_extensions import TypedDict
+
+# dict at runtime, TypedDict exists solely for the typechecking benefits
+class Locale(TypedDict):
+    language: str
+    country: Optional[str]
+
 def get_pref_path(org: str, app: str) -> str: ...
+def get_pref_locales() -> List[Locale]: ...

--- a/docs/reST/ref/context.rst
+++ b/docs/reST/ref/context.rst
@@ -48,5 +48,35 @@ open just in case something obvious comes up.
 
         And on Linux it would resemble
         /home/bob/.local/share/My Program Name/
+    
+   .. versionadded:: 2.1.3
+
+.. function:: get_pref_locales
+
+   | :sl:`get preferred locales set on the system`
+   | :sg:`get_pref_locales() -> list[locale]`
+
+   Returns a list of "locale" dicts, sorted in descending order of preference
+   set on the host OS (the most preferred locale is the first element). May
+   also be an empty list if pygame could not find this information.
+
+   Each "locale" dict contains the language code which can be accessed by the
+   key ``"language"``. This language code is an ISO-639 language specifier 
+   (such as "en" for English, "de" for German, etc).
+   A "locale" dict may also optionally contain a ``"country"`` field, whose
+   value is an ISO-3166 country code (such as "US" for the United States, 
+   "CA" for Canada, etc). If this field is not set or undetermined, it is 
+   ``None``.
+   A "locale" dict which looks like ``{'language': 'en', 'country': 'US'}``
+   indicates the user prefers American English, while
+   ``{'language': 'en', 'country': None}`` indicates that the user prefers
+   English, generically.
+
+   This might be a bit of an expensive call because it has to query the OS. So
+   this function must not be called in a game loop, instead it's best to ask 
+   for this once and save the results. However, this list can change when the
+   user changes a system preference outside of your program. pygame will send
+   a ``LOCALECHANGED`` event in this case, if possible, and you can call this
+   function again to get an updated copy of preferred locales.
 
    .. versionadded:: 2.1.3

--- a/src_c/context.c
+++ b/src_c/context.c
@@ -26,9 +26,81 @@ pg_context_get_pref_path(PyObject *self, PyObject *args, PyObject *kwargs)
     return ret;
 }
 
+static PyObject *
+pg_context_get_pref_locales(PyObject *self, PyObject *_null)
+{
+    PyObject *ret_list = PyList_New(0);
+    if (!ret_list) {
+        return NULL;
+    }
+
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    PyObject *dict, *val = NULL;
+    SDL_Locale *locales = SDL_GetPreferredLocales();
+    if (!locales) {
+        /* Return an empty list if SDL function does not return any useful
+         * information */
+        return ret_list;
+    }
+
+    SDL_Locale *current_locale = locales;
+    while (current_locale->language) {
+        dict = PyDict_New();
+        if (!dict) {
+            goto error;
+        }
+
+        val = PyUnicode_FromString(current_locale->language);
+        if (!val) {
+            goto error;
+        }
+        if (PyDict_SetItemString(dict, "language", val)) {
+            goto error;
+        }
+        Py_DECREF(val);
+
+        if (current_locale->country) {
+            val = PyUnicode_FromString(current_locale->country);
+            if (!val) {
+                goto error;
+            }
+        }
+        else {
+            Py_INCREF(Py_None);
+            val = Py_None;
+        }
+        if (PyDict_SetItemString(dict, "country", val)) {
+            goto error;
+        }
+        Py_DECREF(val);
+
+        /* reset val to NULL because goto XDECREF's this */
+        val = NULL;
+        if (PyList_Append(ret_list, dict)) {
+            goto error;
+        }
+        Py_DECREF(dict);
+        current_locale++;
+    }
+
+    SDL_free(locales);
+    return ret_list;
+error:
+    Py_XDECREF(val);
+    Py_XDECREF(dict);
+    SDL_free(locales);
+    Py_DECREF(ret_list);
+    return NULL;
+#else
+    return ret_list;
+#endif
+}
+
 static PyMethodDef _context_methods[] = {
     {"get_pref_path", (PyCFunction)pg_context_get_pref_path,
      METH_VARARGS | METH_KEYWORDS, DOC_PYGAMECONTEXTGETPREFPATH},
+    {"get_pref_locales", pg_context_get_pref_locales, METH_NOARGS,
+     DOC_PYGAMECONTEXTGETPREFLOCALES},
     {NULL, NULL, 0, NULL}};
 
 MODINIT_DEFINE(context)

--- a/src_c/context.c
+++ b/src_c/context.c
@@ -44,6 +44,9 @@ pg_context_get_pref_locales(PyObject *self, PyObject *_null)
     }
 
     SDL_Locale *current_locale = locales;
+
+    /* The array is terminated when the language attribute of the last struct
+     * in the array is NULL */
     while (current_locale->language) {
         dict = PyDict_New();
         if (!dict) {

--- a/src_c/doc/context_doc.h
+++ b/src_c/doc/context_doc.h
@@ -1,6 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMECONTEXT "pygame module to provide additional context on the system"
 #define DOC_PYGAMECONTEXTGETPREFPATH "get_pref_path(org, app) -> path\nget a writeable folder for your app"
+#define DOC_PYGAMECONTEXTGETPREFLOCALES "get_pref_locales() -> list[locale]\nget preferred locales set on the system"
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -13,5 +14,9 @@ pygame module to provide additional context on the system
 pygame.context.get_pref_path
  get_pref_path(org, app) -> path
 get a writeable folder for your app
+
+pygame.context.get_pref_locales
+ get_pref_locales() -> list[locale]
+get preferred locales set on the system
 
 */

--- a/test/context_test.py
+++ b/test/context_test.py
@@ -39,6 +39,32 @@ class ContextModuleTest(unittest.TestCase):
         except OSError:  # if the dir isn't empty (shouldn't happen)
             raise OSError("pygame.context.get_pref_path folder already occupied")
 
+    def test_get_pref_locales(self):
+        locales = pygame.context.get_pref_locales()
+
+        # check type of return first
+        self.assertIsInstance(locales, list)
+        for lc in locales:
+            self.assertIsInstance(lc, dict)
+            lang = lc["language"]
+            self.assertIsInstance(lang, str)
+
+            # length of language code should be greater than 1
+            self.assertTrue(len(lang) > 1)
+
+            country = lc["country"]
+            if country is not None:
+                # country field is optional, but when defined it should be a
+                # string
+                self.assertIsInstance(country, str)
+
+                # length of country code should be greater than 1
+                self.assertTrue(len(country) > 1)
+
+        # passing args should raise error
+        for arg in (None, 1, "hello"):
+            self.assertRaises(TypeError, pygame.context.get_pref_locales, arg)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add `get_pref_locales` to wrap [`SDL_GetPreferredLocales`](https://wiki.libsdl.org/SDL_GetPreferredLocales)

I believe this is a useful feature to games wanting to customise in-game text to user locale settings.

A companion PR for #2953 which exposes `LOCALECHANGED` event, which is sorta related to this PR.

### Things to discuss
- [X] *Is it fine to put this function in `base.c` (comes in pygame main namespace)? If not, which submodule is more suitable for this kind of function?*
**Resolution:** Make a new module for this function, functions from `SDL_power` and SDL path related functions