### PR TITLE
update constants.c to clang-format version 14.0

### DIFF
--- a/src_c/constants.c
+++ b/src_c/constants.c
@@ -27,12 +27,15 @@
 #include "scrap.h"
 
 /* macros used to create each constant */
-#define ADD_ERROR(x)       \
-    {                      \
-        Py_DECREF(module); \
-        return NULL;       \
-    }                      \
-    else { PyList_Append(all_list, PyUnicode_FromString(x)); }
+#define ADD_ERROR(x)                                      \
+    {                                                     \
+        Py_DECREF(module);                                \
+        return NULL;                                      \
+    }                                                     \
+    else                                                  \
+    {                                                     \
+        PyList_Append(all_list, PyUnicode_FromString(x)); \
+    }
 #define STRINGIZE(x) #x
 #define DEC_CONSTS_(x, y)                           \
     if (PyModule_AddIntConstant(module, x, (int)y)) \


### PR DESCRIPTION
AS the title. 

Our CI just updated to clang-format version 14.0 which apparently changes define formatting a little. Update your clang and clang-format versions people!