### PR TITLE
Remove Solaris compatibility code to re-enable SIGALARM

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2040,20 +2040,6 @@ pg_install_parachute(void)
         }
     }
 
-#if defined(SIGALRM) && defined(HAVE_SIGACTION)
-    { /* Set SIGALRM to be ignored -- necessary on Solaris */
-        struct sigaction action, oaction;
-
-        /* Set SIG_IGN action */
-        memset(&action, 0, (sizeof action));
-        action.sa_handler = SIG_IGN;
-        sigaction(SIGALRM, &action, &oaction);
-        /* Reset original action if it was already being handled */
-        if (oaction.sa_handler != SIG_DFL) {
-            sigaction(SIGALRM, &oaction, NULL);
-        }
-    }
-#endif
 #endif
     return;
 }


### PR DESCRIPTION
Reasoning:

- Solaris seems long dead now as a desktop OS and is nearly dead on servers too: https://www.osnews.com/story/29994/oracle-kills-solaris/
- this code might not even be necessary there anyway as the bug was likely related to interactions between SDL 1 and Solaris, impossible to know conclusively without finding a Solaris desktop user
- Should fix #2017

Perhaps @combs can try it and confirm or anyone else running on linux.

This is the test case provided in the original issue:

```
import signal, time
import pygame
signal.alarm(10)
i = 0
while True:
    print(i, "seconds passed")
    i += 1
    time.sleep(1)
``` 

If all is well it should stop printing after around 10 seconds.