### PR TITLE
wasm disable mutex usage, wasm CI updates

### DIFF
--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -1,27 +1,77 @@
-name: build-emsdk
+name: Build WASM
 
-on: [push]
+# Run CI only on changes to main branch, or any PR to main. Do not run CI on 
+# any other branch. Also, skip any non-source changes from running on CI
+on:
+  push:
+    branches: main
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/build-emsdk.yml'
+
+  pull_request:
+    branches: main
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/build-emsdk.yml'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # pin SDK version to the latest, update manually
+      SDK_VERSION: 0.0.1
+      SDK_ARCHIVE: python-wasm-sdk-stable.tar.bz2
+
+      # use the most recent cython from github, but pin on a commit for CI
+      # stability. This is also needed to benefit from caching cython installs
+      LATEST_CYTHON_COMMIT: 6ac2422b48b689b021a48dff9ee14095232baafe
+
     steps:
     - uses: actions/checkout@v3.0.2
-    - name: pygame-wasm-builder prepare
-      run: |
-            WD=$(pwd)
-            python3 -V
-            echo $WD
-            clang --version | head -n 1
-            echo
-            grep "^Pkg.Revision =" ${ANDROID_HOME}/ndk-bundle/source.properties
-            sudo apt-get update
-            sudo apt-get install bash wget
-            cd $GITHUB_WORKSPACE/..
-            git clone https://github.com/pmp-p/python-wasm-plus.git
-            mkdir $GITHUB_WORKSPACE/../python-wasm-plus/src
-            ln -s $(pwd)/pygame $GITHUB_WORKSPACE/../python-wasm-plus/src/pygame-wasm
-            cd python-wasm-plus
-            bash ./python-wasm-plus.sh
-            bash ./buildapp.sh
+    
+    - name: Cache pip directory for cython
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: wasm-ubuntu-cython-${{ env.LATEST_CYTHON_COMMIT }}
 
+    - name: Install latest cython and regen
+      run: |
+        pip install git+https://github.com/cython/cython.git@${{ env.LATEST_CYTHON_COMMIT }}
+        touch $(find |grep pxd$)
+        python3 setup.py cython_only
+
+    - name: Install python-wasm-sdk
+      run: |
+        mkdir python-wasm-sdk
+        cd python-wasm-sdk
+        curl -sL --retry 5 https://github.com/pygame-web/python-wasm-sdk/releases/download/$SDK_VERSION/$SDK_ARCHIVE | tar xvj
+        mkdir src
+        ln -s $GITHUB_WORKSPACE src/pygame-wasm
+        ls -A
+      working-directory: ../
+
+    - name: Run config
+      run: ./config
+      working-directory: ../python-wasm-sdk
+
+    - name: Building WASM with emsdk
+      run: |
+        python3-wasm setup.py -config -auto -sdl2
+        CC=emcc CFLAGS="-DBUILD_STATIC -DSDL_NO_COMPAT -ferror-limit=1 -Wno-unused-command-line-argument -Wno-unreachable-code-fallthrough -fPIC" \
+        EMCC_CFLAGS="-I$PREFIX/include/SDL2 -s USE_SDL=2 -sUSE_SDL_TTF=2 -sUSE_LIBPNG -sUSE_LIBJPEG" \
+        python3-wasm setup.py build
+      working-directory: ../python-wasm-sdk/src/pygame-wasm

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -39,18 +39,28 @@ jobs:
       # stability. This is also needed to benefit from caching cython installs
       LATEST_CYTHON_COMMIT: 8e29b6d47f6f5b10ec1a37f06db440156ac2ac2e
 
+      WHEELHOUSE_CYTHON: /tmp/wheelhouse/cython
+
     steps:
     - uses: actions/checkout@v3.0.2
-    
-    - name: Cache pip directory for cython
+
+    - name: Cache Cython
+      id: cache-cython
       uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
-        key: wasm-ubuntu-cython-${{ env.LATEST_CYTHON_COMMIT }}
+        path: ${{ env.WHEELHOUSE_CYTHON }}
+        key: wasm-ubuntu-cython-${{ env.LATEST_CYTHON_COMMIT }}-path-${{ env.WHEELHOUSE_CYTHON }}
+
+    # This builds the cython wheel and stores it in cache too
+    - name: Download and build cython on cache miss
+      if: steps.cache-cython.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p $WHEELHOUSE_CYTHON
+        pip wheel --wheel-dir $WHEELHOUSE_CYTHON git+https://github.com/cython/cython.git@$LATEST_CYTHON_COMMIT
 
     - name: Install latest cython and regen
       run: |
