### PR TITLE
Remove more code for legacy Python

### DIFF
--- a/buildconfig/config_darwin.py
+++ b/buildconfig/config_darwin.py
@@ -10,12 +10,6 @@ except ImportError:
     from buildconfig.config_unix import DependencyProg
 
 
-try:
-    basestring_ = basestring
-except NameError:
-    #python 3.
-    basestring_ = str
-
 class Dependency:
     libext = '.dylib'
     def __init__(self, name, checkhead, checklib, libs):
@@ -34,7 +28,7 @@ class Dependency:
         incnames = self.checkhead
         libnames = self.checklib, self.name.lower()
         for dir in incdirs:
-            if isinstance(incnames, basestring_):
+            if isinstance(incnames, str):
                 incnames = [incnames]
 
             for incname in incnames:

--- a/buildconfig/config_emsdk.py
+++ b/buildconfig/config_emsdk.py
@@ -5,8 +5,6 @@ import os
 import sys
 from glob import glob
 
-from distutils.sysconfig import get_python_inc
-
 from .config_unix import get_porttime_dep
 
 configcommand = os.environ.get('SDL_CONFIG', 'sdl-config',)
@@ -19,11 +17,9 @@ else:
 
 EMSDK = os.environ.get('EMSDK', None)
 is_wasm = EMSDK is not None
-
 if not is_wasm:
     print("EMSDK not found")
     raise SystemExit(1)
-
 
 # EMCC_CFLAGS="-s USE_SDL=2 is required to prevent '-iwithsysroot/include/SDL'
 # which is SDL1 from ./emscripten/tools/ports/__init__.py
@@ -34,7 +30,6 @@ os.environ["EMCC_CFLAGS"]=EMCC_CFLAGS.strip()
 
 CC=os.environ.get("CC","emcc")
 os.environ["CC"] = CC.strip()
-
 
 
 class DependencyProg:
@@ -79,19 +74,18 @@ class DependencyProg:
                 inc = f"-I{EMSDK}/upstream/emscripten/cache/sysroot/include/freetype2/freetype "
                 self.cflags = inc + ' ' + self.cflags
 
-
         except (ValueError, TypeError):
-            print ('WARNING: "%s" failed!' % command)
+            print('WARNING: "%s" failed!' % command)
             self.found = 0
             self.ver = '0'
             self.libs = defaultlibs
 
     def configure(self, incdirs, libdir):
         if self.found:
-            print (self.name + '        '[len(self.name):] + ': found ' + self.ver)
+            print(self.name + '        '[len(self.name):] + ': found ' + self.ver)
             self.found = 1
         else:
-            print (self.name + '        '[len(self.name):] + ': not found')
+            print(self.name + '        '[len(self.name):] + ': not found')
 
 class Dependency:
     def __init__(self, name, checkhead, checklib, libs):
@@ -121,15 +115,15 @@ class Dependency:
                     self.lib_dir = dir
 
         if (incname and self.lib_dir and self.inc_dir) or (not incname and self.lib_dir):
-            print (self.name + '        '[len(self.name):] + ': found')
+            print(self.name + '        '[len(self.name):] + ': found')
             self.found = 1
         else:
 
             if self.name in ["FONT","IMAGE","MIXER","PNG","JPEG","FREETYPE"]:
                 self.found = 1
-                print (self.name + '        '[len(self.name):] + ': FORCED (via emsdk builtins)')
+                print(self.name + '        '[len(self.name):] + ': FORCED (via emsdk builtins)')
                 return
-            print (self.name + '        '[len(self.name):] + ': not found')
+            print(self.name + '        '[len(self.name):] + ': not found')
             print(self.name, self.checkhead, self.checklib, incdirs, libdirs)
 
 
@@ -159,9 +153,9 @@ class DependencyPython:
             else:
                 self.inc_dir = os.path.split(fullpath)[0]
         if self.found:
