### PR TITLE
Windows prebuilts updates with freetype and SDL_ttf 2.0.18

### DIFF
--- a/buildconfig/config.py
+++ b/buildconfig/config.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# For MinGW build requires Python 2.4 or better and win32api.
 
 """Quick tool to help setup the needed paths and flags
 in your Setup file. This will call the appropriate sub-config

--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -389,8 +389,8 @@ def setup():
     DEPS.add('IMAGE', 'SDL2_image', ['SDL2_image-[1-9].*'], r'(lib){0,1}SDL2_image\.dll$',
              ['SDL', 'jpeg', 'png', 'tiff'], 0)
     DEPS.add('FONT', 'SDL2_ttf', ['SDL2_ttf-[2-9].*'], r'(lib){0,1}SDL2_ttf\.dll$', ['SDL', 'z', 'freetype'])
-    DEPS.add('FREETYPE', 'freetype', ['freetype-[1-9].*'], r'(lib){0,1}freetype[-0-9]*\.dll$',
-             find_header=r'ft2build\.h', find_lib=r'(lib)?freetype[-0-9]*\.lib')
+    DEPS.add('FREETYPE', 'freetype', ['freetype'], r'freetype[-0-9]*\.dll$',
+             find_header=r'ft2build\.h', find_lib=r'freetype[-0-9]*\.lib')
     DEPS.configure()
     _add_sdl2_dll_deps(DEPS)
     for d in get_definitions():
@@ -411,7 +411,7 @@ def setup_prebuilt_sdl2(prebuilt_dir):
     DEPS = DependencyGroup()
 
     DEPS.add('SDL', 'SDL2', ['SDL2-[1-9].*'], r'(lib){0,1}SDL2\.dll$', required=1)
-    fontDep = DEPS.add('FONT', 'SDL2_ttf', ['SDL2_ttf-[2-9].*'], r'(lib){0,1}SDL2_ttf\.dll$', ['SDL', 'z', 'freetype'])
+    fontDep = DEPS.add('FONT', 'SDL2_ttf', ['SDL2_ttf-[2-9].*'], r'(lib){0,1}SDL2_ttf\.dll$', ['SDL'])
     imageDep = DEPS.add('IMAGE', 'SDL2_image', ['SDL2_image-[1-9].*'], r'(lib){0,1}SDL2_image\.dll$',
                         ['SDL', 'jpeg', 'png', 'tiff'], 0)
     mixerDep = DEPS.add('MIXER', 'SDL2_mixer', ['SDL2_mixer-[1-9].*'], r'(lib){0,1}SDL2_mixer\.dll$',
@@ -421,15 +421,8 @@ def setup_prebuilt_sdl2(prebuilt_dir):
     DEPS.add_dummy('PORTTIME')
     DEPS.configure()
 
-    # force use of the correct freetype DLL
-    ftDep = DEPS.add('FREETYPE', 'freetype', ['SDL2_ttf-[2-9].*', 'freetype-[1-9].*'], r'(lib)?freetype[-0-9]*\.dll$',
-                     find_header=r'ft2build\.h', find_lib=r'libfreetype[-0-9]*\.lib')
-    ftDep.path = fontDep.path
-    ftDep.inc_dir = [
-        os.path.join(prebuilt_dir, 'include').replace('\\', '/')
-    ]
-    ftDep.inc_dir.append('%s/freetype2' % ftDep.inc_dir[0])
-    ftDep.found = True
+    DEPS.add('FREETYPE', 'freetype', ['freetype'], r'freetype[-0-9]*\.dll$',
+                     find_header=r'ft2build\.h', find_lib=r'freetype[-0-9]*\.lib')
 
     png = DEPS.add('PNG', 'png', ['SDL2_image-[2-9].*', 'libpng-[1-9].*'], r'(png|libpng)[-0-9]*\.dll$', ['z'],
                    find_header=r'png\.h', find_lib=r'(lib)?png1[-0-9]*\.lib')
@@ -457,8 +450,6 @@ def setup_prebuilt_sdl2(prebuilt_dir):
         'mpg123': mixerDep.path,
         'opus': mixerDep.path,
         'opusfile': mixerDep.path,
-
-        'freetype': fontDep.path,
     }
     _add_sdl2_dll_deps(DEPS)
     for dll in DEPS.dlls:
@@ -510,11 +501,11 @@ def main():
         if use_prebuilt:
             return setup_prebuilt_sdl2(prebuilt_dir)
     else:
-        print ("Note: cannot find directory \"%s\"; do not use prebuilts." % prebuilt_dir)
+        print("Note: cannot find directory \"%s\"; do not use prebuilts." % prebuilt_dir)
     return setup()
 
 if __name__ == '__main__':
-    print ("""This is the configuration subscript for Windows.
+    print("""This is the configuration subscript for Windows.
 Please run "config.py" for full configuration.""")
 
     import sys

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -22,10 +22,7 @@ def download_sha1_unzip(url, checksum, save_to_directory, unzip=True):
     except ImportError:
         use_requests = False
 
-    try:
-        import urllib.request as urllib
-    except ImportError:
-        import urllib2 as urllib
+    import urllib.request as urllib
     import hashlib
     import zipfile
 
