### PR TITLE
Add an AVX2 version of BLEND_PREMULTIPLIED.

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -734,9 +734,9 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         }
 #endif /*__MMX__*/
 #endif /*__MMX__ || __SSE2__ || PG_ENABLE_ARM_NEON*/
+                    }
 #endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
 #endif /* __EMSCRIPTEN__ */
-                    }
 
                     blit_blend_premultiplied(&info);
                     break;

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -96,11 +96,6 @@ blit_blend_premultiplied(SDL_BlitInfo *info);
 static void
 blit_blend_premultiplied_mmx(SDL_BlitInfo *info);
 #endif /*  __MMX__ */
-#if defined(__MMX__) || defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)
-static void
-blit_blend_premultiplied_sse2(SDL_BlitInfo *info);
-#endif /*defined(__MMX__) || defined(__SSE2__) || \
-          defined(PG_ENABLE_ARM_NEON)*/
 
 static int
 SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
@@ -701,6 +696,18 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                     break;
                 }
                 case PYGAME_BLEND_PREMULTIPLIED: {
+#if !defined(__EMSCRIPTEN__)
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+                    if (src->format->BytesPerPixel == 4 &&
+                        dst->format->BytesPerPixel == 4 &&
+                        src->format->Rmask == dst->format->Rmask &&
+                        src->format->Gmask == dst->format->Gmask &&
+                        src->format->Bmask == dst->format->Bmask &&
+                        info.src_blend != SDL_BLENDMODE_NONE &&
+                        SDL_HasAVX2() && (src != dst)) {
+                        blit_blend_premultiplied_avx2(&info);
+                        break;
+                    }
                     if (src->format->BytesPerPixel == 4 &&
                         dst->format->BytesPerPixel == 4 &&
                         src->format->Rmask == dst->format->Rmask &&
@@ -727,6 +734,8 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         }
 #endif /*__MMX__*/
 #endif /*__MMX__ || __SSE2__ || PG_ENABLE_ARM_NEON*/
+#endif /* SDL_BYTEORDER == SDL_LIL_ENDIAN */
+#endif /* __EMSCRIPTEN__ */
                     }
 
                     blit_blend_premultiplied(&info);
@@ -1401,85 +1410,6 @@ blit_blend_rgba_max(SDL_BlitInfo *info)
         }
     }
 }
-
-#if defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)
-static void
-blit_blend_premultiplied_sse2(SDL_BlitInfo *info)
-{
-    int n;
-    int width = info->width;
-    int height = info->height;
-    Uint32 *srcp = (Uint32 *)info->s_pixels;
-    int srcskip = info->s_skip >> 2;
-    Uint32 *dstp = (Uint32 *)info->d_pixels;
-    int dstskip = info->d_skip >> 2;
-    SDL_PixelFormat *srcfmt = info->src;
-    Uint32 amask = srcfmt->Amask;
-    // Uint64 multmask;
-    Uint64 ones;
-
-    // __m128i multmask_128;
-    __m128i src1, dst1, sub_dst, mm_alpha, mm_zero, ones_128;
-
-    mm_zero = _mm_setzero_si128();
-    // multmask = 0x00FF00FF00FF00FF;  // 0F0F0F0F
-    // multmask_128 = _mm_loadl_epi64((const __m128i *)&multmask);
-    ones = 0x0001000100010001;
-    ones_128 = _mm_loadl_epi64((const __m128i *)&ones);
-
-    while (height--) {
-        /* *INDENT-OFF* */
-        LOOP_UNROLLED4(
-            {
-                Uint32 alpha = *srcp & amask;
-                if (alpha == 0) {
-                    /* do nothing */
-                }
-                else if (alpha == amask) {
-                    *dstp = *srcp;
-                }
-                else {
-                    src1 = _mm_cvtsi32_si128(
-                        *srcp); /* src(ARGB) -> src1 (000000000000ARGB) */
-                    src1 = _mm_unpacklo_epi8(
-                        src1, mm_zero); /* 000000000A0R0G0B -> src1 */
-
-                    dst1 = _mm_cvtsi32_si128(
-                        *dstp); /* dst(ARGB) -> dst1 (000000000000ARGB) */
-                    dst1 = _mm_unpacklo_epi8(
-                        dst1, mm_zero); /* 000000000A0R0G0B -> dst1 */
-
-                    mm_alpha = _mm_cvtsi32_si128(
-                        alpha); /* alpha -> mm_alpha (000000000000A000) */
-                    mm_alpha = _mm_srli_si128(
-                        mm_alpha, 3); /* mm_alpha >> ashift ->
-                                         mm_alpha(000000000000000A) */
-                    mm_alpha = _mm_unpacklo_epi16(
-                        mm_alpha, mm_alpha); /* 0000000000000A0A -> mm_alpha */
-                    mm_alpha = _mm_unpacklo_epi32(
-                        mm_alpha,
-                        mm_alpha); /* 000000000A0A0A0A -> mm_alpha2 */
-
-                    /* pre-multiplied alpha blend */
-                    sub_dst = _mm_add_epi16(dst1, ones_128);
-                    sub_dst = _mm_mullo_epi16(sub_dst, mm_alpha);
-                    sub_dst = _mm_srli_epi16(sub_dst, 8);
-                    dst1 = _mm_add_epi16(src1, dst1);
-                    dst1 = _mm_sub_epi16(dst1, sub_dst);
-                    dst1 = _mm_packus_epi16(dst1, mm_zero);
-
-                    *dstp = _mm_cvtsi128_si32(dst1);
-                }
-                ++srcp;
-                ++dstp;
-            },
-            n, width);
-        /* *INDENT-ON* */
-        srcp += srcskip;
-        dstp += dstskip;
-    }
-}
-#endif /*__SSE2__ || PG_ENABLE_ARM_NEON*/
 
 #ifdef __MMX__
 /* fast ARGB888->(A)RGB888 blending with pixel alpha */

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -29,6 +29,8 @@ void
 blit_blend_rgba_min_sse2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_min_sse2(SDL_BlitInfo *info);