-            print (self.name + '        '[len(self.name):] + ': found', self.ver)
+            print(self.name + '        '[len(self.name):] + ': found', self.ver)
         else:
-            print (self.name + '        '[len(self.name):] + ': not found')
+            print(self.name + '        '[len(self.name):] + ': not found')
 
 sdl_lib_name = 'SDL'
 
@@ -172,7 +166,7 @@ def main(auto_config=False):
     origincdirs = ['/include']
     origlibdirs = []
 
-    print ('\nHunting dependencies...')
+    print('\nHunting dependencies...')
 
     DEPS = [
         DependencyProg('SDL', 'SDL_CONFIG', 'sdl2-config', '2.0', ['sdl']),
@@ -188,13 +182,6 @@ def main(auto_config=False):
         #Dependency('SCRAP', '', 'libX11', ['X11']),
         #Dependency('GFX', 'SDL_gfxPrimitives.h', 'libSDL_gfx.a', ['SDL_gfx']),
     ])
-
-    if not is_wasm:
-        porttime_dep = get_porttime_dep()
-        DEPS.append(
-            Dependency('PORTMIDI', 'portmidi.h', 'libportmidi.a', ['portmidi'])
-        )
-        DEPS.append(porttime_dep)
 
     if not DEPS[0].found:
         raise RuntimeError('Unable to run "sdl-config". Please make sure a development version of SDL is installed.')
@@ -237,6 +224,6 @@ def main(auto_config=False):
     return DEPS
 
 if __name__ == '__main__':
