### PR TITLE
pygame.h is in _sdl2 parent directory

### DIFF
--- a/src_c/cython/pygame/_sdl2/controller.pyx
+++ b/src_c/cython/pygame/_sdl2/controller.pyx
@@ -1,6 +1,6 @@
 from . import error
 
-cdef extern from "pygame.h" nogil:
+cdef extern from "../pygame.h" nogil:
     int pgJoystick_Check(object joy)
     object pgJoystick_New(int);
     void import_pygame_joystick()


### PR DESCRIPTION
this should be harmless but helps fixing static build for https://github.com/pygame/pygame/issues/718.