### PR TITLE
Fixed window not staying centered on second call of `display.set_mode`

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1011,7 +1011,7 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                         if (y == (int)SDL_WINDOWPOS_UNDEFINED_DISPLAY(display))
                             y = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
                     }
-                    else {
+                    else if (!center_window) {
                         SDL_GetWindowPosition(win, &x, &y);
                     }
                 }


### PR DESCRIPTION
References #3131

Fixed an issue where calling `display.set_mode` twice with the environment variable `SDL_VIDEO_CENTERED`.

The problem was the when `pg_set_mode` is called more than once, it finds the previous window that was created. If it finds this it overrides the x and y value of the centered position and causes the window to not center. I added a condition in the branch where a window is found, that was determined earlier in the function i.e. `enter_window`, now the window remains centered.

Here is some sample code for testing this issue:

```python
import pygame
import os

pygame.init()
os.environ['SDL_VIDEO_CENTERED'] = '1'
#print(os.environ['SDL_WINDOW_POS'])
screen = pygame.display.set_mode((100, 100))

play = True

while play:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            play = False
            break
        if event.type == pygame.KEYDOWN:
            if event.key == pygame.K_SPACE:
                screen = pygame.display.set_mode((200, 200))
```