### PR TITLE
Remove old thread compat code

### DIFF
--- a/src_c/_freetype.c
+++ b/src_c/_freetype.c
@@ -760,9 +760,7 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
     else {
         PyObject *str = 0;
         PyObject *path = 0;
-#ifndef WITH_THREAD
-        goto end;
-#endif
+
         source = pgRWops_FromFileObject(original_file);
         if (!source) {
             goto end;
@@ -805,8 +803,7 @@ _ftfont_init(pgFontObject *self, PyObject *args, PyObject *kwds)
     /* FT uses fopen(); as a workaround, always use RWops */
     if (file == original_file)
         Py_INCREF(file);
-    if (!PG_CHECK_THREADS())
-        goto end;
+
     source = pgRWops_FromObject(file);
     if (!source) {
         goto end;

--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -271,14 +271,6 @@ supported Python version. #endif */
     if (!SDL_WasInit(SDL_INIT_JOYSTICK)) \
     return RAISE(pgExc_SDLError, "joystick system not initialized")
 
-/* thread check */
-#ifdef WITH_THREAD
-#define PG_CHECK_THREADS() (1)
-#else /* ~WITH_THREAD */
-#define PG_CHECK_THREADS() \
-    (RAISE(PyExc_NotImplementedError, "Python built without thread support"))
-#endif /* ~WITH_THREAD */
-
 #define PyType_Init(x) (((x).ob_type) = &PyType_Type)
 
 /*

--- a/src_c/base.c
+++ b/src_c/base.c
@@ -346,7 +346,7 @@ pg_init(PyObject *self, PyObject *_null)
     }
 
     /*nice to initialize timer, so startup time will reflec pg_init() time*/
-#if defined(WITH_THREAD) && !defined(MS_WIN32) && defined(SDL_INIT_EVENTTHREAD)
+#if !defined(MS_WIN32) && defined(SDL_INIT_EVENTTHREAD)
     pg_sdl_was_init = SDL_Init(SDL_INIT_EVENTTHREAD | SDL_INIT_TIMER |
                                SDL_INIT_NOPARACHUTE) == 0;
 #else

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -67,9 +67,7 @@
 
 #define JPEG_QUALITY 85
 
-#ifdef WITH_THREAD
 static SDL_mutex *_pg_img_mutex = 0;
-#endif /* WITH_THREAD */
 
 #ifdef WIN32
 #include <windows.h>
@@ -116,7 +114,6 @@ image_load_ext(PyObject *self, PyObject *arg)
     if (name) /* override extension with namehint if given */
         ext = find_extension(name);
 
-#ifdef WITH_THREAD
     /*
     if (ext)
         lock_mutex = !strcasecmp(ext, "gif");
@@ -132,9 +129,6 @@ image_load_ext(PyObject *self, PyObject *arg)
 
     surf = IMG_LoadTyped_RW(rw, 1, ext);
     Py_END_ALLOW_THREADS;
-#else  /* ~WITH_THREAD */
-    surf = IMG_LoadTyped_RW(rw, 1, ext);
-#endif /* ~WITH_THREAD */
 
     if (surf == NULL)
         return RAISE(pgExc_SDLError, IMG_GetError());
@@ -749,7 +743,6 @@ image_get_sdl_image_version(PyObject *self, PyObject *_null)
                          SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_PATCHLEVEL);
 }
 
-#ifdef WITH_THREAD
 static void
 _imageext_free(void *ptr)
 {
@@ -758,7 +751,6 @@ _imageext_free(void *ptr)
         _pg_img_mutex = 0;
     }
 }
-#endif /* WITH_THREAD */
 
 static PyMethodDef _imageext_methods[] = {
     {"load_extended", image_load_ext, METH_VARARGS, DOC_PYGAMEIMAGE},
@@ -776,11 +768,7 @@ MODINIT_DEFINE(imageext)
     static struct PyModuleDef _module = {
         PyModuleDef_HEAD_INIT, "imageext", _imageext_doc, -1,
         _imageext_methods,     NULL,       NULL,          NULL,
-#ifdef WITH_THREAD
         _imageext_free};
-#else  /* ~WITH_THREAD */
-                                         0};
-#endif /* ~WITH_THREAD */
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -799,13 +787,11 @@ MODINIT_DEFINE(imageext)
         return NULL;
     }
 
-#ifdef WITH_THREAD
     _pg_img_mutex = SDL_CreateMutex();
     if (!_pg_img_mutex) {
         PyErr_SetString(pgExc_SDLError, SDL_GetError());
         return NULL;
     }
-#endif /* WITH_THREAD */
 
     /* create the module */
     return PyModule_Create(&_module);


### PR DESCRIPTION
I noticed while looking into #3083 that some older files had these `WITH_THREAD` `#ifdef`s spread liberally around, cluttering the code up a bit and hurting readability.

I researched this and learned that Python used to be able to be built without threading support, which may have been advantageous when threads were exotic, in the python 2 days. The threads documentation states `Changed in version 3.7: This module used to be optional, it is now always available.`

So the only people potentially impacted by this are users on custom builds of Python 3.6, who also update pygame when new releases come out. I'd be surprised if this described any people. Plus we should drop Python 3.6 support soonTM anyways.