### PR TITLE
AppVeyor: Use `py` instead of %PYTHON% and %PYTHON_VERSION% ?

### DIFF
--- a/buildconfig/appveyor.yml
+++ b/buildconfig/appveyor.yml
@@ -84,6 +84,8 @@ environment:
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+  - py --version
+  - py -VV
 
 install:
 


### PR DESCRIPTION
Would use of [`py`](https://docs.python.org/3/using/windows.html#python-launcher-for-windows) allow us to simplify `appveyor.yml` by dropping variables `%PYTHON%` and `%PYTHON_VERSION%`?