### PR TITLE
Use SDL_WaitEventTimeout, update windowevent handling (Minor event refactor part 1)

### DIFF
--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -373,6 +373,11 @@ On Android, the following events can be generated
    If ``None`` is passed as the argument, ALL of the event types are blocked
    from being placed on the queue.
 
+   Note: Blocking some kinds of events (like windowevents) could potentially
+   break internal pygame machinery that relies on these events being unblocked,
+   so use this function with caution. When unsure, it is better to simply
+   ignore an event during event handling, rather than trying to block the event.
+
    .. ## pygame.event.set_blocked ##
 
 .. function:: set_allowed

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -84,10 +84,11 @@ typedef enum {
 
     PGE_MIDIIN,
     PGE_MIDIOUT,
-    PGE_KEYREPEAT, /* Special internal pygame event, for managing key-presses
-                    */
+    PGE_KEYREPEAT, /* Internal pygame event, for managing key-presses */
 
-    /* DO NOT CHANGE THE ORDER OF EVENTS HERE */
+    /* Do not change the order of window events here, they should be in the
+     * same order as defined in 'SDL_WindowEventID' */
+    PGE_WINDOWEVENTSTART,
     PGE_WINDOWSHOWN,
     PGE_WINDOWHIDDEN,
     PGE_WINDOWEXPOSED,
@@ -196,7 +197,8 @@ typedef enum {
     PGPOST_WINDOWICCPROFCHANGED,
     PGPOST_WINDOWDISPLAYCHANGED,
 
-    PGE_USEREVENT, /* this event must stay in this position only */
+    PGE_USEREVENT, /* this event must stay in this position only, all events
+                      after this are custom user events */
 
     PG_NUMEVENTS =
         SDL_LASTEVENT /* Not an event. Indicates end of user events. */


### PR DESCRIPTION
PR to fix #3036

I'm in the process of a minor event refactor. Since my previous larger event refactor I did back in late 2020, I've noticed some things that could have been done better, and now I'll be doing a series of more manageable and easy to review PRs (learning from last time, not going to make another super large try-to-fix-everything PR ;) )
While the goals of the previous refactor was fixing bugs, this one will focus on bugs *and* code quality, I will try to comment and document things better in this PR series.

Coming to this PR, this PR is pretty simple, use `SDL_WaitEventTimeout` and `SDL_PollEvent` over our custom implementation. Doing this has more advantages in the newer SDL version (explained by OP of the linked issue), where `SDL_WaitEventTimeout` saw many good improvements. Our custom implementation only existed to handle `WINDOWEVENT`s, and this PR makes some changes to handle things a bit differently.

This PR should remain compatible with older versions, one minor downside to this PR is that this does not provide any safeguards against users blocking `WINDOWEVENT`, which potentially breaks some internal stuff that rely on checking for `WINDOWEVENT` with an "event watch function". The previous implementation never directly blocked `WINDOWEVENT`s, only filtered *after* pumps, so that event watch functions could use it. This implementation filters blocked events *during* the pump. And there's nothing much we can do about this on our side, except documenting this.