### PR TITLE
wasm: wrong logic masks pgExc_SDLError

### DIFF
--- a/src_c/base.c
+++ b/src_c/base.c
@@ -2097,7 +2097,7 @@ MODINIT_DEFINE(base)
 {
     PyObject *module, *apiobj, *atexit;
     PyObject *atexit_register;
-#if !defined(BUILD_STATIC) || defined(NO_PYGAME_C_API)
+#if !(defined(BUILD_STATIC) && defined(NO_PYGAME_C_API))
     // only pointer via C-api will be used, no need to keep global.
     PyObject *pgExc_SDLError;
 #endif


### PR DESCRIPTION
that is still assigning a local instead of the required global pgExc_SDLError
probably fixes all kind of  `SystemError: returned NULL without setting an exception`  because of pgExc_SDLError == NULL