-        pip install git+https://github.com/cython/cython.git@${{ env.LATEST_CYTHON_COMMIT }}
+        pip install --no-index --find-links $WHEELHOUSE_CYTHON --pre cython
         touch $(find | grep pxd$)
         python3 setup.py cython_only
 
@@ -66,8 +76,8 @@ jobs:
     
     - name: Generate libpygame.a static binaries archive
       run: |
-        mkdir -p dist && cd dist
-        SYS_PYTHON=python3 /opt/python-wasm-sdk/emsdk/upstream/emscripten/emar rcs libpygame.a $(find build/lib.wasm32-*/ | grep o$)
+        mkdir -p dist
+        SYS_PYTHON=python3 /opt/python-wasm-sdk/emsdk/upstream/emscripten/emar rcs dist/libpygame.a $(find build/temp.wasm32-*/ | grep o$)
 
     # Upload the generated files under github actions assets section
     - name: Upload dist

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Build WASM with emsdk
       run: |
-        EMCC_CFLAGS="-I/opt/python-wasm-sdk/devices/emsdk/usr/include/SDL2 -s USE_SDL=2" /opt/python-wasm-sdk/python3-wasm setup.py build
+        EMCC_CFLAGS="-I/opt/python-wasm-sdk/devices/emsdk/usr/include/SDL2 -s USE_SDL=2" /opt/python-wasm-sdk/python3-wasm setup.py build -j3
     
     - name: Generate libpygame.a static binaries archive
       run: |

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -1,4 +1,4 @@
-name: Build WASM
+name: Build WASM (Emscripten)
 
 # Run CI only on changes to main branch, or any PR to main. Do not run CI on 
 # any other branch. Also, skip any non-source changes from running on CI
@@ -29,15 +29,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # pin SDK version to the latest, update manually
-      SDK_VERSION: 0.0.2
+      SDK_VERSION: 0.2.0
       SDK_ARCHIVE: python-wasm-sdk-stable.tar.bz2
 
       # use the most recent cython from github, but pin on a commit for CI
       # stability. This is also needed to benefit from caching cython installs
-      LATEST_CYTHON_COMMIT: 6ac2422b48b689b021a48dff9ee14095232baafe
+      LATEST_CYTHON_COMMIT: 8e29b6d47f6f5b10ec1a37f06db440156ac2ac2e
 
     steps:
     - uses: actions/checkout@v3.0.2
@@ -51,27 +51,27 @@ jobs:
     - name: Install latest cython and regen
       run: |
         pip install git+https://github.com/cython/cython.git@${{ env.LATEST_CYTHON_COMMIT }}
-        touch $(find |grep pxd$)
+        touch $(find | grep pxd$)
         python3 setup.py cython_only
 
     - name: Install python-wasm-sdk
       run: |
-        mkdir python-wasm-sdk
-        cd python-wasm-sdk
-        curl -sL --retry 5 https://github.com/pygame-web/python-wasm-sdk/releases/download/$SDK_VERSION/$SDK_ARCHIVE | tar xvj
-        mkdir src
-        ln -s $GITHUB_WORKSPACE src/pygame-wasm
-        ls -A
+        mkdir python-wasm-sdk && cd python-wasm-sdk
+        curl -sL --retry 5 https://github.com/pygame-web/python-wasm-sdk/releases/download/$SDK_VERSION/$SDK_ARCHIVE | tar xvPj
       working-directory: /opt
 
-    - name: Run config
-      run: ./config
-      working-directory: /opt/python-wasm-sdk
-
-    - name: Building WASM with emsdk
+    - name: Build WASM with emsdk
       run: |
