### PR TITLE
added SCALED flag

### DIFF
--- a/examples/scaletest.py
+++ b/examples/scaletest.py
@@ -33,7 +33,7 @@ def main(imagefile, convert_alpha=False, run_speed_test=False):
         return
 
     # start fullscreen mode
-    screen = pg.display.set_mode((1024, 768), pg.FULLSCREEN)
+    screen = pg.display.set_mode((1024, 768), pg.FULLSCREEN | pg.SCALED)
     if convert_alpha:
         background = background.convert_alpha()
 

--- a/examples/testsprite.py
+++ b/examples/testsprite.py
@@ -54,7 +54,7 @@ if "-flip" in sys.argv:
     flags ^= pg.DOUBLEBUF
 
 if "-fullscreen" in sys.argv:
-    flags ^= pg.FULLSCREEN
+    flags ^= pg.FULLSCREEN | pg.SCALED
 
 if "-sw" in sys.argv:
     flags ^= pg.SWSURFACE


### PR DESCRIPTION
When using FULLSCREEN flag, if there is no SCALED with it my system throws X11 errors.

```
X Error of failed request:  BadRRCrtc (invalid Crtc parameter)
  Major opcode of failed request:  140 (RANDR)
  Minor opcode of failed request:  20 (RRGetCrtcInfo)
  Crtc id in failed request: 0x0
  Serial number of failed request:  234
  Current serial number in output stream:  234
```

SCALED is also needed if using `pygame.display.toggle_fullscreen()`
`pygame.error: X11_XRRSetCrtcConfig failed`

Simple tests can be run
```
import pygame

pygame.init()
# pygame.display.set_mode((640, 480), pygame.SCALED)
pygame.display.set_mode((640, 480), pygame.FULLSCREEN | pygame.SCALED)

while True:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            pygame.quit()
        if event.type == pygame.KEYDOWN:
            if event.key == pygame.K_f:
                pygame.display.toggle_fullscreen()
    pygame.display.flip()

```