### PR TITLE
rblit(), a raw blit only function

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -59,6 +59,12 @@ class Surface:
         area: Optional[RectValue] = None,
         special_flags: int = 0,
     ) -> Rect: ...
+    def rblit(
+            self,
+            source: Surface,
+            dest: Union[Coordinate, RectValue],
+            special_flags: int=0, /
+    ) -> None: ...
     def blits(
         self,
         blit_sequence: Sequence[

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -130,6 +130,33 @@
 
       .. ## Surface.blit ##
 
+   .. method:: rblit
+
+      | :sl:`draw one full image onto another, with no rect being returned`
+      | :sg:`rblit(source, dest, special_flags=0) -> None`
+
+      Draws a source Surface onto this Surface. The draw can be positioned with
+      the dest argument. The dest argument can either be a pair of coordinates representing the position of
+      the upper left corner of the blit or a Rect, where the upper left corner of the rectangle will be used as the
+      position for the blit. The size of the destination rectangle does not
+      effect the blit.
+
+      Pixel alphas will be ignored when blitting to an 8 bit Surface.
+
+      For a surface with colorkey or blanket alpha, a blit to self may give
+      slightly different colors than a non self-blit.
+
+      :returns: always returns ``None``
+      :rtype: None
+
+      .. note:: Takes positional only arguments, with special_flags being optional.
+                rblit is a raw blit function with the intended use of the "blit" alone.
+                Use this whenever you have to draw the entire surface at a position without
+                needing a return rectangle of the area changed. Grants increased performance
+                compared to blit() depending on the surface size.
+
+      .. ## Surface.rblit ##
+
    .. method:: blits
 
       | :sl:`draw many images onto another`

--- a/src_c/doc/surface_doc.h
+++ b/src_c/doc/surface_doc.h
@@ -1,6 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMESURFACE "Surface((width, height), flags=0, depth=0, masks=None) -> Surface\nSurface((width, height), flags=0, Surface) -> Surface\npygame object for representing images"
 #define DOC_SURFACEBLIT "blit(source, dest, area=None, special_flags=0) -> Rect\ndraw one image onto another"
+#define DOC_SURFACERBLIT "rblit(source, dest, special_flags=0) -> None\ndraw one full image onto another, with no rect being returned"
 #define DOC_SURFACEBLITS "blits(blit_sequence=((source, dest), ...), doreturn=1) -> [Rect, ...] or None\nblits(((source, dest, area), ...)) -> [Rect, ...]\nblits(((source, dest, area, special_flags), ...)) -> [Rect, ...]\ndraw many images onto another"
 #define DOC_SURFACECONVERT "convert(Surface=None) -> Surface\nconvert(depth, flags=0) -> Surface\nconvert(masks, flags=0) -> Surface\nchange the pixel format of an image"
 #define DOC_SURFACECONVERTALPHA "convert_alpha(Surface) -> Surface\nconvert_alpha() -> Surface\nchange the pixel format of an image including per pixel alphas"
@@ -63,6 +64,10 @@ pygame object for representing images
 pygame.Surface.blit
  blit(source, dest, area=None, special_flags=0) -> Rect
 draw one image onto another
+
+pygame.Surface.rblit
+ rblit(source, dest, special_flags=0) -> None
+draw one full image onto another, with no rect being returned
 
 pygame.Surface.blits
  blits(blit_sequence=((source, dest), ...), doreturn=1) -> [Rect, ...] or None


### PR DESCRIPTION
Follows #3324.
# Rationale
The blit function is the core function for blitting surfaces and just like blits(), it's a Swiss army knife of a function. It gives you freedom to choose whether you want to draw a portion of the surface, choose a blend flag and get the blit rectangle as return value. We need something more specific and single purpose, that does only one thing, blitting a surface onto another.
# Solution
Having a rblit() function where "r" stands for raw, that draws an entire surface (meaning area=None) and doesn't create and return a new rect.
# Benefits 

- **Higher performance**
You know you'll always draw the entire surface and won't have to create a return rect
- **Ease of use** 

```Python
# instead of writing
surf.blit(img, pos, None, pygame.BLEND_ADD)
# or
surf.blit(img, pos, special_flags=pygame.BLEND_ADD)
# you would have
surf.rblit(img, pos, pygame.BLEND_ADD)
```
- **End user now has choice**
By having a general use function and a more specific one we can better fit the user's needs.
- **Compatibility with blit**
Modifying blit isn't a thing, too many projects would be directly affected. Having a different function will enable current projects to be compatible and recieve the benefits.
# Negatives
I'll be using METH_FASTCALL as a method type. This will enable a faster calling convention but will require positional arguments to be passed.
- **Python 3.6 users will be able to use rblit() but with smaller benefits**

# First performance results
First results show a performance benefit that ranges from 6-10% up to 30-35%. This is assuming the Surface to blit isn't too big. With big images performance lines up with blit().
