### PR TITLE
some wrong relative imports in cython code

### DIFF
--- a/src_c/_sdl2/audio.c
+++ b/src_c/_sdl2/audio.c
@@ -6,7 +6,7 @@
         "depends": [],
         "name": "pygame._sdl2.audio",
         "sources": [
-            "src_c\\cython\\pygame\\_sdl2\\audio.pyx"
+            "src_c/cython/pygame/_sdl2/audio.pyx"
         ]
     },
     "module_name": "pygame._sdl2.audio"
@@ -921,7 +921,7 @@ static const char *__pyx_filename;
 
 
 static const char *__pyx_f[] = {
-  "src_c\\cython\\pygame\\_sdl2\\audio.pyx",
+  "src_c/cython/pygame/_sdl2/audio.pyx",
   "stringsource",
 };
 /* ForceInitThreads.proto */
@@ -2057,6 +2057,7 @@ static const char __pyx_k_dtype_is_object[] = "dtype_is_object";
 static const char __pyx_k_pyx_PickleError[] = "__pyx_PickleError";
 static const char __pyx_k_setstate_cython[] = "__setstate_cython__";
 static const char __pyx_k_audio_format_str[] = "_audio_format_str";
+static const char __pyx_k_pygame__sdl2_sdl2[] = "pygame._sdl2.sdl2";
 static const char __pyx_k_pyx_unpickle_Enum[] = "__pyx_unpickle_Enum";
 static const char __pyx_k_cline_in_traceback[] = "cline_in_traceback";
 static const char __pyx_k_pygame__sdl2_audio[] = "pygame._sdl2.audio";
@@ -2078,7 +2079,7 @@ static const char __pyx_k_AUDIO_ALLOW_FREQUENCY_CHANGE[] = "AUDIO_ALLOW_FREQUENC
 static const char __pyx_k_Audio_system_not_initialised[] = "Audio system not initialised";
 static const char __pyx_k_unable_to_allocate_array_data[] = "unable to allocate array data.";
 static const char __pyx_k_strided_and_direct_or_indirect[] = "<strided and direct or indirect>";
-static const char __pyx_k_src_c_cython_pygame__sdl2_audio[] = "src_c\\cython\\pygame\\_sdl2\\audio.pyx";
+static const char __pyx_k_src_c_cython_pygame__sdl2_audio[] = "src_c/cython/pygame/_sdl2/audio.pyx";
 static const char __pyx_k_Buffer_view_does_not_expose_stri[] = "Buffer view does not expose strides";
 static const char __pyx_k_Can_only_create_a_buffer_that_is[] = "Can only create a buffer that is contiguous in memory.";
 static const char __pyx_k_Cannot_assign_to_read_only_memor[] = "Cannot assign to read-only memoryview";
@@ -2139,7 +2140,6 @@ static PyObject *__pyx_n_s_ValueError;
 static PyObject *__pyx_n_s_View_MemoryView;
 static PyObject *__pyx_kp_s__2;
 static PyObject *__pyx_kp_b__24;
-static PyObject *__pyx_n_s__25;
 static PyObject *__pyx_kp_b__25;
 static PyObject *__pyx_kp_b__26;
 static PyObject *__pyx_kp_b__27;
@@ -2201,6 +2201,7 @@ static PyObject *__pyx_n_s_pack;
 static PyObject *__pyx_n_s_pickle;
 static PyObject *__pyx_n_s_print_exc;
 static PyObject *__pyx_n_s_pygame__sdl2_audio;
+static PyObject *__pyx_n_s_pygame__sdl2_sdl2;
 static PyObject *__pyx_n_s_pyx_PickleError;
 static PyObject *__pyx_n_s_pyx_checksum;
 static PyObject *__pyx_n_s_pyx_getbuffer;
