### PR TITLE
wasm: pygame.surfarray could load on 3.10.5 backport

### DIFF
--- a/src_c/static.c
+++ b/src_c/static.c
@@ -146,6 +146,9 @@ PyInit_video(void);
 PyMODINIT_FUNC
 PyInit__sprite(void);
 
+PyMODINIT_FUNC
+PyInit_pixelcopy(void);
+
 void
 PyGame_static_init()
 {
@@ -158,6 +161,7 @@ PyGame_static_init()
     PyImport_AppendInittab("pygame_bufferproxy", PyInit_bufferproxy);
     PyImport_AppendInittab("pygame_math", PyInit_pg_math);
     PyImport_AppendInittab("pygame_surface", PyInit_surface);
+    PyImport_AppendInittab("pygame_pixelcopy", PyInit_pixelcopy);    
     PyImport_AppendInittab("pygame_transform", PyInit_transform);
     PyImport_AppendInittab("pygame_display", PyInit_display);
     PyImport_AppendInittab("pygame__freetype", PyInit__freetype);

--- a/src_c/static.c
+++ b/src_c/static.c
@@ -161,7 +161,7 @@ PyGame_static_init()
     PyImport_AppendInittab("pygame_bufferproxy", PyInit_bufferproxy);
     PyImport_AppendInittab("pygame_math", PyInit_pg_math);
     PyImport_AppendInittab("pygame_surface", PyInit_surface);
-    PyImport_AppendInittab("pygame_pixelcopy", PyInit_pixelcopy);    
+    PyImport_AppendInittab("pygame_pixelcopy", PyInit_pixelcopy);
     PyImport_AppendInittab("pygame_transform", PyInit_transform);
     PyImport_AppendInittab("pygame_display", PyInit_display);
     PyImport_AppendInittab("pygame__freetype", PyInit__freetype);


### PR DESCRIPTION
but it requires pygame.pixelcopy preloaded.

numpy module from pyodide at https://cdn.jsdelivr.net/pyodide/v0.20.0/full/numpy-1.22.3-cp310-cp310-emscripten_wasm32.whl

live test https://pmp-p.github.io/pygame-wasm-plus/python310.html?beatgame