### PR TITLE
Get rid of sprintf calls in the codebase

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -1000,14 +1000,14 @@ _ftfont_setstrength(pgFontObject *self, PyObject *value, void *closure)
         return -1;
     }
     strength = PyFloat_AS_DOUBLE(strengthobj);
-    Py_DECREF(strengthobj);
     if (strength < 0.0 || strength > 1.0) {
-        char msg[80];
-
-        sprintf(msg, "strength value %.4e is outside range [0, 1]", strength);
-        PyErr_SetString(PyExc_ValueError, msg);
+        PyErr_Format(PyExc_ValueError,
+                     "strength value '%S' is outside range [0, 1]",
+                     strengthobj);
+        Py_DECREF(strengthobj);
         return -1;
     }
+    Py_DECREF(strengthobj);
     self->strength = strength;
     return 0;
 }
@@ -1059,16 +1059,15 @@ _ftfont_setunderlineadjustment(pgFontObject *self, PyObject *value,
         return -1;
     }
     adjustment = PyFloat_AS_DOUBLE(adjustmentobj);
-    Py_DECREF(adjustmentobj);
     if (adjustment < -2.0 || adjustment > 2.0) {
-        char msg[100];
-
-        sprintf(msg,
-                "underline adjustment value %.4e is outside range [-2.0, 2.0]",
-                adjustment);
-        PyErr_SetString(PyExc_ValueError, msg);
+        PyErr_Format(
+            PyExc_ValueError,
+            "underline adjustment value '%S' is outside range [-2.0, 2.0]",
+            adjustmentobj);
+        Py_DECREF(adjustmentobj);
         return -1;
     }
+    Py_DECREF(adjustmentobj);
     self->underline_adjustment = adjustment;
     return 0;
 }

--- a/src_c/camera_v4l2.c
+++ b/src_c/camera_v4l2.c
@@ -35,8 +35,15 @@ v4l2_list_cameras(int *num_devices)
     num = *num_devices;
 
     devices = (char **)malloc(sizeof(char *) * 65);
+    if (!devices) {
+        return NULL;
+    }
 
     device = (char *)malloc(sizeof(char) * 13);
