### PR TITLE
SIMD versions of RGB_ADD, RGBA_ADD, RGB_MUL & RGBA_MUL

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -263,10 +263,88 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                     break;
                 }
                 case PYGAME_BLEND_ADD: {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        !(src->format->Amask != 0 && dst->format->Amask != 0 &&
+                          src->format->Amask != dst->format->Amask) &&
+                        SDL_HasAVX2() && (src != dst)) {
+                        blit_blend_rgb_add_avx2(&info);
+                        break;
+                    }
+#if defined(__SSE2__)
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        !(src->format->Amask != 0 && dst->format->Amask != 0 &&
+                          src->format->Amask != dst->format->Amask) &&
+                        SDL_HasSSE2() && (src != dst)) {
+                        blit_blend_rgb_add_sse2(&info);
+                        break;
+                    }
+#endif /* __SSE2__*/
+#if PG_ENABLE_ARM_NEON
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        !(src->format->Amask != 0 && dst->format->Amask != 0 &&
+                          src->format->Amask != dst->format->Amask) &&
+                        SDL_HasNEON() && (src != dst)) {
+                        blit_blend_rgb_add_sse2(&info);
+                        break;
+                    }
+#endif /* PG_ENABLE_ARM_NEON */
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
                     blit_blend_add(&info);
                     break;
                 }
                 case PYGAME_BLEND_SUB: {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        !(src->format->Amask != 0 && dst->format->Amask != 0 &&
+                          src->format->Amask != dst->format->Amask) &&
+                        SDL_HasAVX2() && (src != dst)) {
+                        blit_blend_rgb_sub_avx2(&info);
+                        break;
+                    }
+#if defined(__SSE2__)
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        !(src->format->Amask != 0 && dst->format->Amask != 0 &&
+                          src->format->Amask != dst->format->Amask) &&
+                        SDL_HasSSE2() && (src != dst)) {
+                        blit_blend_rgb_sub_sse2(&info);
+                        break;
+                    }
+#endif /* __SSE2__*/
+#if PG_ENABLE_ARM_NEON
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        !(src->format->Amask != 0 && dst->format->Amask != 0 &&
+                          src->format->Amask != dst->format->Amask) &&
+                        SDL_HasNEON() && (src != dst)) {
+                        blit_blend_rgb_sub_sse2(&info);
+                        break;
+                    }
+#endif /* PG_ENABLE_ARM_NEON */
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
                     blit_blend_sub(&info);
                     break;
                 }
@@ -323,10 +401,82 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                 }
 
                 case PYGAME_BLEND_RGBA_ADD: {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasAVX2() && (src != dst)) {
+                        blit_blend_rgba_add_avx2(&info);
+                        break;
+                    }
+#if defined(__SSE2__)
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasSSE2() && (src != dst)) {
+                        blit_blend_rgba_add_sse2(&info);
+                        break;
+                    }
+#endif /* __SSE2__*/
+#if PG_ENABLE_ARM_NEON
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasNEON() && (src != dst)) {
+                        blit_blend_rgba_add_sse2(&info);
+                        break;
+                    }
+#endif /* PG_ENABLE_ARM_NEON */
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
                     blit_blend_rgba_add(&info);
                     break;
                 }
                 case PYGAME_BLEND_RGBA_SUB: {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasAVX2() && (src != dst)) {
+                        blit_blend_rgba_sub_avx2(&info);
+                        break;
+                    }
+#if defined(__SSE2__)
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasSSE2() && (src != dst)) {
+                        blit_blend_rgba_sub_sse2(&info);
+                        break;
+                    }
+#endif /* __SSE2__*/
+#if PG_ENABLE_ARM_NEON
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasNEON() && (src != dst)) {
+                        blit_blend_rgba_sub_sse2(&info);
+                        break;
+                    }
+#endif /* PG_ENABLE_ARM_NEON */
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
                     blit_blend_rgba_sub(&info);
                     break;
                 }

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -13,9 +13,25 @@ void
 blit_blend_rgba_mul_sse2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_mul_sse2(SDL_BlitInfo *info);
+void
+blit_blend_rgba_add_sse2(SDL_BlitInfo *info);
+void
+blit_blend_rgb_add_sse2(SDL_BlitInfo *info);
+void
+blit_blend_rgba_sub_sse2(SDL_BlitInfo *info);
+void
+blit_blend_rgb_sub_sse2(SDL_BlitInfo *info);
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
 
 void
 blit_blend_rgba_mul_avx2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_mul_avx2(SDL_BlitInfo *info);
