### PR TITLE
Make sure set_mode always returns a cleared window

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -205,6 +205,11 @@ required).
 
    .. versionchanged:: 1.9.5 ``display`` argument added
 
+   .. versionchanged:: 2.1.3
+      pygame now ensures that subsequent calls to this function clears the
+      window to black. On older versions, this was an implementation detail
+      on the major platforms this function was tested with.
+
    .. ## pygame.display.set_mode ##
 
 .. function:: get_surface

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -843,7 +843,6 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
        screen as the old one */
     int display = _get_display(win);
     char *title = state->title;
-    int init_flip = 0;
     char *scale_env;
 
     char *keywords[] = {"size", "flags", "depth", "display", "vsync", NULL};
@@ -1101,7 +1100,6 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
                 win = SDL_CreateWindow(title, x, y, w_1, h_1, sdl_flags);
                 if (!win)
                     return RAISE(pgExc_SDLError, SDL_GetError());
-                init_flip = 1;
             }
             else {
                 /* set min size to (1,1) to erase any previously set min size
@@ -1311,11 +1309,9 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
         pg_SetDefaultWindowSurface(surface);
         Py_DECREF(surface);
 
-        /* ensure window is initially black */
-        if (init_flip) {
-            SDL_FillRect(surf, NULL, SDL_MapRGB(surf->format, 0, 0, 0));
-            pg_flip_internal(state);
-        }
+        /* ensure window is always black after a set_mode call */
+        SDL_FillRect(surf, NULL, SDL_MapRGB(surf->format, 0, 0, 0));
+        pg_flip_internal(state);
     }
 
     /*set the window icon*/


### PR DESCRIPTION
fixes #3265

From the code, it seemed like retaining older window surface on subsequent `set_mode` calls is intentional, but no pygame version from 1.9.6 to 2.1.2 actually does it (in my testing, on windows)

This PR enforces the display clear on our end unconditionally when `set_mode` is called