### PR TITLE
Use CircleCI for manylinux aarch64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  linux-arm-wheels:
+    working_directory: ~/linux-wheels
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.medium
+
+    environment:
+      # these environment variables will be passed to the docker container
+      - CIBW_ENVIRONMENT: PIP_CONFIG_FILE=buildconfig/pip_config.ini PORTMIDI_INC_PORTTIME=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
+      - CIBW_BUILD: cp* pp*
+      - CIBW_ARCHS: aarch64
+      - CIBW_SKIP: '*-musllinux_*'
+      - CIBW_MANYLINUX_AARCH64_IMAGE: pygame/manylinux2014_base_aarch64
+      - CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: pygame/manylinux2014_base_aarch64
+      - CIBW_BEFORE_BUILD: pip install Sphinx && python setup.py docs
+      - CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300
+      - CIBW_BUILD_VERBOSITY: 2
+
+    steps:
+      - checkout
+      - run:
+          name: Build the Linux wheels.
+          command: |
+            pip3 install --user cibuildwheel==2.5.0
+            PATH="$HOME/.local/bin:$PATH" cibuildwheel --output-dir wheelhouse
+
+      - store_artifacts:
+          path: wheelhouse/
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  build-arm:
+    jobs:
+      - linux-arm-wheels

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -51,13 +51,6 @@ jobs:
           - { image: manylinux2014, arch: x86_64, pyversions: cp* pp* }
           - { image: manylinux2014, arch: i686, pyversions: cp* pp* }
 
-          # split manylinux jobs on aarch64 because each takes a lot
-          # of time on github actions because it's emulated...
-          - { image: manylinux2014, arch: aarch64, pyversions: cp36-* cp310-* }
-          - { image: manylinux2014, arch: aarch64, pyversions: cp37-* pp37-* }
-          - { image: manylinux2014, arch: aarch64, pyversions: cp38-* pp39-* }
-          - { image: manylinux2014, arch: aarch64, pyversions: cp39-* pp39-* }
-
     env:
       # load pip config from this file. Define this in 'CIBW_ENVIRONMENT'
       # because this should not affect cibuildwheel machinery
@@ -75,8 +68,6 @@ jobs:
       CIBW_MANYLINUX_PYPY_X86_64_IMAGE: pygame/${{ matrix.image }}_base_x86_64
       CIBW_MANYLINUX_I686_IMAGE: pygame/${{ matrix.image }}_base_i686
       CIBW_MANYLINUX_PYPY_I686_IMAGE: pygame/${{ matrix.image }}_base_i686
-      CIBW_MANYLINUX_AARCH64_IMAGE: pygame/${{ matrix.image }}_base_aarch64
-      CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: pygame/${{ matrix.image }}_base_aarch64
 
       # command that runs before every build
       CIBW_BEFORE_BUILD: |
@@ -98,12 +89,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3.0.2
-
-    # setup QEMU only on aarch64 matrix
-    - name: Set up QEMU
-      if: ${{ matrix.arch == 'aarch64' }}
-      id: qemu
-      uses: docker/setup-qemu-action@v1
 
     - name: Build and test wheels
       uses: pypa/cibuildwheel@v2.5.0


### PR DESCRIPTION
aarch64 builds on github actions are really slow. Out of curiousity of wanting to know how much time the builds would take if it ran on native aarch64 CI hardware, I setup CircleCI on my fork. I did a bit of reading on it, and it was not too hard to setup.

ATM... our aarch64 builds take about 1.5 hours for doing only cpython versions which is not exactly ideal. In #3187 (the PR that this PR is based on on) I'm trying to add pypy builds and it quickly became clear that adding this would significantly worsen the time taken by the aarch64 builds... So in that PR, I took the approach of further splitting aarch64 builds into 4 parallel builds (this too is not ideal because this means aarch64 docker base images will be pulled 4 times) and now each of those takes anywhere between 35 to 55 minutes, if they ran sequentially it would take around 3 hours for each aarch64 build.

CircleCI takes 20 minutes when both cpython and pypy builds are run sequentially, putting this at par with our manylinux2014 x86_64 github actions CI that takes around the same time, which is a large speedup.

CircleCI however, does not have unlimited builds under its free plan; it has 30,000 "credits" per month. Since I intend to only use one CircleCI workflow (for aarch64 linux), we will get 3,000 build minutes per month (10 "credits" are used per minute spend building). This translates to about 150 builds per month which is well enough for now.

This is intentionally a separate PR because it can be dropped if anyone has serious objections to using CircleCI, but IMHO it's worth adding.