### PR TITLE
Remove deprecated blend argument from test and docs

### DIFF
--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -401,7 +401,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw a straight antialiased line`
    | :sg:`aaline(surface, color, start_pos, end_pos) -> Rect`
-   | :sg:`aaline(surface, color, start_pos, end_pos, blend=1) -> Rect`
 
    Draws a straight antialiased line on the given surface.
 
@@ -489,8 +488,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :param end_pos: end position of the line, (x, y)
    :type end_pos: tuple(int or float, int or float) or
       list(int or float, int or float) or Vector2(int or float, int or float)
-   :param int blend: (optional) if non-zero (default) the line will be blended
-      with the surface's existing pixel shades, otherwise it will overwrite them
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the ``start_pos`` parameter value (float
@@ -508,7 +505,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw multiple contiguous straight antialiased line segments`
    | :sg:`aalines(surface, color, closed, points) -> Rect`
-   | :sg:`aalines(surface, color, closed, points, blend=1) -> Rect`
 
    Draws a sequence of contiguous straight antialiased lines on the given
    surface.
@@ -528,9 +524,6 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       additionally if the ``closed`` parameter is ``True`` another line segment
       will be drawn from ``(x3, y3)`` to ``(x1, y1)``
    :type points: tuple(coordinate) or list(coordinate)
