### PR TITLE
Improve name parsing for windows sysfonts

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -95,7 +95,7 @@ def _parse_font_entry_win(name, font, fonts):
     :return: Tuple of (bold, italic, name)
     """
     true_type_suffix = "(TrueType)"
-    mods = ("demibold", "narrow", "light", "unicode", "bt", "mt")
+    mods = ("demibold", "narrow", "light", "unicode", "bt", "mt", "regular")
     if name.endswith(true_type_suffix):
         name = name.rstrip(true_type_suffix).rstrip()
     name = name.lower().split()


### PR DESCRIPTION
By adding another "mod" to be removed from the name.

While testing Novial's #3184, I downloaded "Poppins Regular" from Google Fonts and installed it into a windows user font directory. Novial's code picks it up fine, but match_font returns none when you search for "poppins." It only knows the name "poppinsregular." This fixes that.

This could impact existing behavior. On a quick scan, I don't see any preinstalled windows fonts that use this pattern (ending with " Regular"). So it won't impact much existing stuff. I think the change is worth it, because it makes the results more correct.