### PR TITLE
Added get_just_pressed() and get_just_released() functions to satisfy global key information

### DIFF
--- a/src_c/doc/event_doc.h
+++ b/src_c/doc/event_doc.h
@@ -17,6 +17,9 @@
 #define DOC_PYGAMEEVENTEVENT "Event(type, dict) -> Event\nEvent(type, **attributes) -> Event\npygame object for representing events"
 #define DOC_EVENTTYPE "type -> int\nevent type identifier."
 #define DOC_EVENTDICT "__dict__ -> dict\nevent attribute dictionary"
+#define DOC_PYGAMEEVENTGETJUSTPRESSED "get_just_pressed() -> int\n get the id of the key that was just pressed"
+#define DOC_PYGAMEEVENTGETJUSTRELEASED "get_just_released() -> int\n get the id of the key that was just released"
+
 
 
 /* Docs in a comment... slightly easier to read. */
@@ -104,5 +107,13 @@ event type identifier.
 pygame.event.Event.__dict__
  __dict__ -> dict
 event attribute dictionary
+
+pygame.event.get_just_pressed
+ get_just_pressed() -> int
+ get the id of the key that was just pressed
+
+pygame.event.get_just_released
+ get_just_released() -> int
+ get the id of the key that was just released
 
 */


### PR DESCRIPTION
As suggested in https://github.com/pygame/pygame/issues/3175 it would be useful to have access to some global information about the event loop, specifically key pressed and releases. ```get_just_pressed()``` when the event loop gets pumped I check if an ```SDL_KEYDOWN``` or ```SDL_KEYUP``` event type occurs. And if some store the ```eventbuf[loop].key.keysym.sym``` to be returned by the respective function. Small example of the functions in action: 

```python
import pygame
pygame.init()

display = pygame.display.set_mode((600, 600))

while True:
	display.fill((0,0,0))
	for event in pygame.event.get(): #Pump The event loop
		pass

	if pygame.event.get_just_pressed() == pygame.K_a: #Check if a key was just pressed, returns -1 if no key was pressed
		print("A key was just pressed!")
	
	if pygame.event.get_just_released() == pygame.K_a: #Check if a key was just released, returns -1 if no key was released
		print("A key was just released!")
			
	pygame.display.update()

```