-        python3-wasm setup.py -config -auto -sdl2
-        CC=emcc CFLAGS="-DBUILD_STATIC -DSDL_NO_COMPAT -ferror-limit=1 -Wno-unused-command-line-argument -Wno-unreachable-code-fallthrough -fPIC" \
-        EMCC_CFLAGS="-I$PREFIX/include/SDL2 -s USE_SDL=2 -sUSE_SDL_TTF=2 -sUSE_LIBPNG -sUSE_LIBJPEG" \
-        python3-wasm setup.py build
-      working-directory: /opt/python-wasm-sdk/src/pygame-wasm
+        EMCC_CFLAGS="-I/opt/python-wasm-sdk/devices/emsdk/usr/include/SDL2 -s USE_SDL=2" /opt/python-wasm-sdk/python3-wasm setup.py build
+    
+    - name: Generate libpygame.a static binaries archive
+      run: |
+        mkdir -p dist && cd dist
+        SYS_PYTHON=python3 /opt/python-wasm-sdk/emsdk/upstream/emscripten/emar rcs libpygame.a $(find build/lib.wasm32-*/ | grep o$)
+
+    # Upload the generated files under github actions assets section
+    - name: Upload dist
+      uses: actions/upload-artifact@v3
+      with:
+        name: pygame-wasm-dist
+        path: ./dist/*

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # pin SDK version to the latest, update manually
-      SDK_VERSION: 0.0.1
+      SDK_VERSION: 0.0.2
       SDK_ARCHIVE: python-wasm-sdk-stable.tar.bz2
 
       # use the most recent cython from github, but pin on a commit for CI
@@ -62,11 +62,11 @@ jobs:
         mkdir src
         ln -s $GITHUB_WORKSPACE src/pygame-wasm
         ls -A
-      working-directory: ../
+      working-directory: /opt
 
     - name: Run config
       run: ./config
-      working-directory: ../python-wasm-sdk
+      working-directory: /opt/python-wasm-sdk
 
     - name: Building WASM with emsdk
       run: |
@@ -74,4 +74,4 @@ jobs:
         CC=emcc CFLAGS="-DBUILD_STATIC -DSDL_NO_COMPAT -ferror-limit=1 -Wno-unused-command-line-argument -Wno-unreachable-code-fallthrough -fPIC" \
         EMCC_CFLAGS="-I$PREFIX/include/SDL2 -s USE_SDL=2 -sUSE_SDL_TTF=2 -sUSE_LIBPNG -sUSE_LIBJPEG" \
         python3-wasm setup.py build
-      working-directory: ../python-wasm-sdk/src/pygame-wasm
+      working-directory: /opt/python-wasm-sdk/src/pygame-wasm

--- a/.github/workflows/build-emsdk.yml
+++ b/.github/workflows/build-emsdk.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # pin SDK version to the latest, update manually
-      SDK_VERSION: 0.2.0
-      SDK_ARCHIVE: python-wasm-sdk-stable.tar.bz2
+      SDK_VERSION: 0.3.3
+      SDK_ARCHIVE: python-wasm-sdk-ubuntu-22.04.tar.lz4
 
       # use the most recent cython from github, but pin on a commit for CI
       # stability. This is also needed to benefit from caching cython installs
@@ -66,13 +66,14 @@ jobs:
 
     - name: Install python-wasm-sdk
       run: |
+        sudo apt-get install lz4
         mkdir python-wasm-sdk && cd python-wasm-sdk
-        curl -sL --retry 5 https://github.com/pygame-web/python-wasm-sdk/releases/download/$SDK_VERSION/$SDK_ARCHIVE | tar xvPj
+        curl -sL --retry 5 https://github.com/pygame-web/python-wasm-sdk/releases/download/$SDK_VERSION/$SDK_ARCHIVE | tar xvP --use-compress-program=lz4
       working-directory: /opt
 
     - name: Build WASM with emsdk
       run: |
-        EMCC_CFLAGS="-I/opt/python-wasm-sdk/devices/emsdk/usr/include/SDL2 -s USE_SDL=2" /opt/python-wasm-sdk/python3-wasm setup.py build -j3
+        EMCC_CFLAGS="-I/opt/python-wasm-sdk/devices/emsdk/usr/include/SDL2 -s USE_SDL=2" /opt/python-wasm-sdk/python3-wasm setup.py build -j$(nproc)
     
     - name: Generate libpygame.a static binaries archive
       run: |

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,16 @@ if consume_arg('-enable-arm-neon'):
     cflags += '-mfpu=neon'
     os.environ['CFLAGS'] = cflags
 
+compile_cython = False
+cython_only = False
 if consume_arg('cython'):
+    compile_cython = True
+
+if consume_arg('cython_only'):
+    compile_cython = True
+    cython_only = True
+
+if compile_cython:
     # compile .pyx files
     # So you can `setup.py cython` or `setup.py cython install`
     try:
@@ -280,6 +289,9 @@ if consume_arg('cython'):
     for i, kwargs in enumerate(queue):
         kwargs['progress'] = f'[{i + 1}/{count}] '
         cythonize_one(**kwargs)
+    
+    if cython_only:
+        sys.exit(0)
 
 no_compilation = any(x in ['lint', 'format', 'docs'] for x in sys.argv)
 AUTO_CONFIG = not os.path.isfile('Setup') and not no_compilation

--- a/src_c/imageext.c
+++ b/src_c/imageext.c
@@ -64,9 +64,11 @@
 
 #define JPEG_QUALITY 85
 
+/*
 #ifdef WITH_THREAD
 static SDL_mutex *_pg_img_mutex = 0;
-#endif /* WITH_THREAD */
+#endif
+*/
 
 #ifdef WIN32
 #include <windows.h>
