### PR TITLE
Extend the set of directories not to look for stubs in

### DIFF
--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         cd buildconfig/stubs
         pip3 install mypy
-        python3 -m mypy.stubtest pygame --allowlist mypy_allow_list.txt
+        python3 -m mypy.stubtest pygame --allowlist mypy_allow_list.txt --mypy-config-file mypy_stubtest.ini
 
     # We upload the generated files under github actions assets
     - name: Upload sdist

--- a/buildconfig/stubs/mypy_allow_list.txt
+++ b/buildconfig/stubs/mypy_allow_list.txt
@@ -12,25 +12,3 @@ pygame\._sdl2\..*\.__test__
 # cython classes have some special dunders for internal use, ignore that in 
 # stubtest
 pygame\._sdl2\..*\.__pyx_.*__
-
- #don't look for stubs for examples or for tests
-pygame\examples
-pygame\tests
-
-# don't look for stubs for pyinstaller hook
-pygame\__pyinstaller
-
-# don't look for stubs for these either
-pygame\draw_py
-pygame\_sprite
-pygame\_freetype
-pygame\_camera
-pygame\_camera_opencv
-pygame\_camera_vidcapture
-pygame\_sdl2\mixer
-pygame\ftfont
-pygame\imageext
-pygame\macosx
-pygame\newbuffer
-pygame\pkgdata
-pygame\pypm

--- a/buildconfig/stubs/mypy_allow_list.txt
+++ b/buildconfig/stubs/mypy_allow_list.txt
@@ -12,3 +12,25 @@ pygame\._sdl2\..*\.__test__
 # cython classes have some special dunders for internal use, ignore that in 
 # stubtest
 pygame\._sdl2\..*\.__pyx_.*__
+
+ #don't look for stubs for examples or for tests
+pygame\examples
+pygame\tests
+
+# don't look for stubs for pyinstaller hook
+pygame\__pyinstaller
+
+# don't look for stubs for these either
+pygame\draw_py
+pygame\_sprite
+pygame\_freetype
+pygame\_camera
+pygame\_camera_opencv
+pygame\_camera_vidcapture
+pygame\_sdl2\mixer
+pygame\ftfont
+pygame\imageext
+pygame\macosx
+pygame\newbuffer
+pygame\pkgdata
+pygame\pypm

--- a/buildconfig/stubs/mypy_stubtest.ini
+++ b/buildconfig/stubs/mypy_stubtest.ini
@@ -1,0 +1,5 @@
+[mypy]
+exclude = (?x)(
+    /tests/ |
+    /examples/ |
+    /__pyinstaller/)

--- a/buildconfig/stubs/mypy_stubtest.ini
+++ b/buildconfig/stubs/mypy_stubtest.ini
@@ -2,4 +2,5 @@
 exclude = (?x)(
     /tests/ |
     /examples/ |
-    /__pyinstaller/)
+    /__pyinstaller/ |
+    ^pygame\.examples\.)


### PR DESCRIPTION
Usually these files are not part of the public interface to pygame and thus don't need type stubs.

Hopefully will get us closer to the stub test CI passing.