+void
+blit_blend_premultiplied_sse2(SDL_BlitInfo *info);
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
 
 void
@@ -51,3 +53,5 @@ void
 blit_blend_rgba_min_avx2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_min_avx2(SDL_BlitInfo *info);
+void
+blit_blend_premultiplied_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -1030,8 +1030,8 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
                         *dstp = _mm_cvtsi128_si32(mm_dst);
                     }
 
-                    srcp = (Uint32 *)srcp256 + srcskip;
-                    dstp = (Uint32 *)dstp256 + dstskip;
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
                 },
                 n, pre_8_width);
         }
@@ -1086,8 +1086,8 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -941,12 +941,10 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -1032,8 +1030,8 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
                         *dstp = _mm_cvtsi128_si32(mm_dst);
                     }
 
-                    srcp += srcpxskip;
-                    dstp += dstpxskip;
+                    srcp = (Uint32 *)srcp256 + srcskip;
+                    dstp = (Uint32 *)dstp256 + dstskip;
                 },
                 n, pre_8_width);
         }
@@ -1085,8 +1083,6 @@ blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -928,3 +928,178 @@ blit_blend_rgb_min_avx2(SDL_BlitInfo *info)
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
+
+#if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+    !defined(SDL_DISABLE_IMMINTRIN_H)
+void
+blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
+{
+    int n;
+    int width = info->width;
+    int height = info->height;
+
+    Uint32 *srcp = (Uint32 *)info->s_pixels;
+    int srcskip = info->s_skip >> 2;
+    int srcpxskip = info->s_pxskip >> 2;
+    int srceightpxskip = 8 * srcpxskip;
+
+    Uint32 *dstp = (Uint32 *)info->d_pixels;
+    int dstskip = info->d_skip >> 2;
+    int dstpxskip = info->d_pxskip >> 2;
+    int dsteightpxskip = 8 * dstpxskip;
+
+    int pre_8_width = width % 8;
+    int post_8_width = (width - pre_8_width) / 8;
+
+    /* if either surface has a non-zero alpha mask use that as our mask */
+    Uint32 amask = info->src->Amask | info->dst->Amask;
+
+    __m256i *srcp256 = (__m256i *)info->s_pixels;
+    __m256i *dstp256 = (__m256i *)info->d_pixels;
+
+    __m128i mm_src, mm_dst, mm_zero, mm_alpha, mm_sub_dst, mm_ones;
+    __m256i mm256_src, mm256_dst, mm256_shuff_mask_A, mm256_shuff_mask_B,
+        mm256_src_shuff, mm256_dstA, mm256_dstB, mm256_ones, mm256_alpha,
+        mm256_shuff_alpha_mask_A, mm256_shuff_alpha_mask_B;
+
+    mm_zero = _mm_setzero_si128();
+    mm_ones = _mm_set_epi64x(0x0000000000000000, 0x0001000100010001);
+
+    mm256_shuff_mask_A =
+        _mm256_set_epi8(0x80, 23, 0x80, 22, 0x80, 21, 0x80, 20, 0x80, 19, 0x80,
+                        18, 0x80, 17, 0x80, 16, 0x80, 7, 0x80, 6, 0x80, 5,
+                        0x80, 4, 0x80, 3, 0x80, 2, 0x80, 1, 0x80, 0);
+
+    mm256_shuff_alpha_mask_A =
+        _mm256_set_epi8(0x80, 23, 0x80, 23, 0x80, 23, 0x80, 23, 0x80, 19, 0x80,
+                        19, 0x80, 19, 0x80, 19, 0x80, 7, 0x80, 7, 0x80, 7,
+                        0x80, 7, 0x80, 3, 0x80, 3, 0x80, 3, 0x80, 3);
+
+    mm256_shuff_mask_B =
+        _mm256_set_epi8(0x80, 31, 0x80, 30, 0x80, 29, 0x80, 28, 0x80, 27, 0x80,
+                        26, 0x80, 25, 0x80, 24, 0x80, 15, 0x80, 14, 0x80, 13,
+                        0x80, 12, 0x80, 11, 0x80, 10, 0x80, 9, 0x80, 8);
+
+    mm256_shuff_alpha_mask_B =
+        _mm256_set_epi8(0x80, 31, 0x80, 31, 0x80, 31, 0x80, 31, 0x80, 27, 0x80,
+                        27, 0x80, 27, 0x80, 27, 0x80, 15, 0x80, 15, 0x80, 15,
+                        0x80, 15, 0x80, 11, 0x80, 11, 0x80, 11, 0x80, 11);
+
+    mm256_ones = _mm256_set_epi8(
+        0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
+        0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
+        0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01);
+
+    while (height--) {
+        if (pre_8_width > 0) {
+            /* one pixel at a time - same as current sse2 version */
+            LOOP_UNROLLED4(
+                {
+                    Uint32 alpha = *srcp & amask;
+                    if (alpha == 0) {
+                        /* do nothing */
+                    }
+                    else if (alpha == amask) {
+                        *dstp = *srcp;
+                    }
+                    else {
+                        mm_src = _mm_cvtsi32_si128(*srcp);
+                        /*mm_src = 0x000000000000000000000000AARRGGBB*/
+                        mm_src = _mm_unpacklo_epi8(mm_src, mm_zero);
+                        /*mm_src = 0x000000000000000000AA00RR00GG00BB*/
+                        mm_dst = _mm_cvtsi32_si128(*dstp);
+                        /*mm_dst = 0x000000000000000000000000AARRGGBB*/
+                        mm_dst = _mm_unpacklo_epi8(mm_dst, mm_zero);
+                        /*mm_dst = 0x000000000000000000AA00RR00GG00BB*/
+
+                        mm_alpha = _mm_cvtsi32_si128(alpha);
+                        /* alpha -> mm_alpha (000000000000A000) */
+                        mm_alpha = _mm_srli_si128(mm_alpha, 3);
+                        /* mm_alpha >> ashift -> mm_alpha(000000000000000A) */
+                        mm_alpha = _mm_unpacklo_epi16(mm_alpha, mm_alpha);
+                        /* 0000000000000A0A -> mm_alpha */
+                        mm_alpha = _mm_unpacklo_epi32(mm_alpha, mm_alpha);
+                        /* 000000000A0A0A0A -> mm_alpha2 */
+
+                        /* pre-multiplied alpha blend */
+                        mm_sub_dst = _mm_add_epi16(mm_dst, mm_ones);
+                        mm_sub_dst = _mm_mullo_epi16(mm_sub_dst, mm_alpha);
+                        mm_sub_dst = _mm_srli_epi16(mm_sub_dst, 8);
+                        mm_dst = _mm_add_epi16(mm_src, mm_dst);
+                        mm_dst = _mm_sub_epi16(mm_dst, mm_sub_dst);
+                        mm_dst = _mm_packus_epi16(mm_dst, mm_zero);
+
+                        *dstp = _mm_cvtsi128_si32(mm_dst);
+                    }
+
+                    srcp += srcpxskip;
+                    dstp += dstpxskip;
+                },
+                n, pre_8_width);
+        }
+        srcp256 = (__m256i *)srcp;
+        dstp256 = (__m256i *)dstp;
+        if (post_8_width > 0) {
+            /*8 pixels at a time, need to use shuffle to get everything
+                lined up - see mul for an example*/
+            LOOP_UNROLLED4(
+                {
+                    mm256_src = _mm256_loadu_si256(srcp256);
+                    mm256_dst = _mm256_loadu_si256(dstp256);
+
+                    /* insert 8 pixel at a time blend here */
+
+                    /* do everything A set first */
+                    mm256_dstA =
+                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_A);
+                    mm256_src_shuff =
+                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_A);
+                    mm256_alpha = _mm256_shuffle_epi8(
+                        mm256_src, mm256_shuff_alpha_mask_A);
+                    mm256_src_shuff =
+                        _mm256_add_epi16(mm256_src_shuff, mm256_dstA);
+                    mm256_dstA = _mm256_add_epi16(mm256_dstA, mm256_ones);
+                    mm256_dstA = _mm256_mullo_epi16(mm256_alpha, mm256_dstA);
+                    mm256_dstA = _mm256_srli_epi16(mm256_dstA, 8);
+
+                    mm256_dstA = _mm256_sub_epi16(mm256_src_shuff, mm256_dstA);
+
+                    /* now do B set */
+                    mm256_dstB =
+                        _mm256_shuffle_epi8(mm256_dst, mm256_shuff_mask_B);
+                    mm256_src_shuff =
+                        _mm256_shuffle_epi8(mm256_src, mm256_shuff_mask_B);
+                    mm256_alpha = _mm256_shuffle_epi8(
+                        mm256_src, mm256_shuff_alpha_mask_B);
+                    mm256_src_shuff =
+                        _mm256_add_epi16(mm256_src_shuff, mm256_dstB);
+                    mm256_dstB = _mm256_add_epi16(mm256_dstB, mm256_ones);
+                    mm256_dstB = _mm256_mullo_epi16(mm256_alpha, mm256_dstB);
+                    mm256_dstB = _mm256_srli_epi16(mm256_dstB, 8);
+
+                    mm256_dstB = _mm256_sub_epi16(mm256_src_shuff, mm256_dstB);
+
+                    /* now pack A & B together */
+                    mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
+                    _mm256_storeu_si256(dstp256, mm256_dst);
+
+                    srcp256++;
+                    dstp256++;
+                    srcp += srceightpxskip;
+                    dstp += dsteightpxskip;
+                },
+                n, post_8_width);
+        }
+        srcp += srcskip;
+        dstp += dstskip;
+    }
+}
+#else
+void
+blit_blend_premultiplied_avx2(SDL_BlitInfo *info)
+{
+    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
+    blit_blend_premultiplied_sse2(info);
+}
+#endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+          !defined(SDL_DISABLE_IMMINTRIN_H) */


### PR DESCRIPTION
In some quick testing this seems to be between 2-6x faster than the current SSE2 version depending on the size of the blit. Obviously more and, better testing would be useful. Perhaps @itzpr3d4t0r would like to have a look with those fancy performance graphs they've bene using for ublits.

In my testing larger blits have bigger performance improvements as they can take better advantage of the parallelism.

--- 

This is intended for version 2.1.4 assuming the AVX2 versions of the special blendmodes in 2.1.3 don't have any issues once released into userland.

If I have a chance to fix up the ancient `.convert_alpha()` PR I think a good demo might be showing the performance difference between a bunch of alpha blits of the same image in 2.1.3 using the normal alpha blending, and then the exact same image converted to pre-multiplied format and blitted using this flag for hopefully some decent performance wins.