@@ -18819,7 +18820,6 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_View_MemoryView, __pyx_k_View_MemoryView, sizeof(__pyx_k_View_MemoryView), 0, 0, 1, 1},
   {&__pyx_kp_s__2, __pyx_k__2, sizeof(__pyx_k__2), 0, 0, 1, 0},
   {&__pyx_kp_b__24, __pyx_k__24, sizeof(__pyx_k__24), 0, 0, 0, 0},
-  {&__pyx_n_s__25, __pyx_k__25, sizeof(__pyx_k__25), 0, 0, 1, 1},
   {&__pyx_kp_b__25, __pyx_k__25, sizeof(__pyx_k__25), 0, 0, 0, 0},
   {&__pyx_kp_b__26, __pyx_k__26, sizeof(__pyx_k__26), 0, 0, 0, 0},
   {&__pyx_kp_b__27, __pyx_k__27, sizeof(__pyx_k__27), 0, 0, 0, 0},
@@ -18881,6 +18881,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_pickle, __pyx_k_pickle, sizeof(__pyx_k_pickle), 0, 0, 1, 1},
   {&__pyx_n_s_print_exc, __pyx_k_print_exc, sizeof(__pyx_k_print_exc), 0, 0, 1, 1},
   {&__pyx_n_s_pygame__sdl2_audio, __pyx_k_pygame__sdl2_audio, sizeof(__pyx_k_pygame__sdl2_audio), 0, 0, 1, 1},
+  {&__pyx_n_s_pygame__sdl2_sdl2, __pyx_k_pygame__sdl2_sdl2, sizeof(__pyx_k_pygame__sdl2_sdl2), 0, 0, 1, 1},
   {&__pyx_n_s_pyx_PickleError, __pyx_k_pyx_PickleError, sizeof(__pyx_k_pyx_PickleError), 0, 0, 1, 1},
   {&__pyx_n_s_pyx_checksum, __pyx_k_pyx_checksum, sizeof(__pyx_k_pyx_checksum), 0, 0, 1, 1},
   {&__pyx_n_s_pyx_getbuffer, __pyx_k_pyx_getbuffer, sizeof(__pyx_k_pyx_getbuffer), 0, 0, 1, 1},
