### PR TITLE
Make pgBuffer_Release retain previously set errors

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -1170,7 +1170,12 @@ static void
 pgBuffer_Release(pg_buffer *pg_view_p)
 {
     assert(pg_view_p && pg_view_p->release_buffer);
+    /* some calls to this function expect this function to not clear previously
+     * set errors, so save and restore any potential errors here */
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type, &value, &traceback);
     pg_view_p->release_buffer((Py_buffer *)pg_view_p);
+    PyErr_Restore(type, value, traceback);
 }
 
 static void


### PR DESCRIPTION
Quickfix PR

Starbuck found the original bug which came as a result of my PR #3041 which changed a freetype function to set a python error first before calling `pgBuffer_Release`, which can discard the error in some codepaths. While I could not reproduce the error myself nor did the CI catch it, I did notice that this pattern is followed in a few more places, so I decided to fix the `pgBuffer_Release` function itself to save state of the old errors, because generally free functions are expected to do that.