### PR TITLE
Use more optimal line functions in polygon

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2257,7 +2257,7 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
             minx = MIN(minx, point_x[i]);
             maxx = MAX(maxx, point_x[i]);
         }
-        draw_line(surf, minx, miny, maxx, miny, color, drawn_area);
+        drawhorzlineclipbounding(surf, color, minx, miny, maxx, drawn_area);
         PyMem_Free(x_intersect);
         return;
     }
@@ -2303,8 +2303,8 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
         qsort(x_intersect, n_intersections, sizeof(int), compare_int);
 
         for (i = 0; (i < n_intersections); i += 2) {
-            draw_line(surf, x_intersect[i], y, x_intersect[i + 1], y, color,
-                      drawn_area);
+            drawhorzlineclipbounding(surf, color, x_intersect[i], y,
+                                     x_intersect[i + 1], drawn_area);
         }
     }
 
@@ -2322,8 +2322,8 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
         y = point_y[i];
 
         if ((miny < y) && (point_y[i_previous] == y) && (y < maxy)) {
-            draw_line(surf, point_x[i], y, point_x[i_previous], y, color,
-                      drawn_area);
+            drawhorzlineclipbounding(surf, color, point_x[i], y,
+                                     point_x[i_previous], drawn_area);
         }
     }
     PyMem_Free(x_intersect);


### PR DESCRIPTION
Patch by MightyJosip

Fixes #3135 

Here's a more realistic test case:
```py
import time
import pygame
surf = pygame.Surface((1280, 720))
s = time.time()

for scale in range(1, 9):
    for _ in range(1000):
        pygame.draw.polygon(surf, "red", [[0,0], [0,100], [100,100]])
        pygame.draw.polygon(surf, "blue", [[150,100], [400,200], [300,500], [700,200]])

print(time.time() - s)
```

Numbers:
dev4 = 2.299182653427124 seconds
this patch = 0.255979061126709 seconds

Output is visually the same, I haven't checked pixel by pixel