### PR TITLE
scale(), scale_by(), smoothscale(), smoothscale_by() reorganization and speed up

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -521,13 +521,66 @@ stretch(SDL_Surface *src, SDL_Surface *dst)
     }
 }
 
+static SDL_Surface *
+scale_to(pgSurfaceObject *srcobj, pgSurfaceObject *dstobj, int width,
+         int height)
+{
+    SDL_Surface *src = NULL;
+    SDL_Surface *retsurf = NULL;
+
+    if (width < 0 || height < 0)
+        return RAISE(PyExc_ValueError, "Cannot scale to negative size");
+
+    src = pgSurface_AsSurface(srcobj);
+
+    if (!dstobj) {
+        retsurf = newsurf_fromsurf(src, width, height);
+        if (!retsurf)
+            return NULL;
+    }
+    else {
+        retsurf = pgSurface_AsSurface(dstobj);
+    }
+
+    if (retsurf->w != width || retsurf->h != height) {
+        return (SDL_Surface *)(RAISE(
+            PyExc_ValueError,
+            "Destination surface not the given width or height."));
+    }
+
+    if (src->format->BytesPerPixel != retsurf->format->BytesPerPixel) {
+        return (SDL_Surface *)(RAISE(
+            PyExc_ValueError,
+            "Source and destination surfaces need the same format."));
+    }
+
+    if ((width && height) && (src->w && src->h)) {
+        SDL_LockSurface(retsurf);
+        pgSurface_Lock(srcobj);
+
+        Py_BEGIN_ALLOW_THREADS;
+        if (width == 2 * src->w && height == 2 * src->h) {
+            scale2xraw(src, retsurf);
+        }
+        else {
+            stretch(src, retsurf);
+        }
+        Py_END_ALLOW_THREADS;
+
+        pgSurface_Unlock(srcobj);
+        SDL_UnlockSurface(retsurf);
+    }
+
+    return retsurf;
+}
+
 static PyObject *
 surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     pgSurfaceObject *surfobj;
     PyObject *surfobj2 = NULL;
     PyObject *size;
-    SDL_Surface *surf, *newsurf;
+    SDL_Surface *newsurf;
     int width, height;
     static char *keywords[] = {"surface", "size", "dest_surface", NULL};
 
@@ -539,43 +592,8 @@ surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!pg_TwoIntsFromObj(size, &width, &height))
         return RAISE(PyExc_TypeError, "size must be two numbers");
 
-    if (width < 0 || height < 0)
-        return RAISE(PyExc_ValueError, "Cannot scale to negative size");
-
-    surf = pgSurface_AsSurface(surfobj);
-
-    if (!surfobj2) {
-        newsurf = newsurf_fromsurf(surf, width, height);
-        if (!newsurf)
-            return NULL;
-    }
-    else
-        newsurf = pgSurface_AsSurface(surfobj2);
-
-    if (newsurf->w != width || newsurf->h != height)
-        return RAISE(PyExc_ValueError,
-                     "Destination surface not the given width or height.");
-
-    /* check to see if the format of the surface is the same. */
-    if (surf->format->BytesPerPixel != newsurf->format->BytesPerPixel)
-        return RAISE(PyExc_ValueError,
-                     "Source and destination surfaces need the same format.");
-
-    if ((width && height) && (surf->w && surf->h)) {
-        SDL_LockSurface(newsurf);
-        pgSurface_Lock(surfobj);
-
-        Py_BEGIN_ALLOW_THREADS;
-        if (width == 2 * surf->w && height == 2 * surf->h) {
-            scale2xraw(surf, newsurf);
-        }
-        else {
-            stretch(surf, newsurf);
-        }
-        Py_END_ALLOW_THREADS;
-
-        pgSurface_Unlock(surfobj);
-        SDL_UnlockSurface(newsurf);
+    if (!(newsurf = scale_to(surfobj, surfobj2, width, height))) {
+        return NULL;
     }
 
     if (surfobj2) {
@@ -591,37 +609,32 @@ surf_scale_by(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *surfobj;
     PyObject *surfobj2 = NULL;
-    PyObject *new_args = NULL;
     PyObject *factorobj = NULL;
-    float scale, scaley;
-    SDL_Surface *surf;
-    int width, height;
+    float scalex, scaley;
+    SDL_Surface *surf, *newsurf;
     static char *keywords[] = {"surface", "factor", "dest_surface", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O", keywords, &surfobj,
-                                     &factorobj, &surfobj2))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O|O!", keywords,
+                                     &pgSurface_Type, &surfobj, &factorobj,
+                                     &pgSurface_Type, &surfobj2))
         return NULL;
 
