### PR TITLE
Pkgdata import in init for PyInstaller

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -332,6 +332,14 @@ try:
 except (ImportError, IOError):
     pass
 
+# this internal module needs to be included for dependency
+# finders, but can't be deleted, as some tests need it
+try:
+    import pygame.pkgdata
+
+except (ImportError, IOError):
+    pass
+
 
 def packager_imports():
     """some additional imports that py2app/py2exe will want to see"""


### PR DESCRIPTION
This is a simple fix for #3070

In https://github.com/pygame/pygame/commit/a8b563f3dc25f5f79637eb5fb8f6ffd582d44245, the removal of "import pygame.pkgdata" apparently removed the only pkgdata import in the whole library (in python code)

But the font module imports it in C code, and needs it.

So this just uses the same solution as pygame.imageext right above it in init. It even has a comment explaining these are for bundlers like PyInstaller or Py2exe. This is a less flimsy solution than the status quo of before.

Thanks to Mario for reporting!