### PR TITLE
Add FASTCALL compat macros, update Color.update to use the same

### DIFF
--- a/src_c/_pygame.h
+++ b/src_c/_pygame.h
@@ -281,6 +281,41 @@ supported Python version. #endif */
 
 #define PyType_Init(x) (((x).ob_type) = &PyType_Type)
 
+/* CPython 3.6 had initial and undocumented FASTCALL support, but we play it
+ * safe by not relying on implementation details */
+#if PY_VERSION_HEX < 0x03070000
+
+/* Macro for naming a pygame fastcall wrapper function */
+#define PG_FASTCALL_NAME(func) _##func##_fastcall_wrap
+
+/* used to forward declare compat functions */
+#define PG_DECLARE_FASTCALL_FUNC(func, self_type) \
+    static PyObject *PG_FASTCALL_NAME(func)(self_type * self, PyObject * args)
+
+/* Using this macro on a function defined with the FASTCALL calling convention
+ * adds a wrapper definition that uses regular python VARARGS convention.
+ * Since it is guaranteed that the 'args' object is a tuple, we can directly
+ * call PySequence_Fast_ITEMS and PyTuple_GET_SIZE on it (which are macros that
+ * assume the same, and don't do error checking) */
+#define PG_WRAP_FASTCALL_FUNC(func, self_type)                            \
+    PG_DECLARE_FASTCALL_FUNC(func, self_type)                             \
+    {                                                                     \
+        return func(self, (PyObject *const *)PySequence_Fast_ITEMS(args), \
+                    PyTuple_GET_SIZE(args));                              \
+    }
+
+#define PG_FASTCALL METH_VARARGS
+
+#else /* PY_VERSION_HEX >= 0x03070000 */
+/* compat macros are no-op on python versions that support fastcall */
+#define PG_FASTCALL_NAME(func) func
+#define PG_DECLARE_FASTCALL_FUNC(func, self_type)
+#define PG_WRAP_FASTCALL_FUNC(func, self_type)
+
+#define PG_FASTCALL METH_FASTCALL
+
+#endif /* PY_VERSION_HEX >= 0x03070000 */
+
 /*
  * event module internals
  */

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -93,7 +93,8 @@ _color_lerp(pgColorObject *, PyObject *, PyObject *);
 static PyObject *
 _premul_alpha(pgColorObject *, PyObject *);
 static PyObject *
-_color_update(pgColorObject *, PyObject *, PyObject *);
+_color_update(pgColorObject *self, PyObject *const *args, Py_ssize_t nargs);
+PG_DECLARE_FASTCALL_FUNC(_color_update, pgColorObject);
 
 /* Getters/setters */
 static PyObject *
@@ -200,7 +201,8 @@ static PyMethodDef _color_methods[] = {
      DOC_COLORLERP},
     {"premul_alpha", (PyCFunction)_premul_alpha, METH_NOARGS,
      DOC_COLORPREMULALPHA},
-    {"update", (PyCFunction)_color_update, METH_VARARGS, DOC_COLORUPDATE},
+    {"update", (PyCFunction)PG_FASTCALL_NAME(_color_update), PG_FASTCALL,
+     DOC_COLORUPDATE},
     {NULL, NULL, 0, NULL}};
 
 /**
@@ -833,50 +835,37 @@ _premul_alpha(pgColorObject *color, PyObject *_null)
 }
 
 static PyObject *
-_color_update(pgColorObject *self, PyObject *args, PyObject *kwargs)
+_color_update(pgColorObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     Uint8 *rgba = self->data;
-    PyObject *r_or_obj;
-    PyObject *g = NULL;
-    PyObject *b = NULL;
-    PyObject *a = NULL;
-
-    if (!PyArg_ParseTuple(args, "O|OOO", &r_or_obj, &g, &b, &a)) {
-        return NULL;
-    }
-
-    if (!g) {
-        if (_parse_color_from_single_object(r_or_obj, rgba)) {
+    if (nargs == 1) {
+        if (_parse_color_from_single_object(args[0], rgba)) {
             return NULL;
         }
     }
-    else {
+    else if (nargs == 3 || nargs == 4) {
+        Py_ssize_t i;
         Uint32 color = 0;
-
-        /* Color(R,G,B[,A]) */
-        if (!_get_color(r_or_obj, &color) || color > 255) {
-            return RAISE(PyExc_ValueError, "invalid color argument");
-        }
-        rgba[0] = (Uint8)color;
-        if (!_get_color(g, &color) || color > 255) {
-            return RAISE(PyExc_ValueError, "invalid color argument");
-        }
-        rgba[1] = (Uint8)color;
-        if (!b || !_get_color(b, &color) || color > 255) {
-            return RAISE(PyExc_ValueError, "invalid color argument");
-        }
-        rgba[2] = (Uint8)color;
-
-        if (a) {
-            if (!_get_color(a, &color) || color > 255) {
+        for (i = 0; i < nargs; i++) {
+            if (!_get_color(args[i], &color) || color > 255) {
                 return RAISE(PyExc_ValueError, "invalid color argument");
             }
-            self->len = 4;
-            rgba[3] = (Uint8)color;
+            rgba[i] = (Uint8)color;
         }
+        /* Update len only if alpha component was passed (because the previous
+         * implementation of this function behaved so) */
+        if (nargs == 4) {
+            self->len = 4;
+        }
+    }
+    else {
+        return RAISE(PyExc_TypeError,
+                     "update can take only 1, 3 or 4 arguments");
     }
     Py_RETURN_NONE;
 }
+
+PG_WRAP_FASTCALL_FUNC(_color_update, pgColorObject)
 
 /**
  * color.r


### PR DESCRIPTION
PR to setup some groundwork on #3324

This PR basically adds some compat macros to make defining fastcall functions easier while we still retain python 3.6 support.

To illustrate this, I picked `Color.update` which seemed like a good example because
1) This kind of function does not benefit much from having keyword arguments (and it did not in the past either, most importantly)
2) Using `FASTCALL` here also happens to simplify the implementation of the actual function. I personally like this aspect of the PR more than its performance boost
3) And of course, there is a small speedboost. On a benchmark I measured a 20% improvement in the mean, and the standard deviation about the mean reduced a bit too. However, it is to be noted that even before using `FASTCALL`, `Color.update` was a relatively cheap function anyways. It only takes of the order of a few 100 nanoseconds.
