### PR TITLE
pygame.draw.nclines() function

### DIFF
--- a/buildconfig/stubs/pygame/draw.pyi
+++ b/buildconfig/stubs/pygame/draw.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union, Tuple
 
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -58,6 +58,10 @@ def lines(
     points: Sequence[Coordinate],
     width: int = 1,
 ) -> Rect: ...
+def nclines(
+        surface: Surface,
+        draw_sequence: Sequence[Tuple[ColorValue, Coordinate, Coordinate, int]], /
+) -> None: ...
 def aaline(
     surface: Surface,
     color: ColorValue,

--- a/docs/reST/ref/draw.rst
+++ b/docs/reST/ref/draw.rst
@@ -397,6 +397,33 @@ object around the draw calls (see :func:`pygame.Surface.lock` and
 
    .. ## pygame.draw.lines ##
 
+.. function:: nclines
+
+   | :sl:`draw multiple line segments on a surface`
+   | :sg:`nclines(surface, draw_sequence) -> None`
+
+   Draws a sequence of straight line segments on the given surface. There are
+   no endcaps or miter joints. For thick lines the ends are squared off.
+
+   :param Surface surface: the surface to draw the lines on
+   :param draw_sequence: a sequence composed of (color, pos1, pos2, width) where:
+
+      - color: color to draw with, the alpha value is optional if using a tuple ``(RGB[A])``,
+
+      - pos1, pos2: two (x, y) pairs that indicate the line segment's start and end positions
+
+      - width(optional): indicates the thickness of the circle (default=1)
+                         | if ``width >= 1``, used for line thickness
+                         | if ``width <= 0``, nothing will be drawn
+
+   :returns: always returns `None`
+   :rtype: None
+
+   .. note:: Takes positional only arguments in the order: surface, draw_sequence
+             ``width`` for each line must be >= 1 and pos1 must be different from pos2.
+
+   .. ## pygame.draw.nclines ##
+
 .. function:: aaline
 
    | :sl:`draw a straight antialiased line`

--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -7,6 +7,7 @@
 #define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"
 #define DOC_PYGAMEDRAWLINE "line(surface, color, start_pos, end_pos) -> Rect\nline(surface, color, start_pos, end_pos, width=1) -> Rect\ndraw a straight line"
 #define DOC_PYGAMEDRAWLINES "lines(surface, color, closed, points) -> Rect\nlines(surface, color, closed, points, width=1) -> Rect\ndraw multiple contiguous straight line segments"
+#define DOC_PYGAMEDRAWNCLINES "nclines(surface, draw_sequence) -> None\ndraw multiple line segments on a surface"
 #define DOC_PYGAMEDRAWAALINE "aaline(surface, color, start_pos, end_pos) -> Rect\naaline(surface, color, start_pos, end_pos, blend=1) -> Rect\ndraw a straight antialiased line"
 #define DOC_PYGAMEDRAWAALINES "aalines(surface, color, closed, points) -> Rect\naalines(surface, color, closed, points, blend=1) -> Rect\ndraw multiple contiguous straight antialiased line segments"
 
@@ -52,6 +53,10 @@ pygame.draw.lines
  lines(surface, color, closed, points) -> Rect
  lines(surface, color, closed, points, width=1) -> Rect
 draw multiple contiguous straight line segments
+
+pygame.draw.nclines
+ nclines(surface, draw_sequence) -> None
+draw multiple line segments on a surface
 
 pygame.draw.aaline
  aaline(surface, color, start_pos, end_pos) -> Rect


### PR DESCRIPTION
Implements one of #3269 . Follows #3324.
This one implements the `nclines()` function for drawing many unconnected line segments at once. The function's use case should be heterogeneous lines sequences, of different length, colors and width.
In my visual tests in the case of "width=1" lines, the result is a tiny bit different than the current `lines()` function, nothing too significant tho.
First performance results show a bigger benefit for width=1 lines at 70% improvement, with a mean improvement of around 30%. Improvements vary depending on line scale and width. 