-    if (!_get_factor(factorobj, &scale, &scaley)) {
+    if (!_get_factor(factorobj, &scalex, &scaley)) {
         return NULL;
     }
 
     surf = pgSurface_AsSurface(surfobj);
 
-    width = (int)(surf->w * scale);
-    height = (int)(surf->h * scaley);
-
-    if (width < 0 || height < 0)
-        return RAISE(PyExc_ValueError, "Cannot scale to negative size");
-
-    if (surfobj2)
-        new_args = Py_BuildValue("O(ii)O", surfobj, width, height, surfobj2);
-    else
-        new_args = Py_BuildValue("O(ii)", surfobj, width, height);
-    if (new_args == NULL)
+    if (!(newsurf =
+              scale_to(surfobj, surfobj2, surf->w * scalex, surf->h * scaley)))
         return NULL;
 
-    return surf_scale(self, new_args, NULL);
+    if (surfobj2) {
+        Py_INCREF(surfobj2);
+        return surfobj2;
+    }
+    else
+        return (PyObject *)pgSurface_New(newsurf);
 }
 
 static PyObject *
@@ -1468,14 +1481,79 @@ scalesmooth(SDL_Surface *src, SDL_Surface *dst, struct _module_state *st)
         free(temppix);
 }
 
+static SDL_Surface *
+smoothscale_to(PyObject *self, pgSurfaceObject *srcobj,
+               pgSurfaceObject *dstobj, int width, int height)
+{
+    SDL_Surface *src = NULL;
+    SDL_Surface *retsurf = NULL;
+    int bpp;
+    if (width < 0 || height < 0)
+        return (SDL_Surface *)(RAISE(PyExc_ValueError,
+                                     "Cannot scale to negative size"));
+
+    src = pgSurface_AsSurface(srcobj);
+
+    bpp = src->format->BytesPerPixel;
+    if (bpp < 3 || bpp > 4)
+        return (SDL_Surface *)(RAISE(
+            PyExc_ValueError,
+            "Only 24-bit or 32-bit surfaces can be smoothly scaled"));
+
+    if (!dstobj) {
+        retsurf = newsurf_fromsurf(src, width, height);
+        if (!retsurf)
+            return NULL;
+    }
+    else
+        retsurf = pgSurface_AsSurface(dstobj);
+
+    if (retsurf->w != width || retsurf->h != height)
+        return (SDL_Surface *)(RAISE(
+            PyExc_ValueError,
+            "Destination surface not the given width or height."));
+
+    if (((width * bpp + 3) >> 2) > retsurf->pitch)
+        return (SDL_Surface *)(RAISE(
+            PyExc_ValueError,
+            "SDL Error: destination surface pitch not 4-byte aligned."));
+
+    if (width && height) {
+        SDL_LockSurface(retsurf);
+        pgSurface_Lock(srcobj);
+
+        /* handle trivial case */
+        if (src->w == width && src->h == height) {
+            int y;
+            Py_BEGIN_ALLOW_THREADS;
+            for (y = 0; y < height; y++) {
+                memcpy((Uint8 *)retsurf->pixels + y * retsurf->pitch,
+                       (Uint8 *)src->pixels + y * src->pitch, width * bpp);
+            }
+            Py_END_ALLOW_THREADS;
+        }
+        else {
+            struct _module_state *st = GETSTATE(self);
+            Py_BEGIN_ALLOW_THREADS;
+            scalesmooth(src, retsurf, st);
+            Py_END_ALLOW_THREADS;
+        }
+
+        pgSurface_Unlock(srcobj);
+        SDL_UnlockSurface(retsurf);
+    }
+
+    return retsurf;
+}
+
 static PyObject *
 surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     pgSurfaceObject *surfobj;
     PyObject *surfobj2 = NULL;
     PyObject *size;
-    SDL_Surface *surf, *newsurf;
-    int width, height, bpp;
+    SDL_Surface *newsurf;
+    int width, height;
     static char *keywords[] = {"surface", "size", "dest_surface", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O|O!", keywords,
@@ -1486,57 +1564,8 @@ surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!pg_TwoIntsFromObj(size, &width, &height))
         return RAISE(PyExc_TypeError, "size must be two numbers");
 
