### PR TITLE
wasm: add pygame.gfxdraw to static preloader

### DIFF
--- a/src_c/static.c
+++ b/src_c/static.c
@@ -152,7 +152,6 @@ PyInit_pixelcopy(void);
 PyMODINIT_FUNC
 PyInit_gfxdraw(void);
 
-
 void
 PyGame_static_init()
 {

--- a/src_c/static.c
+++ b/src_c/static.c
@@ -149,6 +149,10 @@ PyInit__sprite(void);
 PyMODINIT_FUNC
 PyInit_pixelcopy(void);
 
+PyMODINIT_FUNC
+PyInit_gfxdraw(void);
+
+
 void
 PyGame_static_init()
 {
@@ -167,6 +171,7 @@ PyGame_static_init()
     PyImport_AppendInittab("pygame__freetype", PyInit__freetype);
     PyImport_AppendInittab("pygame_font", PyInit_font);
     PyImport_AppendInittab("pygame_draw", PyInit_draw);
+    PyImport_AppendInittab("pygame_gfxdraw", PyInit_gfxdraw);
     PyImport_AppendInittab("pygame_imageext", PyInit_imageext);
     PyImport_AppendInittab("pygame_image", PyInit_image);
     PyImport_AppendInittab("pygame_mask", PyInit_mask);


### PR DESCRIPTION
as it was missing and does not rely on numpy there's no reason not to.