### PR TITLE
Fix drawing of circles there intersect -+INT_MAX

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1952,7 +1952,8 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
 
     if (x0 < 0) {
         xmin = x0 + INT_MAX + 1;
-    } else {
+    }
+    else {
         xmax = INT_MAX - x0;
     }
 
@@ -1969,15 +1970,16 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
         /* optimisation to avoid overdrawing and repeated return rect checks:
            only draw a line if y-step is about to be decreased. */
         if (f >= 0) {
-            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin), y0 + y - 1,
-                                     x0 + MIN(x - 1, xmax), drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin), y0 - y, x0 + MIN(x - 1, xmax),
+            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin),
+                                     y0 + y - 1, x0 + MIN(x - 1, xmax),
                                      drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin), y0 - y,
+                                     x0 + MIN(x - 1, xmax), drawn_area);
         }
-        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 + x - 1, x0 + MIN(y - 1, xmax),
-                                 drawn_area);
-        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 - x, x0 + MIN(y - 1, xmax),
-                                 drawn_area);
+        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 + x - 1,
+                                 x0 + MIN(y - 1, xmax), drawn_area);
+        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 - x,
+                                 x0 + MIN(y - 1, xmax), drawn_area);
     }
 }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1947,6 +1947,14 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
     int ddF_y = -2 * radius;
     int x = 0;
     int y = radius;
+    int xmin = INT_MAX;
+    int xmax = INT_MIN;
+
+    if (x0 < 0) {
+        xmin = x0 + INT_MAX + 1;
+    } else {
+        xmax = INT_MAX - x0;
+    }
 
     while (x < y) {
         if (f >= 0) {
@@ -1961,14 +1969,14 @@ draw_circle_filled(SDL_Surface *surf, int x0, int y0, int radius, Uint32 color,
         /* optimisation to avoid overdrawing and repeated return rect checks:
            only draw a line if y-step is about to be decreased. */
         if (f >= 0) {
-            drawhorzlineclipbounding(surf, color, x0 - x, y0 + y - 1,
-                                     x0 + x - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - x, y0 - y, x0 + x - 1,
+            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin), y0 + y - 1,
+                                     x0 + MIN(x - 1, xmax), drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - MIN(x, xmin), y0 - y, x0 + MIN(x - 1, xmax),
                                      drawn_area);
         }
-        drawhorzlineclipbounding(surf, color, x0 - y, y0 + x - 1, x0 + y - 1,
+        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 + x - 1, x0 + MIN(y - 1, xmax),
                                  drawn_area);
-        drawhorzlineclipbounding(surf, color, x0 - y, y0 - x, x0 + y - 1,
+        drawhorzlineclipbounding(surf, color, x0 - MIN(y, xmin), y0 - x, x0 + MIN(y - 1, xmax),
                                  drawn_area);
     }
 }


### PR DESCRIPTION
A fix for https://github.com/pygame/pygame/issues/3143

`draw_circle_filled` calls `drawhorzlineclipbounding` the arguments
was not protected for signed interger overflow - which produced a
write bar when e.g. a circle like:
`pygame.draw.circle(display, (255,255,255), (-1e30,300), 10 )` was
drawn.

This commit limit the `x` corrdinate to `drawhorzlineclipbounding`
so signed interger overflow is avoided.