@@ -447,16 +449,18 @@ imageext_get_sdl_image_version(PyObject *self, PyObject *_null)
                          SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_PATCHLEVEL);
 }
 
-#ifdef WITH_THREAD
+/*
 static void
 _imageext_free(void *ptr)
 {
+#ifdef WITH_THREAD
     if (_pg_img_mutex) {
         SDL_DestroyMutex(_pg_img_mutex);
         _pg_img_mutex = 0;
     }
+#endif
 }
-#endif /* WITH_THREAD */
+*/
 
 static PyMethodDef _imageext_methods[] = {
     {"load_extended", image_load_ext, METH_VARARGS, DOC_PYGAMEIMAGE},
@@ -471,14 +475,15 @@ static PyMethodDef _imageext_methods[] = {
 
 MODINIT_DEFINE(imageext)
 {
-    static struct PyModuleDef _module = {
-        PyModuleDef_HEAD_INIT, "imageext", _imageext_doc, -1,
-        _imageext_methods,     NULL,       NULL,          NULL,
-#ifdef WITH_THREAD
-        _imageext_free};
-#else  /* ~WITH_THREAD */
-                                         0};
-#endif /* ~WITH_THREAD */
+    static struct PyModuleDef _module = {PyModuleDef_HEAD_INIT,
+                                         "imageext",
+                                         _imageext_doc,
+                                         -1,
+                                         _imageext_methods,
+                                         NULL,
+                                         NULL,
+                                         NULL,
+                                         NULL}; /* _imageext_free commented */
 
     /* imported needed apis; Do this first so if there is an error
        the module is not loaded.
@@ -497,13 +502,15 @@ MODINIT_DEFINE(imageext)
         return NULL;
     }
 
-#ifdef WITH_THREAD
-    _pg_img_mutex = SDL_CreateMutex();
-    if (!_pg_img_mutex) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return NULL;
-    }
-#endif /* WITH_THREAD */
+    /*
+    #ifdef WITH_THREAD
+        _pg_img_mutex = SDL_CreateMutex();
+        if (!_pg_img_mutex) {
+            PyErr_SetString(pgExc_SDLError, SDL_GetError());
+            return NULL;
+        }
+    #endif
+    */
 
     /* create the module */
     return PyModule_Create(&_module);


### PR DESCRIPTION
I added a mutex for event module in #3177 and this was not guarded on emscripten. This PR fixes this and also comments unneeded mutex create/destroy in imageext module. 

The PR also makes it so that `set_timer` always fails on WASM now (because threading is an issue on WASM). This needs more work in the future, and possibly an alternate implementation to work better with the constraints of browsers.

Following #3185, this makes WASM CI run only on source changes.

I (along with a lot of help from @pmp-p) also changed the CI to use `python-wasm-sdk` prebuilts to save a lot of compile time on pygame CI, and added some cython (latest) build caching too. After this PR, our WASM builds should take around a minute, previously it took anywhere between 25 and 40 minutes (usually averaging out at 30 min)