### PR TITLE
I tried cleaning Scale2X but I have a few questions

### DIFF
--- a/src_c/scale2x.c
+++ b/src_c/scale2x.c
@@ -48,10 +48,8 @@
   blindly assume you didn't flounder.
 */
 
-void
-scale2x(SDL_Surface *src, SDL_Surface *dst)
+void scale2x(SDL_Surface* src, SDL_Surface* dst)
 {
-    int looph, loopw;
 
     Uint8 *srcpix = (Uint8 *)src->pixels;
     Uint8 *dstpix = (Uint8 *)dst->pixels;
@@ -61,139 +59,36 @@ scale2x(SDL_Surface *src, SDL_Surface *dst)
     const int width = src->w;
     const int height = src->h;
 
-    switch (src->format->BytesPerPixel) {
-        case 1: {
-            Uint8 E0, E1, E2, E3, B, D, E, F, H;
-            for (looph = 0; looph < height; ++looph) {
-                for (loopw = 0; loopw < width; ++loopw) {
-                    B = *(Uint8 *)(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                   (1 * loopw));
-                    D = *(Uint8 *)(srcpix + (looph * srcpitch) +
-                                   (1 * MAX(0, loopw - 1)));
-                    E = *(Uint8 *)(srcpix + (looph * srcpitch) + (1 * loopw));
-                    F = *(Uint8 *)(srcpix + (looph * srcpitch) +
-                                   (1 * MIN(width - 1, loopw + 1)));
-                    H = *(Uint8 *)(srcpix +
-                                   (MIN(height - 1, looph + 1) * srcpitch) +
-                                   (1 * loopw));
+    int bytes_ppixel = src->format->BytesPerPixel; 
+    Uint32 E0, E1, E2, E3, B, D, E, F, H;
+    // I had to sacrifice Uint16/8. the compiler shall fill the remaining area with zeroes
+    for(int looph = 0; looph < height; ++looph)
+        for (int loopw = 0; loopw < width; ++loopw)
+        {
+            // multiply by bytes_ppixel rather than doing a case for each different scenario
+            B = *(Uint32 *)(srcpix + (MAX(0, looph - 1) * srcpitch) + (bytes_ppixel * loopw));
 
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
+            D = *(Uint32 *)(srcpix + (looph * srcpitch) + (bytes_ppixel * MAX(0, loopw - 1)));
 
-                    *(Uint8 *)(dstpix + looph * 2 * dstpitch + loopw * 2 * 1) =
-                        E0;
-                    *(Uint8 *)(dstpix + looph * 2 * dstpitch +
-                               (loopw * 2 + 1) * 1) = E1;
-                    *(Uint8 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                               loopw * 2 * 1) = E2;
-                    *(Uint8 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                               (loopw * 2 + 1) * 1) = E3;
-                }
-            }
-            break;
+            E = *(Uint32 *)(srcpix + (looph * srcpitch) + (bytes_ppixel * loopw));
+
+            F = *(Uint32 *)(srcpix + (looph * srcpitch) + (bytes_ppixel * MIN(width - 1, loopw + 1)));
+
+            H = *(Uint32 *)(srcpix + (MIN(height - 1, looph + 1) * srcpitch) + (bytes_ppixel * loopw));
+            
+            E0 = D == B && B != F && D != H ? D : E;
+            E1 = B == F && B != D && F != H ? F : E;
+            E2 = D == H && D != B && H != F ? D : E;
+            E3 = H == F && D != H && B != F ? F : E;            
+
+            *(Uint32 *)(dstpix + looph * 2 * dstpitch + loopw * 2 * bytes_ppixel) = E0;
+
+            *(Uint32 *)(dstpix + looph * 2 * dstpitch + (loopw * 2 + 1) * bytes_ppixel) = E1;
+                    
+            *(Uint32 *)(dstpix + (looph * 2 + 1) * dstpitch + loopw * 2 * bytes_ppixel) = E2;
+            
+            *(Uint32 *)(dstpix + (looph * 2 + 1) * dstpitch + (loopw * 2 + 1) * bytes_ppixel) = E3;
         }
-        case 2: {
-            Uint16 E0, E1, E2, E3, B, D, E, F, H;
-            for (looph = 0; looph < height; ++looph) {
-                for (loopw = 0; loopw < width; ++loopw) {
-                    B = *(Uint16 *)(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                    (2 * loopw));
-                    D = *(Uint16 *)(srcpix + (looph * srcpitch) +
-                                    (2 * MAX(0, loopw - 1)));
-                    E = *(Uint16 *)(srcpix + (looph * srcpitch) + (2 * loopw));
-                    F = *(Uint16 *)(srcpix + (looph * srcpitch) +
-                                    (2 * MIN(width - 1, loopw + 1)));
-                    H = *(Uint16 *)(srcpix +
-                                    (MIN(height - 1, looph + 1) * srcpitch) +
-                                    (2 * loopw));
-
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
-
-                    *(Uint16 *)(dstpix + looph * 2 * dstpitch +
-                                loopw * 2 * 2) = E0;
-                    *(Uint16 *)(dstpix + looph * 2 * dstpitch +
-                                (loopw * 2 + 1) * 2) = E1;
-                    *(Uint16 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                loopw * 2 * 2) = E2;
-                    *(Uint16 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                (loopw * 2 + 1) * 2) = E3;
-                }
-            }
-            break;
-        }
-        case 3: {
-            int E0, E1, E2, E3, B, D, E, F, H;
-            for (looph = 0; looph < height; ++looph) {
-                for (loopw = 0; loopw < width; ++loopw) {
-                    B = READINT24(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                  (3 * loopw));
-                    D = READINT24(srcpix + (looph * srcpitch) +
-                                  (3 * MAX(0, loopw - 1)));
-                    E = READINT24(srcpix + (looph * srcpitch) + (3 * loopw));
-                    F = READINT24(srcpix + (looph * srcpitch) +
-                                  (3 * MIN(width - 1, loopw + 1)));
-                    H = READINT24(srcpix +
-                                  (MIN(height - 1, looph + 1) * srcpitch) +
-                                  (3 * loopw));
-
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
-
-                    WRITEINT24((dstpix + looph * 2 * dstpitch + loopw * 2 * 3),
-                               E0);
-                    WRITEINT24(
-                        (dstpix + looph * 2 * dstpitch + (loopw * 2 + 1) * 3),
-                        E1);
-                    WRITEINT24(
-                        (dstpix + (looph * 2 + 1) * dstpitch + loopw * 2 * 3),
-                        E2);
-                    WRITEINT24((dstpix + (looph * 2 + 1) * dstpitch +
-                                (loopw * 2 + 1) * 3),
-                               E3);
-                }
-            }
-            break;
-        }
-        default: { /*case 4:*/
-            Uint32 E0, E1, E2, E3, B, D, E, F, H;
-            for (looph = 0; looph < height; ++looph) {
-                for (loopw = 0; loopw < width; ++loopw) {
-                    B = *(Uint32 *)(srcpix + (MAX(0, looph - 1) * srcpitch) +
-                                    (4 * loopw));
-                    D = *(Uint32 *)(srcpix + (looph * srcpitch) +
-                                    (4 * MAX(0, loopw - 1)));
-                    E = *(Uint32 *)(srcpix + (looph * srcpitch) + (4 * loopw));
-                    F = *(Uint32 *)(srcpix + (looph * srcpitch) +
-                                    (4 * MIN(width - 1, loopw + 1)));
-                    H = *(Uint32 *)(srcpix +
-                                    (MIN(height - 1, looph + 1) * srcpitch) +
-                                    (4 * loopw));
-
-                    E0 = D == B && B != F && D != H ? D : E;
-                    E1 = B == F && B != D && F != H ? F : E;
-                    E2 = D == H && D != B && H != F ? D : E;
-                    E3 = H == F && D != H && B != F ? F : E;
-
-                    *(Uint32 *)(dstpix + looph * 2 * dstpitch +
-                                loopw * 2 * 4) = E0;
-                    *(Uint32 *)(dstpix + looph * 2 * dstpitch +
-                                (loopw * 2 + 1) * 4) = E1;
-                    *(Uint32 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                loopw * 2 * 4) = E2;
-                    *(Uint32 *)(dstpix + (looph * 2 + 1) * dstpitch +
-                                (loopw * 2 + 1) * 4) = E3;
-                }
-            }
-            break;
-        }
-    }
 }
 
 void


### PR DESCRIPTION
function got dropped to 47 lines from 146, the logic should be the same with a small difference.

Since I removed the switch that contained all scenarios, I had no choice but to pick Uint32 as the main holder of `E0, E1, E2, E3, B, D, E, F, H;`
if the bytes per pixel of the sdl surface is 1 or  2, the remaining bits of Uint32 should be filled with zeroes. So I believe I have not increased memory.

I need further details regarding `READINT24` and `WRITEINT24` macros and why in case 3 you used `int` but in `default:` you used `Uint32`