### PR TITLE
fix name/definition conflict for pgSurface_New

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -104,7 +104,7 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
 
 /* statics */
 static PyObject *
-pgSurface_New(SDL_Surface *info, int owner);
+pgSurface_New2(SDL_Surface *info, int owner);
 static PyObject *
 surf_subtype_new(PyTypeObject *type, SDL_Surface *s, int owner);
 static PyObject *
@@ -394,7 +394,7 @@ static PyTypeObject pgSurface_Type = {
     (PyObject_IsInstance((x), (PyObject *)&pgSurface_Type))
 
 static PyObject *
-pgSurface_New(SDL_Surface *s, int owner)
+pgSurface_New2(SDL_Surface *s, int owner)
 {
     return surf_subtype_new(&pgSurface_Type, s, owner);
 }
@@ -3801,7 +3801,7 @@ MODINIT_DEFINE(surface)
 
     /* export the c api */
     c_api[0] = &pgSurface_Type;
-    c_api[1] = pgSurface_New;
+    c_api[1] = pgSurface_New2;
     c_api[2] = pgSurface_Blit;
     c_api[3] = pgSurface_SetSurface;
     apiobj = encapsulate_api(c_api, "surface");


### PR DESCRIPTION
There's a name conflict between https://github.com/pygame/pygame/blob/a1725cf7375f50a1719c09c758096617b2f4dc07/src_c/include/_pygame.h#L295 and  https://github.com/pygame/pygame/blob/a1725cf7375f50a1719c09c758096617b2f4dc07/src_c/surface.c#L107   

i suggest `pgSurface_New2` for the latter instead  because `pgSurface_New` already mentionned in C-API docs with a single argument.

that conflict appears when turning off C-API and trying to build static for https://github.com/pygame/pygame/issues/718