### PR TITLE
Fix DLL loading problems on Windows Store Python installations

### DIFF
--- a/src_py/__init__.py
+++ b/src_py/__init__.py
@@ -28,8 +28,14 @@ import os
 
 # Choose Windows display driver
 if os.name == "nt":
+    pygame_dir = os.path.split(__file__)[0]
+
     # pypy does not find the dlls, so we add package folder to PATH.
-    os.environ["PATH"] = os.environ["PATH"] + ";" + os.path.split(__file__)[0]
+    os.environ["PATH"] = os.environ["PATH"] + ";" + pygame_dir
+
+    # windows store python does not find the dlls, so we run this
+    if sys.version_info > (3, 8):
+        os.add_dll_directory(pygame_dir)  # only available in 3.8+
 
 # when running under X11, always set the SDL window WM_CLASS to make the
 #   window managers correctly match the pygame window.


### PR DESCRIPTION
We've all been there as pygame contributors. You look at reddit or discord or stackoverflow, and somebody comes in and says "pygame doesn't work: `pygame.error: DLL load failed libmpg123`"

Where do you even start with that? It works on my machine^TM. It seems to work on the vast majority of machines, but it just doesn't work for some people.

Thanks to @EcoFreshKase for helping track this down on discord. The difference is that some people are using Windows Store Python. We've known Windows Store Python is flaky for a while, but I've never put two and two together with this issue.

EcoFreshKase confirms that this fix solves the DLL loading on their machine, with Windows Store Python. They were having the issue before.

Also thanks to @jacqobi for proposing a version of this fix a while ago: https://github.com/pygame/pygame/issues/2647#issuecomment-957864812