### PR TITLE
Improve clang format source file detection

### DIFF
--- a/src_c/_sdl2/touch.c
+++ b/src_c/_sdl2/touch.c
@@ -22,7 +22,6 @@
 
 #include "../doc/touch_doc.h"
 
-
 static PyObject *
 pg_touch_num_devices(PyObject *self, PyObject *_null)
 {
@@ -59,8 +58,7 @@ pg_touch_num_fingers(PyObject *self, PyObject *device_id)
 
     VIDEO_INIT_CHECK();
 
-    fingercount =
-        SDL_GetNumTouchFingers(PyLong_AsLongLong(device_id));
+    fingercount = SDL_GetNumTouchFingers(PyLong_AsLongLong(device_id));
     if (fingercount == 0) {
         return RAISE(pgExc_SDLError, SDL_GetError());
     }
@@ -81,16 +79,14 @@ _pg_insobj(PyObject *dict, char *name, PyObject *v)
 static PyObject *
 pg_touch_get_finger(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    char* keywords[] = {"touchid", "index", NULL};
+    char *keywords[] = {"touchid", "index", NULL};
     SDL_TouchID touchid;
     int index;
     SDL_Finger *finger;
     PyObject *fingerobj;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "Li", keywords,
-                                     &touchid, &index))
-    {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "Li", keywords, &touchid,
+                                     &index)) {
         return NULL;
     }
 
@@ -118,11 +114,14 @@ pg_touch_get_finger(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyMethodDef _touch_methods[] = {
-    {"get_num_devices", pg_touch_num_devices, METH_NOARGS, DOC_PYGAMESDL2TOUCHGETNUMDEVICES},
+    {"get_num_devices", pg_touch_num_devices, METH_NOARGS,
+     DOC_PYGAMESDL2TOUCHGETNUMDEVICES},
     {"get_device", pg_touch_get_device, METH_O, DOC_PYGAMESDL2TOUCHGETDEVICE},
 
-    {"get_num_fingers", pg_touch_num_fingers, METH_O, DOC_PYGAMESDL2TOUCHGETNUMFINGERS},
-    {"get_finger", (PyCFunction)pg_touch_get_finger, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMESDL2TOUCHGETFINGER},
+    {"get_num_fingers", pg_touch_num_fingers, METH_O,
+     DOC_PYGAMESDL2TOUCHGETNUMFINGERS},
+    {"get_finger", (PyCFunction)pg_touch_get_finger,
+     METH_VARARGS | METH_KEYWORDS, DOC_PYGAMESDL2TOUCHGETFINGER},
 
     {NULL, NULL, 0, NULL}};
 


### PR DESCRIPTION
Previously, on windows, `setup.py format` would format the doc headers, and did not format touch.c (Due to it being in `/_sdl2/`). This pr fixes both of these issues (and formats touch.c)