@@ -89,8 +86,8 @@ def get_urls(x86=True, x64=True):
         '137f86474691f4e12e76e07d58d5920c8d844d5b',
         ],
         [
-        'https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-VC.zip',
-        '1436df41ebc47ac36e02ec9bda5699e80ff9bd27',
+        'https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.18-VC.zip',
+        'a421d47e9336ab722eac4ba107fab7f7b080eb4e',
         ],
         [
         'https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-VC.zip',
@@ -105,15 +102,13 @@ def get_urls(x86=True, x64=True):
     ])
     if x86:
         url_sha1.append([
-         # 'https://pygame.org/ftp/prebuilt-x86-pygame-1.9.2-20150922.zip',
-         'https://github.com/pygame/pygame/releases/download/2.1.3.dev2/prebuilt-x86-pygame-1.9.2-20150922.zip',
-         'dbce1d5ea27b3da17273e047826d172e1c34b478'
+         'https://github.com/pygame/pygame/releases/download/2.1.3.dev4/prebuilt-x86-pygame-2.1.4-20220319.zip',
+         'bff2e50d65ec35274d33203e9fcaf5d53b31a696'
         ])
     if x64:
         url_sha1.append([
-         # 'https://pygame.org/ftp/prebuilt-x64-pygame-1.9.2-20150922.zip',
-         'https://github.com/pygame/pygame/releases/download/2.1.3.dev2/prebuilt-x64-pygame-1.9.2-20150922.zip',
-         '3a5af3427b3aa13a0aaf5c4cb08daaed341613ed'
+         'https://github.com/pygame/pygame/releases/download/2.1.3.dev4/prebuilt-x64-pygame-2.1.4-20220319.zip',
+         '16b46596744ce9ef80e7e40fa72ddbafef1cf586'
         ])
     return url_sha1
 
@@ -179,12 +174,12 @@ def place_downloaded_prebuilts(temp_dir, move_to_dir, x86=True, x64=True):
     """
     prebuilt_x64 = os.path.join(
         temp_dir,
-        'prebuilt-x64-pygame-1.9.2-20150922',
+        'prebuilt-x64-pygame-2.1.4-20220319',
         'prebuilt-x64'
     )
     prebuilt_x86 = os.path.join(
         temp_dir,
-        'prebuilt-x86-pygame-1.9.2-20150922',
+        'prebuilt-x86-pygame-2.1.4-20220319',
         'prebuilt-x86'
     )
 
@@ -251,12 +246,12 @@ def place_downloaded_prebuilts(temp_dir, move_to_dir, x86=True, x64=True):
         copy(
             os.path.join(
                 temp_dir,
-                'SDL2_ttf-devel-2.0.15-VC/SDL2_ttf-2.0.15'
+                'SDL2_ttf-devel-2.0.18-VC/SDL2_ttf-2.0.18'
             ),
             os.path.join(
                 move_to_dir,
                 prebuilt_dir,
-                'SDL2_ttf-2.0.15'
+                'SDL2_ttf-2.0.18'
             )
         )
         copy(

--- a/buildconfig/download_win_prebuilt.py
+++ b/buildconfig/download_win_prebuilt.py
@@ -93,12 +93,6 @@ def get_urls(x86=True, x64=True):
         'https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-VC.zip',
         '9097148f4529cf19f805ccd007618dec280f0ecc',
         ],
-        [
-        # 'https://www.ijg.org/files/jpegsr9d.zip',
-        # 'https://www.pygame.org/ftp/jpegsr9d.zip',
-        'https://github.com/pygame/pygame/releases/download/2.1.3.dev2/jpegsr9d.zip',
-        'ed10aa2b5a0fcfe74f8a6f7611aeb346b06a1f99',
-        ],
     ])
     if x86:
         url_sha1.append([
@@ -203,23 +197,6 @@ def place_downloaded_prebuilts(temp_dir, move_to_dir, x86=True, x64=True):
     for prebuilt_dir in prebuilt_dirs:
         path = os.path.join(move_to_dir, prebuilt_dir)
         print("copying into %s" % path)
-
-        # update jpeg
-        for file in ('jerror.h', 'jmorecfg.h', 'jpeglib.h'):
-            shutil.copyfile(
-                os.path.join(
-                    temp_dir,
-                    'jpegsr9d',
-                    'jpeg-9d',
-                    file
-                ),
-                os.path.join(
-                    move_to_dir,
-                    prebuilt_dir,
-                    'include',
-                    file
-                )
-            )
 
         copy(
             os.path.join(


### PR DESCRIPTION
For #3023
Also fixes #1113 
Also makes progress on #464 and #2574

This PR updates our SDL_ttf version to 2.0.18 (from 2.0.15) on Windows. This is a little more complex than usual, since SDL_ttf now is statically links to freetype. We were relying on their freetype DLL for pygame.freetype. 

So I thought this was a good opportunity to go through and modernize the old "pygame-1.9.2-prebuilt" downloads. I removed a bunch of superfluous stuff, bringing the download size down a lot, and then I added in a modern freetype DLL and headers provided by https://github.com/ubawurinna/freetype-windows-binaries

SDL_ttf 2.0.18 is exciting because it has a multiline text rendering API, it has support for color emojis, and has harfbuzz support (harfbuzz is also statically linked into the SDL_ttf lib so we don't need to worry about that).

Emojis through pygame.font:
![Capture](https://user-images.githubusercontent.com/46412508/159149653-07b98822-8a40-4761-987a-b5f8bd625716.PNG)