### PR TITLE
Deprecate event.joy and joystick.get_id

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1293,10 +1293,13 @@ pg_EventGetAttr(PyObject *o, PyObject *attr_name)
     PyObject *result = PyObject_GenericGetAttr(o, attr_name);
 
     if (!result) {
+        PyObject *type, *value, *traceback;
+        PyErr_Fetch(&type, &value, &traceback);
         result = PyDict_GetItem(((pgEventObject *)o)->dict, attr_name);
 
         if (!result) {
-            return NULL; /* error is set by GenericGetAttr already */
+            PyErr_Restore(type, value, traceback);
+            return NULL;
         }
         PyErr_Clear();
     }

--- a/src_c/joystick.c
+++ b/src_c/joystick.c
@@ -187,6 +187,12 @@ static PyObject *
 joy_get_id(PyObject *self, PyObject *_null)
 {
     int joy_id = pgJoystick_AsID(self);
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "joytick.get_id is deprecated and will be removed in the "
+                     "future. Use get_instance_id instead.",
+                     1) != 0) {
+        return NULL;
+    }
     return PyLong_FromLong(joy_id);
 }
 

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -1,6 +1,7 @@
 import collections
 import time
 import unittest
+import warnings
 
 import pygame
 
@@ -160,6 +161,29 @@ class EventTypeTest(unittest.TestCase):
         self.assertFalse(a == c)
         self.assertTrue(a != d)
         self.assertFalse(a == d)
+
+    def test_joy_attrib_warns(self):
+        ev1 = pygame.event.Event(pygame.JOYBUTTONDOWN, joy=0)
+        ev2 = pygame.event.Event(pygame.event.custom_type(), joy=0)
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as warns:
+            self.assertEqual(len(warns), 0)
+            ev1.joy  # Should raise deprecationwarning
+            self.assertEqual(len(warns), 1)
+            self.assertTrue(issubclass(warns[0].category, DeprecationWarning))
+            ev2.joy  # Should not raise deprecationwarning (custom type)
+            self.assertEqual(len(warns), 1)
+
+            # setting and deleting should work just like a normal attribute would
+            ev1.joy = 1
+            self.assertEqual(ev1.joy, 1)
+
+            del ev2.joy
+            with self.assertRaises(AttributeError):
+                ev2.joy
+
+        warnings.simplefilter("default")
 
 
 race_condition_notification = """


### PR DESCRIPTION
`event.joy` and `joystick.get_id` is deprecated in the docs (and has been for a long time now), and should be removed soon. PR #2834 does that already, but since there were no prior warnings (as in python warnings), removing it now would break a fair amount of existing code. Hopefully by waiting a release or two, with warnings on these, there won't be much issues.