### PR TITLE
fix/norm function pointer calls for METH_NOARGS

### DIFF
--- a/src_c/_camera.c
+++ b/src_c/_camera.c
@@ -150,7 +150,7 @@ surf_colorspace(PyObject *self, PyObject *arg)
 
 /* list_cameras() - lists cameras available on the computer */
 PyObject *
-list_cameras(PyObject *self, PyObject *arg)
+list_cameras(PyObject *self, PyObject *_null)
 {
 #if defined(__unix__) || defined(PYGAME_WINDOWS_CAMERA)
     PyObject *ret_list;
@@ -202,7 +202,7 @@ list_cameras(PyObject *self, PyObject *arg)
 
 /* start() - opens, inits, and starts capturing on the camera */
 PyObject *
-camera_start(pgCameraObject *self, PyObject *args)
+camera_start(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__)
     if (v4l2_open_device(self) == 0) {
@@ -235,7 +235,7 @@ camera_start(pgCameraObject *self, PyObject *args)
 
 /* stop() - stops capturing, uninits, and closes the camera */
 PyObject *
-camera_stop(pgCameraObject *self, PyObject *args)
+camera_stop(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__)
     if (v4l2_stop_capturing(self) == 0)
@@ -256,7 +256,7 @@ camera_stop(pgCameraObject *self, PyObject *args)
 /* get_controls() - gets current values of user controls */
 /* TODO: Support brightness, contrast, and other common controls */
 PyObject *
-camera_get_controls(pgCameraObject *self, PyObject *args)
+camera_get_controls(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__)
     int value;
@@ -333,7 +333,7 @@ camera_set_controls(pgCameraObject *self, PyObject *arg, PyObject *kwds)
 
 /* get_size() - returns the dimensions of the images being recorded */
 PyObject *
-camera_get_size(pgCameraObject *self, PyObject *args)
+camera_get_size(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__) || defined(PYGAME_WINDOWS_CAMERA)
     return Py_BuildValue("(ii)", self->width, self->height);
@@ -343,7 +343,7 @@ camera_get_size(pgCameraObject *self, PyObject *args)
 
 /* query_image() - checks if a frame is ready */
 PyObject *
-camera_query_image(pgCameraObject *self, PyObject *args)
+camera_query_image(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__)
     return PyBool_FromLong(v4l2_query_buffer(self));
@@ -446,7 +446,7 @@ camera_get_image(pgCameraObject *self, PyObject *arg)
 
 /* get_raw() - returns an unmodified image as a string from the buffer */
 PyObject *
-camera_get_raw(pgCameraObject *self, PyObject *args)
+camera_get_raw(pgCameraObject *self, PyObject *_null)
 {
 #if defined(__unix__)
     return v4l2_read_raw(self);

--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -41,7 +41,7 @@ static int
 _ft_clear(PyObject *);
 
 static PyObject *
-_ft_quit(PyObject *);
+_ft_quit(PyObject *, PyObject *);
 static PyObject *
 _ft_init(PyObject *, PyObject *, PyObject *);
 static PyObject *
@@ -51,7 +51,7 @@ _ft_get_error(PyObject *, PyObject *);
 static PyObject *
 _ft_get_init(PyObject *, PyObject *);
 static PyObject *
-_ft_autoinit(PyObject *);
+_ft_autoinit(PyObject *, PyObject *);
 static PyObject *
 _ft_get_cache_size(PyObject *, PyObject *);
 static PyObject *
@@ -97,7 +97,7 @@ _ftfont_getsizedheight(pgFontObject *, PyObject *);
 static PyObject *
 _ftfont_getsizedglyphheight(pgFontObject *, PyObject *);
 static PyObject *
-_ftfont_getsizes(pgFontObject *);
+_ftfont_getsizes(pgFontObject *, PyObject *);
 
 /* static PyObject *_ftfont_copy(pgFontObject *); */
 
@@ -1564,7 +1564,7 @@ _ftfont_getsizedglyphheight(pgFontObject *self, PyObject *args)
 }
 
 static PyObject *
-_ftfont_getsizes(pgFontObject *self)
+_ftfont_getsizes(pgFontObject *self, PyObject *_null)
 {
     int nsizes;
     int i;
@@ -2006,7 +2006,7 @@ pgFont_New(const char *filename, long font_index)
  ***************************************************************/
 
 static PyObject *
-_ft_autoinit(PyObject *self)
+_ft_autoinit(PyObject *self, PyObject *_null)
 {
     int cache_size = FREETYPE_MOD_STATE(self)->cache_size;
 
@@ -2025,7 +2025,7 @@ _ft_autoinit(PyObject *self)
 }
 
 static PyObject *
-_ft_quit(PyObject *self)
+_ft_quit(PyObject *self, PyObject *_null)
 {
     _FreeTypeState *state = FREETYPE_STATE;
 
@@ -2056,14 +2056,14 @@ _ft_init(PyObject *self, PyObject *args, PyObject *kwds)
         state->cache_size = cache_size;
         state->resolution =
             (resolution ? (FT_UInt)resolution : PGFT_DEFAULT_RESOLUTION);
-        return _ft_autoinit(self);
+        return _ft_autoinit(self, NULL);
     }
 
     Py_RETURN_NONE;
 }
 
 static PyObject *
-_ft_get_error(PyObject *self, PyObject *args)
+_ft_get_error(PyObject *self, PyObject *_null)
 {
     FreeTypeInstance *ft;
     ASSERT_GRAB_FREETYPE(ft, 0);
@@ -2076,7 +2076,7 @@ _ft_get_error(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-_ft_get_version(PyObject *self, PyObject *args)
+_ft_get_version(PyObject *self, PyObject *_null)
 {
     /* Return the linked FreeType2 version */
     return Py_BuildValue("iii", FREETYPE_MAJOR, FREETYPE_MINOR,
@@ -2084,14 +2084,14 @@ _ft_get_version(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-_ft_get_cache_size(PyObject *self, PyObject *args)
+_ft_get_cache_size(PyObject *self, PyObject *_null)
 {
     return PyLong_FromUnsignedLong(
         (unsigned long)(FREETYPE_STATE->cache_size));
 }
 
 static PyObject *
-_ft_get_default_resolution(PyObject *self, PyObject *args)
+_ft_get_default_resolution(PyObject *self, PyObject *_null)
 {
     return PyLong_FromUnsignedLong(
         (unsigned long)(FREETYPE_STATE->resolution));
@@ -2113,13 +2113,13 @@ _ft_set_default_resolution(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-_ft_get_init(PyObject *self, PyObject *args)
+_ft_get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(FREETYPE_MOD_STATE(self)->freetype ? 1 : 0);
 }
 
 static PyObject *
-_ft_get_default_font(PyObject *self, PyObject *args)
+_ft_get_default_font(PyObject *self, PyObject *_null)
 {
     return PyUnicode_FromString(DEFAULT_FONT_NAME);
 }

--- a/src_c/_sdl2/touch.c
+++ b/src_c/_sdl2/touch.c
@@ -24,7 +24,7 @@
 
 
 static PyObject *
-pg_touch_num_devices(PyObject *self, PyObject *args)
+pg_touch_num_devices(PyObject *self, PyObject *_null)
 {
     return PyLong_FromLong(SDL_GetNumTouchDevices());
 }

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -301,7 +301,7 @@ pg_mod_autoquit(const char *modname)
 }
 
 static PyObject *
-pg_init(PyObject *self)
+pg_init(PyObject *self, PyObject *_null)
 {
     int i = 0, success = 0, fail = 0;
 
@@ -357,7 +357,7 @@ pg_atexit_quit(void)
 }
 
 static PyObject *
-pg_get_sdl_version(PyObject *self)
+pg_get_sdl_version(PyObject *self, PyObject *_null)
 {
     SDL_version v;
 
@@ -366,7 +366,7 @@ pg_get_sdl_version(PyObject *self)
 }
 
 static PyObject *
-pg_get_sdl_byteorder(PyObject *self)
+pg_get_sdl_byteorder(PyObject *self, PyObject *_null)
 {
     return PyLong_FromLong(SDL_BYTEORDER);
 }
@@ -437,14 +437,14 @@ _pg_quit(void)
 }
 
 static PyObject *
-pg_quit(PyObject *self)
+pg_quit(PyObject *self, PyObject *_null)
 {
     _pg_quit();
     Py_RETURN_NONE;
 }
 
 static PyObject *
-pg_get_init(PyObject *self, PyObject *args)
+pg_get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(pg_is_init);
 }
@@ -627,7 +627,7 @@ pg_RGBAFromObj(PyObject *obj, Uint8 *RGBA)
 }
 
 static PyObject *
-pg_get_error(PyObject *self)
+pg_get_error(PyObject *self, PyObject *_null)
 {
     return PyUnicode_FromString(SDL_GetError());
 }

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -776,7 +776,7 @@ _color_repr(pgColorObject *color)
  * color.normalize()
  */
 static PyObject *
-_color_normalize(pgColorObject *color, PyObject *args)
+_color_normalize(pgColorObject *color, PyObject *_null)
 {
     double rgba[4];
     rgba[0] = color->data[0] / 255.0;
@@ -860,7 +860,7 @@ _color_lerp(pgColorObject *self, PyObject *args, PyObject *kw)
  * color.premul_alpha()
  */
 static PyObject *
-_premul_alpha(pgColorObject *color, PyObject *args)
+_premul_alpha(pgColorObject *color, PyObject *_null)
 {
     Uint8 new_rgba[4];
     new_rgba[0] = (Uint8)(((color->data[0] + 1) * color->data[3]) >> 8);

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -177,7 +177,7 @@ display_resource_end:
 
 /* init routines */
 static PyObject *
-pg_display_quit(PyObject *self)
+pg_display_quit(PyObject *self, PyObject *_null)
 {
     _DisplayState *state = DISPLAY_STATE;
     _display_state_cleanup(state);
@@ -221,7 +221,7 @@ _pg_mac_display_init(void)
 }
 
 static PyObject *
-pg_display_init(PyObject *self)
+pg_display_init(PyObject *self, PyObject *_null)
 {
     const char *drivername;
     /* Compatibility:
@@ -249,13 +249,13 @@ pg_display_init(PyObject *self)
 }
 
 static PyObject *
-pg_get_init(PyObject *self)
+pg_get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(SDL_WasInit(SDL_INIT_VIDEO) != 0);
 }
 
 static PyObject *
-pg_get_active(PyObject *self)
+pg_get_active(PyObject *self, PyObject *_null)
 {
     Uint32 flags = SDL_GetWindowFlags(pg_GetDefaultWindow());
     return PyBool_FromLong((flags & SDL_WINDOW_SHOWN) &&
@@ -449,7 +449,7 @@ pg_GetVideoInfo(pg_VideoInfo *info)
 }
 
 static PyObject *
-pgInfo(PyObject *self)
+pgInfo(PyObject *self, PyObject *_null)
 {
     pg_VideoInfo info;
     VIDEO_INIT_CHECK();
@@ -457,7 +457,7 @@ pgInfo(PyObject *self)
 }
 
 static PyObject *
-pg_get_wm_info(PyObject *self)
+pg_get_wm_info(PyObject *self, PyObject *_null)
 {
     PyObject *dict;
     PyObject *tmp;
@@ -586,7 +586,7 @@ pg_get_wm_info(PyObject *self)
 
 /* display functions */
 static PyObject *
-pg_get_driver(PyObject *self)
+pg_get_driver(PyObject *self, PyObject *_null)
 {
     const char *name = NULL;
     VIDEO_INIT_CHECK();
@@ -597,7 +597,7 @@ pg_get_driver(PyObject *self)
 }
 
 static PyObject *
-pg_get_surface(PyObject *self)
+pg_get_surface(PyObject *self, PyObject *_null)
 {
     _DisplayState *state = DISPLAY_MOD_STATE(self);
     SDL_Window *win = pg_GetDefaultWindow();
@@ -886,7 +886,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
 
     if (!SDL_WasInit(SDL_INIT_VIDEO)) {
         /* note SDL works special like this too */
-        if (!pg_display_init(NULL))
+        if (!pg_display_init(NULL, NULL))
             return NULL;
     }
 
@@ -1384,7 +1384,7 @@ _pg_get_default_display_masks(int bpp, Uint32 *Rmask, Uint32 *Gmask,
 }
 
 static PyObject *
-pg_window_size(PyObject *self)
+pg_window_size(PyObject *self, PyObject *_null)
 {
     SDL_Window *win = pg_GetDefaultWindow();
     int w, h;
@@ -1576,7 +1576,7 @@ pg_flip_internal(_DisplayState *state)
 }
 
 static PyObject *
-pg_flip(PyObject *self)
+pg_flip(PyObject *self, PyObject *_null)
 {
     if (pg_flip_internal(DISPLAY_MOD_STATE(self)) < 0) {
         return NULL;
@@ -1585,7 +1585,7 @@ pg_flip(PyObject *self)
 }
 
 static PyObject *
-pg_num_displays(PyObject *self)
+pg_num_displays(PyObject *self, PyObject *_null)
 {
     int ret = SDL_GetNumVideoDisplays();
     if (ret < 0)
@@ -1624,7 +1624,7 @@ pg_update(PyObject *self, PyObject *arg)
         return RAISE(pgExc_SDLError, "Display mode not set");
 
     if (pg_renderer != NULL) {
-        return pg_flip(self);
+        return pg_flip(self, NULL);
     }
     SDL_GetWindowSize(win, &wide, &high);
 
@@ -1633,7 +1633,7 @@ pg_update(PyObject *self, PyObject *arg)
 
     /*determine type of argument we got*/
     if (PyTuple_Size(arg) == 0) {
-        return pg_flip(self);
+        return pg_flip(self, NULL);
     }
 
     if (PyTuple_GET_ITEM(arg, 0) == Py_None) {
@@ -1941,7 +1941,7 @@ pg_set_caption(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-pg_get_caption(PyObject *self)
+pg_get_caption(PyObject *self, PyObject *_null)
 {
     _DisplayState *state = DISPLAY_MOD_STATE(self);
     SDL_Window *win = pg_GetDefaultWindow();
@@ -1967,7 +1967,7 @@ pg_set_icon(PyObject *self, PyObject *arg)
         return NULL;
 
     if (!SDL_WasInit(SDL_INIT_VIDEO)) {
-        if (!pg_display_init(NULL))
+        if (!pg_display_init(NULL, NULL))
             return NULL;
     }
     Py_INCREF(surface);
@@ -1979,7 +1979,7 @@ pg_set_icon(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-pg_iconify(PyObject *self)
+pg_iconify(PyObject *self, PyObject *_null)
 {
     SDL_Window *win = pg_GetDefaultWindow();
     VIDEO_INIT_CHECK();
@@ -2048,7 +2048,7 @@ pg_get_desktop_screen_sizes(PyObject *self)
 }
 
 static PyObject *
-pg_is_fullscreen(PyObject *self)
+pg_is_fullscreen(PyObject *self, PyObject *_null)
 {
     SDL_Window *win = pg_GetDefaultWindow();
     int flags;
@@ -2066,7 +2066,7 @@ pg_is_fullscreen(PyObject *self)
 }
 
 static PyObject *
-pg_toggle_fullscreen(PyObject *self, PyObject *args)
+pg_toggle_fullscreen(PyObject *self, PyObject *_null)
 {
     SDL_Window *win = pg_GetDefaultWindow();
     int result, flags;

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -567,7 +567,7 @@ pg_GetKeyRepeat(int *delay, int *interval)
 }
 
 static PyObject *
-pgEvent_AutoQuit(PyObject *self)
+pgEvent_AutoQuit(PyObject *self, PyObject *_null)
 {
     if (_pg_event_is_init) {
         if (_pg_repeat_timer) {
@@ -585,7 +585,7 @@ pgEvent_AutoQuit(PyObject *self)
 }
 
 static PyObject *
-pgEvent_AutoInit(PyObject *self)
+pgEvent_AutoInit(PyObject *self, PyObject *_null)
 {
     if (!_pg_event_is_init) {
         pg_key_repeat_delay = 0;
@@ -1574,7 +1574,7 @@ set_grab(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-get_grab(PyObject *self)
+get_grab(PyObject *self, PyObject *_null)
 {
     SDL_Window *win;
     SDL_bool mode = SDL_FALSE;
@@ -1629,7 +1629,7 @@ _pg_event_wait(SDL_Event *event, int timeout)
 }
 
 static PyObject *
-pg_event_pump(PyObject *self)
+pg_event_pump(PyObject *self, PyObject *_null)
 {
     VIDEO_INIT_CHECK();
     _pg_event_pump(1);
@@ -1637,7 +1637,7 @@ pg_event_pump(PyObject *self)
 }
 
 static PyObject *
-pg_event_poll(PyObject *self)
+pg_event_poll(PyObject *self, PyObject *_null)
 {
     SDL_Event event;
     VIDEO_INIT_CHECK();
@@ -2192,7 +2192,7 @@ pg_event_get_blocked(PyObject *self, PyObject *obj)
 }
 
 static PyObject *
-pg_event_custom_type(PyObject *self)
+pg_event_custom_type(PyObject *self, PyObject *_null)
 {
     if (_custom_event < PG_NUMEVENTS)
         return PyLong_FromLong(_custom_event++);

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -145,7 +145,7 @@ font_resource(const char *filename)
 }
 
 static PyObject *
-fontmodule_init(PyObject *self)
+fontmodule_init(PyObject *self, PyObject *_null)
 {
     if (!font_initialized) {
         if (TTF_Init())
@@ -157,7 +157,7 @@ fontmodule_init(PyObject *self)
 }
 
 static PyObject *
-fontmodule_quit(PyObject *self)
+fontmodule_quit(PyObject *self, PyObject *_null)
 {
     if (font_initialized) {
         TTF_Quit();
@@ -168,35 +168,35 @@ fontmodule_quit(PyObject *self)
 }
 
 static PyObject *
-get_init(PyObject *self)
+get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(font_initialized);
 }
 
 /* font object methods */
 static PyObject *
-font_get_height(PyObject *self, PyObject *args)
+font_get_height(PyObject *self, PyObject *_null)
 {
     TTF_Font *font = PyFont_AsFont(self);
     return PyLong_FromLong(TTF_FontHeight(font));
 }
 
 static PyObject *
-font_get_descent(PyObject *self, PyObject *args)
+font_get_descent(PyObject *self, PyObject *_null)
 {
     TTF_Font *font = PyFont_AsFont(self);
     return PyLong_FromLong(TTF_FontDescent(font));
 }
 
 static PyObject *
-font_get_ascent(PyObject *self, PyObject *args)
+font_get_ascent(PyObject *self, PyObject *_null)
 {
     TTF_Font *font = PyFont_AsFont(self);
     return PyLong_FromLong(TTF_FontAscent(font));
 }
 
 static PyObject *
-font_get_linesize(PyObject *self, PyObject *args)
+font_get_linesize(PyObject *self, PyObject *_null)
 {
     TTF_Font *font = PyFont_AsFont(self);
     return PyLong_FromLong(TTF_FontLineSkip(font));
@@ -247,7 +247,7 @@ font_setter_bold(PyObject *self, PyObject *value, void *closure)
 
 /* Implements get_bold() */
 static PyObject *
-font_get_bold(PyObject *self, PyObject *args)
+font_get_bold(PyObject *self, PyObject *_null)
 {
     return _font_get_style_flag_as_py_bool(self, TTF_STYLE_BOLD);
 }
@@ -293,7 +293,7 @@ font_setter_italic(PyObject *self, PyObject *value, void *closure)
 
 /* Implements get_italic() */
 static PyObject *
-font_get_italic(PyObject *self, PyObject *args)
+font_get_italic(PyObject *self, PyObject *_null)
 {
     return _font_get_style_flag_as_py_bool(self, TTF_STYLE_ITALIC);
 }
@@ -340,7 +340,7 @@ font_setter_underline(PyObject *self, PyObject *value, void *closure)
 
 /* Implements get_underline() */
 static PyObject *
-font_get_underline(PyObject *self, PyObject *args)
+font_get_underline(PyObject *self, PyObject *_null)
 {
     return _font_get_style_flag_as_py_bool(self, TTF_STYLE_UNDERLINE);
 }
@@ -813,7 +813,7 @@ static PyTypeObject PyFont_Type = {
 
 /*font module methods*/
 static PyObject *
-get_default_font(PyObject *self)
+get_default_font(PyObject *self, PyObject *_null)
 {
     return PyUnicode_FromString(font_defaultname);
 }

--- a/src_c/image.c
+++ b/src_c/image.c
@@ -227,7 +227,7 @@ image_save(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-image_get_extended(PyObject *self)
+image_get_extended(PyObject *self, PyObject *_null)
 {
     if (extverobj == NULL)
         Py_RETURN_FALSE;

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -743,7 +743,7 @@ image_save_ext(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-image_get_sdl_image_version(PyObject *self, PyObject *arg)
+image_get_sdl_image_version(PyObject *self, PyObject *_null)
 {
     return Py_BuildValue("iii", SDL_IMAGE_MAJOR_VERSION,
                          SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_PATCHLEVEL);

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -37,7 +37,7 @@ _joy_map_insert(pgJoystickObject *jstick);
 #define pgJoystick_Check(x) ((x)->ob_type == &pgJoystick_Type)
 
 static PyObject *
-init(PyObject *self)
+init(PyObject *self, PyObject *_null)
 {
     if (!SDL_WasInit(SDL_INIT_JOYSTICK)) {
         if (SDL_InitSubSystem(SDL_INIT_JOYSTICK))
@@ -48,7 +48,7 @@ init(PyObject *self)
 }
 
 static PyObject *
-quit(PyObject *self)
+quit(PyObject *self, PyObject *_null)
 {
     /* Walk joystick objects to deallocate the stick objects. */
     pgJoystickObject *cur = joylist_head;
@@ -68,7 +68,7 @@ quit(PyObject *self)
 }
 
 static PyObject *
-get_init(PyObject *self)
+get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(SDL_WasInit(SDL_INIT_JOYSTICK) != 0);
 }
@@ -110,14 +110,14 @@ Joystick(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-get_count(PyObject *self, PyObject *args)
+get_count(PyObject *self, PyObject *_null)
 {
     JOYSTICK_INIT_CHECK();
     return PyLong_FromLong(SDL_NumJoysticks());
 }
 
 static PyObject *
-joy_init(PyObject *self, PyObject *args)
+joy_init(PyObject *self, PyObject *_null)
 {
     pgJoystickObject *jstick = (pgJoystickObject *)self;
 
@@ -162,7 +162,7 @@ _joy_map_insert(pgJoystickObject *jstick)
 }
 
 static PyObject *
-joy_quit(PyObject *self, PyObject *args)
+joy_quit(PyObject *self, PyObject *_null)
 {
     pgJoystickObject *joy = (pgJoystickObject *)self;
 
@@ -175,21 +175,21 @@ joy_quit(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-joy_get_init(PyObject *self, PyObject *args)
+joy_get_init(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
     return PyBool_FromLong(joy != NULL);
 }
 
 static PyObject *
-joy_get_id(PyObject *self, PyObject *args)
+joy_get_id(PyObject *self, PyObject *_null)
 {
     int joy_id = pgJoystick_AsID(self);
     return PyLong_FromLong(joy_id);
 }
 
 static PyObject *
-joy_get_instance_id(PyObject *self, PyObject *args)
+joy_get_instance_id(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
 
@@ -202,7 +202,7 @@ joy_get_instance_id(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-joy_get_guid(PyObject *self, PyObject *args)
+joy_get_guid(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
     SDL_JoystickGUID guid;
@@ -243,7 +243,7 @@ _pg_powerlevel_string(SDL_JoystickPowerLevel level)
 }
 
 static PyObject *
-joy_get_power_level(PyObject *self, PyObject *args)
+joy_get_power_level(PyObject *self, PyObject *_null)
 {
     SDL_JoystickPowerLevel level;
     const char *leveltext;
@@ -313,7 +313,7 @@ joy_rumble(pgJoystickObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-joy_stop_rumble(pgJoystickObject *self)
+joy_stop_rumble(pgJoystickObject *self, PyObject *_null)
 {
 #if SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_Joystick *joy = self->joy;
@@ -323,14 +323,14 @@ joy_stop_rumble(pgJoystickObject *self)
 }
 
 static PyObject *
-joy_get_name(PyObject *self, PyObject *args)
+joy_get_name(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
     return PyUnicode_FromString(SDL_JoystickName(joy));
 }
 
 static PyObject *
-joy_get_numaxes(PyObject *self, PyObject *args)
+joy_get_numaxes(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
     JOYSTICK_INIT_CHECK();
@@ -368,7 +368,7 @@ joy_get_axis(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-joy_get_numbuttons(PyObject *self, PyObject *args)
+joy_get_numbuttons(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
 
@@ -406,7 +406,7 @@ joy_get_button(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-joy_get_numballs(PyObject *self, PyObject *args)
+joy_get_numballs(PyObject *self, PyObject *_null)
 {
     SDL_Joystick *joy = pgJoystick_AsSDL(self);
 
@@ -446,7 +446,7 @@ joy_get_ball(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-joy_get_numhats(PyObject *self, PyObject *args)
+joy_get_numhats(PyObject *self, PyObject *_null)
 {
     Uint32 value;
     SDL_Joystick *joy = pgJoystick_AsSDL(self);

--- a/src_c/key.c
+++ b/src_c/key.c
@@ -50,7 +50,7 @@ key_set_repeat(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-key_get_repeat(PyObject *self, PyObject *args)
+key_get_repeat(PyObject *self, PyObject *_null)
 {
     int delay = 0, interval = 0;
 
@@ -144,7 +144,7 @@ static PyTypeObject pgScancodeWrapper_Type = {
 };
 
 static PyObject *
-key_get_pressed(PyObject *self, PyObject *args)
+key_get_pressed(PyObject *self, PyObject *_null)
 {
     int num_keys;
     const Uint8 *key_state;
@@ -750,7 +750,7 @@ key_code(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-key_get_mods(PyObject *self, PyObject *args)
+key_get_mods(PyObject *self, PyObject *_null)
 {
     VIDEO_INIT_CHECK();
 
@@ -772,7 +772,7 @@ key_set_mods(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-key_get_focused(PyObject *self, PyObject *args)
+key_get_focused(PyObject *self, PyObject *_null)
 {
     VIDEO_INIT_CHECK();
 
@@ -780,7 +780,7 @@ key_get_focused(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-key_start_text_input(PyObject *self, PyObject *args)
+key_start_text_input(PyObject *self, PyObject *_null)
 {
     /* https://wiki.libsdl.org/SDL_StartTextInput */
     SDL_StartTextInput();
@@ -788,7 +788,7 @@ key_start_text_input(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-key_stop_text_input(PyObject *self, PyObject *args)
+key_stop_text_input(PyObject *self, PyObject *_null)
 {
     /* https://wiki.libsdl.org/SDL_StopTextInput */
     SDL_StopTextInput();

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -74,7 +74,7 @@ abs_diff_uint32(Uint32 a, Uint32 b)
 
 /* Copies the given mask. */
 static PyObject *
-mask_copy(PyObject *self, PyObject *args)
+mask_copy(PyObject *self, PyObject *_null)
 {
     bitmask_t *new_bitmask = bitmask_copy(pgMask_AsBitmap(self));
 
@@ -90,10 +90,10 @@ mask_copy(PyObject *self, PyObject *args)
  * subclasses that override the __copy__() method to also override the copy()
  * method automatically. */
 static PyObject *
-mask_call_copy(PyObject *self, PyObject *args)
+mask_call_copy(PyObject *self, PyObject *_null)
 {
     return PyObject_CallMethodObjArgs(self, PyUnicode_FromString("__copy__"),
-                                      args);
+                                      NULL);
 }
 
 static PyObject *
@@ -293,7 +293,7 @@ mask_overlap_mask(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-mask_fill(PyObject *self, PyObject *args)
+mask_fill(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
 
@@ -303,7 +303,7 @@ mask_fill(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mask_clear(PyObject *self, PyObject *args)
+mask_clear(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
 
@@ -313,7 +313,7 @@ mask_clear(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mask_invert(PyObject *self, PyObject *args)
+mask_invert(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
 
@@ -404,7 +404,7 @@ mask_erase(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-mask_count(PyObject *self, PyObject *args)
+mask_count(PyObject *self, PyObject *_null)
 {
     bitmask_t *m = pgMask_AsBitmap(self);
 
@@ -412,7 +412,7 @@ mask_count(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mask_centroid(PyObject *self, PyObject *args)
+mask_centroid(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
     int x, y;
@@ -444,7 +444,7 @@ mask_centroid(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mask_angle(PyObject *self, PyObject *args)
+mask_angle(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
     int x, y;
@@ -1469,7 +1469,7 @@ get_bounding_rects(bitmask_t *input, int *num_bounding_boxes,
 }
 
 static PyObject *
-mask_get_bounding_rects(PyObject *self, PyObject *args)
+mask_get_bounding_rects(PyObject *self, PyObject *_null)
 {
     SDL_Rect *regions;
     SDL_Rect *aregion;

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -246,7 +246,7 @@ vector_str(pgVector *self);
 static PyObject *
 vector_project_onto(pgVector *self, PyObject *other);
 static PyObject *
-vector_copy(pgVector *self);
+vector_copy(pgVector *self, PyObject *_null);
 
 /*
 static Py_ssize_t vector_readbuffer(pgVector *self, Py_ssize_t segment, void
@@ -790,7 +790,7 @@ vector_nonzero(pgVector *self)
 }
 
 static PyObject *
-vector_copy(pgVector *self)
+vector_copy(pgVector *self, PyObject *_null)
 {
     pgVector *ret = (pgVector *)pgVector_NEW(self->dim);
     Py_ssize_t i;
@@ -1192,7 +1192,7 @@ vector_richcompare(PyObject *o1, PyObject *o2, int op)
 }
 
 static PyObject *
-vector_length(pgVector *self, PyObject *args)
+vector_length(pgVector *self, PyObject *_null)
 {
     double length_squared =
         _scalar_product(self->coords, self->coords, self->dim);
@@ -1200,7 +1200,7 @@ vector_length(pgVector *self, PyObject *args)
 }
 
 static PyObject *
-vector_length_squared(pgVector *self, PyObject *args)
+vector_length_squared(pgVector *self, PyObject *_null)
 {
     double length_squared =
         _scalar_product(self->coords, self->coords, self->dim);
@@ -1208,7 +1208,7 @@ vector_length_squared(pgVector *self, PyObject *args)
 }
 
 static PyObject *
-vector_normalize(pgVector *self, PyObject *args)
+vector_normalize(pgVector *self, PyObject *_null)
 {
     pgVector *ret;
 
@@ -1225,7 +1225,7 @@ vector_normalize(pgVector *self, PyObject *args)
 }
 
 static PyObject *
-vector_normalize_ip(pgVector *self, PyObject *args)
+vector_normalize_ip(pgVector *self, PyObject *_null)
 {
     Py_ssize_t i;
     double length;
@@ -1245,7 +1245,7 @@ vector_normalize_ip(pgVector *self, PyObject *args)
 }
 
 static PyObject *
-vector_is_normalized(pgVector *self, PyObject *args)
+vector_is_normalized(pgVector *self, PyObject *_null)
 {
     double length_squared =
         _scalar_product(self->coords, self->coords, self->dim);
@@ -2253,7 +2253,7 @@ vector2_angle_to(pgVector *self, PyObject *other)
 }
 
 static PyObject *
-vector2_as_polar(pgVector *self, PyObject *args)
+vector2_as_polar(pgVector *self, PyObject *_null)
 {
     double r, phi;
     r = sqrt(_scalar_product(self->coords, self->coords, self->dim));
@@ -2275,13 +2275,13 @@ vector2_from_polar(pgVector *self, PyObject *args)
     Py_RETURN_NONE;
 }
 static PyObject *
-vector_getsafepickle(pgRectObject *self, void *closure)
+vector_getsafepickle(pgRectObject *self, void *_null)
 {
     Py_RETURN_TRUE;
 }
 /* for pickling */
 static PyObject *
-vector2_reduce(PyObject *oself, PyObject *args)
+vector2_reduce(PyObject *oself, PyObject *_null)
 {
     pgVector *self = (pgVector *)oself;
     return Py_BuildValue("(O(dd))", Py_TYPE(oself), self->coords[0],
@@ -3168,7 +3168,7 @@ vector3_angle_to(pgVector *self, PyObject *other)
 }
 
 static PyObject *
-vector3_as_spherical(pgVector *self, PyObject *args)
+vector3_as_spherical(pgVector *self, PyObject *_null)
 {
     double r, theta, phi;
     r = sqrt(_scalar_product(self->coords, self->coords, self->dim));
@@ -3206,7 +3206,7 @@ vector3_project(pgVector *self, PyObject *other)
 
 /* For pickling. */
 static PyObject *
-vector3_reduce(PyObject *oself, PyObject *args)
+vector3_reduce(PyObject *oself, PyObject *_null)
 {
     pgVector *self = (pgVector *)oself;
     return Py_BuildValue("(O(ddd))", Py_TYPE(oself), self->coords[0],
@@ -4124,7 +4124,7 @@ static PyTypeObject pgVectorElementwiseProxy_Type = {
 };
 
 static PyObject *
-vector_elementwise(pgVector *vec, PyObject *args)
+vector_elementwise(pgVector *vec, PyObject *_null)
 {
     vector_elementwiseproxy *proxy;
     if (!pgVector_Check(vec)) {
@@ -4142,7 +4142,7 @@ vector_elementwise(pgVector *vec, PyObject *args)
 }
 
 static PyObject *
-math_enable_swizzling(pgVector *self)
+math_enable_swizzling(pgVector *self, PyObject *_null)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "pygame.math.enable_swizzling() is deprecated, "
@@ -4155,7 +4155,7 @@ math_enable_swizzling(pgVector *self)
 }
 
 static PyObject *
-math_disable_swizzling(pgVector *self)
+math_disable_swizzling(pgVector *self, PyObject *_null)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "pygame.math.disable_swizzling() is deprecated, "

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -497,14 +497,14 @@ _init(int freq, int size, int channels, int chunk, char *devicename,
 }
 
 static PyObject *
-pgMixer_AutoInit(PyObject *self)
+pgMixer_AutoInit(PyObject *self, PyObject *_null)
 {
     /* Return init with defaults */
     return _init(0, 0, 0, 0, NULL, -1);
 }
 
 static PyObject *
-quit(PyObject *self)
+quit(PyObject *self, PyObject *_null)
 {
     int i;
     if (SDL_WasInit(SDL_INIT_AUDIO)) {
@@ -567,7 +567,7 @@ init(PyObject *self, PyObject *args, PyObject *keywds)
 }
 
 static PyObject *
-get_init(PyObject *self)
+get_init(PyObject *self, PyObject *_null)
 {
     int freq, channels, realform;
     Uint16 format;
@@ -663,7 +663,7 @@ pgSound_Play(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-snd_get_num_channels(PyObject *self, PyObject *args)
+snd_get_num_channels(PyObject *self, PyObject *_null)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     MIXER_INIT_CHECK();
@@ -687,7 +687,7 @@ snd_fadeout(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-snd_stop(PyObject *self, PyObject *args)
+snd_stop(PyObject *self, PyObject *_null)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     MIXER_INIT_CHECK();
@@ -713,7 +713,7 @@ snd_set_volume(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-snd_get_volume(PyObject *self, PyObject *args)
+snd_get_volume(PyObject *self, PyObject *_null)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     int volume;
@@ -724,7 +724,7 @@ snd_get_volume(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-snd_get_length(PyObject *self, PyObject *args)
+snd_get_length(PyObject *self, PyObject *_null)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     int freq, channels, mixerbytes, numsamples;
@@ -745,7 +745,7 @@ snd_get_length(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-snd_get_raw(PyObject *self, PyObject *args)
+snd_get_raw(PyObject *self, PyObject *_null)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
 
@@ -1082,7 +1082,7 @@ chan_queue(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-chan_get_busy(PyObject *self)
+chan_get_busy(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     MIXER_INIT_CHECK();
@@ -1107,7 +1107,7 @@ chan_fadeout(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-chan_stop(PyObject *self)
+chan_stop(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     MIXER_INIT_CHECK();
@@ -1119,7 +1119,7 @@ chan_stop(PyObject *self)
 }
 
 static PyObject *
-chan_pause(PyObject *self)
+chan_pause(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     MIXER_INIT_CHECK();
@@ -1129,7 +1129,7 @@ chan_pause(PyObject *self)
 }
 
 static PyObject *
-chan_unpause(PyObject *self)
+chan_unpause(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     MIXER_INIT_CHECK();
@@ -1198,7 +1198,7 @@ chan_set_volume(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-chan_get_volume(PyObject *self)
+chan_get_volume(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     int volume;
@@ -1211,7 +1211,7 @@ chan_get_volume(PyObject *self)
 }
 
 static PyObject *
-chan_get_sound(PyObject *self)
+chan_get_sound(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     PyObject *sound;
@@ -1225,7 +1225,7 @@ chan_get_sound(PyObject *self)
 }
 
 static PyObject *
-chan_get_queue(PyObject *self)
+chan_get_queue(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
     PyObject *sound;
@@ -1252,7 +1252,7 @@ chan_set_endevent(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-chan_get_endevent(PyObject *self)
+chan_get_endevent(PyObject *self, PyObject *_null)
 {
     int channelnum = pgChannel_AsInt(self);
 
@@ -1360,7 +1360,7 @@ static PyTypeObject pgChannel_Type = {
 /*mixer module methods*/
 
 static PyObject *
-get_num_channels(PyObject *self)
+get_num_channels(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
     return PyLong_FromLong(Mix_GroupCount(-1));
@@ -1412,7 +1412,7 @@ set_reserved(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-get_busy(PyObject *self)
+get_busy(PyObject *self, PyObject *_null)
 {
     if (!SDL_WasInit(SDL_INIT_AUDIO))
         return PyBool_FromLong(0);
@@ -1457,7 +1457,7 @@ mixer_fadeout(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mixer_stop(PyObject *self)
+mixer_stop(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 
@@ -1468,7 +1468,7 @@ mixer_stop(PyObject *self)
 }
 
 static PyObject *
-mixer_pause(PyObject *self)
+mixer_pause(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 
@@ -1477,7 +1477,7 @@ mixer_pause(PyObject *self)
 }
 
 static PyObject *
-mixer_unpause(PyObject *self)
+mixer_unpause(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -198,7 +198,7 @@ mouse_set_visible(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-mouse_get_visible(PyObject *self, PyObject *args)
+mouse_get_visible(PyObject *self, PyObject *_null)
 {
     int result;
 
@@ -442,7 +442,7 @@ mouse_set_cursor(PyObject *self, PyObject *args, PyObject *kwds)
 
 // mouse.get_cursor goes through a python layer first, see cursors.py
 static PyObject *
-mouse_get_cursor(PyObject *self)
+mouse_get_cursor(PyObject *self, PyObject *_null)
 {
     VIDEO_INIT_CHECK();
 

--- a/src_c/music.c
+++ b/src_c/music.c
@@ -125,7 +125,7 @@ music_play(PyObject *self, PyObject *args, PyObject *keywds)
 }
 
 static PyObject *
-music_get_busy(PyObject *self, PyObject *args)
+music_get_busy(PyObject *self, PyObject *_null)
 {
     int playing;
 
@@ -162,7 +162,7 @@ music_fadeout(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-music_stop(PyObject *self, PyObject *args)
+music_stop(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 
@@ -181,7 +181,7 @@ music_stop(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-music_pause(PyObject *self, PyObject *args)
+music_pause(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 
@@ -190,7 +190,7 @@ music_pause(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-music_unpause(PyObject *self, PyObject *args)
+music_unpause(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 
@@ -201,7 +201,7 @@ music_unpause(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-music_rewind(PyObject *self, PyObject *args)
+music_rewind(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 
@@ -230,7 +230,7 @@ music_set_volume(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-music_get_volume(PyObject *self, PyObject *args)
+music_get_volume(PyObject *self, PyObject *_null)
 {
     int volume;
     MIXER_INIT_CHECK();
@@ -262,7 +262,7 @@ music_set_pos(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-music_get_pos(PyObject *self, PyObject *args)
+music_get_pos(PyObject *self, PyObject *_null)
 {
     long ticks;
 
@@ -292,7 +292,7 @@ music_set_endevent(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-music_get_endevent(PyObject *self, PyObject *args)
+music_get_endevent(PyObject *self, PyObject *_null)
 {
     return PyLong_FromLong(endmusic_event);
 }
@@ -444,7 +444,7 @@ music_load(PyObject *self, PyObject *args, PyObject *keywds)
 }
 
 static PyObject *
-music_unload(PyObject *self, PyObject *noarg)
+music_unload(PyObject *self, PyObject *_null)
 {
     MIXER_INIT_CHECK();
 

--- a/src_c/newbuffer.c
+++ b/src_c/newbuffer.c
@@ -331,7 +331,7 @@ buffer_get_buffer(BufferObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-buffer_release_buffer(BufferObject *self, PyObject *args)
+buffer_release_buffer(BufferObject *self, PyObject *_null)
 {
     int flags = self->flags;
     Py_buffer *view_p = self->view_p;

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -358,7 +358,7 @@ _pg_do_rects_intersect(SDL_Rect *A, SDL_Rect *B)
 }
 
 static PyObject *
-pg_rect_normalize(pgRectObject *self, PyObject *args)
+pg_rect_normalize(pgRectObject *self, PyObject *_null)
 {
     pgRect_Normalize(&pgRect_AsRect(self));
 
@@ -1086,7 +1086,7 @@ pg_rect_clamp_ip(pgRectObject *self, PyObject *args)
 
 /* for pickling */
 static PyObject *
-pg_rect_reduce(pgRectObject *self, PyObject *args)
+pg_rect_reduce(pgRectObject *self, PyObject *_null)
 {
     return Py_BuildValue("(O(iiii))", Py_TYPE(self), (int)self->r.x,
                          (int)self->r.y, (int)self->r.w, (int)self->r.h);
@@ -1094,7 +1094,7 @@ pg_rect_reduce(pgRectObject *self, PyObject *args)
 
 /* for copy module */
 static PyObject *
-pg_rect_copy(pgRectObject *self, PyObject *args)
+pg_rect_copy(pgRectObject *self, PyObject *_null)
 {
     return _pg_rect_subtype_new4(Py_TYPE(self), self->r.x, self->r.y,
                                  self->r.w, self->r.h);

--- a/src_c/scrap.c
+++ b/src_c/scrap.c
@@ -129,7 +129,7 @@ _scrap_init(PyObject *self, PyObject *args)
  * Note: All platforms supported here.
  */
 static PyObject *
-_scrap_get_init(PyObject *self, PyObject *args)
+_scrap_get_init(PyObject *self, PyObject *_null)
 {
     return PyBool_FromLong(pygame_scrap_initialized());
 }
@@ -139,7 +139,7 @@ _scrap_get_init(PyObject *self, PyObject *args)
  * Gets the currently available types from the active clipboard.
  */
 static PyObject *
-_scrap_get_types(PyObject *self, PyObject *args)
+_scrap_get_types(PyObject *self, PyObject *_null)
 {
     int i = 0;
     char **types;
@@ -321,7 +321,7 @@ _scrap_put_scrap(PyObject *self, PyObject *args)
  * Checks whether the pygame window has lost the clipboard.
  */
 static PyObject *
-_scrap_lost_scrap(PyObject *self, PyObject *args)
+_scrap_lost_scrap(PyObject *self, PyObject *_null)
 {
     PYGAME_SCRAP_INIT_CHECK();
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -993,7 +993,7 @@ surf_unmap_rgb(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-surf_lock(PyObject *self, PyObject *args)
+surf_lock(PyObject *self, PyObject *_null)
 {
     if (!pgSurface_Lock((pgSurfaceObject *)self))
         return NULL;
@@ -1001,14 +1001,14 @@ surf_lock(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_unlock(PyObject *self, PyObject *args)
+surf_unlock(PyObject *self, PyObject *_null)
 {
     pgSurface_Unlock((pgSurfaceObject *)self);
     Py_RETURN_NONE;
 }
 
 static PyObject *
-surf_mustlock(PyObject *self, PyObject *args)
+surf_mustlock(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     return PyBool_FromLong(SDL_MUSTLOCK(surf) ||
@@ -1016,7 +1016,7 @@ surf_mustlock(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_locked(PyObject *self, PyObject *args)
+surf_get_locked(PyObject *self, PyObject *_null)
 {
     pgSurfaceObject *surf = (pgSurfaceObject *)self;
 
@@ -1026,7 +1026,7 @@ surf_get_locked(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_locks(PyObject *self, PyObject *args)
+surf_get_locks(PyObject *self, PyObject *_null)
 {
     pgSurfaceObject *surf = (pgSurfaceObject *)self;
     Py_ssize_t len, i = 0;
@@ -1048,7 +1048,7 @@ surf_get_locks(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_palette(PyObject *self, PyObject *args)
+surf_get_palette(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SDL_Palette *pal = NULL;
@@ -1296,7 +1296,7 @@ surf_set_colorkey(pgSurfaceObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_colorkey(pgSurfaceObject *self, PyObject *args)
+surf_get_colorkey(pgSurfaceObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     Uint32 mapped_color;
@@ -1397,7 +1397,7 @@ surf_set_alpha(pgSurfaceObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_alpha(pgSurfaceObject *self, PyObject *args)
+surf_get_alpha(pgSurfaceObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SDL_BlendMode mode;
@@ -1419,7 +1419,7 @@ surf_get_alpha(pgSurfaceObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_blendmode(PyObject *self, PyObject *args)
+surf_get_blendmode(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SDL_BlendMode mode;
@@ -1430,7 +1430,7 @@ surf_get_blendmode(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_copy(pgSurfaceObject *self, PyObject *args)
+surf_copy(pgSurfaceObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     PyObject *final;
@@ -1750,7 +1750,7 @@ surf_set_clip(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_clip(PyObject *self, PyObject *args)
+surf_get_clip(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2235,7 +2235,7 @@ _PgSurface_SrcAlpha(SDL_Surface *surf)
 }
 
 static PyObject *
-surf_get_flags(PyObject *self, PyObject *args)
+surf_get_flags(PyObject *self, PyObject *_null)
 {
     Uint32 sdl_flags = 0;
     Uint32 window_flags = 0;
@@ -2284,7 +2284,7 @@ surf_get_flags(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_pitch(PyObject *self, PyObject *args)
+surf_get_pitch(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2294,7 +2294,7 @@ surf_get_pitch(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_size(PyObject *self, PyObject *args)
+surf_get_size(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2304,7 +2304,7 @@ surf_get_size(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_width(PyObject *self, PyObject *args)
+surf_get_width(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2314,7 +2314,7 @@ surf_get_width(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_height(PyObject *self, PyObject *args)
+surf_get_height(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2353,7 +2353,7 @@ surf_get_rect(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-surf_get_bitsize(PyObject *self, PyObject *args)
+surf_get_bitsize(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     if (!surf)
@@ -2363,7 +2363,7 @@ surf_get_bitsize(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_bytesize(PyObject *self, PyObject *args)
+surf_get_bytesize(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     if (!surf)
@@ -2372,7 +2372,7 @@ surf_get_bytesize(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_masks(PyObject *self, PyObject *args)
+surf_get_masks(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2398,7 +2398,7 @@ surf_set_masks(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_shifts(PyObject *self, PyObject *args)
+surf_get_shifts(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2423,7 +2423,7 @@ surf_set_shifts(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_losses(PyObject *self, PyObject *args)
+surf_get_losses(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
 
@@ -2547,7 +2547,7 @@ surf_subsurface(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_offset(PyObject *self, PyObject *args)
+surf_get_offset(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     struct pgSubSurface_Data *subdata;
@@ -2562,7 +2562,7 @@ surf_get_offset(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_abs_offset(PyObject *self, PyObject *args)
+surf_get_abs_offset(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     struct pgSubSurface_Data *subdata;
@@ -2591,7 +2591,7 @@ surf_get_abs_offset(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_parent(PyObject *self, PyObject *args)
+surf_get_parent(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     struct pgSubSurface_Data *subdata;
@@ -2608,7 +2608,7 @@ surf_get_parent(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_abs_parent(PyObject *self, PyObject *args)
+surf_get_abs_parent(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surf = pgSurface_AsSurface(self);
     struct pgSubSurface_Data *subdata;
@@ -2983,7 +2983,7 @@ surf_get_view(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_get_buffer(PyObject *self, PyObject *args)
+surf_get_buffer(PyObject *self, PyObject *_null)
 {
     SDL_Surface *surface = pgSurface_AsSurface(self);
     PyObject *proxy_obj;

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -40,7 +40,7 @@ static SDL_mutex *timermutex = NULL;
 static intptr_t pg_timer_id = 0;
 
 static PyObject *
-pg_time_autoquit(PyObject *self)
+pg_time_autoquit(PyObject *self, PyObject *_null)
 {
     pgEventTimer *hunt, *todel;
     /* We can let errors silently pass in this function, because this
@@ -65,7 +65,7 @@ pg_time_autoquit(PyObject *self)
 }
 
 static PyObject *
-pg_time_autoinit(PyObject *self)
+pg_time_autoinit(PyObject *self, PyObject *_null)
 {
     /* allocate a mutex for timer data holding struct*/
     if (!timermutex) {
@@ -223,7 +223,7 @@ accurate_delay(int ticks)
 }
 
 static PyObject *
-time_get_ticks(PyObject *self)
+time_get_ticks(PyObject *self, PyObject *_null)
 {
     if (!SDL_WasInit(SDL_INIT_TIMER))
         return PyLong_FromLong(0);
@@ -426,21 +426,21 @@ clock_tick_busy_loop(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-clock_get_fps(PyObject *self, PyObject *args)
+clock_get_fps(PyObject *self, PyObject *_null)
 {
     PyClockObject *_clock = (PyClockObject *)self;
     return PyFloat_FromDouble(_clock->fps);
 }
 
 static PyObject *
-clock_get_time(PyObject *self, PyObject *args)
+clock_get_time(PyObject *self, PyObject *_null)
 {
     PyClockObject *_clock = (PyClockObject *)self;
     return PyLong_FromLong(_clock->timepassed);
 }
 
 static PyObject *
-clock_get_rawtime(PyObject *self, PyObject *args)
+clock_get_rawtime(PyObject *self, PyObject *_null)
 {
     PyClockObject *_clock = (PyClockObject *)self;
     return PyLong_FromLong(_clock->rawpassed);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1581,7 +1581,7 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-surf_get_smoothscale_backend(PyObject *self, PyObject *args)
+surf_get_smoothscale_backend(PyObject *self, PyObject *_null)
 {
     return PyUnicode_FromString(GETSTATE(self)->filter_type);
 }


### PR DESCRIPTION
- FIXES ( ie when *_null arg is missing in C)  are related to Web Assembly port ( most of it currently working ).
some background here https://blog.pyodide.org/posts/function-pointer-cast-handling/

- the rest is a normalization of METH_NOARGS conventions, *noarg was used only once here https://github.com/pmp-p/pygame-wasm/blob/37cc2e82ebba825dc90aedbd7ee620b93931a8ee/src_c/music.c#L447

once done i will be able to add fixes to support better Limited API and full wasm support which must be reviewed more carefully than this one.

As the current changes proposed where made guided by a checker (https://gist.github.com/pmp-p/5641b7edfffba457d3eed875454ab5ca)

