### PR TITLE
Simplify some boolean handling

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -247,7 +247,7 @@ static PyObject *
 aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
     pgSurfaceObject *surfobj;
-    PyObject *colorobj, *closedobj;
+    PyObject *colorobj;
     PyObject *points, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint32 color;
@@ -258,16 +258,15 @@ aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
     int l, t;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
-    int result;
-    int closed = 0; /* Default closed. */
-    int blend = 1;  /* Default blend. */
+    int result, closed;
+    int blend = 1; /* Default blend. */
     Py_ssize_t loop, length;
     static char *keywords[] = {"surface", "color", "closed",
                                "points",  "blend", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OpO|i", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,
-                                     &closedobj, &points, &blend)) {
+                                     &closed, &points, &blend)) {
         return NULL; /* Exception already set. */
     }
 
@@ -290,12 +289,6 @@ aalines(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     CHECK_LOAD_COLOR(colorobj)
-
-    closed = PyObject_IsTrue(closedobj);
-
-    if (-1 == closed) {
-        return RAISE(PyExc_TypeError, "closed argument is invalid");
-    }
 
     if (!PySequence_Check(points)) {
         return RAISE(PyExc_TypeError,
@@ -390,7 +383,7 @@ static PyObject *
 lines(PyObject *self, PyObject *arg, PyObject *kwargs)
 {
     pgSurfaceObject *surfobj;
-    PyObject *colorobj, *closedobj;
+    PyObject *colorobj;
     PyObject *points, *item = NULL;
     SDL_Surface *surf = NULL;
     Uint32 color;
@@ -404,9 +397,9 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
     static char *keywords[] = {"surface", "color", "closed",
                                "points",  "width", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OOO|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OpO|i", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,
-                                     &closedobj, &points, &width)) {
+                                     &closed, &points, &width)) {
         return NULL; /* Exception already set. */
     }
 
@@ -419,12 +412,6 @@ lines(PyObject *self, PyObject *arg, PyObject *kwargs)
     }
 
     CHECK_LOAD_COLOR(colorobj)
-
-    closed = PyObject_IsTrue(closedobj);
-
-    if (-1 == closed) {
-        return RAISE(PyExc_TypeError, "closed argument is invalid");
-    }
 
     if (!PySequence_Check(points)) {
         return RAISE(PyExc_TypeError,

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -798,22 +798,12 @@ get_default_font(PyObject *self, PyObject *_null)
 static PyObject *
 get_ttf_version(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    PyObject *linkedobj = NULL;
     int linked = 1; /* Default is linked version. */
 
     static char *keywords[] = {"linked", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", keywords,
-                                     &linkedobj)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|p", keywords, &linked)) {
         return NULL; /* Exception already set. */
-    }
-
-    if (NULL != linkedobj) {
-        linked = PyObject_IsTrue(linkedobj);
-
-        if (-1 == linked) {
-            return RAISE(PyExc_TypeError, "linked argument must be a boolean");
-        }
     }
 
     if (linked) {

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1443,22 +1443,12 @@ mixer_unpause(PyObject *self, PyObject *_null)
 static PyObject *
 mixer_get_sdl_mixer_version(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    PyObject *linkedobj = NULL;
     int linked = 1; /* Default is linked version. */
 
     static char *keywords[] = {"linked", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", keywords,
-                                     &linkedobj)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|p", keywords, &linked)) {
         return NULL; /* Exception already set. */
-    }
-
-    if (NULL != linkedobj) {
-        linked = PyObject_IsTrue(linkedobj);
-
-        if (-1 == linked) {
-            return RAISE(PyExc_TypeError, "linked argument must be a boolean");
-        }
     }
 
     /* MIXER_INIT_CHECK() is not required for these methods. */


### PR DESCRIPTION
This doesn't change the status quo with how booleans are handled at all, it just simplifies the code, using the "p" flag of PyArg_Parse, rather than PyObject_IsTrue.

This is for #3096. Depends how people want to proceed whether this closes it.