### PR TITLE
pygame.draw.polygons() function

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -22,6 +22,10 @@ def polygon(
     points: Sequence[Coordinate],
     width: int = 0,
 ) -> Rect: ...
+def polygons(
+        surface: Surface,
+        draw_sequence: Sequence[Tuple[Sequence[Coordinate], ColorValue, Optional[int]]]
+) -> None: ...
 def circle(
     surface: Surface,
     color: ColorValue,

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -148,6 +148,40 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    .. ## pygame.draw.polygon ##
 
+.. function:: polygons
+
+   | :sl:`draw a sequence of polygons on a surface`
+   | :sg:`polygons(surface, draw_sequence) -> None`
+
+   Draws a sequence of polygons on the given surface.
+
+   :param surface: the surface to draw the polygons on
+   :param draw_sequence: a sequence of (points, color, width) where:
+
+        - points: a sequence of 3 or more (x, y) coordinates that make up the vertices
+                  of the polygon, each *coordinate* in the sequence must be a
+                  tuple/list/:class:`pygame.math.Vector2` of 2 ints/floats,
+                  e.g. ``[(x1, y1), (x2, y2), (x3, y3)]``
+
+        - color: the color to draw the polygon with, the alpha value is optional if
+                 using a tuple ``(RGB[A])``
+
+        - width(optional): indicates the thickness of the polygon (default=0)
+                           | if width == 0, fill the polygon
+                           | if width > 0, used for line thickness
+                           | if width < 0, nothing will be drawn
+
+   :returns: always returns `None`
+   :rtype: None
+
+   .. note:: Takes positional only arguments in the order: surface, draw_sequence
+
+   :raises ValueError: if ``len(points) < 3`` (must have at least 3 points)
+   :raises TypeError: if ``points`` is not a sequence or ``points`` does not
+      contain number pairs
+
+   .. ## pygame.draw.polygons ##
+
 .. function:: circle
 
    | :sl:`draw a circle`

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -2,6 +2,7 @@
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
 #define DOC_PYGAMEDRAWRECT "rect(surface, color, rect) -> Rect\nrect(surface, color, rect, width=0, border_radius=0, border_top_left_radius=-1, border_top_right_radius=-1, border_bottom_left_radius=-1, border_bottom_right_radius=-1) -> Rect\ndraw a rectangle"
 #define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
+#define DOC_PYGAMEDRAWPOLYGONS "polygons(surface, draw_sequence) -> None\ndraw a sequence of polygons on a surface"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface, color, center, radius) -> Rect\ncircle(surface, color, center, radius, width=0, draw_top_right=None, draw_top_left=None, draw_bottom_left=None, draw_bottom_right=None) -> Rect\ndraw a circle"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
 #define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
@@ -27,6 +28,10 @@ pygame.draw.polygon
  polygon(surface, color, points) -> Rect
  polygon(surface, color, points, width=0) -> Rect
 draw a polygon
+
+pygame.draw.polygons
+ polygons(surface, draw_sequence) -> None
+draw a sequence of polygons on a surface
 
 pygame.draw.circle
  circle(surface, color, center, radius) -> Rect


### PR DESCRIPTION
Implements one of #3269. Follows #3324.
This one implements the `polygons()` function for drawing many polygons at once. The function's use case should be heterogeneous polygon sequences, with both hollow and filled ones of different scales and colors.