@@ -19604,7 +19605,7 @@ if (!__Pyx_RefNanny) {
   #endif
 
   /* "pygame/_sdl2/audio.pyx":1
- * from . import error             # <<<<<<<<<<<<<<
+ * from pygame._sdl2.sdl2 import error             # <<<<<<<<<<<<<<
  * 
  * 
  */
@@ -19613,7 +19614,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_INCREF(__pyx_n_s_error);
   __Pyx_GIVEREF(__pyx_n_s_error);
   PyList_SET_ITEM(__pyx_t_1, 0, __pyx_n_s_error);
-  __pyx_t_2 = __Pyx_Import(__pyx_n_s__25, __pyx_t_1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_Import(__pyx_n_s_pygame__sdl2_sdl2, __pyx_t_1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_1 = __Pyx_ImportFrom(__pyx_t_2, __pyx_n_s_error); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1, __pyx_L1_error)
@@ -20035,7 +20036,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
   /* "pygame/_sdl2/audio.pyx":1
- * from . import error             # <<<<<<<<<<<<<<
+ * from pygame._sdl2.sdl2 import error             # <<<<<<<<<<<<<<
  * 
  * 
  */

--- a/src_c/_sdl2/controller.c
+++ b/src_c/_sdl2/controller.c
@@ -1513,6 +1513,7 @@ static const char __pyx_k_set_eventstate[] = "set_eventstate";
 static const char __pyx_k_max_controllers[] = "max_controllers";
 static const char __pyx_k_setstate_cython[] = "__setstate_cython__";
 static const char __pyx_k_internal_mod_init[] = "_internal_mod_init";
+static const char __pyx_k_pygame__sdl2_sdl2[] = "pygame._sdl2.sdl2";
 static const char __pyx_k_cline_in_traceback[] = "cline_in_traceback";
 static const char __pyx_k_pygame__sdl2_controller[] = "pygame._sdl2.controller";
 static const char __pyx_k_gamecontroller_init_check[] = "_gamecontroller_init_check";
@@ -1567,6 +1568,7 @@ static PyObject *__pyx_n_s_name;
 static PyObject *__pyx_n_s_name_forindex;
 static PyObject *__pyx_n_s_num;
 static PyObject *__pyx_n_s_pygame__sdl2_controller;
+static PyObject *__pyx_n_s_pygame__sdl2_sdl2;
 static PyObject *__pyx_n_s_quit;
 static PyObject *__pyx_n_s_reduce;
 static PyObject *__pyx_n_s_reduce_cython;
@@ -6243,6 +6245,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_name_forindex, __pyx_k_name_forindex, sizeof(__pyx_k_name_forindex), 0, 0, 1, 1},
   {&__pyx_n_s_num, __pyx_k_num, sizeof(__pyx_k_num), 0, 0, 1, 1},
   {&__pyx_n_s_pygame__sdl2_controller, __pyx_k_pygame__sdl2_controller, sizeof(__pyx_k_pygame__sdl2_controller), 0, 0, 1, 1},
+  {&__pyx_n_s_pygame__sdl2_sdl2, __pyx_k_pygame__sdl2_sdl2, sizeof(__pyx_k_pygame__sdl2_sdl2), 0, 0, 1, 1},
   {&__pyx_n_s_quit, __pyx_k_quit, sizeof(__pyx_k_quit), 0, 0, 1, 1},
   {&__pyx_n_s_reduce, __pyx_k_reduce, sizeof(__pyx_k_reduce), 0, 0, 1, 1},
   {&__pyx_n_s_reduce_cython, __pyx_k_reduce_cython, sizeof(__pyx_k_reduce_cython), 0, 0, 1, 1},
@@ -6763,7 +6766,7 @@ if (!__Pyx_RefNanny) {
   #endif
 
   /* "pygame/_sdl2/controller.pyx":1
- * from . import error             # <<<<<<<<<<<<<<
+ * from pygame._sdl2.sdl2 import error             # <<<<<<<<<<<<<<
  * 
  * cdef extern from "../pygame.h" nogil:
  */
@@ -6772,7 +6775,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_INCREF(__pyx_n_s_error);
   __Pyx_GIVEREF(__pyx_n_s_error);
   PyList_SET_ITEM(__pyx_t_1, 0, __pyx_n_s_error);
-  __pyx_t_2 = __Pyx_Import(__pyx_kp_s__5, __pyx_t_1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_Import(__pyx_n_s_pygame__sdl2_sdl2, __pyx_t_1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_1 = __Pyx_ImportFrom(__pyx_t_2, __pyx_n_s_error); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1, __pyx_L1_error)
@@ -6965,7 +6968,7 @@ if (!__Pyx_RefNanny) {
   PyType_Modified(__pyx_ptype_6pygame_5_sdl2_10controller_Controller);
 
   /* "pygame/_sdl2/controller.pyx":1
- * from . import error             # <<<<<<<<<<<<<<
+ * from pygame._sdl2.sdl2 import error             # <<<<<<<<<<<<<<
  * 
  * cdef extern from "../pygame.h" nogil:
  */

--- a/src_c/_sdl2/controller.c
+++ b/src_c/_sdl2/controller.c
@@ -6,7 +6,7 @@
         "depends": [],
         "name": "pygame._sdl2.controller",
         "sources": [
-            "src_c\\cython\\pygame\\_sdl2\\controller.pyx"
+            "src_c/cython/pygame/_sdl2/controller.pyx"
         ]
     },
     "module_name": "pygame._sdl2.controller"
@@ -920,7 +920,7 @@ static const char *__pyx_filename;
 
 
 static const char *__pyx_f[] = {
-  "src_c\\cython\\pygame\\_sdl2\\controller.pyx",
+  "src_c/cython/pygame/_sdl2/controller.pyx",
   "stringsource",
 };
 
@@ -1522,7 +1522,7 @@ static const char __pyx_k_Index_is_invalid_or_not_a_suppor[] = "Index is invalid
 static const char __pyx_k_gamecontroller_system_not_initia[] = "gamecontroller system not initialized";
 static const char __pyx_k_self__controller_cannot_be_conve[] = "self._controller cannot be converted to a Python object for pickling";
 static const char __pyx_k_should_be_a_pygame_joystick_Joys[] = "should be a pygame.joystick.Joystick object.";
-static const char __pyx_k_src_c_cython_pygame__sdl2_contro[] = "src_c\\cython\\pygame\\_sdl2\\controller.pyx";
+static const char __pyx_k_src_c_cython_pygame__sdl2_contro[] = "src_c/cython/pygame/_sdl2/controller.pyx";
 static PyObject *__pyx_n_s_CLOSEDCHECK;
 static PyObject *__pyx_n_s_Controller;
 static PyObject *__pyx_kp_s_Could_not_open_controller_d;

--- a/src_c/_sdl2/mixer.c
+++ b/src_c/_sdl2/mixer.c
@@ -6,7 +6,7 @@
         "depends": [],
         "name": "pygame._sdl2.mixer",
         "sources": [
-            "src_c\\cython\\pygame\\_sdl2\\mixer.pyx"
+            "src_c/cython/pygame/_sdl2/mixer.pyx"
         ]
     },
     "module_name": "pygame._sdl2.mixer"
@@ -923,7 +923,7 @@ static const char *__pyx_filename;
 
 static const char *__pyx_f[] = {
   "stringsource",
-  "src_c\\cython\\pygame\\_sdl2\\mixer.pyx",
+  "src_c/cython/pygame/_sdl2/mixer.pyx",
 };
 /* ForceInitThreads.proto */
 #ifndef __PYX_FORCE_INIT_THREADS
@@ -1969,6 +1969,7 @@ static const char __pyx_k_mode[] = "mode";
 static const char __pyx_k_name[] = "name";
 static const char __pyx_k_ndim[] = "ndim";
 static const char __pyx_k_pack[] = "pack";
+static const char __pyx_k_sdl2[] = "sdl2";
 static const char __pyx_k_size[] = "size";
 static const char __pyx_k_step[] = "step";
 static const char __pyx_k_stop[] = "stop";
@@ -2073,7 +2074,6 @@ static PyObject *__pyx_kp_s_Unable_to_convert_item_to_object;
 static PyObject *__pyx_n_s_ValueError;
 static PyObject *__pyx_n_s_View_MemoryView;
 static PyObject *__pyx_kp_b__22;
-static PyObject *__pyx_n_s__23;
 static PyObject *__pyx_kp_b__23;
 static PyObject *__pyx_kp_b__24;
 static PyObject *__pyx_kp_b__25;
@@ -2129,6 +2129,7 @@ static PyObject *__pyx_n_s_reduce;
 static PyObject *__pyx_n_s_reduce_cython;
 static PyObject *__pyx_n_s_reduce_ex;
 static PyObject *__pyx_kp_u_s;
+static PyObject *__pyx_n_s_sdl2;
 static PyObject *__pyx_kp_s_self_callback_self_userdata_cann;
 static PyObject *__pyx_n_s_setstate;
 static PyObject *__pyx_n_s_setstate_cython;
@@ -17342,7 +17343,6 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_ValueError, __pyx_k_ValueError, sizeof(__pyx_k_ValueError), 0, 0, 1, 1},
   {&__pyx_n_s_View_MemoryView, __pyx_k_View_MemoryView, sizeof(__pyx_k_View_MemoryView), 0, 0, 1, 1},
   {&__pyx_kp_b__22, __pyx_k__22, sizeof(__pyx_k__22), 0, 0, 0, 0},
-  {&__pyx_n_s__23, __pyx_k__23, sizeof(__pyx_k__23), 0, 0, 1, 1},
   {&__pyx_kp_b__23, __pyx_k__23, sizeof(__pyx_k__23), 0, 0, 0, 0},
   {&__pyx_kp_b__24, __pyx_k__24, sizeof(__pyx_k__24), 0, 0, 0, 0},
   {&__pyx_kp_b__25, __pyx_k__25, sizeof(__pyx_k__25), 0, 0, 0, 0},
@@ -17398,6 +17398,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_reduce_cython, __pyx_k_reduce_cython, sizeof(__pyx_k_reduce_cython), 0, 0, 1, 1},
   {&__pyx_n_s_reduce_ex, __pyx_k_reduce_ex, sizeof(__pyx_k_reduce_ex), 0, 0, 1, 1},
   {&__pyx_kp_u_s, __pyx_k_s, sizeof(__pyx_k_s), 0, 1, 0, 0},
