### PR TITLE
Wrong path when creating symlink in the workflow file for pygame-wasm

### DIFF
--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -20,7 +20,7 @@ jobs:
             cd $GITHUB_WORKSPACE/..
             git clone https://github.com/pmp-p/python-wasm-plus.git
             mkdir $GITHUB_WORKSPACE/../python-wasm-plus/src
-            ln -s $(pwd)/pygame GITHUB_WORKSPACE/../python-wasm-plus/src/pygame-wasm
+            ln -s $(pwd)/pygame $GITHUB_WORKSPACE/../python-wasm-plus/src/pygame-wasm
             cd python-wasm-plus
             bash ./python-wasm-plus.sh
             bash ./buildapp.sh


### PR DESCRIPTION
There seems to be a missing `$` when creating the symlink