-    if (width < 0 || height < 0)
-        return RAISE(PyExc_ValueError, "Cannot scale to negative size");
-
-    surf = pgSurface_AsSurface(surfobj);
-
-    bpp = surf->format->BytesPerPixel;
-    if (bpp < 3 || bpp > 4)
-        return RAISE(PyExc_ValueError,
-                     "Only 24-bit or 32-bit surfaces can be smoothly scaled");
-
-    if (!surfobj2) {
-        newsurf = newsurf_fromsurf(surf, width, height);
-        if (!newsurf)
-            return NULL;
-    }
-    else
-        newsurf = pgSurface_AsSurface(surfobj2);
-
-    if (newsurf->w != width || newsurf->h != height)
-        return RAISE(PyExc_ValueError,
-                     "Destination surface not the given width or height.");
-
-    if (((width * bpp + 3) >> 2) > newsurf->pitch)
-        return RAISE(
-            PyExc_ValueError,
-            "SDL Error: destination surface pitch not 4-byte aligned.");
-
-    if (width && height) {
-        SDL_LockSurface(newsurf);
-        pgSurface_Lock(surfobj);
-
-        /* handle trivial case */
-        if (surf->w == width && surf->h == height) {
-            int y;
-            Py_BEGIN_ALLOW_THREADS;
-            for (y = 0; y < height; y++) {
-                memcpy((Uint8 *)newsurf->pixels + y * newsurf->pitch,
-                       (Uint8 *)surf->pixels + y * surf->pitch, width * bpp);
-            }
-            Py_END_ALLOW_THREADS;
-        }
-        else {
-            struct _module_state *st = GETSTATE(self);
-            Py_BEGIN_ALLOW_THREADS;
-            scalesmooth(surf, newsurf, st);
-            Py_END_ALLOW_THREADS;
-        }
-
-        pgSurface_Unlock(surfobj);
-        SDL_UnlockSurface(newsurf);
-    }
+    if (!(newsurf = smoothscale_to(self, surfobj, surfobj2, width, height)))
+        return NULL;
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
@@ -1554,12 +1583,12 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *new_args = NULL;
     PyObject *factorobj = NULL;
     float scale, scaley;
-    SDL_Surface *surf;
-    int width, height;
+    SDL_Surface *surf, *newsurf;
     static char *keywords[] = {"surface", "factor", "dest_surface", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O", keywords, &surfobj,
-                                     &factorobj, &surfobj2))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O|O!", keywords,
+                                     &pgSurface_Type, &surfobj, &factorobj,
+                                     &pgSurface_Type, &surfobj2))
         return NULL;
 
     if (!_get_factor(factorobj, &scale, &scaley)) {
@@ -1568,20 +1597,16 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
 
     surf = pgSurface_AsSurface(surfobj);
 
-    width = (int)(surf->w * scale);
-    height = (int)(surf->h * scaley);
-
-    if (width < 0 || height < 0)
-        return RAISE(PyExc_ValueError, "Cannot scale to negative size");
-
-    if (surfobj2)
-        new_args = Py_BuildValue("O(ii)O", surfobj, width, height, surfobj2);
-    else
-        new_args = Py_BuildValue("O(ii)", surfobj, width, height);
-    if (new_args == NULL)
+    if (!(newsurf = smoothscale_to(self, surfobj, surfobj2, surf->w * scale,
+                                   surf->h * scaley)))
         return NULL;
 
-    return surf_scalesmooth(self, new_args, NULL);
+    if (surfobj2) {
+        Py_INCREF(surfobj2);
+        return surfobj2;
+    }
+    else
+        return (PyObject *)pgSurface_New(newsurf);
 }
 
 static PyObject *

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -578,7 +578,7 @@ static PyObject *
 surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     pgSurfaceObject *surfobj;
-    PyObject *surfobj2 = NULL;
+    pgSurfaceObject *surfobj2 = NULL;
     PyObject *size;
     SDL_Surface *newsurf;
     int width, height;
@@ -598,7 +598,7 @@ surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
-        return surfobj2;
+        return (PyObject *)surfobj2;
     }
     else
         return (PyObject *)pgSurface_New(newsurf);
@@ -607,8 +607,8 @@ surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 surf_scale_by(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    PyObject *surfobj;
-    PyObject *surfobj2 = NULL;
+    pgSurfaceObject *surfobj;
+    pgSurfaceObject *surfobj2 = NULL;
     PyObject *factorobj = NULL;
     float scalex, scaley;
     SDL_Surface *surf, *newsurf;
@@ -631,7 +631,7 @@ surf_scale_by(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
-        return surfobj2;
+        return (PyObject *)surfobj2;
     }
     else
         return (PyObject *)pgSurface_New(newsurf);
@@ -1550,7 +1550,7 @@ static PyObject *
 surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     pgSurfaceObject *surfobj;
-    PyObject *surfobj2 = NULL;
+    pgSurfaceObject *surfobj2 = NULL;
     PyObject *size;
     SDL_Surface *newsurf;
     int width, height;
@@ -1569,7 +1569,7 @@ surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
-        return surfobj2;
+        return (PyObject *)surfobj2;
     }
     else
         return (PyObject *)pgSurface_New(newsurf);
@@ -1578,9 +1578,8 @@ surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    PyObject *surfobj;
-    PyObject *surfobj2 = NULL;
-    PyObject *new_args = NULL;
+    pgSurfaceObject *surfobj;
+    pgSurfaceObject *surfobj2 = NULL;
     PyObject *factorobj = NULL;
     float scale, scaley;
     SDL_Surface *surf, *newsurf;
