### PR TITLE
Fix new static analyzer (VS 2022) warnings

### DIFF
--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -293,6 +293,10 @@ _get_weights(PyObject *weights, float *wr, float *wg, float *wb)
 
         for (i = 0; i < 3; ++i) {
             item = PySequence_GetItem(weights, i);
+            if (!item) {
+                success = 0;
+                break;
+            }
             if (PyNumber_Check(item)) {
                 PyObject *num;
 


### PR DESCRIPTION
PR to fix #3251

This commit was initially a part of #3231, where the issue was found, and I tested a fix on the same branch which has VS 2022 running on CI

Since the fix can be merged in independently, I cherry picked the commit into a new branch to create another PR that should be easier to merge in (this just fixes some error handling issues and also adds better error reporting in the case of some integers being out of the expected range)

(yes, this PR did turn out to be much smaller than I initially expected, I was hoping a whole wall of new warnings)