### PR TITLE
cull circles outside the clipping area

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -717,8 +717,10 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 
     SDL_GetClipRect(surf, &cliprect);
 
-    if (posx > cliprect.x+cliprect.w+radius || posx < cliprect.x-radius ||
-        posy > cliprect.y+cliprect.h+radius || posy < cliprect.y-radius) {
+    if (posx > cliprect.x + cliprect.w + radius ||
+        posx < cliprect.x - radius ||
+        posy > cliprect.y + cliprect.h + radius ||
+        posy < cliprect.y - radius) {
         return pgRect_New4(0, 0, 0, 0);
     }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -662,6 +662,7 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
+    SDL_Rect cliprect;
     PyObject *posobj, *radiusobj;
     int posx, posy, radius;
     int width = 0; /* Default values. */
@@ -712,6 +713,13 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (width > radius) {
         width = radius;
+    }
+
+    SDL_GetClipRect(surf, &cliprect);
+
+    if (posx > cliprect.x+cliprect.w+radius || posx < cliprect.x-radius ||
+        posy > cliprect.y+cliprect.h+radius || posy < cliprect.y-radius) {
+        return pgRect_New4(0, 0, 0, 0);
     }
 
     if (!pgSurface_Lock(surfobj)) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -721,7 +721,7 @@ circle(PyObject *self, PyObject *args, PyObject *kwargs)
         posx < cliprect.x - radius ||
         posy > cliprect.y + cliprect.h + radius ||
         posy < cliprect.y - radius) {
-        return pgRect_New4(0, 0, 0, 0);
+        return pgRect_New4(posx, posy, 0, 0);
     }
 
     if (!pgSurface_Lock(surfobj)) {


### PR DESCRIPTION
Drawing a circle previously meant running Bresenham's circle drawing
algorithm point by point, and then only setting pixels within the clip
rect. If the whole circle is outside of the clip rect, we can just stop
early and not run Bresenhams's algorithm at all.

Also fixes #3151, by not entering the faulty code path at all, but for the sake of correctness, we should do both.