+void
+blit_blend_rgba_add_avx2(SDL_BlitInfo *info);
+void
+blit_blend_rgb_add_avx2(SDL_BlitInfo *info);
+void
+blit_blend_rgba_sub_avx2(SDL_BlitInfo *info);
+void
+blit_blend_rgb_sub_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -382,7 +382,7 @@ blit_blend_rgb_add_avx2(SDL_BlitInfo *info)
                     mm_src = _mm_cvtsi32_si128(*srcp);
                     mm_dst = _mm_cvtsi32_si128(*dstp);
 
-                    mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                     mm_dst = _mm_adds_epu8(mm_dst, mm_src);
 
                     *dstp = _mm_cvtsi128_si32(mm_dst);
@@ -400,7 +400,7 @@ blit_blend_rgb_add_avx2(SDL_BlitInfo *info)
                     mm256_src = _mm256_loadu_si256(srcp256);
                     mm256_dst = _mm256_loadu_si256(dstp256);
 
-                    mm256_src = _mm256_xor_si256(mm256_src, mm256_alpha_mask);
+                    mm256_src = _mm256_subs_epu8(mm256_src, mm256_alpha_mask);
                     mm256_dst = _mm256_adds_epu8(mm256_dst, mm256_src);
 
                     _mm256_storeu_si256(dstp256, mm256_dst);

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -475,7 +475,7 @@ blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
                     mm_src = _mm_cvtsi32_si128(*srcp);
                     mm_dst = _mm_cvtsi32_si128(*dstp);
 
-                    mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                     mm_dst = _mm_adds_epu8(mm_dst, mm_src);
 
                     *dstp = _mm_cvtsi128_si32(mm_dst);
@@ -493,7 +493,7 @@ blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
                     mm_src = _mm_cvtsi64_si128(*srcp64);
                     mm_dst = _mm_cvtsi64_si128(*dstp64);
 
-                    mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                     mm_dst = _mm_adds_epu8(mm_dst, mm_src);
 
                     *dstp64 = _mm_cvtsi128_si64(mm_dst);
@@ -534,7 +534,7 @@ blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
                 mm_src = _mm_cvtsi32_si128(*srcp);
                 mm_dst = _mm_cvtsi32_si128(*dstp);
 
