### PR TITLE
Fix controller build on SDL < 2.0.9

### DIFF
--- a/src_c/_sdl2/controller.c
+++ b/src_c/_sdl2/controller.c
@@ -709,6 +709,7 @@ static CYTHON_INLINE float __PYX_NAN() {
 #include <string.h>
 #include <stdio.h>
 #include "SDL.h"
+#include "../controllercompat.c"
 #include "../pygame.h"
 #ifdef _OPENMP
 #include <omp.h>
@@ -926,7 +927,7 @@ static const char *__pyx_f[] = {
 /*--- Type declarations ---*/
 struct __pyx_obj_6pygame_5_sdl2_10controller_Controller;
 
-/* "pygame/_sdl2/controller.pxd":104
+/* "pygame/_sdl2/controller.pxd":107
  * cdef void _controller_autoquit()
  * 
  * cdef class Controller:             # <<<<<<<<<<<<<<
@@ -5526,9 +5527,9 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   PyObject *__pyx_t_1 = NULL;
   PyObject *__pyx_t_2 = NULL;
   PyObject *__pyx_t_3 = NULL;
-  int __pyx_t_4;
-  long __pyx_t_5;
-  PyObject *__pyx_t_6 = NULL;
+  long __pyx_t_4;
+  PyObject *__pyx_t_5 = NULL;
+  int __pyx_t_6;
   double __pyx_t_7;
   double __pyx_t_8;
   Uint16 __pyx_t_9;
@@ -5545,7 +5546,7 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
  *         """
  *         _gamecontroller_init_check()             # <<<<<<<<<<<<<<
  *         self._CLOSEDCHECK()
- *         if not SDL_VERSION_ATLEAST(2, 0, 9):
+ * 
  */
   __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_gamecontroller_init_check); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 248, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
@@ -5570,8 +5571,8 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
  *         """
  *         _gamecontroller_init_check()
  *         self._CLOSEDCHECK()             # <<<<<<<<<<<<<<
- *         if not SDL_VERSION_ATLEAST(2, 0, 9):
- *             return False
+ * 
+ *         duration = max(duration, 0)
  */
   __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_CLOSEDCHECK); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
@@ -5592,58 +5593,27 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "pygame/_sdl2/controller.pyx":250
- *         _gamecontroller_init_check()
+  /* "pygame/_sdl2/controller.pyx":251
  *         self._CLOSEDCHECK()
- *         if not SDL_VERSION_ATLEAST(2, 0, 9):             # <<<<<<<<<<<<<<
- *             return False
- * 
- */
-  __pyx_t_4 = ((!(SDL_VERSION_ATLEAST(2, 0, 9) != 0)) != 0);
-  if (__pyx_t_4) {
-
-    /* "pygame/_sdl2/controller.pyx":251
- *         self._CLOSEDCHECK()
- *         if not SDL_VERSION_ATLEAST(2, 0, 9):
- *             return False             # <<<<<<<<<<<<<<
- * 
- *         duration = max(duration, 0)
- */
-    __Pyx_XDECREF(__pyx_r);
-    __Pyx_INCREF(Py_False);
-    __pyx_r = Py_False;
-    goto __pyx_L0;
-
-    /* "pygame/_sdl2/controller.pyx":250
- *         _gamecontroller_init_check()
- *         self._CLOSEDCHECK()
- *         if not SDL_VERSION_ATLEAST(2, 0, 9):             # <<<<<<<<<<<<<<
- *             return False
- * 
- */
-  }
-
-  /* "pygame/_sdl2/controller.pyx":253
- *             return False
  * 
  *         duration = max(duration, 0)             # <<<<<<<<<<<<<<
  *         low = min(max(low_frequency, 0.0), 1.0)
  *         high = min(max(high_frequency, 0.0), 1.0)
  */
-  __pyx_t_5 = 0;
+  __pyx_t_4 = 0;
   __Pyx_INCREF(__pyx_v_duration);
   __pyx_t_1 = __pyx_v_duration;
-  __pyx_t_3 = __Pyx_PyInt_From_long(__pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 253, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_From_long(__pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 251, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_6 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 253, __pyx_L1_error)
+  __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_GT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 251, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 253, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (__pyx_t_4) {
-    __pyx_t_6 = __Pyx_PyInt_From_long(__pyx_t_5); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 253, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_2 = __pyx_t_6;
-    __pyx_t_6 = 0;
+  __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 251, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  if (__pyx_t_6) {
+    __pyx_t_5 = __Pyx_PyInt_From_long(__pyx_t_4); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 251, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_2 = __pyx_t_5;
+    __pyx_t_5 = 0;
   } else {
     __Pyx_INCREF(__pyx_t_1);
     __pyx_t_2 = __pyx_t_1;
@@ -5655,7 +5625,7 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __Pyx_DECREF_SET(__pyx_v_duration, __pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "pygame/_sdl2/controller.pyx":254
+  /* "pygame/_sdl2/controller.pyx":252
  * 
  *         duration = max(duration, 0)
  *         low = min(max(low_frequency, 0.0), 1.0)             # <<<<<<<<<<<<<<
@@ -5666,14 +5636,14 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __pyx_t_8 = 0.0;
   __Pyx_INCREF(__pyx_v_low_frequency);
   __pyx_t_1 = __pyx_v_low_frequency;
-  __pyx_t_6 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 254, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_3 = PyObject_RichCompare(__pyx_t_6, __pyx_t_1, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 254, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 254, __pyx_L1_error)
+  __pyx_t_5 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 252, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_5);
+  __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_1, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 252, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 252, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (__pyx_t_4) {
-    __pyx_t_3 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 254, __pyx_L1_error)
+  if (__pyx_t_6) {
+    __pyx_t_3 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 252, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_t_2 = __pyx_t_3;
     __pyx_t_3 = 0;
@@ -5685,17 +5655,17 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __Pyx_INCREF(__pyx_t_2);
   __pyx_t_1 = __pyx_t_2;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 254, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 252, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_6 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 254, __pyx_L1_error)
+  __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 252, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 254, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (__pyx_t_4) {
-    __pyx_t_6 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 254, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_2 = __pyx_t_6;
-    __pyx_t_6 = 0;
+  __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 252, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  if (__pyx_t_6) {
+    __pyx_t_5 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 252, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_2 = __pyx_t_5;
+    __pyx_t_5 = 0;
   } else {
     __Pyx_INCREF(__pyx_t_1);
     __pyx_t_2 = __pyx_t_1;
@@ -5707,25 +5677,25 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __pyx_v_low = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "pygame/_sdl2/controller.pyx":255
+  /* "pygame/_sdl2/controller.pyx":253
  *         duration = max(duration, 0)
  *         low = min(max(low_frequency, 0.0), 1.0)
  *         high = min(max(high_frequency, 0.0), 1.0)             # <<<<<<<<<<<<<<
  * 
- *         return not SDL_GameControllerRumble(
+ *         return not PG_GameControllerRumble(
  */
   __pyx_t_7 = 1.0;
   __pyx_t_8 = 0.0;
   __Pyx_INCREF(__pyx_v_high_frequency);
   __pyx_t_1 = __pyx_v_high_frequency;
-  __pyx_t_6 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 255, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_3 = PyObject_RichCompare(__pyx_t_6, __pyx_t_1, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 255, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 255, __pyx_L1_error)
+  __pyx_t_5 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 253, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_5);
+  __pyx_t_3 = PyObject_RichCompare(__pyx_t_5, __pyx_t_1, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 253, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 253, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (__pyx_t_4) {
-    __pyx_t_3 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 255, __pyx_L1_error)
+  if (__pyx_t_6) {
+    __pyx_t_3 = PyFloat_FromDouble(__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 253, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_t_2 = __pyx_t_3;
     __pyx_t_3 = 0;
@@ -5737,17 +5707,17 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __Pyx_INCREF(__pyx_t_2);
   __pyx_t_1 = __pyx_t_2;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 255, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 253, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_6 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 255, __pyx_L1_error)
+  __pyx_t_5 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 253, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 255, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (__pyx_t_4) {
-    __pyx_t_6 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 255, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_2 = __pyx_t_6;
-    __pyx_t_6 = 0;
+  __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 253, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  if (__pyx_t_6) {
+    __pyx_t_5 = PyFloat_FromDouble(__pyx_t_7); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 253, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_2 = __pyx_t_5;
+    __pyx_t_5 = 0;
   } else {
     __Pyx_INCREF(__pyx_t_1);
     __pyx_t_2 = __pyx_t_1;
@@ -5759,40 +5729,40 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __pyx_v_high = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "pygame/_sdl2/controller.pyx":257
+  /* "pygame/_sdl2/controller.pyx":255
  *         high = min(max(high_frequency, 0.0), 1.0)
  * 
- *         return not SDL_GameControllerRumble(             # <<<<<<<<<<<<<<
+ *         return not PG_GameControllerRumble(             # <<<<<<<<<<<<<<
  *             self._controller, low * 0xFFFF, high * 0xFFFF, duration
  *         )
  */
   __Pyx_XDECREF(__pyx_r);
 
-  /* "pygame/_sdl2/controller.pyx":258
+  /* "pygame/_sdl2/controller.pyx":256
  * 
- *         return not SDL_GameControllerRumble(
+ *         return not PG_GameControllerRumble(
  *             self._controller, low * 0xFFFF, high * 0xFFFF, duration             # <<<<<<<<<<<<<<
  *         )
  * 
  */
-  __pyx_t_1 = PyNumber_Multiply(__pyx_v_low, __pyx_int_65535); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 258, __pyx_L1_error)
+  __pyx_t_1 = PyNumber_Multiply(__pyx_v_low, __pyx_int_65535); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 256, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_9 = __Pyx_PyInt_As_Uint16(__pyx_t_1); if (unlikely((__pyx_t_9 == ((Uint16)-1)) && PyErr_Occurred())) __PYX_ERR(0, 258, __pyx_L1_error)
+  __pyx_t_9 = __Pyx_PyInt_As_Uint16(__pyx_t_1); if (unlikely((__pyx_t_9 == ((Uint16)-1)) && PyErr_Occurred())) __PYX_ERR(0, 256, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = PyNumber_Multiply(__pyx_v_high, __pyx_int_65535); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 258, __pyx_L1_error)
+  __pyx_t_1 = PyNumber_Multiply(__pyx_v_high, __pyx_int_65535); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 256, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_10 = __Pyx_PyInt_As_Uint16(__pyx_t_1); if (unlikely((__pyx_t_10 == ((Uint16)-1)) && PyErr_Occurred())) __PYX_ERR(0, 258, __pyx_L1_error)
+  __pyx_t_10 = __Pyx_PyInt_As_Uint16(__pyx_t_1); if (unlikely((__pyx_t_10 == ((Uint16)-1)) && PyErr_Occurred())) __PYX_ERR(0, 256, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_11 = __Pyx_PyInt_As_Uint32(__pyx_v_duration); if (unlikely((__pyx_t_11 == ((Uint32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 258, __pyx_L1_error)
+  __pyx_t_11 = __Pyx_PyInt_As_Uint32(__pyx_v_duration); if (unlikely((__pyx_t_11 == ((Uint32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 256, __pyx_L1_error)
 
-  /* "pygame/_sdl2/controller.pyx":257
+  /* "pygame/_sdl2/controller.pyx":255
  *         high = min(max(high_frequency, 0.0), 1.0)
  * 
- *         return not SDL_GameControllerRumble(             # <<<<<<<<<<<<<<
+ *         return not PG_GameControllerRumble(             # <<<<<<<<<<<<<<
  *             self._controller, low * 0xFFFF, high * 0xFFFF, duration
  *         )
  */
-  __pyx_t_1 = __Pyx_PyBool_FromLong((!(SDL_GameControllerRumble(__pyx_v_self->_controller, __pyx_t_9, __pyx_t_10, __pyx_t_11) != 0))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 257, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyBool_FromLong((!(PG_GameControllerRumble(__pyx_v_self->_controller, __pyx_t_9, __pyx_t_10, __pyx_t_11) != 0))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 255, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -5811,7 +5781,7 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   __Pyx_XDECREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_3);
-  __Pyx_XDECREF(__pyx_t_6);
+  __Pyx_XDECREF(__pyx_t_5);
   __Pyx_AddTraceback("pygame._sdl2.controller.Controller.rumble", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -5823,7 +5793,7 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_26rumble(stru
   return __pyx_r;
 }
 
-/* "pygame/_sdl2/controller.pyx":261
+/* "pygame/_sdl2/controller.pyx":259
  *         )
  * 
  *     def stop_rumble(self):             # <<<<<<<<<<<<<<
@@ -5851,20 +5821,19 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_28stop_rumble
   PyObject *__pyx_t_1 = NULL;
   PyObject *__pyx_t_2 = NULL;
   PyObject *__pyx_t_3 = NULL;
-  int __pyx_t_4;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("stop_rumble", 0);
 
-  /* "pygame/_sdl2/controller.pyx":265
+  /* "pygame/_sdl2/controller.pyx":263
  *         Stop any rumble effect playing on the controller.
  *         """
  *         _gamecontroller_init_check()             # <<<<<<<<<<<<<<
  *         self._CLOSEDCHECK()
- *         if SDL_VERSION_ATLEAST(2, 0, 9):
+ *         PG_GameControllerRumble(self._controller, 0, 0, 1)
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_gamecontroller_init_check); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 265, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_gamecontroller_init_check); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 263, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_2))) {
@@ -5878,19 +5847,18 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_28stop_rumble
   }
   __pyx_t_1 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 265, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 263, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "pygame/_sdl2/controller.pyx":266