+    if (!device) {
+        return NULL;
+    }
+
     strcpy(device, "/dev/video");
     fd = open(device, O_RDONLY);
     if (fd != -1) {
@@ -47,7 +54,11 @@ v4l2_list_cameras(int *num_devices)
     close(fd);
     /* v4l2 cameras can be /dev/video and /dev/video0 to /dev/video63 */
     for (i = 0; i < 64; i++) {
-        sprintf(device, "/dev/video%d", i);
+        int ret = PyOS_snprintf(device, 13, "/dev/video%d", i);
+        if (ret < 0 || ret >= 13) {
+            return NULL;
+        }
+
         fd = open(device, O_RDONLY);
         if (fd != -1) {
             devices[num] = device;

--- a/src_c/camera_v4l2.c
+++ b/src_c/camera_v4l2.c
@@ -29,53 +29,64 @@ char **
 v4l2_list_cameras(int *num_devices)
 {
     char **devices;
-    char *device;
+    char *device = NULL;
     int num, i, fd;
 
-    num = *num_devices;
+    num = *num_devices = 0;
 
     devices = (char **)malloc(sizeof(char *) * 65);
     if (!devices) {
         return NULL;
     }
 
-    device = (char *)malloc(sizeof(char) * 13);
-    if (!device) {
-        return NULL;
-    }
-
-    strcpy(device, "/dev/video");
-    fd = open(device, O_RDONLY);
-    if (fd != -1) {
-        devices[num] = device;
-        num++;
-        device = (char *)malloc(sizeof(char) * 13);
-    }
-    close(fd);
     /* v4l2 cameras can be /dev/video and /dev/video0 to /dev/video63 */
-    for (i = 0; i < 64; i++) {
-        int ret = PyOS_snprintf(device, 13, "/dev/video%d", i);
-        if (ret < 0 || ret >= 13) {
-            return NULL;
+    for (i = -1; i < 64; i++) {
+        device = (char *)malloc(sizeof(char) * 13);
+        if (!device) {
+            goto error;
+        }
+
+        if (i == -1) {
+            strcpy(device, "/dev/video");
+        }
+        else {
+            int ret = PyOS_snprintf(device, 13, "/dev/video%d", i);
+            if (ret < 0 || ret >= 13) {
+                goto error;
+            }
         }
 
         fd = open(device, O_RDONLY);
-        if (fd != -1) {
+        if (fd == -1) {
+            free(device);
+        }
+        else {
+            /* 'device' is in array now, don't free it here */
             devices[num] = device;
             num++;
-            device = (char *)malloc(sizeof(char) * 13);
         }
-        close(fd);
+        device = NULL;
+
+        if (close(fd) == -1) {
+            /* Error while closing file */
+            goto error;
+        }
     }
 
-    if (num == *num_devices) {
-        free(device);
-    }
-    else {
-        *num_devices = num;
-    }
-
+    *num_devices = num;
     return devices;
+
+error:
+    /* During goto here, 'device' must be either NULL or free-able allocated
+     * memory */
+    free(device);
+
+    /* free individual 'device' already in devices array */
+    for (i = 0; i < num; i++) {
+        free(devices[i]);
+    }
+    free(devices);
+    return NULL;
 }
 
 /* A wrapper around a VIDIOC_S_FMT ioctl to check for format compatibility */

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -700,11 +700,9 @@ _color_dealloc(pgColorObject *color)
 static PyObject *
 _color_repr(pgColorObject *color)
 {
-    /* Max. would be(255, 255, 255, 255) */
-    char buf[21];
-    PyOS_snprintf(buf, sizeof(buf), "(%d, %d, %d, %d)", color->data[0],
-                  color->data[1], color->data[2], color->data[3]);
-    return PyUnicode_FromString(buf);
+    return PyUnicode_FromFormat("(%d, %d, %d, %d)", color->data[0],
+                                color->data[1], color->data[2],
+                                color->data[3]);
 }
 
 /**

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -349,7 +349,7 @@ pg_vidinfo_str(PyObject *self)
         "         blit_hw = %u, blit_hw_CC = %u, blit_hw_A = %u,\n"
         "         blit_sw = %u, blit_sw_CC = %u, blit_sw_A = %u,\n"
         "         bitsize  = %u, bytesize = %u,\n"
-        "         masks =  (%u, %u, %u, %u),\n"
+        "         masks =  (0x%08x, 0x%08x, 0x%08x, 0x%08x),\n"
         "         shifts = (%u, %u, %u, %u),\n"
         "         losses =  (%u, %u, %u, %u),\n"
         "         current_w = %d, current_h = %d\n"

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -330,7 +330,6 @@ pg_vidinfo_getattr(PyObject *self, char *name)
 PyObject *
 pg_vidinfo_str(PyObject *self)
 {
-    char str[1024];
     int current_w = -1;
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
@@ -345,26 +344,25 @@ pg_vidinfo_str(PyObject *self)
         current_h = info->current_h;
     }
 
-    sprintf(str,
-            "<VideoInfo(hw = %u, wm = %u,video_mem = %u\n"
-            "         blit_hw = %u, blit_hw_CC = %u, blit_hw_A = %u,\n"
-            "         blit_sw = %u, blit_sw_CC = %u, blit_sw_A = %u,\n"
-            "         bitsize  = %u, bytesize = %u,\n"
-            "         masks =  (%u, %u, %u, %u),\n"
-            "         shifts = (%u, %u, %u, %u),\n"
-            "         losses =  (%u, %u, %u, %u),\n"
-            "         current_w = %d, current_h = %d\n"
-            "         pixel_format = %s)\n"
-            ">\n",
-            info->hw_available, info->wm_available, info->video_mem,
-            info->blit_hw, info->blit_hw_CC, info->blit_hw_A, info->blit_sw,
-            info->blit_sw_CC, info->blit_sw_A, info->vfmt->BitsPerPixel,
-            info->vfmt->BytesPerPixel, info->vfmt->Rmask, info->vfmt->Gmask,
-            info->vfmt->Bmask, info->vfmt->Amask, info->vfmt->Rshift,
-            info->vfmt->Gshift, info->vfmt->Bshift, info->vfmt->Ashift,
-            info->vfmt->Rloss, info->vfmt->Gloss, info->vfmt->Bloss,
-            info->vfmt->Aloss, current_w, current_h, pixel_format_name);
-    return PyUnicode_FromString(str);
+    return PyUnicode_FromFormat(
+        "<VideoInfo(hw = %u, wm = %u,video_mem = %u\n"
+        "         blit_hw = %u, blit_hw_CC = %u, blit_hw_A = %u,\n"
+        "         blit_sw = %u, blit_sw_CC = %u, blit_sw_A = %u,\n"
+        "         bitsize  = %u, bytesize = %u,\n"
+        "         masks =  (%u, %u, %u, %u),\n"
+        "         shifts = (%u, %u, %u, %u),\n"
+        "         losses =  (%u, %u, %u, %u),\n"
+        "         current_w = %d, current_h = %d\n"
+        "         pixel_format = %s)\n"
+        ">",
+        info->hw_available, info->wm_available, info->video_mem, info->blit_hw,
+        info->blit_hw_CC, info->blit_hw_A, info->blit_sw, info->blit_sw_CC,
+        info->blit_sw_A, info->vfmt->BitsPerPixel, info->vfmt->BytesPerPixel,
+        info->vfmt->Rmask, info->vfmt->Gmask, info->vfmt->Bmask,
+        info->vfmt->Amask, info->vfmt->Rshift, info->vfmt->Gshift,
+        info->vfmt->Bshift, info->vfmt->Ashift, info->vfmt->Rloss,
+        info->vfmt->Gloss, info->vfmt->Bloss, info->vfmt->Aloss, current_w,
+        current_h, pixel_format_name);
 }
 
 static PyTypeObject pgVidInfo_Type = {

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1278,42 +1278,8 @@ PyObject *
 pg_event_str(PyObject *self)
 {
     pgEventObject *e = (pgEventObject *)self;
-    char *str;
-    PyObject *strobj;
-    PyObject *pyobj;
-    char *s;
-    size_t size;
-    PyObject *encodedobj;
-
-    strobj = PyObject_Str(e->dict);
-    if (strobj == NULL) {
-        return NULL;
-    }
-    encodedobj = PyUnicode_AsUTF8String(strobj);
-    Py_DECREF(strobj);
-    strobj = encodedobj;
-    encodedobj = NULL;
-    if (strobj == NULL) {
-        return NULL;
-    }
-    s = PyBytes_AsString(strobj);
-    size = (11 + strlen(_pg_name_from_eventtype(e->type)) + strlen(s) +
-            sizeof(e->type) * 3 + 1);
-
-    str = (char *)PyMem_Malloc(size);
-    if (!str) {
-        Py_DECREF(strobj);
-        return PyErr_NoMemory();
-    }
-    sprintf(str, "<Event(%d-%s %s)>", e->type,
-            _pg_name_from_eventtype(e->type), s);
-
-    Py_DECREF(strobj);
-
-    pyobj = PyUnicode_FromString(str);
-    PyMem_Free(str);
-
-    return (pyobj);
+    return PyUnicode_FromFormat("<Event(%d-%s %S)>", e->type,
+                                _pg_name_from_eventtype(e->type), e->dict);
 }
 
 static int

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -654,12 +654,9 @@ _PGFT_Render_Array(FreeTypeInstance *ft, pgFontObject *fontobj,
         return -1;
     }
     if (_validate_view_format(view_p->format)) {
-        static const char fmt[] = "Unsupported array item format '%.*s'";
-        char msg[100 + sizeof(fmt)];
-
-        sprintf(msg, fmt, (int)(sizeof(msg) - sizeof(fmt)), view_p->format);
+        PyErr_Format(PyExc_ValueError, "Unsupported array item format '%s'",
+                     view_p->format);
         pgBuffer_Release(&pg_view);
-        PyErr_SetString(PyExc_ValueError, msg);
         return -1;
     }
 

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1377,11 +1377,8 @@ static PyNumberMethods pg_rect_as_number = {
 static PyObject *
 pg_rect_repr(pgRectObject *self)
 {
-    char string[256];
-
-    sprintf(string, "<rect(%d, %d, %d, %d)>", self->r.x, self->r.y, self->r.w,
-            self->r.h);
-    return PyUnicode_FromString(string);
+    return PyUnicode_FromFormat("<rect(%d, %d, %d, %d)>", self->r.x, self->r.y,
+                                self->r.w, self->r.h);
 }
 
 static PyObject *

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -468,10 +468,14 @@ clock_dealloc(PyObject *self)
 PyObject *
 clock_str(PyObject *self)
 {
-    char str[1024];
+    char str[64];
     PyClockObject *_clock = (PyClockObject *)self;
 
-    sprintf(str, "<Clock(fps=%.2f)>", (float)_clock->fps);
+    int ret = PyOS_snprintf(str, 64, "<Clock(fps=%.2f)>", _clock->fps);
+    if (ret < 0 || ret >= 64) {
+        return RAISE(PyExc_RuntimeError,
+                     "Internal PyOS_snprintf call failed!");
+    }
 
     return PyUnicode_FromString(str);
 }

--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -1,4 +1,3 @@
-# coding: ascii
 # pygame - Python Game Library
 # Copyright (C) 2000-2001  Pete Shinners
 #

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -1,4 +1,3 @@
-# coding: ascii
 # pygame - Python Game Library
 # Copyright (C) 2000-2003  Pete Shinners
 #


### PR DESCRIPTION
sprintf is considered an 'unsafe' function, sometimes compilers warn about its usage, so use PyOS_snprintf/PyUnicode_FromFormat/PyErr_Format in its place