### PR TITLE
setup.py: fix user+deprecation warnings on 3.11+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,9 @@ import sys
 import os
 
 # just import these always and fail early if not present
-import distutils
 from setuptools import setup
+
+import distutils
 
 import distutils.ccompiler
 

--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -20,21 +20,23 @@
 """sysfont, used in the font module to find system fonts"""
 
 import os
-import subprocess
 import sys
 import warnings
 from os.path import basename, dirname, exists, join, splitext
 
 from pygame.font import Font
 
+if sys.platform != "emscripten":
+    if os.name == "nt":
+        import winreg as _winreg
+    import subprocess
+
+
 OpenType_extensions = frozenset((".ttf", ".ttc", ".otf"))
 Sysfonts = {}
 Sysalias = {}
 
 is_init = False
-
-if os.name == "nt":
-    import winreg as _winreg
 
 
 def _simplename(name):
@@ -195,6 +197,9 @@ def initsysfonts_darwin():
 def initsysfonts_unix(path="fc-list"):
     """use the fc-list from fontconfig to get a list of fonts"""
     fonts = {}
+
+    if sys.platform == "emscripten":
+        return fonts
 
     try:
         proc = subprocess.run(


### PR DESCRIPTION
should fix both
```
setup.py:71: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils
```
```
_distutils_hack/__init__.py:17: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
```