-    print ("""This is the configuration subscript for Unix.
+    print("""This is the configuration subscript for Unix.
 Please run "config.py" for full configuration.""")
 

--- a/buildconfig/config_emsdk.py
+++ b/buildconfig/config_emsdk.py
@@ -5,8 +5,6 @@ import os
 import sys
 from glob import glob
 
-from .config_unix import get_porttime_dep
-
 configcommand = os.environ.get('SDL_CONFIG', 'sdl-config',)
 configcommand = configcommand + ' --version --cflags --libs'
 localbase = os.environ.get('LOCALBASE', '')

--- a/buildconfig/config_emsdk.py
+++ b/buildconfig/config_emsdk.py
@@ -1,18 +1,18 @@
 """Config on Emscripten SDK is almost like Unix"""
 
-import os, sys
-from glob import glob
-import platform
 import logging
+import os
+import sys
+from glob import glob
+
 from distutils.sysconfig import get_python_inc
+
+from .config_unix import get_porttime_dep
 
 configcommand = os.environ.get('SDL_CONFIG', 'sdl-config',)
 configcommand = configcommand + ' --version --cflags --libs'
 localbase = os.environ.get('LOCALBASE', '')
-if os.environ.get('PYGAME_EXTRA_BASE', ''):
-    extrabases = os.environ['PYGAME_EXTRA_BASE'].split(':')
-else:
-    extrabases = []
+extrabases = os.environ.get('PYGAME_EXTRA_BASE', '').split(':')
 
 EMSDK = os.environ.get('EMSDK', None)
 is_wasm = EMSDK is not None

--- a/buildconfig/config_emsdk.py
+++ b/buildconfig/config_emsdk.py
@@ -12,7 +12,10 @@ from .config_unix import get_porttime_dep
 configcommand = os.environ.get('SDL_CONFIG', 'sdl-config',)
 configcommand = configcommand + ' --version --cflags --libs'
 localbase = os.environ.get('LOCALBASE', '')
-extrabases = os.environ.get('PYGAME_EXTRA_BASE', '').split(':')
+if os.environ.get('PYGAME_EXTRA_BASE'):
+    extrabases = os.environ['PYGAME_EXTRA_BASE'].split(':')
+else:
+    extrabases = []
 
 EMSDK = os.environ.get('EMSDK', None)
 is_wasm = EMSDK is not None

--- a/buildconfig/config_msys2.py
+++ b/buildconfig/config_msys2.py
@@ -16,6 +16,11 @@ import subprocess
 from glob import glob
 from distutils.sysconfig import get_python_inc
 
+try:
+    BuildError
+except NameError:
+    BuildError = TypeError
+
 
 def get_ptr_size():
     return 64 if sys.maxsize > 2**32 else 32

--- a/buildconfig/config_msys2.py
+++ b/buildconfig/config_msys2.py
@@ -16,11 +16,6 @@ import subprocess
 from glob import glob
 from distutils.sysconfig import get_python_inc
 
-try:
-    BuildError
-except NameError:
-    BuildError = TypeError
-
 
 def get_ptr_size():
     return 64 if sys.maxsize > 2**32 else 32
@@ -31,7 +26,7 @@ def as_machine_type(size):
         return "x86"
     if size == 64:
         return "x64"
-    raise BuildError("Unknown pointer size {}".format(size))
+    raise TypeError("Unknown pointer size {}".format(size))
 
 def get_machine_type():
     return as_machine_type(get_ptr_size())

--- a/buildconfig/config_msys2.py
+++ b/buildconfig/config_msys2.py
@@ -26,7 +26,7 @@ def as_machine_type(size):
         return "x86"
     if size == 64:
         return "x64"
-    raise TypeError("Unknown pointer size {}".format(size))
+    raise ValueError("Unknown pointer size {}".format(size))
 
 def get_machine_type():
     return as_machine_type(get_ptr_size())

--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -24,7 +24,7 @@ def as_machine_type(size):
         return "x86"
     if size == 64:
         return "x64"
-    raise TypeError("Unknown pointer size {}".format(size))
+    raise ValueError("Unknown pointer size {}".format(size))
 
 def get_machine_type():
     return as_machine_type(get_ptr_size())

--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -14,6 +14,11 @@ import logging
 from glob import glob
 from distutils.sysconfig import get_python_inc
 
+try:
+    BuildError
+except NameError:
+    BuildError = TypeError
+
 
 def get_ptr_size():
     return 64 if sys.maxsize > 2**32 else 32

--- a/buildconfig/config_win.py
+++ b/buildconfig/config_win.py
@@ -14,11 +14,6 @@ import logging
 from glob import glob
 from distutils.sysconfig import get_python_inc
 
-try:
-    BuildError
-except NameError:
-    BuildError = TypeError
-
 
 def get_ptr_size():
     return 64 if sys.maxsize > 2**32 else 32
@@ -29,7 +24,7 @@ def as_machine_type(size):
         return "x86"
     if size == 64:
         return "x64"
-    raise BuildError("Unknown pointer size {}".format(size))
+    raise TypeError("Unknown pointer size {}".format(size))
 
 def get_machine_type():
     return as_machine_type(get_ptr_size())

--- a/buildconfig/stubs/pygame/.flake8
+++ b/buildconfig/stubs/pygame/.flake8
@@ -17,10 +17,6 @@
 
 [flake8]
 ignore = B303, E301, E302, E305, E501, E701, E704, E741, F401, F403, F405, F811, W504
-# We are checking with Python 3 but many of the stubs are Python 2 stubs.
-# A nice future improvement would be to provide separate .flake8
-# configurations for Python 2 and Python 3 files.
-# builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
 exclude = ./.*,@*
 max-line-length = 130
 statistics = True

--- a/buildconfig/stubs/pygame/.flake8
+++ b/buildconfig/stubs/pygame/.flake8
@@ -16,10 +16,11 @@
 #       W504 line break after binary operator
 
 [flake8]
-ignore = F401, F403, F405, F811, E301, E302, E305, E501, E701, E704, E741, B303, W504
+ignore = B303, E301, E302, E305, E501, E701, E704, E741, F401, F403, F405, F811, W504
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 # A nice future improvement would be to provide separate .flake8
 # configurations for Python 2 and Python 3 files.
-builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
-exclude = .venv*,@*,.git
+# builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
+exclude = ./.*,@*
 max-line-length = 130
+statistics = True

--- a/docs/reST/ext/boilerplate.py
+++ b/docs/reST/ext/boilerplate.py
@@ -3,7 +3,7 @@
 from ext.utils import Visitor, get_name, GetError, get_refid, as_refid, as_refuri
 from ext.indexer import get_descinfo, get_descinfo_refid
 
-from sphinx.addnodes import desc, desc_signature, desc_content
+from sphinx.addnodes import desc, desc_content, desc_classname, desc_name, desc_signature
 from sphinx.addnodes import index as section_prelude_end_class
 from sphinx.domains.python import PyClasslike
 
@@ -299,10 +299,8 @@ def toc_ref(fullname, refid):
 def decorate_signatures(desc, classname):
     prefix = classname + "."
     for child in desc.children:
-        if isinstance(child, sphinx.addnodes.desc_signature) and isinstance(
-            child[0], sphinx.addnodes.desc_name
-        ):
-            new_desc_classname = sphinx.addnodes.desc_classname("", prefix)
+        if isinstance(child, desc_signature) and isinstance(child[0], desc_name):
+            new_desc_classname = desc_classname("", prefix)
             child.insert(0, new_desc_classname)
 
 

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,7 @@ def spawn(self, cmd, **kwargs):
     should_use_avx2 = False
     # try to be thorough in detecting that we are on a platform that potentially supports AVX2
     machine_name = platform.machine()
-    if ((machine_name.startswith("x86") or
-        machine_name.startswith("i686") or
+    if ((machine_name.startswith(("x86", "i686")) or
         machine_name.lower() == "amd64") and
             os.environ.get("MAC_ARCH") != "arm64"):
         should_use_avx2 = True
@@ -173,7 +172,7 @@ def compilation_help():
     print('---\n')
 
 
-if not hasattr(sys, 'version_info') or sys.version_info < (3, 5):
+if not hasattr(sys, 'version_info') or sys.version_info < (3, 6):
     compilation_help()
     raise SystemExit("Pygame requires Python3 version 3.6 or above.")
 if IS_PYPY and sys.pypy_version_info < (7,):
@@ -375,10 +374,7 @@ if consume_arg("-noheaders"):
 
 # sanity check for any arguments
 if len(sys.argv) == 1 and sys.stdout.isatty():
-    if sys.version_info[0] >= 3:
-        reply = input('\nNo Arguments Given, Perform Default Install? [Y/n]')
-    else:
-        reply = raw_input('\nNo Arguments Given, Perform Default Install? [Y/n]')
+    reply = input('\nNo Arguments Given, Perform Default Install? [Y/n]')
     if not reply or reply[0].lower() != 'n':
         sys.argv.append('install')
 

--- a/test/pixelarray_test.py
+++ b/test/pixelarray_test.py
@@ -1,14 +1,10 @@
-import sys
-import platform
-
-try:
-    reduce
-except NameError:
-    from functools import reduce
-import operator
-import weakref
 import gc
+import operator
+import platform
+import sys
 import unittest
+import weakref
+from functools import reduce
 
 from pygame.tests.test_utils import SurfaceSubclass
 

--- a/test/test_utils/arrinter.py
+++ b/test/test_utils/arrinter.py
@@ -13,18 +13,15 @@ __all__ = [
     "ArrayInterface",
 ]
 
-try:
-    c_ssize_t  # Undefined in early Python versions
-except NameError:
-    if sizeof(c_uint) == sizeof(c_void_p):
-        c_size_t = c_uint
-        c_ssize_t = c_int
-    elif sizeof(c_ulong) == sizeof(c_void_p):
-        c_size_t = c_ulong
-        c_ssize_t = c_long
-    elif sizeof(c_ulonglong) == sizeof(c_void_p):
-        c_size_t = c_ulonglong
-        c_ssize_t = c_longlong
+if sizeof(c_uint) == sizeof(c_void_p):
+    c_size_t = c_uint
+    c_ssize_t = c_int
+elif sizeof(c_ulong) == sizeof(c_void_p):
+    c_size_t = c_ulong
+    c_ssize_t = c_long
+elif sizeof(c_ulonglong) == sizeof(c_void_p):
+    c_size_t = c_ulonglong
+    c_ssize_t = c_longlong
 
 
 SIZEOF_VOID_P = sizeof(c_void_p)
@@ -35,7 +32,7 @@ elif SIZEOF_VOID_P <= sizeof(c_long):
 elif "c_longlong" in globals() and SIZEOF_VOID_P <= sizeof(c_longlong):
     Py_intptr_t = c_longlong
 else:
-    raise RuntimeError("Unrecognized pointer size %i" % (pointer_size,))
+    raise RuntimeError("Unrecognized pointer size %i" % (SIZEOF_VOID_P,))
 
 
 class PyArrayInterface(Structure):

--- a/test/test_utils/async_sub.py
+++ b/test/test_utils/async_sub.py
@@ -140,7 +140,7 @@ class Popen(subprocess.Popen):
             sent = self.send(data)
             if sent is None:
                 raise Exception("Other end disconnected!")
-            data = buffer(data, sent)
+            data = memoryview(data, sent)
 
     def get_conn_maxsize(self, which, maxsize):
         if maxsize is None:

--- a/test/test_utils/buftools.py
+++ b/test/test_utils/buftools.py
@@ -46,14 +46,9 @@ from pygame.newbuffer import (
 )
 
 import unittest
-import sys
 import ctypes
 import operator
-
-try:
-    reduce
-except NameError:
-    from functools import reduce
+from functools import reduce
 
 __all__ = ["Exporter", "Importer"]
 
@@ -188,10 +183,10 @@ class Exporter(pygame.newbuffer.BufferMixin):
         self.buf = ctypes.addressof(self._buf) + offset
 
     def buffer_info(self):
-        return (addressof(self.buffer), self.shape[0])
+        return (ctypes.addressof(self.buffer), self.shape[0])
 
     def tobytes(self):
-        return cast(self.buffer, POINTER(c_char))[0 : self._len]
+        return ctypes.cast(self.buffer, ctypes.POINTER(ctypes.c_char))[0 : self._len]
 
     def __len__(self):
         return self.shape[0]

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -161,8 +161,7 @@ And now, my famous members
 
 __version__ = "$URL: http://pypng.googlecode.com/svn/trunk/code/png.py $ $Rev: 228 $"
 
-from array import array
-from pygame.tests.test_utils import tostring
+import io
 import itertools
 import math
 import operator
@@ -170,6 +169,10 @@ import struct
 import sys
 import zlib
 import warnings
+from array import array
+from functools import reduce
+
+from pygame.tests.test_utils import tostring
 
 __all__ = ["Image", "Reader", "Writer", "write_chunks", "from_array"]
 
@@ -1379,7 +1382,7 @@ class Reader:
                 kw["bytes"] = _guess
             elif isinstance(_guess, str):
                 kw["filename"] = _guess
-            elif isinstance(_guess, file):
+            elif isinstance(_guess, io.IOBase):
                 kw["file"] = _guess
 
         if "filename" in kw:
@@ -1420,7 +1423,7 @@ class Reader:
                 )
             checksum = self.file.read(4)
             if len(checksum) != 4:
-                raise ValueError("Chunk %s too short for checksum.", tag)
+                raise ValueError("Chunk %s too short for checksum.", checksum)
             if seek and type != seek:
                 continue
             verify = zlib.crc32(strtobytes(type))


### PR DESCRIPTION
Use `flake8 --select=F821` to find and fix all `undefined names` in the codebase.
The majority of these are about builtins that were removed or moved in the transition from Python 2 to Python 3.

The failing test seems unrelated.