### PR TITLE
Accelerate RGBA_SUB AVX

### DIFF
--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -482,8 +482,8 @@ blit_blend_rgba_sub_avx2(SDL_BlitInfo *info)
             n, aligned_8_length);
     }
 
-    srcp = srcp256;
-    dstp = dstp256;
+    srcp = (Uint32 *)srcp256;
+    dstp = (Uint32 *)dstp256;
 
     if (after_8_length > 0) {
         LOOP_UNROLLED4(


### PR DESCRIPTION
After days of fruitlessly looking around alphablit.c coming up with harebrained optimization ideas, I've finally got some good results.

This is a proof of concept run on a random AVX blitter code, but **I think my strategy here will be applicable to plenty of the other blitters.**

In my test code (100k, 300x301 blits) this took the runtime from 0.95 seconds to 0.76 seconds.

My first realization was that a for loop over the pixels of an image doesn't need to care about height vs width, it just has to iterate over pixels, which are laid out linearly in memory. This is great, because it reduces the amount of optimization "misses." The AVX code can run super fast on 8 pixel groups at a time, but at the end of every line it has to go a little slower to accommodate the non-divisible-by-8 pixels. So worst case scenario, the amount of missed optimization pixels is 7*height. But it doesn't have to go line by line, instead it can iterate over all the pixels, since they are continuous. This reduces the worst case scenario number of missed optimization pixels to 7.

This was responsible for the majority of the performance gain I saw, reducing the runtime of my test to 0.82 seconds.

My second realization -- more of a suspicion -- was that doing the "odd man out" pixels first would hurt performance because of memory alignment stuff that I don't really understand. Changing the order so that it did the accelerated pixels first then the non accelerated pixels second yielded the rest of the performance gain.