### PR TITLE
Add pre-commit to run setup.py format and lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,14 @@ repos:
     hooks:
       - id: format
         name: format
-        entry: python3 setup.py format
+        entry: bash -c "python3 setup.py format"
         language: python
         additional_dependencies:
           - black
           - clang-format
       - id: lint
         name: lint
-        entry: python3 setup.py lint
+        entry: bash -c "python3 setup.py lint"
         language: python
         additional_dependencies:
           - black
@@ -28,21 +28,21 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:
-      - id: check-builtin-literals
-      - id: check-executables-have-shebangs
-      - id: check-shebang-scripts-are-executable
+      # - id: check-builtin-literals
+      # - id: check-executables-have-shebangs
+      # - id: check-shebang-scripts-are-executable
       - id: check-yaml
       - id: detect-private-key
-      - id: end-of-file-fixer
+      #- id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: trailing-whitespace
+      #- id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
       - id: bandit
         args:
-          - --skip B101,B110,B301,B306,B307,B310,B311,B314,B324,B403,B404,B405,B602,B603,B605,B607
+          - --skip=B101,B110,B301,B306,B307,B310,B311,B314,B324,B403,B404,B405,B602,B603,B605,B607
 
   # Waiting for pygame/pygame#3216
   #- repo: https://github.com/codespell-project/codespell
@@ -69,7 +69,7 @@ repos:
         args:
           - --py36-plus
 
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
-    hooks:
-      - id: setup-cfg-fmt
+  #- repo: https://github.com/asottile/setup-cfg-fmt
+  #  rev: v1.20.1
+  #  hooks:
+  #    - id: setup-cfg-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,75 @@
+# To enable these pre-commit hook run:
+# `python3 -m pip install pre-commit` or `brew install pre-commit`
+# Then in the project root directory run `pre-commit install`
+# Learn more about this config here: https://pre-commit.com/
+
+# default_language_version:
+#   python: python3.10
+
+repos:
+  - repo: local
+    hooks:
+      - id: format
+        name: format
+        entry: python3 setup.py format
+        language: python
+        additional_dependencies:
+          - black
+          - clang-format
+      - id: lint
+        name: lint
+        entry: python3 setup.py lint
+        language: python
+        additional_dependencies:
+          - black
+          - clang-format
+          - pylint
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-builtin-literals
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        args:
+          - --skip B101,B110,B301,B306,B307,B310,B311,B314,B324,B403,B404,B405,B602,B603,B605,B607
+
+  # Waiting for pygame/pygame#3216
+  #- repo: https://github.com/codespell-project/codespell
+  #  rev: v2.1.0
+  #  hooks:
+  #    - id: codespell  # See setup.cfg for args
+
+  #- repo: https://github.com/timothycrosley/isort
+  #  rev: 5.10.1
+  #  hooks:
+  #    - id: isort  # See setup.cfg for args
+
+  #- repo: https://github.com/pre-commit/mirrors-mypy
+  #  rev: v0.960
+  #  hooks:
+  #    - id: mypy
+  #      additional_dependencies:
+  #        - types-all
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.1
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py36-plus
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.20.1
+    hooks:
+      - id: setup-cfg-fmt

--- a/buildconfig/ci/travis/.travis_osx_rename_whl.py
+++ b/buildconfig/ci/travis/.travis_osx_rename_whl.py
@@ -21,7 +21,7 @@ if len(filenames) < 1:
 elif len(filenames) > 1:
     print("Multiple wheels found:")
     for f in filenames:
-        print("  {}".format(f))
+        print(f"  {f}")
 
 for path in filenames:
     new_path = path.replace('_x86_64', '_intel')


### PR DESCRIPTION
Add [`pre-commit`](https://pre-commit.com) to run `setup.py format` and `setup.py lint` on the changed files on every commit.  Avoids creating pull requests that will fail the basic continuous integration tests. Avoids having to run these format and lint manually.  Makes it easy to add other tools like bandit, codespell, isort, mypy, etc.

To enable these pre-commit hooks run:
`python3 -m pip install pre-commit` or `brew install pre-commit`
Then in the project root directory run `pre-commit install`
Learn more about this config here: https://pre-commit.com

As discussed at https://github.com/pygame/pygame/pull/3208#issuecomment-1146624904