-   :param int blend: (optional) if non-zero (default) each line will be blended
-      with the surface's existing pixel shades, otherwise the pixels will be
-      overwritten
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the first point in the

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -401,6 +401,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw a straight antialiased line`
    | :sg:`aaline(surface, color, start_pos, end_pos) -> Rect`
+   | :sg:`aaline(surface, color, start_pos, end_pos, blend=1) -> Rect`
 
    Draws a straight antialiased line on the given surface.
 
@@ -488,6 +489,8 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
    :param end_pos: end position of the line, (x, y)
    :type end_pos: tuple(int or float, int or float) or
       list(int or float, int or float) or Vector2(int or float, int or float)
+   :param int blend: (optional) (deprecated) if non-zero (default) the line will be blended
+      with the surface's existing pixel shades, otherwise it will overwrite them
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the ``start_pos`` parameter value (float
@@ -505,6 +508,7 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    | :sl:`draw multiple contiguous straight antialiased line segments`
    | :sg:`aalines(surface, color, closed, points) -> Rect`
+   | :sg:`aalines(surface, color, closed, points, blend=1) -> Rect`
 
    Draws a sequence of contiguous straight antialiased lines on the given
    surface.
@@ -524,6 +528,9 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
       additionally if the ``closed`` parameter is ``True`` another line segment
       will be drawn from ``(x3, y3)`` to ``(x1, y1)``
    :type points: tuple(coordinate) or list(coordinate)
+   :param int blend: (optional) (deprecated) if non-zero (default) each line will be blended
+      with the surface's existing pixel shades, otherwise the pixels will be
+      overwritten
 
    :returns: a rect bounding the changed pixels, if nothing is drawn the
       bounding rect's position will be the position of the first point in the

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2463,20 +2463,12 @@ class AALineMixin(BaseLineMixin):
 
     def test_aaline__kwargs(self):
         """Ensures draw aaline accepts the correct kwargs
-        with and without a blend arg.
         """
         surface = pygame.Surface((4, 4))
         color = pygame.Color("yellow")
         start_pos = (1, 1)
         end_pos = (2, 2)
         kwargs_list = [
-            {
-                "surface": surface,
-                "color": color,
-                "start_pos": start_pos,
-                "end_pos": end_pos,
-                "blend": 1,
-            },
             {
                 "surface": surface,
                 "color": color,
@@ -2495,7 +2487,6 @@ class AALineMixin(BaseLineMixin):
         bounds_rect = self.draw_aaline(
             start_pos=(1, 2),
             end_pos=(2, 1),
-            blend=1,
             color=(10, 20, 30),
             surface=pygame.Surface((3, 2)),
         )
@@ -2526,7 +2517,6 @@ class AALineMixin(BaseLineMixin):
             "color": pygame.Color("red"),
             "start_pos": (2, 1),
             "end_pos": (2, 2),
-            "blend": 1,
         }
 
         for name in ("end_pos", "start_pos", "color", "surface"):
@@ -2542,10 +2532,6 @@ class AALineMixin(BaseLineMixin):
         color = pygame.Color("blue")
         start_pos = (0, 1)
         end_pos = (1, 2)
-
-        with self.assertRaises(TypeError):
-            # Invalid blend.
-            bounds_rect = self.draw_aaline(surface, color, start_pos, end_pos, "1")
 
         with self.assertRaises(TypeError):
             # Invalid end_pos.
@@ -2569,44 +2555,32 @@ class AALineMixin(BaseLineMixin):
         color = pygame.Color("green")
         start_pos = (1, 0)
         end_pos = (2, 0)
-        blend = 1
         kwargs_list = [
             {
                 "surface": pygame.Surface,  # Invalid surface.
                 "color": color,
                 "start_pos": start_pos,
                 "end_pos": end_pos,
-                "blend": blend,
             },
             {
                 "surface": surface,
                 "color": 2.3,  # Invalid color.
                 "start_pos": start_pos,
                 "end_pos": end_pos,
-                "blend": blend,
             },
             {
                 "surface": surface,
                 "color": color,
                 "start_pos": (0, 0, 0),  # Invalid start_pos.
                 "end_pos": end_pos,
-                "blend": blend,
             },
             {
                 "surface": surface,
                 "color": color,
                 "start_pos": start_pos,
                 "end_pos": (0,),  # Invalid end_pos.
-                "blend": blend,
             },
-            {
-                "surface": surface,
-                "color": color,
-                "start_pos": start_pos,
-                "end_pos": end_pos,
-                "blend": 1.2,
-            },
-        ]  # Invalid blend.
+        ]
 
         for kwargs in kwargs_list:
             with self.assertRaises(TypeError):
@@ -2624,7 +2598,6 @@ class AALineMixin(BaseLineMixin):
                 "color": color,
                 "start_pos": start_pos,
                 "end_pos": end_pos,
-                "blend": 1,
                 "invalid": 1,
             },
             {
@@ -2646,16 +2619,14 @@ class AALineMixin(BaseLineMixin):
         color = (255, 255, 0, 0)
         start_pos = (0, 1)
         end_pos = (1, 2)
-        blend = 0
         kwargs = {
             "surface": surface,
             "color": color,
             "start_pos": start_pos,
             "end_pos": end_pos,
-            "blend": blend,
         }
 
-        for name in ("surface", "color", "start_pos", "end_pos", "blend"):
+        for name in ("surface", "color", "start_pos", "end_pos"):
             kwargs.pop(name)
 
             if "surface" == name:
@@ -2670,32 +2641,9 @@ class AALineMixin(BaseLineMixin):
                 )
             else:
                 bounds_rect = self.draw_aaline(
-                    surface, color, start_pos, end_pos, blend, **kwargs
+                    surface, color, start_pos, end_pos, **kwargs
                 )
 
-            self.assertIsInstance(bounds_rect, pygame.Rect)
-
-    def test_aaline__valid_blend_values(self):
-        """Ensures draw aaline accepts different blend values."""
-        expected_color = pygame.Color("yellow")
-        surface_color = pygame.Color("white")
-        surface = pygame.Surface((3, 4))
-        pos = (2, 1)
-        kwargs = {
-            "surface": surface,
-            "color": expected_color,
-            "start_pos": pos,
-            "end_pos": (2, 2),
-            "blend": None,
-        }
-
-        for blend in (-10, -2, -1, 0, 1, 2, 10):
-            surface.fill(surface_color)  # Clear for each test.
-            kwargs["blend"] = blend
-
-            bounds_rect = self.draw_aaline(**kwargs)
-
-            self.assertEqual(surface.get_at(pos), expected_color)
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
     def test_aaline__valid_start_pos_formats(self):
@@ -2708,7 +2656,6 @@ class AALineMixin(BaseLineMixin):
             "color": expected_color,
             "start_pos": None,
             "end_pos": (2, 2),
-            "blend": 0,
         }
         x, y = 2, 1  # start position
         positions = ((x, y), (x + 0.01, y), (x, y + 0.01), (x + 0.01, y + 0.01))
@@ -2737,7 +2684,6 @@ class AALineMixin(BaseLineMixin):
             "color": expected_color,
             "start_pos": (2, 1),
             "end_pos": None,
-            "blend": 0,
         }
         x, y = 2, 2  # end position
         positions = ((x, y), (x + 0.02, y), (x, y + 0.02), (x + 0.02, y + 0.02))
@@ -2763,7 +2709,6 @@ class AALineMixin(BaseLineMixin):
             "color": pygame.Color("red"),
             "start_pos": None,
             "end_pos": (2, 2),
-            "blend": 0,
         }
 
         start_pos_fmts = (
@@ -2787,7 +2732,6 @@ class AALineMixin(BaseLineMixin):
             "color": pygame.Color("red"),
             "start_pos": (2, 2),
             "end_pos": None,
-            "blend": 0,
         }
 
         end_pos_fmts = (
@@ -2815,7 +2759,6 @@ class AALineMixin(BaseLineMixin):
             "color": None,
             "start_pos": pos,
             "end_pos": (2, 1),
-            "blend": 0,
         }
         greens = (
             (0, 255, 0),
@@ -2845,7 +2788,6 @@ class AALineMixin(BaseLineMixin):
             "color": None,
             "start_pos": (1, 1),
             "end_pos": (2, 1),
-            "blend": 0,
         }
 
         for expected_color in (2.3, self):
@@ -2880,8 +2822,7 @@ class AALineMixin(BaseLineMixin):
     def test_aaline__bounding_rect(self):
         """Ensures draw aaline returns the correct bounding rect.
 
-        Tests lines with endpoints on and off the surface and blending
-        enabled and disabled.
+        Tests lines with endpoints on and off the surface.
         """
         line_color = pygame.Color("red")
         surf_color = pygame.Color("blue")
@@ -2900,19 +2841,18 @@ class AALineMixin(BaseLineMixin):
             for pos in rect_corners_mids_and_center(surf_rect):
                 helper_rect.center = pos
 
-                for blend in (False, True):  # Test non-blending and blending.
-                    for start, end in self._rect_lines(helper_rect):
-                        surface.fill(surf_color)  # Clear for each test.
+                for start, end in self._rect_lines(helper_rect):
+                    surface.fill(surf_color)  # Clear for each test.
 
-                        bounding_rect = self.draw_aaline(
-                            surface, line_color, start, end, blend
-                        )
+                    bounding_rect = self.draw_aaline(
+                        surface, line_color, start, end
+                    )
 
-                        # Calculating the expected_rect after the line is
-                        # drawn (it uses what is actually drawn).
-                        expected_rect = create_bounding_rect(surface, surf_color, start)
+                    # Calculating the expected_rect after the line is
+                    # drawn (it uses what is actually drawn).
+                    expected_rect = create_bounding_rect(surface, surf_color, start)
 
-                        self.assertEqual(bounding_rect, expected_rect)
+                    self.assertEqual(bounding_rect, expected_rect)
 
     def test_aaline__surface_clip(self):
         """Ensures draw aaline respects a surface's clip area."""
@@ -2931,41 +2871,40 @@ class AALineMixin(BaseLineMixin):
         for center in rect_corners_mids_and_center(clip_rect):
             pos_rect.center = center
 
-            for blend in (0, 1):  # Test non-blending and blending.
-                # Get the expected points by drawing the aaline without the
-                # clip area set.
-                surface.set_clip(None)
-                surface.fill(surface_color)
-                self.draw_aaline(
-                    surface, aaline_color, pos_rect.midtop, pos_rect.midbottom, blend
-                )
+            # Get the expected points by drawing the aaline without the
+            # clip area set.
+            surface.set_clip(None)
+            surface.fill(surface_color)
+            self.draw_aaline(
+                surface, aaline_color, pos_rect.midtop, pos_rect.midbottom
+            )
 
-                # Need to get the points that are NOT surface_color due to the
-                # way blend=0 uses the color black to antialias.
-                expected_pts = get_color_points(
-                    surface, surface_color, clip_rect, False
-                )
+            # Need to get the points that are NOT surface_color due to the
+            # way blend=0 uses the color black to antialias.
+            expected_pts = get_color_points(
+                surface, surface_color, clip_rect, False
+            )
 
-                # Clear the surface and set the clip area. Redraw the aaline
-                # and check that only the clip area is modified.
-                surface.fill(surface_color)
-                surface.set_clip(clip_rect)
+            # Clear the surface and set the clip area. Redraw the aaline
+            # and check that only the clip area is modified.
+            surface.fill(surface_color)
+            surface.set_clip(clip_rect)
 
-                self.draw_aaline(
-                    surface, aaline_color, pos_rect.midtop, pos_rect.midbottom, blend
-                )
+            self.draw_aaline(
+                surface, aaline_color, pos_rect.midtop, pos_rect.midbottom
+            )
 
-                surface.lock()  # For possible speed up.
+            surface.lock()  # For possible speed up.
 
-                # Check all the surface points to ensure the expected_pts
-                # are not surface_color.
-                for pt in ((x, y) for x in range(surfw) for y in range(surfh)):
-                    if pt in expected_pts:
-                        self.assertNotEqual(surface.get_at(pt), surface_color, pt)
-                    else:
-                        self.assertEqual(surface.get_at(pt), surface_color, pt)
+            # Check all the surface points to ensure the expected_pts
+            # are not surface_color.
+            for pt in ((x, y) for x in range(surfw) for y in range(surfh)):
+                if pt in expected_pts:
+                    self.assertNotEqual(surface.get_at(pt), surface_color, pt)
+                else:
+                    self.assertEqual(surface.get_at(pt), surface_color, pt)
 
-                surface.unlock()
+            surface.unlock()
 
 
 # Commented out to avoid cluttering the test output. Add back in if draw_py
@@ -3317,7 +3256,6 @@ class AALinesMixin(BaseLineMixin):
         bounds_rect = self.draw_aalines(
             closed=1,
             points=((0, 0), (1, 1), (2, 2)),
-            blend=1,
             color=(10, 20, 30),
             surface=pygame.Surface((3, 2)),
         )
@@ -3422,7 +3360,6 @@ class AALinesMixin(BaseLineMixin):
                 "color": color,
                 "closed": closed,
                 "points": points,
-                "blend": 1,
                 "invalid": 1,
             },
             {
@@ -3444,16 +3381,14 @@ class AALinesMixin(BaseLineMixin):
         color = (255, 255, 0, 0)
         closed = 0
         points = ((1, 2), (2, 1))
-        blend = 1
         kwargs = {
             "surface": surface,
             "color": color,
             "closed": closed,
             "points": points,
-            "blend": blend,
         }
 
-        for name in ("surface", "color", "closed", "points", "blend"):
+        for name in ("surface", "color", "closed", "points"):
             kwargs.pop(name)
 
             if "surface" == name:
@@ -3468,33 +3403,11 @@ class AALinesMixin(BaseLineMixin):
                 )
             else:
                 bounds_rect = self.draw_aalines(
-                    surface, color, closed, points, blend, **kwargs
+                    surface, color, closed, points, **kwargs
                 )
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
 
-    def test_aalines__valid_blend_values(self):
-        """Ensures draw aalines accepts different blend values."""
-        expected_color = pygame.Color("yellow")
-        surface_color = pygame.Color("white")
-        surface = pygame.Surface((3, 4))
-        pos = (1, 1)
-        kwargs = {
-            "surface": surface,
-            "color": expected_color,
-            "closed": False,
-            "points": (pos, (1, 3)),
-            "blend": None,
-        }
-
-        for blend in (-10, -2, -1, 0, 1, 2, 10):
-            surface.fill(surface_color)  # Clear for each test.
-            kwargs["blend"] = blend
-
-            bounds_rect = self.draw_aalines(**kwargs)
-
-            self.assertEqual(surface.get_at(pos), expected_color, blend)
-            self.assertIsInstance(bounds_rect, pygame.Rect)
 
     def test_aalines__valid_points_format(self):
         """Ensures draw aalines accepts different points formats."""
@@ -3506,7 +3419,6 @@ class AALinesMixin(BaseLineMixin):
             "color": expected_color,
             "closed": False,
             "points": None,
-            "blend": 0,
         }
 
         # The point type can be a tuple/list/Vector2.
@@ -3547,7 +3459,6 @@ class AALinesMixin(BaseLineMixin):
             "color": pygame.Color("red"),
             "closed": False,
             "points": None,
-            "blend": 1,
         }
 
         points_fmts = (
@@ -3573,7 +3484,6 @@ class AALinesMixin(BaseLineMixin):
             "color": pygame.Color("red"),
             "closed": False,
             "points": None,
-            "blend": 1,
         }
 
         for points in ([], ((1, 1),)):  # Too few points.
@@ -3594,7 +3504,6 @@ class AALinesMixin(BaseLineMixin):
             "color": line_color,
             "closed": None,
             "points": ((1, 1), (4, 1), (4, 4), (1, 4)),
-            "blend": 0,
         }
 
         true_values = (-7, 1, 10, "2", 3.1, (4,), [5], True)
@@ -3621,7 +3530,6 @@ class AALinesMixin(BaseLineMixin):
             "color": None,
             "closed": False,
             "points": (pos, (2, 1)),
-            "blend": 0,
         }
         greens = (
             (0, 255, 0),
@@ -3651,7 +3559,6 @@ class AALinesMixin(BaseLineMixin):
             "color": None,
             "closed": False,
             "points": ((1, 1), (1, 2)),
-            "blend": 0,
         }
 
         for expected_color in (2.3, self):
@@ -3714,19 +3621,18 @@ class AALinesMixin(BaseLineMixin):
                 pts = (pos_rect.midleft, pos_rect.midtop, pos_rect.midright)
                 pos = pts[0]  # Rect position if nothing drawn.
 
-                for blend in (False, True):  # Test non-blending and blending.
-                    for closed in (True, False):
-                        surface.fill(surf_color)  # Clear for each test.
+                for closed in (True, False):
+                    surface.fill(surf_color)  # Clear for each test.
 
-                        bounding_rect = self.draw_aalines(
-                            surface, line_color, closed, pts, blend
-                        )
+                    bounding_rect = self.draw_aalines(
+                        surface, line_color, closed, pts
+                    )
 
-                        # Calculating the expected_rect after the lines are
-                        # drawn (it uses what is actually drawn).
-                        expected_rect = create_bounding_rect(surface, surf_color, pos)
+                    # Calculating the expected_rect after the lines are
+                    # drawn (it uses what is actually drawn).
+                    expected_rect = create_bounding_rect(surface, surf_color, pos)
 
-                        self.assertEqual(bounding_rect, expected_rect)
+                    self.assertEqual(bounding_rect, expected_rect)
 
     def test_aalines__surface_clip(self):
         """Ensures draw aalines respects a surface's clip area."""
@@ -3745,39 +3651,38 @@ class AALinesMixin(BaseLineMixin):
         for center in rect_corners_mids_and_center(clip_rect):
             pos_rect.center = center
             pts = (pos_rect.midtop, pos_rect.center, pos_rect.midbottom)
-
             for closed in (True, False):  # Test closed and not closed.
-                for blend in (0, 1):  # Test non-blending and blending.
-                    # Get the expected points by drawing the aalines without
-                    # the clip area set.
-                    surface.set_clip(None)
-                    surface.fill(surface_color)
-                    self.draw_aalines(surface, aaline_color, closed, pts, blend)
+                # Get the expected points by drawing the aalines without
+                # the clip area set.
+                surface.set_clip(None)
+                surface.fill(surface_color)
+                self.draw_aalines(surface, aaline_color, closed, pts)
+    
 
-                    # Need to get the points that are NOT surface_color due to
-                    # the way blend=0 uses the color black to antialias.
-                    expected_pts = get_color_points(
-                        surface, surface_color, clip_rect, False
-                    )
+                # Need to get the points that are NOT surface_color due to
+                # the way blend=0 uses the color black to antialias.
+                expected_pts = get_color_points(
+                    surface, surface_color, clip_rect, False
+                )
 
-                    # Clear the surface and set the clip area. Redraw the
-                    # aalines and check that only the clip area is modified.
-                    surface.fill(surface_color)
-                    surface.set_clip(clip_rect)
+                # Clear the surface and set the clip area. Redraw the
+                # aalines and check that only the clip area is modified.
+                surface.fill(surface_color)
+                surface.set_clip(clip_rect)
 
-                    self.draw_aalines(surface, aaline_color, closed, pts, blend)
+                self.draw_aalines(surface, aaline_color, closed, pts)
 
-                    surface.lock()  # For possible speed up.
+                surface.lock()  # For possible speed up.
 
-                    # Check all the surface points to ensure the expected_pts
-                    # are not surface_color.
-                    for pt in ((x, y) for x in range(surfw) for y in range(surfh)):
-                        if pt in expected_pts:
-                            self.assertNotEqual(surface.get_at(pt), surface_color, pt)
-                        else:
-                            self.assertEqual(surface.get_at(pt), surface_color, pt)
+                # Check all the surface points to ensure the expected_pts
+                # are not surface_color.
+                for pt in ((x, y) for x in range(surfw) for y in range(surfh)):
+                    if pt in expected_pts:
+                        self.assertNotEqual(surface.get_at(pt), surface_color, pt)
+                    else:
+                        self.assertEqual(surface.get_at(pt), surface_color, pt)
 
-                    surface.unlock()
+                surface.unlock()
 
 
 # Commented out to avoid cluttering the test output. Add back in if draw_py

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2462,8 +2462,7 @@ class AALineMixin(BaseLineMixin):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_aaline__kwargs(self):
-        """Ensures draw aaline accepts the correct kwargs
-        """
+        """Ensures draw aaline accepts the correct kwargs"""
         surface = pygame.Surface((4, 4))
         color = pygame.Color("yellow")
         start_pos = (1, 1)
@@ -2844,9 +2843,7 @@ class AALineMixin(BaseLineMixin):
                 for start, end in self._rect_lines(helper_rect):
                     surface.fill(surf_color)  # Clear for each test.
 
-                    bounding_rect = self.draw_aaline(
-                        surface, line_color, start, end
-                    )
+                    bounding_rect = self.draw_aaline(surface, line_color, start, end)
 
                     # Calculating the expected_rect after the line is
                     # drawn (it uses what is actually drawn).
@@ -2875,22 +2872,16 @@ class AALineMixin(BaseLineMixin):
             # clip area set.
             surface.set_clip(None)
             surface.fill(surface_color)
-            self.draw_aaline(
-                surface, aaline_color, pos_rect.midtop, pos_rect.midbottom
-            )
+            self.draw_aaline(surface, aaline_color, pos_rect.midtop, pos_rect.midbottom)
 
-            expected_pts = get_color_points(
-                surface, surface_color, clip_rect, False
-            )
+            expected_pts = get_color_points(surface, surface_color, clip_rect, False)
 
             # Clear the surface and set the clip area. Redraw the aaline
             # and check that only the clip area is modified.
             surface.fill(surface_color)
             surface.set_clip(clip_rect)
 
-            self.draw_aaline(
-                surface, aaline_color, pos_rect.midtop, pos_rect.midbottom
-            )
+            self.draw_aaline(surface, aaline_color, pos_rect.midtop, pos_rect.midbottom)
 
             surface.lock()  # For possible speed up.
 
@@ -3227,18 +3218,12 @@ class AALinesMixin(BaseLineMixin):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_aalines__kwargs(self):
-        """Ensures draw aalines accepts the correct kwargs.
-        """
+        """Ensures draw aalines accepts the correct kwargs."""
         surface = pygame.Surface((4, 4))
         color = pygame.Color("yellow")
         points = ((0, 0), (1, 1), (2, 2))
         kwargs_list = [
-            {
-                "surface": surface,
-                "color": color,
-                "closed": False,
-                "points": points
-            },
+            {"surface": surface, "color": color, "closed": False, "points": points},
         ]
 
         for kwargs in kwargs_list:
@@ -3399,7 +3384,6 @@ class AALinesMixin(BaseLineMixin):
                 )
 
             self.assertIsInstance(bounds_rect, pygame.Rect)
-
 
     def test_aalines__valid_points_format(self):
         """Ensures draw aalines accepts different points formats."""
@@ -3616,9 +3600,7 @@ class AALinesMixin(BaseLineMixin):
                 for closed in (True, False):
                     surface.fill(surf_color)  # Clear for each test.
 
-                    bounding_rect = self.draw_aalines(
-                        surface, line_color, closed, pts
-                    )
+                    bounding_rect = self.draw_aalines(surface, line_color, closed, pts)
 
                     # Calculating the expected_rect after the lines are
                     # drawn (it uses what is actually drawn).
@@ -3649,7 +3631,7 @@ class AALinesMixin(BaseLineMixin):
                 surface.set_clip(None)
                 surface.fill(surface_color)
                 self.draw_aalines(surface, aaline_color, closed, pts)
-    
+
                 expected_pts = get_color_points(
                     surface, surface_color, clip_rect, False
                 )

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -3229,8 +3229,7 @@ class AALinesMixin(BaseLineMixin):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
     def test_aalines__kwargs(self):
-        """Ensures draw aalines accepts the correct kwargs
-        with and without a blend arg.
+        """Ensures draw aalines accepts the correct kwargs.
         """
         surface = pygame.Surface((4, 4))
         color = pygame.Color("yellow")
@@ -3240,10 +3239,8 @@ class AALinesMixin(BaseLineMixin):
                 "surface": surface,
                 "color": color,
                 "closed": False,
-                "points": points,
-                "blend": 1,
+                "points": points
             },
-            {"surface": surface, "color": color, "closed": False, "points": points},
         ]
 
         for kwargs in kwargs_list:
@@ -3286,7 +3283,6 @@ class AALinesMixin(BaseLineMixin):
             "color": pygame.Color("red"),
             "closed": 1,
             "points": ((2, 2), (1, 1)),
-            "blend": 1,
         }
 
         for name in ("points", "closed", "color", "surface"):
@@ -3330,7 +3326,6 @@ class AALinesMixin(BaseLineMixin):
             "color": pygame.Color("green"),
             "closed": False,
             "points": ((1, 2), (2, 1)),
-            "blend": 1,
         }
 
         invalid_kwargs = {
@@ -3338,10 +3333,9 @@ class AALinesMixin(BaseLineMixin):
             "color": 2.3,
             "closed": InvalidBool(),
             "points": (0, 0, 0),
-            "blend": 1.2,
         }
 
-        for kwarg in ("surface", "color", "closed", "points", "blend"):
+        for kwarg in ("surface", "color", "closed", "points"):
             kwargs = dict(valid_kwargs)
             kwargs[kwarg] = invalid_kwargs[kwarg]
 

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -2879,8 +2879,6 @@ class AALineMixin(BaseLineMixin):
                 surface, aaline_color, pos_rect.midtop, pos_rect.midbottom
             )
 
-            # Need to get the points that are NOT surface_color due to the
-            # way blend=0 uses the color black to antialias.
             expected_pts = get_color_points(
                 surface, surface_color, clip_rect, False
             )
@@ -3652,9 +3650,6 @@ class AALinesMixin(BaseLineMixin):
                 surface.fill(surface_color)
                 self.draw_aalines(surface, aaline_color, closed, pts)
     
-
-                # Need to get the points that are NOT surface_color due to
-                # the way blend=0 uses the color black to antialias.
                 expected_pts = get_color_points(
                     surface, surface_color, clip_rect, False
                 )


### PR DESCRIPTION
Fixes #3250.

Removes`blend` argument from all calls to 'draw.aaline' and 'draw.aalines'. Also removes unit tests focused solely on this argument, and so don't make sense anymore. The unit tests using the `blend` argument now pass without deprecation warnings. The function generating these deprecation warnings is still present in the code and may be removed once the `blend` argument is removed (in 2.2).

Removes all mentions of the `blend` argument in the docs. 