+  /* "pygame/_sdl2/controller.pyx":264
  *         """
  *         _gamecontroller_init_check()
  *         self._CLOSEDCHECK()             # <<<<<<<<<<<<<<
- *         if SDL_VERSION_ATLEAST(2, 0, 9):
- *             SDL_GameControllerRumble(self._controller, 0, 0, 1)
+ *         PG_GameControllerRumble(self._controller, 0, 0, 1)
  */
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_CLOSEDCHECK); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 266, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_CLOSEDCHECK); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 264, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -5904,36 +5872,19 @@ static PyObject *__pyx_pf_6pygame_5_sdl2_10controller_10Controller_28stop_rumble
   }
   __pyx_t_1 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 266, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 264, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "pygame/_sdl2/controller.pyx":267
+  /* "pygame/_sdl2/controller.pyx":265
  *         _gamecontroller_init_check()
  *         self._CLOSEDCHECK()
- *         if SDL_VERSION_ATLEAST(2, 0, 9):             # <<<<<<<<<<<<<<
- *             SDL_GameControllerRumble(self._controller, 0, 0, 1)
+ *         PG_GameControllerRumble(self._controller, 0, 0, 1)             # <<<<<<<<<<<<<<
  */
-  __pyx_t_4 = (SDL_VERSION_ATLEAST(2, 0, 9) != 0);
-  if (__pyx_t_4) {
+  (void)(PG_GameControllerRumble(__pyx_v_self->_controller, 0, 0, 1));
 
-    /* "pygame/_sdl2/controller.pyx":268
- *         self._CLOSEDCHECK()
- *         if SDL_VERSION_ATLEAST(2, 0, 9):
- *             SDL_GameControllerRumble(self._controller, 0, 0, 1)             # <<<<<<<<<<<<<<
- */
-    (void)(SDL_GameControllerRumble(__pyx_v_self->_controller, 0, 0, 1));
-
-    /* "pygame/_sdl2/controller.pyx":267
- *         _gamecontroller_init_check()
- *         self._CLOSEDCHECK()
- *         if SDL_VERSION_ATLEAST(2, 0, 9):             # <<<<<<<<<<<<<<
- *             SDL_GameControllerRumble(self._controller, 0, 0, 1)
- */
-  }
-
-  /* "pygame/_sdl2/controller.pyx":261
+  /* "pygame/_sdl2/controller.pyx":259
  *         )
  * 
  *     def stop_rumble(self):             # <<<<<<<<<<<<<<

--- a/src_c/controllercompat.c
+++ b/src_c/controllercompat.c
@@ -6,7 +6,7 @@
 #include <SDL.h>
 
 /*
- * Compat thing for controller (see https://github.com/pygame/pygame/pull/3270)
+ * Compat thing for controller (see https://github.com/pygame/pygame/pull/3272)
  */
 int
 PG_GameControllerRumble(SDL_GameController *gamecontroller,

--- a/src_c/controllercompat.c
+++ b/src_c/controllercompat.c
@@ -1,13 +1,11 @@
 /*
- * This file should not exist. If you exist in the future and are wondering if
- * this file is cool, it is not.
+ * Compat file specifically for controller (see https://github.com/pygame/pygame/pull/3272)
+ * we had trouble using pgcompat.c, because it would be included twice, or it would lead to
+ * flakiness on compilers, because of threads...
  */
 
 #include <SDL.h>
 
-/*
- * Compat thing for controller (see https://github.com/pygame/pygame/pull/3272)
- */
 int
 PG_GameControllerRumble(SDL_GameController *gamecontroller,
                         Uint16 low_frequency_rumble,
@@ -17,6 +15,7 @@ PG_GameControllerRumble(SDL_GameController *gamecontroller,
     return SDL_GameControllerRumble(gamecontroller, low_frequency_rumble,
                                     high_frequency_rumble, duration_ms);
 #else
+    SDL_SetError("pygame built without controller rumble support");
     return -1;
 #endif
 }

--- a/src_c/controllercompat.c
+++ b/src_c/controllercompat.c
@@ -1,7 +1,8 @@
 /*
- * Compat file specifically for controller (see https://github.com/pygame/pygame/pull/3272)
- * we had trouble using pgcompat.c, because it would be included twice, or it would lead to
- * flakiness on compilers, because of threads...
+ * Compat file specifically for controller (see
+ * https://github.com/pygame/pygame/pull/3272) we had trouble using pgcompat.c,
+ * because it would be included twice, or it would lead to flakiness on
+ * compilers, because of threads...
  */
 
 #include <SDL.h>

--- a/src_c/controllercompat.c
+++ b/src_c/controllercompat.c
@@ -1,0 +1,22 @@
+/*
+ * This file should not exist. If you exist in the future and are wondering if
+ * this file is cool, it is not.
+ */
+
+#include <SDL.h>
+
+/*
+ * Compat thing for controller (see https://github.com/pygame/pygame/pull/3270)
+ */
+int
+PG_GameControllerRumble(SDL_GameController *gamecontroller,
+                        Uint16 low_frequency_rumble,
+                        Uint16 high_frequency_rumble, Uint32 duration_ms)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+    return SDL_GameControllerRumble(gamecontroller, low_frequency_rumble,
+                                    high_frequency_rumble, duration_ms);
+#else
+    return -1;
+#endif
+}

--- a/src_c/cython/pygame/_sdl2/controller.pxd
+++ b/src_c/cython/pygame/_sdl2/controller.pxd
@@ -94,9 +94,12 @@ cdef extern from "SDL.h" nogil:
 
     SDL_bool SDL_IsGameController(int joystick_index)
     SDL_JoystickGUID SDL_JoystickGetGUID(SDL_Joystick* joystick)
-    int SDL_GameControllerRumble(SDL_GameController *gamecontroller,
-                                 Uint16 low_frequency_rumble, Uint16 high_frequency_rumble,
-                                 Uint32 duration_ms)
+
+cdef extern from "../controllercompat.c" nogil:
+    int PG_GameControllerRumble(SDL_GameController *gamecontroller,
+                                Uint16 low_frequency_rumble,
+                                Uint16 high_frequency_rumble,
+                                Uint32 duration_ms)
 
 cdef bint _controller_autoinit()
 cdef void _controller_autoquit()

--- a/src_c/cython/pygame/_sdl2/controller.pyx
+++ b/src_c/cython/pygame/_sdl2/controller.pyx
@@ -247,14 +247,12 @@ cdef class Controller:
         """
         _gamecontroller_init_check()
         self._CLOSEDCHECK()
-        if not SDL_VERSION_ATLEAST(2, 0, 9):
-            return False
-
+        
         duration = max(duration, 0)
         low = min(max(low_frequency, 0.0), 1.0)
         high = min(max(high_frequency, 0.0), 1.0)
 
-        return not SDL_GameControllerRumble(
+        return not PG_GameControllerRumble(
             self._controller, low * 0xFFFF, high * 0xFFFF, duration
         )
 
@@ -264,5 +262,4 @@ cdef class Controller:
         """
         _gamecontroller_init_check()
         self._CLOSEDCHECK()
-        if SDL_VERSION_ATLEAST(2, 0, 9):
-            SDL_GameControllerRumble(self._controller, 0, 0, 1)
+        PG_GameControllerRumble(self._controller, 0, 0, 1)


### PR DESCRIPTION
Continuation from #3238 

Cliffnotes version:
We (Emc and I) realized pygame won't build on 2.0.8 (except on gcc ubuntu runner, because weird optimizations), because of this controller function.
It took me like 6 different attempts, over 2 weeks, and many hours of CI time, but I finally have something that works on my computer and the test runners.

This will support my other PR to get pygame to better realize its legacy SDL version support, and it will support Emc's FRect PR (by allowing him to easily test on SDL 2.0.8, which is relevant to FRect).