### PR TITLE
Fix segfault in resource loading function

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -691,7 +691,6 @@ _rwops_from_pystr(PyObject *obj)
     }
 
     encoded = PyBytes_AS_STRING(oencoded);
-    Py_DECREF(oencoded);
 
     rw = SDL_RWFromFile(encoded, "rb");
     if (rw) {
@@ -710,9 +709,11 @@ _rwops_from_pystr(PyObject *obj)
             strcpy(extension, ext);
         }
         rw->hidden.unknown.data1 = (void *)extension;
+        Py_DECREF(oencoded);
         return rw;
     }
 
+    Py_DECREF(oencoded);
     /* Clear SDL error and set our own error message for filenotfound errors
      * TODO: Check SDL error here and forward any non filenotfound related
      * errors correctly here */


### PR DESCRIPTION
Fixed a segfault bug I introduced in my old PR #2840

The issue here is that `PyBytes_AS_STRING` returns a reference to an internal C string, so the python bytes object must only be freed after the usage of the returned value is finished.

To reproduce this issue, do
```py
import pygame
[pygame.image.load("any/image/path/here.png") for _ in range(100000)]
```

This issue was reported on windows and python 3.7, and does not seem to happen in newer python versions, probably due to python gc changes. Since this is a randomly popping segfault, so it needs a loop to be caught.

Big cheers to Grimmys for reporting this issue and testing with the above minimal reproducer, and Starbuck for providing 3.7 wheels to reproduce this bug and assistance with debugging 🥳 