### PR TITLE
setup.cfg: Sort pylint disables to simplify future edits

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [tox:tox]
 envlist = py{36,37,38,39,310}
-skipsdist = True
 skip_missing_interpreters = True
+skipsdist = True
 
 [testenv]
 deps =
     numpy
 setenv =
-    SDL_VIDEODRIVER=dummy
     SDL_AUDIODRIVER=disk
+    SDL_VIDEODRIVER=dummy
 passenv =
     PORTMIDI_INC_PORTTIME
 commands =
@@ -21,48 +21,47 @@ pyinstaller40 =
 	hook-dirs = pygame.__pyinstaller:get_hook_dirs
 
 [isort]
-multi_line_output = 3
-line_length = 88
+include_trailing_comma = True
 known_first_party = pygame
 known_third_party = numpy, distutils, setuptools, sphinx
-include_trailing_comma = True
+line_length = 88
+multi_line_output = 3
 src_paths = src_py
 
 [pylint.MESSAGES CONTROL]
 extension-pkg-whitelist=pygame
 enable=
     use-symbolic-message-instead,
-    fixme,
 
 disable=
-    missing-docstring,
-    invalid-name,
-    import-error,
-    fixme,
-    no-member,
-    wrong-import-order,
-    wrong-import-position,
-    useless-object-inheritance,
+    attribute-defined-outside-init,
+    broad-except,
+    duplicate-code,
     empty-docstring,
-    undefined-all-variable,
-    import-outside-toplevel,
+    fixme,
     global-statement,
     global-variable-undefined,
+    import-error,
+    import-outside-toplevel,
+    invalid-name,
+    missing-docstring,
+    no-member,
     no-name-in-module,
+    protected-access,
+    raise-missing-from,
     redefined-builtin,
     redefined-outer-name,
-    broad-except,
-    too-many-lines,
-    too-many-locals,
-    raise-missing-from,
-    unused-wildcard-import,
-    attribute-defined-outside-init,
-    undefined-variable,
+    super-with-arguments,
+    too-few-public-methods,
     too-many-arguments,
     too-many-branches,
-    too-few-public-methods,
     too-many-instance-attributes,
-    super-with-arguments,
+    too-many-lines,
+    too-many-locals,
+    undefined-all-variable,
+    undefined-variable,
     unused-import, # False positive because there are no __all__ sometime.
-    protected-access,
-    duplicate-code,
+    unused-wildcard-import,
+    useless-object-inheritance,
+    wrong-import-order,
+    wrong-import-position,


### PR DESCRIPTION
Sorting long lists makes it easier to spot missing entries and more difficult to create duplicate entries.

In VSCode, select lines, Shift-Command-P and Sort Lines Ascending.

Removed `fixme` from the enable list because it is also on the disable list and it must be disabled.