### PR TITLE
More efficiently track pixels in AVX blitters

### DIFF
--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -4,8 +4,6 @@
 #include <immintrin.h>
 #endif /* defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H) */
 
-#define __AVX2__
-
 #define RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING()     \
     char warning[128];                                 \
     PyOS_snprintf(warning, sizeof(warning),            \

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -4,6 +4,8 @@
 #include <immintrin.h>
 #endif /* defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H) */
 
+#define __AVX2__
+
 #define RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING()     \
     char warning[128];                                 \
     PyOS_snprintf(warning, sizeof(warning),            \
@@ -24,12 +26,10 @@ blit_blend_rgba_mul_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -120,13 +120,11 @@ blit_blend_rgba_mul_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -151,12 +149,10 @@ blit_blend_rgb_mul_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -258,13 +254,11 @@ blit_blend_rgb_mul_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -289,12 +283,10 @@ blit_blend_rgba_add_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -335,13 +327,11 @@ blit_blend_rgba_add_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -366,12 +356,10 @@ blit_blend_rgb_add_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -421,13 +409,11 @@ blit_blend_rgb_add_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -452,12 +438,10 @@ blit_blend_rgba_sub_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -498,13 +482,11 @@ blit_blend_rgba_sub_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -529,12 +511,10 @@ blit_blend_rgb_sub_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -584,13 +564,11 @@ blit_blend_rgb_sub_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -615,12 +593,10 @@ blit_blend_rgba_max_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -661,13 +637,11 @@ blit_blend_rgba_max_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -692,12 +666,10 @@ blit_blend_rgb_max_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -747,13 +719,11 @@ blit_blend_rgb_max_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -778,12 +748,10 @@ blit_blend_rgba_min_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -824,13 +792,11 @@ blit_blend_rgba_min_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else
@@ -855,12 +821,10 @@ blit_blend_rgb_min_avx2(SDL_BlitInfo *info)
     Uint32 *srcp = (Uint32 *)info->s_pixels;
     int srcskip = info->s_skip >> 2;
     int srcpxskip = info->s_pxskip >> 2;
-    int srceightpxskip = 8 * srcpxskip;
 
     Uint32 *dstp = (Uint32 *)info->d_pixels;
     int dstskip = info->d_skip >> 2;
     int dstpxskip = info->d_pxskip >> 2;
-    int dsteightpxskip = 8 * dstpxskip;
 
     int pre_8_width = width % 8;
     int post_8_width = (width - pre_8_width) / 8;
@@ -910,13 +874,11 @@ blit_blend_rgb_min_avx2(SDL_BlitInfo *info)
 
                     srcp256++;
                     dstp256++;
-                    srcp += srceightpxskip;
-                    dstp += dsteightpxskip;
                 },
                 n, post_8_width);
         }
-        srcp += srcskip;
-        dstp += dstskip;
+        srcp = (Uint32 *)srcp256 + srcskip;
+        dstp = (Uint32 *)dstp256 + dstskip;
     }
 }
 #else


### PR DESCRIPTION
I think I've finally found a win in the blitter code :smile:

In the multi-pixel bits, the pixel location is being tracked by two pointers on each surface. One "big pointer" that increments "one forward", which is many bytes, and then the "small pointer" that increments forward in increments of 8 to keep up with the big pointer.

However, the pointers are pointing at the same location, so we can take advantage of that to use the big pointer to update the small pointer after the loop. This reduces the amount of work in the hot loop.

I measured between 9 and 17% speedups from this, depending on how demanding the blit mode is.

I also saw that this strategy can be used in some SSE blitters, but I wanted to put this in for review first.