@@ -1603,7 +1602,7 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
-        return surfobj2;
+        return (PyObject *)surfobj2;
     }
     else
         return (PyObject *)pgSurface_New(newsurf);

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -625,8 +625,8 @@ surf_scale_by(PyObject *self, PyObject *args, PyObject *kwargs)
 
     surf = pgSurface_AsSurface(surfobj);
 
-    if (!(newsurf =
-              scale_to(surfobj, surfobj2, surf->w * scalex, surf->h * scaley)))
+    if (!(newsurf = scale_to(surfobj, surfobj2, (int)(surf->w * scalex),
+                             (int)(surf->h * scaley))))
         return NULL;
 
     if (surfobj2) {
@@ -1596,8 +1596,9 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
 
     surf = pgSurface_AsSurface(surfobj);
 
-    if (!(newsurf = smoothscale_to(self, surfobj, surfobj2, surf->w * scale,
-                                   surf->h * scaley)))
+    if (!(newsurf =
+              smoothscale_to(self, surfobj, surfobj2, (int)(surf->w * scale),
+                             (int)(surf->h * scaley))))
         return NULL;
 
     if (surfobj2) {

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -592,7 +592,8 @@ surf_scale(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!pg_TwoIntsFromObj(size, &width, &height))
         return RAISE(PyExc_TypeError, "size must be two numbers");
 
-    if (!(newsurf = scale_to(surfobj, surfobj2, width, height))) {
+    newsurf = scale_to(surfobj, surfobj2, width, height);
+    if (!newsurf) {
         return NULL;
     }
 
@@ -624,10 +625,11 @@ surf_scale_by(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     surf = pgSurface_AsSurface(surfobj);
-
-    if (!(newsurf = scale_to(surfobj, surfobj2, (int)(surf->w * scalex),
-                             (int)(surf->h * scaley))))
+    newsurf = scale_to(surfobj, surfobj2, (int)(surf->w * scalex),
+                       (int)(surf->h * scaley));
+    if (!newsurf) {
         return NULL;
+    }
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
@@ -1564,8 +1566,10 @@ surf_scalesmooth(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!pg_TwoIntsFromObj(size, &width, &height))
         return RAISE(PyExc_TypeError, "size must be two numbers");
 
-    if (!(newsurf = smoothscale_to(self, surfobj, surfobj2, width, height)))
+    newsurf = smoothscale_to(self, surfobj, surfobj2, width, height);
+    if (!newsurf) {
         return NULL;
+    }
 
     if (surfobj2) {
         Py_INCREF(surfobj2);
@@ -1596,10 +1600,11 @@ surf_scalesmooth_by(PyObject *self, PyObject *args, PyObject *kwargs)
 
     surf = pgSurface_AsSurface(surfobj);
 
-    if (!(newsurf =
-              smoothscale_to(self, surfobj, surfobj2, (int)(surf->w * scale),
-                             (int)(surf->h * scaley))))
+    newsurf = smoothscale_to(self, surfobj, surfobj2, (int)(surf->w * scale),
+                             (int)(surf->h * scaley));
+    if (!newsurf) {
         return NULL;
+    }
 
     if (surfobj2) {
         Py_INCREF(surfobj2);


### PR DESCRIPTION
Implements #3315.
Results are a bit strange, but the functions do work. I used this code:
```Python
from timeit import timeit

import pygame
from pygame.transform import scale, scale_by, smoothscale, smoothscale_by

pygame.init()
WIDTH, HEIGHT = 500, 500
win = pygame.display.set_mode((WIDTH, HEIGHT))

IMAGE = pygame.image.load("images/cell.png").convert()
GLOB = {
    "scale": scale,
    "IMAGE": IMAGE,
    "scale_by": scale_by,
    "smoothscale": smoothscale,
    "smoothscale_by": smoothscale_by
}


def test(test_str: str):
    print(timeit(test_str, globals=GLOB))

print("SCALE: ", end="")
test("scale(IMAGE, (100, 100))")

print("SCALE_BY: ", end="")
test("scale_by(IMAGE, 2.45)")

print("SMOOTHSCALE: ", end="")
test("smoothscale(IMAGE, (100, 100))")

print("SMOOTHSCALE_BY: ", end="")
test("smoothscale_by(IMAGE, 2.45)")
```
and got these results:
OLD
```
SCALE: 10.217117799999869
SCALE_BY: 13.330813199999284
SMOOTHSCALE: 17.059421400000247
SMOOTHSCALE_BY: 22.5625871000002
```
NEW
```
SCALE: 7.131523500000185
SCALE_BY: 10.155133100000057
SMOOTHSCALE: 16.981359200000043
SMOOTHSCALE_BY: 22.357186100000035
```

