### PR TITLE
VideoInfo string missing closing parenthesis

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -354,7 +354,7 @@ pg_vidinfo_str(PyObject *self)
             "         shifts = (%u, %u, %u, %u),\n"
             "         losses =  (%u, %u, %u, %u),\n"
             "         current_w = %d, current_h = %d\n"
-            "         pixel_format = %s\n"
+            "         pixel_format = %s)\n"
             ">\n",
             info->hw_available, info->wm_available, info->video_mem,
             info->blit_hw, info->blit_hw_CC, info->blit_hw_A, info->blit_sw,


### PR DESCRIPTION
Even the documentation shows:
```
<VideoInfo(hw = 0, wm = 1,video_mem = 0
        blit_hw = 0, blit_hw_CC = 0, blit_hw_A = 0,
        blit_sw = 0, blit_sw_CC = 0, blit_sw_A = 0,
        bitsize  = 32, bytesize = 4,
        masks =  (16711680, 65280, 255, 0),
        shifts = (16, 8, 0, 0),
        losses =  (0, 0, 0, 8),
        current_w = 1920, current_h = 1080
>
```

But the last line before the `>` should be:
```
        current_w = 1920, current_h = 1080)
```

This is the standard way of dealing with open and closing parenthesis.