### PR TITLE
Fix Chimp tutorial code to use the correct module name alias

### DIFF
--- a/docs/reST/tut/ChimpLineByLine.rst
+++ b/docs/reST/tut/ChimpLineByLine.rst
@@ -408,7 +408,7 @@ We still have a black window on the screen. Lets show our background
 while we wait for the other resources to load. ::
 
   screen.blit(background, (0, 0))
-  pygame.display.flip()
+  pg.display.flip()
 
 This will blit our entire background onto the display window. The
 blit is self explanatory, but what about this flip routine?
@@ -518,7 +518,7 @@ Now that all the objects are in the right place, time to draw them. ::
 
   screen.blit(background, (0, 0))
   allsprites.draw(screen)
-  pygame.display.flip()
+  pg.display.flip()
 
 The first blit call will draw the background onto the entire screen. This
 erases everything we saw from the previous frame (slightly inefficient, but


### PR DESCRIPTION
## Description
I went through the Line-By-Line Chimp Tutorial ([pygame/pygame/blob/main/docs/reST/tut/ChimpLineByLine.rst](https://github.com/pygame/pygame/blob/main/docs/reST/tut/ChimpLineByLine.rst)) however I was unable to run the code as shown because some of the code blocks use the variable `pygame` instead of `pg`. Since `pygame` was not defined, you would not be able to run this program.

Note that the example code for the Chimp game has the correct variable name and works as expected (https://github.com/pygame/pygame/blob/main/examples/chimp.py). 

## Changes
- In the code for section "Display the Background while Setup Finishes", I updated `pygame` to `pg`
- In the code for section "Draw Objects in the Scene", I updated `pygame` to `pg`