### PR TITLE
Small fixes to the documentation header

### DIFF
--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -8,16 +8,15 @@
  #}
 {%- macro header() %}
   <div class="header">
-    <table>
-      <tr>
-	<td class="logo">
+	<div class="flex-container">
+	<div class="logo">
 	  <a href="{{ theme_home_uri }}">
 {%-         set logo_path = '_static/' + logo %}
 	    <img src="{{ pathto(logo_path, 1) }}"/>
 	  </a>
 	  <h5>pygame documentation</h5>
-	</td>
-	<td class="pagelinks">
+	</div>
+	<div class="pagelinks">
 	  <div class="top">
 	    <a href="{{ theme_home_uri }}">Pygame Home</a> ||
 	    <a href="{{ pathto(master_doc) }}">Help Contents</a> ||
@@ -88,9 +87,8 @@ We render three sets of items based on how useful to most apps.
 
 
 {%-   endif  %}
-	</td>
-      </tr>
-    </table>
+</div>
+</div>
   </div>
 {%- endmacro %}
 

--- a/docs/reST/themes/classic/static/pygame.css_t
+++ b/docs/reST/themes/classic/static/pygame.css_t
@@ -85,21 +85,20 @@ div.header {
     line-height: 1.2em;
 }
 
-div.header table {
+div.header > div {
     border: {{ theme_headerborder }};
     border-collapse: collapse;
     background-color: {{ theme_headerbgcolor }};
 }
 
-div.header td {
-    border-right: {{ theme_headerborder }};
-}
-
 div.header .logo {
     background-color: {{ theme_logobgcolor }};
-    text-align: center;
-    vertical-align: middle;
     padding: 0.3em;
+    border-right: 3px solid black;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
 }
 
 div.header .logo img {
@@ -112,6 +111,7 @@ div.header .pagelinks {
     padding: 0.3em;
     text-align: center;
     vertical-align: middle;
+    flex-grow: 1;
 }
 
 div.header p.top {
@@ -134,6 +134,22 @@ div.header .pagelinks a:hover {
 
 div.document {
     background-color: {{ theme_bgcolor }};
+}
+
+.flex-container {
+    display: flex;
+    flex-direction: row;
+}
+
+@media only screen and (max-width: 680px) {
+  .flex-container {
+    flex-direction: column;
+  }
+
+  div.header .logo {
+      border-right: none;
+      border-bottom: 3px solid black;
+  }
 }
 
 /* on wide screens center text, and max width for readable area.  */


### PR DESCRIPTION
- Replaced the html table with css flex box to make the header in the documentation stretch out all the way on the right side.
- Also fixed the black borders in the header to be drawn the same on all screen sizes.