-                mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                 mm_dst = _mm_adds_epu8(mm_dst, mm_src);
 
                 *dstp = _mm_cvtsi128_si32(mm_dst);

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -329,3 +329,445 @@ blit_blend_rgb_mul_sse2(SDL_BlitInfo *info)
 }
 #endif /* defined(ENV64BIT) */
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
+#if defined(ENV64BIT)
+void
+blit_blend_rgba_add_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int srcdoublepxskip = 2 * dstpxskip;
+    int dstdoublepxskip = 2 * dstpxskip;
+
+    int pre_2_width = width % 2;
+    int post_2_width = (width - pre_2_width) / 2;
+
+    __m128i mm_src, mm_dst;
+
+    while (height--) {
+        if (pre_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi32_si128(*srcp);
+                    mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                    *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_2_width);
+        }
+        srcp64 = (Uint64 *)srcp;
+        dstp64 = (Uint64 *)dstp;
+        if (post_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi64_si128(*srcp64);
+                    mm_dst = _mm_cvtsi64_si128(*dstp64);
+
+                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
+
+                    srcp64++;
+                    dstp64++;
+                    srcp += srcdoublepxskip;
+                    dstp += dstdoublepxskip;
+                },
+                n, post_2_width);
+        }
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#else
+void
+blit_blend_rgba_add_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    __m128i mm_src, mm_dst;
+
+    while (height--) {
+        LOOP_UNROLLED4(
+            {
+                mm_src = _mm_cvtsi32_si128(*srcp);
+                mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                srcp += srcpxskip;
+                dstp += dstpxskip;
+            },
+            n, width);
+
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#endif /* defined(ENV64BIT) */
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
+#if defined(ENV64BIT)
+void
+blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int srcdoublepxskip = 2 * dstpxskip;
+    int dstdoublepxskip = 2 * dstpxskip;
+
+    int pre_2_width = width % 2;
+    int post_2_width = (width - pre_2_width) / 2;
+
+    Uint32 amask = info->src->Amask | info->dst->Amask;
+    Uint64 amask64 = (((Uint64)amask) << 32) | (Uint64)amask;
+
+    __m128i mm_src, mm_dst, mm_alpha_mask;
+
+    mm_alpha_mask = _mm_set_epi64x(0x0000000000000000, amask64);
+
+    while (height--) {
+        if (pre_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi32_si128(*srcp);
+                    mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                    mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                    *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_2_width);
+        }
+        srcp64 = (Uint64 *)srcp;
+        dstp64 = (Uint64 *)dstp;
+        if (post_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi64_si128(*srcp64);
+                    mm_dst = _mm_cvtsi64_si128(*dstp64);
+
+                    mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
+
+                    srcp64++;
+                    dstp64++;
+                    srcp += srcdoublepxskip;
+                    dstp += dstdoublepxskip;
+                },
+                n, post_2_width);
+        }
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#else
+void
+blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    __m128i mm_src, mm_dst, mm_alpha_mask;
+    mm_alpha_mask = _mm_cvtsi32_si128(info->src->Amask | info->dst->Amask);
+
+    while (height--) {
+        LOOP_UNROLLED4(
+            {
+                mm_src = _mm_cvtsi32_si128(*srcp);
+                mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                mm_src = _mm_xor_si128(mm_src, mm_alpha_mask);
+                mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                srcp += srcpxskip;
+                dstp += dstpxskip;
+            },
+            n, width);
+
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#endif /* defined(ENV64BIT) */
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
+#if defined(ENV64BIT)
+void
+blit_blend_rgba_sub_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int srcdoublepxskip = 2 * dstpxskip;
+    int dstdoublepxskip = 2 * dstpxskip;
+
+    int pre_2_width = width % 2;
+    int post_2_width = (width - pre_2_width) / 2;
+
+    __m128i mm_src, mm_dst;
+
+    while (height--) {
+        if (pre_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi32_si128(*srcp);
+                    mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                    *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_2_width);
+        }
+        srcp64 = (Uint64 *)srcp;
+        dstp64 = (Uint64 *)dstp;
+        if (post_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi64_si128(*srcp64);
+                    mm_dst = _mm_cvtsi64_si128(*dstp64);
+
+                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
+
+                    srcp64++;
+                    dstp64++;
+                    srcp += srcdoublepxskip;
+                    dstp += dstdoublepxskip;
+                },
+                n, post_2_width);
+        }
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#else
+void
+blit_blend_rgba_sub_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    __m128i mm_src, mm_dst;
+
+    while (height--) {
+        LOOP_UNROLLED4(
+            {
+                mm_src = _mm_cvtsi32_si128(*srcp);
+                mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                srcp += srcpxskip;
+                dstp += dstpxskip;
+            },
+            n, width);
+
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#endif /* defined(ENV64BIT) */
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
+#if defined(ENV64BIT)
+void
+blit_blend_rgb_sub_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int srcdoublepxskip = 2 * dstpxskip;
+    int dstdoublepxskip = 2 * dstpxskip;
+
+    int pre_2_width = width % 2;
+    int post_2_width = (width - pre_2_width) / 2;
+
+    Uint32 amask = info->src->Amask | info->dst->Amask;
+    Uint64 amask64 = (((Uint64)amask) << 32) | (Uint64)amask;
+
+    __m128i mm_src, mm_dst, mm_alpha_mask;
+
+    mm_alpha_mask = _mm_set_epi64x(0x0000000000000000, amask64);
+
+    while (height--) {
+        if (pre_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi32_si128(*srcp);
+                    mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                    *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_2_width);
+        }
+        srcp64 = (Uint64 *)srcp;
+        dstp64 = (Uint64 *)dstp;
+        if (post_2_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi64_si128(*srcp64);
+                    mm_dst = _mm_cvtsi64_si128(*dstp64);
+
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
+
+                    srcp64++;
+                    dstp64++;
+                    srcp += srcdoublepxskip;
+                    dstp += dstdoublepxskip;
+                },
+                n, post_2_width);
+        }
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#else
+void
+blit_blend_rgb_sub_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    __m128i mm_src, mm_dst, mm_alpha_mask;
+    mm_alpha_mask = _mm_cvtsi32_si128(info->src->Amask | info->dst->Amask);
+
+    while (height--) {
+        LOOP_UNROLLED4(
+            {
+                mm_src = _mm_cvtsi32_si128(*srcp);
+                mm_dst = _mm_cvtsi32_si128(*dstp);
+
+                mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                srcp += srcpxskip;
+                dstp += dstpxskip;
+            },
+            n, width);
+
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#endif /* defined(ENV64BIT) */
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -331,72 +331,6 @@ blit_blend_rgb_mul_sse2(SDL_BlitInfo *info)
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
 
 #if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
-#if defined(ENV64BIT)
-void
-blit_blend_rgba_add_sse2(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    int srcpxskip = info->s_pxskip >> 2;
-
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    int dstpxskip = info->d_pxskip >> 2;
-
-    int srcdoublepxskip = 2 * dstpxskip;
-    int dstdoublepxskip = 2 * dstpxskip;
-
-    int pre_2_width = width % 2;
-    int post_2_width = (width - pre_2_width) / 2;
-
-    __m128i mm_src, mm_dst;
-
-    while (height--) {
-        if (pre_2_width > 0) {
-            LOOP_UNROLLED4(
-                {
-                    mm_src = _mm_cvtsi32_si128(*srcp);
-                    mm_dst = _mm_cvtsi32_si128(*dstp);
-
-                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
-
-                    *dstp = _mm_cvtsi128_si32(mm_dst);
-
-                    srcp += srcpxskip;
-                    dstp += dstpxskip;
-                },
-                n, pre_2_width);
-        }
-        srcp64 = (Uint64 *)srcp;
-        dstp64 = (Uint64 *)dstp;
-        if (post_2_width > 0) {
-            LOOP_UNROLLED4(
-                {
-                    mm_src = _mm_cvtsi64_si128(*srcp64);
-                    mm_dst = _mm_cvtsi64_si128(*dstp64);
-
-                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
-
-                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
-
-                    srcp64++;
-                    dstp64++;
-                    srcp += srcdoublepxskip;
-                    dstp += dstdoublepxskip;
-                },
-                n, post_2_width);
-        }
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-#else
 void
 blit_blend_rgba_add_sse2(SDL_BlitInfo *info)
 {
@@ -412,70 +346,24 @@ blit_blend_rgba_add_sse2(SDL_BlitInfo *info)
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
 
+    int srcquadpxskip = 4 * dstpxskip;
+    int dstquadpxskip = 4 * dstpxskip;
+
+    int pre_4_width = width % 4;
+    int post_4_width = (width - pre_4_width) / 4;
+
     __m128i mm_src, mm_dst;
 
-    while (height--) {
-        LOOP_UNROLLED4(
-            {
-                mm_src = _mm_cvtsi32_si128(*srcp);
-                mm_dst = _mm_cvtsi32_si128(*dstp);
-
-                mm_dst = _mm_adds_epu8(mm_dst, mm_src);
-
-                *dstp = _mm_cvtsi128_si32(mm_dst);
-
-                srcp += srcpxskip;
-                dstp += dstpxskip;
-            },
-            n, width);
-
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-#endif /* defined(ENV64BIT) */
-#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
-
-#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
-#if defined(ENV64BIT)
-void
-blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    int srcpxskip = info->s_pxskip >> 2;
-
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    int dstpxskip = info->d_pxskip >> 2;
-
-    int srcdoublepxskip = 2 * dstpxskip;
-    int dstdoublepxskip = 2 * dstpxskip;
-
-    int pre_2_width = width % 2;
-    int post_2_width = (width - pre_2_width) / 2;
-
-    Uint32 amask = info->src->Amask | info->dst->Amask;
-    Uint64 amask64 = (((Uint64)amask) << 32) | (Uint64)amask;
-
-    __m128i mm_src, mm_dst, mm_alpha_mask;
-
-    mm_alpha_mask = _mm_set_epi64x(0x0000000000000000, amask64);
+    __m128i *srcp128 = (__m128i *)info->s_pixels;
+    __m128i *dstp128 = (__m128i *)info->d_pixels;
 
     while (height--) {
-        if (pre_2_width > 0) {
+        if (pre_4_width > 0) {
             LOOP_UNROLLED4(
                 {
                     mm_src = _mm_cvtsi32_si128(*srcp);
                     mm_dst = _mm_cvtsi32_si128(*dstp);
 
-                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                     mm_dst = _mm_adds_epu8(mm_dst, mm_src);
 
                     *dstp = _mm_cvtsi128_si32(mm_dst);
@@ -483,33 +371,34 @@ blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
                     srcp += srcpxskip;
                     dstp += dstpxskip;
                 },
-                n, pre_2_width);
+                n, pre_4_width);
         }
-        srcp64 = (Uint64 *)srcp;
-        dstp64 = (Uint64 *)dstp;
-        if (post_2_width > 0) {
+        srcp128 = (__m128i *)srcp;
+        dstp128 = (__m128i *)dstp;
+        if (post_4_width > 0) {
             LOOP_UNROLLED4(
                 {
-                    mm_src = _mm_cvtsi64_si128(*srcp64);
-                    mm_dst = _mm_cvtsi64_si128(*dstp64);
+                    mm_src = _mm_loadu_si128(srcp128);
+                    mm_dst = _mm_loadu_si128(dstp128);
 
-                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                     mm_dst = _mm_adds_epu8(mm_dst, mm_src);
 
-                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
+                    _mm_storeu_si128(dstp128, mm_dst);
 
-                    srcp64++;
-                    dstp64++;
-                    srcp += srcdoublepxskip;
-                    dstp += dstdoublepxskip;
+                    srcp128++;
+                    dstp128++;
+                    srcp += srcquadpxskip;
+                    dstp += dstquadpxskip;
                 },
-                n, post_2_width);
+                n, post_4_width);
         }
         srcp += srcskip;
         dstp += dstskip;
     }
 }
-#else
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
 void
 blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
 {
@@ -525,178 +414,98 @@ blit_blend_rgb_add_sse2(SDL_BlitInfo *info)
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
 
-    __m128i mm_src, mm_dst, mm_alpha_mask;
-    mm_alpha_mask = _mm_cvtsi32_si128(info->src->Amask | info->dst->Amask);
+    int srcquadpxskip = 4 * dstpxskip;
+    int dstquadpxskip = 4 * dstpxskip;
 
-    while (height--) {
-        LOOP_UNROLLED4(
-            {
-                mm_src = _mm_cvtsi32_si128(*srcp);
-                mm_dst = _mm_cvtsi32_si128(*dstp);
+    int pre_4_width = width % 4;
+    int post_4_width = (width - pre_4_width) / 4;
 
-                mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
-                mm_dst = _mm_adds_epu8(mm_dst, mm_src);
-
-                *dstp = _mm_cvtsi128_si32(mm_dst);
-
-                srcp += srcpxskip;
-                dstp += dstpxskip;
-            },
-            n, width);
-
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-#endif /* defined(ENV64BIT) */
-#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
-
-#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
-#if defined(ENV64BIT)
-void
-blit_blend_rgba_sub_sse2(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    int srcpxskip = info->s_pxskip >> 2;
-
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    int dstpxskip = info->d_pxskip >> 2;
-
-    int srcdoublepxskip = 2 * dstpxskip;
-    int dstdoublepxskip = 2 * dstpxskip;
-
-    int pre_2_width = width % 2;
-    int post_2_width = (width - pre_2_width) / 2;
-
-    __m128i mm_src, mm_dst;
-
-    while (height--) {
-        if (pre_2_width > 0) {
-            LOOP_UNROLLED4(
-                {
-                    mm_src = _mm_cvtsi32_si128(*srcp);
-                    mm_dst = _mm_cvtsi32_si128(*dstp);
-
-                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
-
-                    *dstp = _mm_cvtsi128_si32(mm_dst);
-
-                    srcp += srcpxskip;
-                    dstp += dstpxskip;
-                },
-                n, pre_2_width);
-        }
-        srcp64 = (Uint64 *)srcp;
-        dstp64 = (Uint64 *)dstp;
-        if (post_2_width > 0) {
-            LOOP_UNROLLED4(
-                {
-                    mm_src = _mm_cvtsi64_si128(*srcp64);
-                    mm_dst = _mm_cvtsi64_si128(*dstp64);
-
-                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
-
-                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
-
-                    srcp64++;
-                    dstp64++;
-                    srcp += srcdoublepxskip;
-                    dstp += dstdoublepxskip;
-                },
-                n, post_2_width);
-        }
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-#else
-void
-blit_blend_rgba_sub_sse2(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    int srcpxskip = info->s_pxskip >> 2;
-
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    int dstpxskip = info->d_pxskip >> 2;
-
-    __m128i mm_src, mm_dst;
-
-    while (height--) {
-        LOOP_UNROLLED4(
-            {
-                mm_src = _mm_cvtsi32_si128(*srcp);
-                mm_dst = _mm_cvtsi32_si128(*dstp);
-
-                mm_dst = _mm_subs_epu8(mm_dst, mm_src);
-
-                *dstp = _mm_cvtsi128_si32(mm_dst);
-
-                srcp += srcpxskip;
-                dstp += dstpxskip;
-            },
-            n, width);
-
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-#endif /* defined(ENV64BIT) */
-#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
-
-#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
-#if defined(ENV64BIT)
-void
-blit_blend_rgb_sub_sse2(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    Uint64 *srcp64 = (Uint64 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    int srcpxskip = info->s_pxskip >> 2;
-
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    Uint64 *dstp64 = (Uint64 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    int dstpxskip = info->d_pxskip >> 2;
-
-    int srcdoublepxskip = 2 * dstpxskip;
-    int dstdoublepxskip = 2 * dstpxskip;
-
-    int pre_2_width = width % 2;
-    int post_2_width = (width - pre_2_width) / 2;
+    __m128i *srcp128 = (__m128i *)info->s_pixels;
+    __m128i *dstp128 = (__m128i *)info->d_pixels;
 
     Uint32 amask = info->src->Amask | info->dst->Amask;
-    Uint64 amask64 = (((Uint64)amask) << 32) | (Uint64)amask;
 
     __m128i mm_src, mm_dst, mm_alpha_mask;
 
-    mm_alpha_mask = _mm_set_epi64x(0x0000000000000000, amask64);
+    mm_alpha_mask = _mm_set_epi32(amask, amask, amask, amask);
 
     while (height--) {
-        if (pre_2_width > 0) {
+        if (pre_4_width > 0) {
             LOOP_UNROLLED4(
                 {
                     mm_src = _mm_cvtsi32_si128(*srcp);
                     mm_dst = _mm_cvtsi32_si128(*dstp);
 
                     mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                    *dstp = _mm_cvtsi128_si32(mm_dst);
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_4_width);
+        }
+        srcp128 = (__m128i *)srcp;
+        dstp128 = (__m128i *)dstp;
+        if (post_4_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_loadu_si128(srcp128);
+                    mm_dst = _mm_loadu_si128(dstp128);
+
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_adds_epu8(mm_dst, mm_src);
+
+                    _mm_storeu_si128(dstp128, mm_dst);
+
+                    srcp128++;
+                    dstp128++;
+                    srcp += srcquadpxskip;
+                    dstp += dstquadpxskip;
+                },
+                n, post_4_width);
+        }
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
+void
+blit_blend_rgba_sub_sse2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+
+    int srcquadpxskip = 4 * dstpxskip;
+    int dstquadpxskip = 4 * dstpxskip;
+
+    int pre_4_width = width % 4;
+    int post_4_width = (width - pre_4_width) / 4;
+
+    __m128i mm_src, mm_dst;
+
+    __m128i *srcp128 = (__m128i *)info->s_pixels;
+    __m128i *dstp128 = (__m128i *)info->d_pixels;
+
+    while (height--) {
+        if (pre_4_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi32_si128(*srcp);
+                    mm_dst = _mm_cvtsi32_si128(*dstp);
+
                     mm_dst = _mm_subs_epu8(mm_dst, mm_src);
 
                     *dstp = _mm_cvtsi128_si32(mm_dst);
@@ -704,33 +513,34 @@ blit_blend_rgb_sub_sse2(SDL_BlitInfo *info)
                     srcp += srcpxskip;
                     dstp += dstpxskip;
                 },
-                n, pre_2_width);
+                n, pre_4_width);
         }
-        srcp64 = (Uint64 *)srcp;
-        dstp64 = (Uint64 *)dstp;
-        if (post_2_width > 0) {
+        srcp128 = (__m128i *)srcp;
+        dstp128 = (__m128i *)dstp;
+        if (post_4_width > 0) {
             LOOP_UNROLLED4(
                 {
-                    mm_src = _mm_cvtsi64_si128(*srcp64);
-                    mm_dst = _mm_cvtsi64_si128(*dstp64);
+                    mm_src = _mm_loadu_si128(srcp128);
+                    mm_dst = _mm_loadu_si128(dstp128);
 
-                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
                     mm_dst = _mm_subs_epu8(mm_dst, mm_src);
 
-                    *dstp64 = _mm_cvtsi128_si64(mm_dst);
+                    _mm_storeu_si128(dstp128, mm_dst);
 
-                    srcp64++;
-                    dstp64++;
-                    srcp += srcdoublepxskip;
-                    dstp += dstdoublepxskip;
+                    srcp128++;
+                    dstp128++;
+                    srcp += srcquadpxskip;
+                    dstp += dstquadpxskip;
                 },
-                n, post_2_width);
+                n, post_4_width);
         }
         srcp += srcskip;
         dstp += dstskip;
     }
 }
-#else
+#endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
+
+#if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
 void
 blit_blend_rgb_sub_sse2(SDL_BlitInfo *info)
 {
@@ -746,28 +556,60 @@ blit_blend_rgb_sub_sse2(SDL_BlitInfo *info)
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
 
+    int srcquadpxskip = 4 * dstpxskip;
+    int dstquadpxskip = 4 * dstpxskip;
+
+    int pre_4_width = width % 4;
+    int post_4_width = (width - pre_4_width) / 4;
+
+    __m128i *srcp128 = (__m128i *)info->s_pixels;
+    __m128i *dstp128 = (__m128i *)info->d_pixels;
+
+    Uint32 amask = info->src->Amask | info->dst->Amask;
+
     __m128i mm_src, mm_dst, mm_alpha_mask;
-    mm_alpha_mask = _mm_cvtsi32_si128(info->src->Amask | info->dst->Amask);
+
+    mm_alpha_mask = _mm_set_epi32(amask, amask, amask, amask);
 
     while (height--) {
-        LOOP_UNROLLED4(
-            {
-                mm_src = _mm_cvtsi32_si128(*srcp);
-                mm_dst = _mm_cvtsi32_si128(*dstp);
+        if (pre_4_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_cvtsi32_si128(*srcp);
+                    mm_dst = _mm_cvtsi32_si128(*dstp);
 
-                mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
-                mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
 
-                *dstp = _mm_cvtsi128_si32(mm_dst);
+                    *dstp = _mm_cvtsi128_si32(mm_dst);
 
-                srcp += srcpxskip;
-                dstp += dstpxskip;
-            },
-            n, width);
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_4_width);
+        }
+        srcp128 = (__m128i *)srcp;
+        dstp128 = (__m128i *)dstp;
+        if (post_4_width > 0) {
+            LOOP_UNROLLED4(
+                {
+                    mm_src = _mm_loadu_si128(srcp128);
+                    mm_dst = _mm_loadu_si128(dstp128);
 
+                    mm_src = _mm_subs_epu8(mm_src, mm_alpha_mask);
+                    mm_dst = _mm_subs_epu8(mm_dst, mm_src);
+
+                    _mm_storeu_si128(dstp128, mm_dst);
+
+                    srcp128++;
+                    dstp128++;
+                    srcp += srcquadpxskip;
+                    dstp += dstquadpxskip;
+                },
+                n, post_4_width);
+        }
         srcp += srcskip;
         dstp += dstskip;
     }
 }
-#endif /* defined(ENV64BIT) */
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */


### PR DESCRIPTION
Using the same blueprint as in the RGBA_MUL/RGB_MUL pull requests, this one adds, the much simpler to create, SIMD versions of the ADD and MUL special blend modes for blitting in SSE2 and AVX2 flavours.

If you found the SIMD code tricky to understand in the other two PRs this one is a lot more approachable - especially for the RGBA flavours as the 'active' code that actually blends the pixels from one surface with another is just one instruction, helpfully named exactly the same thing as the blend mode. See:

```
mm_dst = _mm_adds_epu8(mm_dst, mm_src);
```

which as intel describes it does:

> Add packed unsigned 8-bit integers in a and b using saturation, and store the results in dst.

Saturation meaning the values for each pixel are clamped between 0 and 255. In SSE2 we have 128 bit registers - so with four channel values between 0 and 255 in each pixel (red, green, blue and alpha) we can see that 128 divided by 4, then divided by 8 bits per channel, we get four pixels worth of data in each register and can thus speed through our adding operation pretty swiftly.

Everything else is just setup to get us to that single line that does the blend.

AVX2 version works the same except we can do 8 pixels at a time due to the larger registers.

There is one more of these PRs, after this one, for the remaining special effect blend modes MIN & MAX.

N.B.
I expect there is some future improvement work to be done on the standard alpha blend and the pre-multiplied blend, but I'd like to see how these special effect modes work out in user land first - plus I would need some time to work on those improvements when work is less busy :)