+  {&__pyx_n_s_sdl2, __pyx_k_sdl2, sizeof(__pyx_k_sdl2), 0, 0, 1, 1},
   {&__pyx_kp_s_self_callback_self_userdata_cann, __pyx_k_self_callback_self_userdata_cann, sizeof(__pyx_k_self_callback_self_userdata_cann), 0, 0, 1, 0},
   {&__pyx_n_s_setstate, __pyx_k_setstate, sizeof(__pyx_k_setstate), 0, 0, 1, 1},
   {&__pyx_n_s_setstate_cython, __pyx_k_setstate_cython, sizeof(__pyx_k_setstate_cython), 0, 0, 1, 1},
@@ -18074,7 +18075,7 @@ if (!__Pyx_RefNanny) {
   #endif
 
   /* "pygame/_sdl2/mixer.pyx":1
- * from . import error             # <<<<<<<<<<<<<<
+ * from .sdl2 import error             # <<<<<<<<<<<<<<
  * import traceback
  * 
  */
@@ -18083,7 +18084,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_INCREF(__pyx_n_s_error);
   __Pyx_GIVEREF(__pyx_n_s_error);
   PyList_SET_ITEM(__pyx_t_1, 0, __pyx_n_s_error);
-  __pyx_t_2 = __Pyx_Import(__pyx_n_s__23, __pyx_t_1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 1, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_Import(__pyx_n_s_sdl2, __pyx_t_1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 1, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_1 = __Pyx_ImportFrom(__pyx_t_2, __pyx_n_s_error); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 1, __pyx_L1_error)
@@ -18093,7 +18094,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
   /* "pygame/_sdl2/mixer.pyx":2
- * from . import error
+ * from .sdl2 import error
  * import traceback             # <<<<<<<<<<<<<<
  * 
  * #https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC79
@@ -18113,7 +18114,7 @@ if (!__Pyx_RefNanny) {
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_postmix, Py_None) < 0) __PYX_ERR(1, 57, __pyx_L1_error)
 
   /* "pygame/_sdl2/mixer.pyx":1
- * from . import error             # <<<<<<<<<<<<<<
+ * from .sdl2 import error             # <<<<<<<<<<<<<<
  * import traceback
  * 
  */

--- a/src_c/_sdl2/mixer.c
+++ b/src_c/_sdl2/mixer.c
@@ -1969,7 +1969,6 @@ static const char __pyx_k_mode[] = "mode";
 static const char __pyx_k_name[] = "name";
 static const char __pyx_k_ndim[] = "ndim";
 static const char __pyx_k_pack[] = "pack";
-static const char __pyx_k_sdl2[] = "sdl2";
 static const char __pyx_k_size[] = "size";
 static const char __pyx_k_step[] = "step";
 static const char __pyx_k_stop[] = "stop";
@@ -2021,6 +2020,7 @@ static const char __pyx_k_allocate_buffer[] = "allocate_buffer";
 static const char __pyx_k_dtype_is_object[] = "dtype_is_object";
 static const char __pyx_k_pyx_PickleError[] = "__pyx_PickleError";
 static const char __pyx_k_setstate_cython[] = "__setstate_cython__";
+static const char __pyx_k_pygame__sdl2_sdl2[] = "pygame._sdl2.sdl2";
 static const char __pyx_k_pyx_unpickle_Enum[] = "__pyx_unpickle_Enum";
 static const char __pyx_k_cline_in_traceback[] = "cline_in_traceback";
 static const char __pyx_k_strided_and_direct[] = "<strided and direct>";
@@ -2116,6 +2116,7 @@ static PyObject *__pyx_n_s_pack;
 static PyObject *__pyx_n_s_pickle;
 static PyObject *__pyx_n_s_postmix;
 static PyObject *__pyx_n_s_print_exc;
+static PyObject *__pyx_n_s_pygame__sdl2_sdl2;
 static PyObject *__pyx_n_s_pyx_PickleError;
 static PyObject *__pyx_n_s_pyx_checksum;
 static PyObject *__pyx_n_s_pyx_getbuffer;
@@ -2129,7 +2130,6 @@ static PyObject *__pyx_n_s_reduce;
 static PyObject *__pyx_n_s_reduce_cython;
 static PyObject *__pyx_n_s_reduce_ex;
 static PyObject *__pyx_kp_u_s;
-static PyObject *__pyx_n_s_sdl2;
 static PyObject *__pyx_kp_s_self_callback_self_userdata_cann;
 static PyObject *__pyx_n_s_setstate;
 static PyObject *__pyx_n_s_setstate_cython;
@@ -17385,6 +17385,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_pickle, __pyx_k_pickle, sizeof(__pyx_k_pickle), 0, 0, 1, 1},
   {&__pyx_n_s_postmix, __pyx_k_postmix, sizeof(__pyx_k_postmix), 0, 0, 1, 1},
   {&__pyx_n_s_print_exc, __pyx_k_print_exc, sizeof(__pyx_k_print_exc), 0, 0, 1, 1},
+  {&__pyx_n_s_pygame__sdl2_sdl2, __pyx_k_pygame__sdl2_sdl2, sizeof(__pyx_k_pygame__sdl2_sdl2), 0, 0, 1, 1},
   {&__pyx_n_s_pyx_PickleError, __pyx_k_pyx_PickleError, sizeof(__pyx_k_pyx_PickleError), 0, 0, 1, 1},
   {&__pyx_n_s_pyx_checksum, __pyx_k_pyx_checksum, sizeof(__pyx_k_pyx_checksum), 0, 0, 1, 1},
   {&__pyx_n_s_pyx_getbuffer, __pyx_k_pyx_getbuffer, sizeof(__pyx_k_pyx_getbuffer), 0, 0, 1, 1},
@@ -17398,7 +17399,6 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_reduce_cython, __pyx_k_reduce_cython, sizeof(__pyx_k_reduce_cython), 0, 0, 1, 1},
   {&__pyx_n_s_reduce_ex, __pyx_k_reduce_ex, sizeof(__pyx_k_reduce_ex), 0, 0, 1, 1},
   {&__pyx_kp_u_s, __pyx_k_s, sizeof(__pyx_k_s), 0, 1, 0, 0},
