### PR TITLE
Fix undefined name: get_python_inc()

### DIFF
--- a/buildconfig/config_emsdk.py
+++ b/buildconfig/config_emsdk.py
@@ -5,6 +5,8 @@ import os
 import sys
 from glob import glob
 
+from distutils.sysconfig import get_python_inc
+
 configcommand = os.environ.get('SDL_CONFIG', 'sdl-config',)
 configcommand = configcommand + ' --version --cflags --libs'
 localbase = os.environ.get('LOCALBASE', '')

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ disable=
     invalid-name,
     missing-docstring,
     no-member,
-    no-name-in-module,
     protected-access,
     raise-missing-from,
     redefined-builtin,
@@ -61,7 +60,6 @@ disable=
     undefined-all-variable,
     undefined-variable,
     unused-import, # False positive because there are no __all__ sometime.
-    unused-wildcard-import,
     useless-object-inheritance,
     wrong-import-order,
     wrong-import-position,


### PR DESCRIPTION
Fix the last remaining _undefined name_ (like #3207) by importing `get_python_inc` for line 150.  This import is done in several other files but it is missing from this file.
```
buildconfig/config_darwin.py:from distutils.sysconfig import get_python_inc
buildconfig/config_darwin.py:            fullpath = os.path.join(get_python_inc(0), self.header)
... [ missing ] ...
buildconfig/config_emsdk.py:            fullpath = os.path.join(get_python_inc(0), self.header)
buildconfig/config_msys2.py:from distutils.sysconfig import get_python_inc
buildconfig/config_msys2.py:            fullpath = os.path.join(get_python_inc(0), self.header)
buildconfig/config_unix.py:from distutils.sysconfig import get_python_inc
buildconfig/config_unix.py:            fullpath = os.path.join(get_python_inc(0), self.header)
buildconfig/config_win.py:from distutils.sysconfig import get_python_inc
buildconfig/config_win.py:            fullpath = os.path.join(get_python_inc(0), self.header)
```
Pylint:
* `fixme` was in both the `enable` list and the `disable` list!
* Enable checks for `no-name-in-module` and `unused-wildcard-import`