### PR TITLE
Fixed windows version parsing in Camera that errored on versions like 8.1

### DIFF
--- a/src_py/camera.py
+++ b/src_py/camera.py
@@ -125,7 +125,7 @@ def _setup_backend(backend):
 def get_backends():
     possible_backends = []
 
-    if sys.platform == "win32" and int(platform.win32_ver()[0]) >= 8:
+    if sys.platform == "win32" and int(platform.win32_ver()[0].split('.')[0]) >= 8:
         possible_backends.append("_camera (MSMF)")
 
     if "linux" in sys.platform:

--- a/src_py/camera.py
+++ b/src_py/camera.py
@@ -125,7 +125,7 @@ def _setup_backend(backend):
 def get_backends():
     possible_backends = []
 
-    if sys.platform == "win32" and int(platform.win32_ver()[0].split('.')[0]) >= 8:
+    if sys.platform == "win32" and int(platform.win32_ver()[0].split(".")[0]) >= 8:
         possible_backends.append("_camera (MSMF)")
 
     if "linux" in sys.platform:


### PR DESCRIPTION
...that have a "." in the name (e.g. Windows 8.1), now it converts only the integer before the first ".".