### PR TITLE
Drop python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,13 +83,6 @@ jobs:
         # builds on macOS
         include:
           - { 
-            name: "MacOS x86_64 (cp36-cp37)",
-            os: macos-10.15,
-            macarch: x86_64,
-            pyversions: cp36-* cp37-*
-          }
-
-          - { 
             name: "MacOS x86_64 (cp37-cp38)",
             os: macos-10.15,
             macarch: x86_64,
@@ -104,17 +97,25 @@ jobs:
           }
 
           - { 
-            name: "MacOS x86_64 (pp37)",
+            name: "MacOS x86_64 (pp37-pp38-pp39)",
             os: macos-10.15,
             macarch: x86_64,
-            pyversions: pp37-*
+            pyversions: pp37-* pp38-* pp39-*
           }
 
           - { 
-            name: "MacOS arm64 (cp38-cp39-cp310)",
+            name: "MacOS arm64 (cp38-cp39)",
             os: macos-11,
             macarch: arm64,
-            pyversions: cp38-* cp39-* cp310-*
+            pyversions: cp38-* cp39-*
+          }
+
+
+          - { 
+            name: "MacOS arm64 (cp310)",
+            os: macos-11,
+            macarch: arm64,
+            pyversions: cp310-*
           }
 
         # seperate into matrix for concurrency. 

--- a/.github/workflows/ubuntu-sdist.yml
+++ b/.github/workflows/ubuntu-sdist.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -63,21 +63,21 @@ jobs:
       run: python3 -m pygame.tests -v --exclude opengl,timing --time_out 300
     
     - name: Test typestubs
-      if: matrix.os == 'ubuntu-20.04' # run stubest only once
+      if: matrix.os == 'ubuntu-22.04' # run stubest only once
       run: |
         cd buildconfig/stubs
         python3 -m mypy.stubtest pygame --allowlist mypy_allow_list.txt
 
     # We upload the generated files under github actions assets
     - name: Upload sdist
