### PR TITLE
`get_fonts` stop returning `None`, warn `fc-list` issues

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -31,6 +31,8 @@ OpenType_extensions = frozenset((".ttf", ".ttc", ".otf"))
 Sysfonts = {}
 Sysalias = {}
 
+is_init = False
+
 if os.name == "nt":
     import winreg as _winreg
 
@@ -332,6 +334,11 @@ def initsysfonts():
 
     Has different initialisation functions for different platforms.
     """
+    global is_init
+    if is_init:
+        # no need to re-init
+        return
+
     if sys.platform == "win32":
         fonts = initsysfonts_win32()
     elif sys.platform == "darwin":
@@ -340,8 +347,7 @@ def initsysfonts():
         fonts = initsysfonts_unix()
     Sysfonts.update(fonts)
     create_aliases()
-    if not Sysfonts:  # dummy so we don't try to reinit
-        Sysfonts[None] = None
+    is_init = True
 
 
 def font_constructor(fontpath, size, bold, italic):
@@ -394,8 +400,7 @@ def SysFont(name, size, bold=False, italic=False, constructor=None):
     if constructor is None:
         constructor = font_constructor
 
-    if not Sysfonts:
-        initsysfonts()
+    initsysfonts()
 
     gotbold = gotitalic = False
     fontname = None
@@ -451,11 +456,8 @@ def get_fonts():
     removed. This is how pygame internally stores the font
     names for matching.
     """
-    if not Sysfonts:
-        initsysfonts()
-
-    # 'Sysfonts' can contain a sentinel 'None' key, don't forward that to users
-    return [i for i in Sysfonts if i is not None]
+    initsysfonts()
+    return list(Sysfonts)
 
 
 def match_font(name, bold=0, italic=0):
@@ -470,8 +472,7 @@ def match_font(name, bold=0, italic=0):
 
     If no match is found, None is returned.
     """
-    if not Sysfonts:
-        initsysfonts()
+    initsysfonts()
 
     fontname = None
     if isinstance(name, (str, bytes)):


### PR DESCRIPTION
PR to fix #3156

Makes sure `get_fonts` does not return `None` in the return list in some cases.

Also adds warnings for when there is an issue with `fc-list` usage (without this command, no system font will be loaded, added a warning for this too)

Under Ubuntu/Debian and derivatives this command is available with the `fontconfig` package installable from `apt`