-  {&__pyx_n_s_sdl2, __pyx_k_sdl2, sizeof(__pyx_k_sdl2), 0, 0, 1, 1},
   {&__pyx_kp_s_self_callback_self_userdata_cann, __pyx_k_self_callback_self_userdata_cann, sizeof(__pyx_k_self_callback_self_userdata_cann), 0, 0, 1, 0},
   {&__pyx_n_s_setstate, __pyx_k_setstate, sizeof(__pyx_k_setstate), 0, 0, 1, 1},
   {&__pyx_n_s_setstate_cython, __pyx_k_setstate_cython, sizeof(__pyx_k_setstate_cython), 0, 0, 1, 1},
@@ -18075,7 +18075,7 @@ if (!__Pyx_RefNanny) {
   #endif
 
   /* "pygame/_sdl2/mixer.pyx":1
- * from .sdl2 import error             # <<<<<<<<<<<<<<
+ * from pygame._sdl2.sdl2 import error             # <<<<<<<<<<<<<<
  * import traceback
  * 
  */
@@ -18084,7 +18084,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_INCREF(__pyx_n_s_error);
   __Pyx_GIVEREF(__pyx_n_s_error);
   PyList_SET_ITEM(__pyx_t_1, 0, __pyx_n_s_error);
-  __pyx_t_2 = __Pyx_Import(__pyx_n_s_sdl2, __pyx_t_1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 1, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_Import(__pyx_n_s_pygame__sdl2_sdl2, __pyx_t_1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 1, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_1 = __Pyx_ImportFrom(__pyx_t_2, __pyx_n_s_error); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 1, __pyx_L1_error)
@@ -18094,7 +18094,7 @@ if (!__Pyx_RefNanny) {
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
   /* "pygame/_sdl2/mixer.pyx":2
- * from .sdl2 import error
+ * from pygame._sdl2.sdl2 import error
  * import traceback             # <<<<<<<<<<<<<<
  * 
  * #https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC79
@@ -18114,7 +18114,7 @@ if (!__Pyx_RefNanny) {
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_postmix, Py_None) < 0) __PYX_ERR(1, 57, __pyx_L1_error)
 
   /* "pygame/_sdl2/mixer.pyx":1
- * from .sdl2 import error             # <<<<<<<<<<<<<<
+ * from pygame._sdl2.sdl2 import error             # <<<<<<<<<<<<<<
  * import traceback
  * 
  */

--- a/src_c/cython/pygame/_sdl2/audio.pyx
+++ b/src_c/cython/pygame/_sdl2/audio.pyx
@@ -1,4 +1,4 @@
-from . import error
+from .sdl2 import error
 
 
 # expose constants to python.

--- a/src_c/cython/pygame/_sdl2/audio.pyx
+++ b/src_c/cython/pygame/_sdl2/audio.pyx
@@ -1,4 +1,4 @@
-from .sdl2 import error
+from pygame._sdl2.sdl2 import error
 
 
 # expose constants to python.

--- a/src_c/cython/pygame/_sdl2/controller.pyx
+++ b/src_c/cython/pygame/_sdl2/controller.pyx
@@ -1,4 +1,4 @@
-from .sdl2 import error
+from pygame._sdl2.sdl2 import error
 
 cdef extern from "../pygame.h" nogil:
     int pgJoystick_Check(object joy)

--- a/src_c/cython/pygame/_sdl2/controller.pyx
+++ b/src_c/cython/pygame/_sdl2/controller.pyx
@@ -1,4 +1,4 @@
-from . import error
+from .sdl2 import error
 
 cdef extern from "../pygame.h" nogil:
     int pgJoystick_Check(object joy)

--- a/src_c/cython/pygame/_sdl2/mixer.pyx
+++ b/src_c/cython/pygame/_sdl2/mixer.pyx
@@ -1,4 +1,4 @@
-from .sdl2 import error
+from pygame._sdl2.sdl2 import error
 import traceback
 
 #https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC79

--- a/src_c/cython/pygame/_sdl2/mixer.pyx
+++ b/src_c/cython/pygame/_sdl2/mixer.pyx
@@ -1,4 +1,4 @@
-from . import error
+from .sdl2 import error
 import traceback
 
 #https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC79


### PR DESCRIPTION
```
>>> pygame._sdl2.sdl2.error is pygame._sdl2.controller.error
True
```

but pygame._sdl2.error is an alias ( from sdl2 import * ) in  pygame._sdl2 package
```
>>> pygame._sdl2.error
<class 'pygame._sdl2.sdl2.error'>
```