-      if: matrix.os == 'ubuntu-20.04' # upload sdist only once
+      if: matrix.os == 'ubuntu-22.04' # upload sdist only once
       uses: actions/upload-artifact@v2
       with:
         name: pygame-sdist
         path: dist/*.tar.gz
 
 #   - name: Upload binaries to Github Releases
-#     if: github.event_name == 'release' && matrix.os == 'ubuntu-18.04' # upload sdist only once
+#     if: github.event_name == 'release' && matrix.os == 'ubuntu-20.04' # upload sdist only once
 #     uses: svenstaro/upload-release-action@v2
 #     with:
 #       repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
 #       tag: ${{ github.ref }}
 #
 #   - name: Upload binaries to PyPI
-#     if: github.event_name == 'release' && matrix.os == 'ubuntu-18.04' # upload sdist only once
+#     if: github.event_name == 'release' && matrix.os == 'ubuntu-20.04' # upload sdist only once
 #     env:
 #      TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
 #      TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ own rotozoom function.  The surfarray module requires the Python
 NumPy package for its multidimensional numeric arrays.
 Dependency versions:
 
-* CPython >= 3.6 or PyPy3
+* CPython >= 3.7 or PyPy3
 * SDL >= 2.0.1
 * SDL_mixer >= 2.0.0
 * SDL_image >= 2.0.0

--- a/buildconfig/appveyor.yml
+++ b/buildconfig/appveyor.yml
@@ -16,18 +16,6 @@ environment:
       secure: FtHM0I+wubit/UWOzHsykHayL06KImKRZQznRUHUfzM=
 
   matrix:
-    - PYTHON: "pypy3.exe"
-      PYTHON_VERSION: "3.6.0"
-      PYTHON_ARCH: "32"
-      PYPY_VERSION: "pypy3.6-v7.3.2-win32"
-      PYPY_DOWNLOAD: "powershell buildconfig\\ci\\appveyor\\download_pypy.ps1"
-
-    - PYTHON: "C:\\Python36\\python"
-      PYTHONPATH: "C:\\Python36"
-      PYTHON_VERSION: "3.6.0"
-      PYTHON_ARCH: "32"
-      USE_ANALYZE: ""
-
     - PYTHON: "C:\\Python37\\python"
       PYTHONPATH: "C:\\Python37"
       PYTHON_VERSION: "3.7.0"
@@ -52,11 +40,11 @@ environment:
       PYTHON_ARCH: "32"
       USE_ANALYZE: ""
 
-    - PYTHON: "C:\\Python36-x64\\python"
-      PYTHONPATH: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.0"
+    - PYTHON: "pypy3.exe"
+      PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
-      USE_ANALYZE: ""
+      PYPY_VERSION: "pypy3.7-v7.3.9-win64"
+      PYPY_DOWNLOAD: "powershell buildconfig\\ci\\appveyor\\download_pypy.ps1"
 
     - PYTHON: "C:\\Python37-x64\\python"
       PYTHONPATH: "C:\\Python37-x64"

--- a/buildconfig/ci/appveyor/download_pypy.ps1
+++ b/buildconfig/ci/appveyor/download_pypy.ps1
@@ -31,7 +31,7 @@ function DownloadPyPy($which_pypy) {
 
 
 function main ($pypy_version) {
-   DownloadPyPy "pypy3.6-v7.3.2-win32"
+   DownloadPyPy "pypy3.7-v7.3.9-win64"
 }
 
 main $pypy_version

--- a/buildconfig/manylinux-build/build-wheels.sh
+++ b/buildconfig/manylinux-build/build-wheels.sh
@@ -3,12 +3,12 @@ set -e -x
 
 
 if [[ "$1" == "buildpypy" ]]; then
-    export SUPPORTED_PYTHONS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 pp37-pypy37_pp75"
+    export SUPPORTED_PYTHONS="cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 pp37-pypy37_pp75"
 else
     if [ `uname -m` == "aarch64" ]; then
-       export SUPPORTED_PYTHONS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310"
+       export SUPPORTED_PYTHONS="cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310"
     else
-       export SUPPORTED_PYTHONS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
+       export SUPPORTED_PYTHONS="cp37-cp37m cp38-cp38 cp39-cp39"
     fi
 fi
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310}
 skipsdist = True
 skip_missing_interpreters = True
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ METADATA = {
         "Programming Language :: Objective C",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -60,7 +59,7 @@ METADATA = {
         "Operating System :: Unix",
         "Operating System :: MacOS",
     ],
-    "python_requires": '>=3.6',
+    "python_requires": '>=3.7',
 }
 
 import re
@@ -173,11 +172,11 @@ def compilation_help():
     print('---\n')
 
 
-if not hasattr(sys, 'version_info') or sys.version_info < (3, 5):
+if not hasattr(sys, 'version_info') or sys.version_info < (3, 7):
     compilation_help()
-    raise SystemExit("Pygame requires Python3 version 3.6 or above.")
+    raise SystemExit("Pygame requires Python3 version 3.7 or above.")
 if IS_PYPY and sys.pypy_version_info < (7,):
-    raise SystemExit("Pygame requires PyPy version 7.0.0 above, compatible with CPython >= 3.6")
+    raise SystemExit("Pygame requires PyPy version 7.0.0 above, compatible with CPython >= 3.7")
 
 
 def consume_arg(name):

--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -478,15 +478,6 @@ pgRWops_FromFileObject(PyObject *obj)
     rw->write = _pg_rw_write;
     rw->close = _pg_rw_close;
 
-/* https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads */
-/* ^ in Python >= 3.7, we don't have to call this function, and in 3.11
- * it will be removed */
-#if PY_VERSION_HEX < 0x03070000
-#ifdef WITH_THREAD
-    PyEval_InitThreads();
-#endif /* WITH_THREAD */
-#endif
-
     return rw;
 }
 


### PR DESCRIPTION
I almost definitely missed stuff, but I think I got the important bits.

Python 3.6 has been out of security fixes since 2021.

It would be good to consolidate our version support, reduce the number of wheels where possible, and get rid of old APIs.

Ankith I discussed CI needs on discord, it will still need work after this PR
I got the mac ones I think (If you think the distribution of versions is strange, I'm factoring in slots for 3.11 and more pypy versions)
I'm a bit scared to tackle pypy appveyor, so I left it, but that definitely needs to be updated (in another PR)

CI plan for Mac that Ankith likes (for the future):
![Capture](https://user-images.githubusercontent.com/46412508/166901046-d4209711-d09d-4025-96ed-51523a103295.PNG)

