### PR TITLE
Optimized _vector_distance_helper

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1642,7 +1642,7 @@ _vector_distance_helper(pgVector *self, PyObject *other)
         double dx, dy;
 
         if (dim != otherv->dim) {
-            PyErr_SetString(PyExc_TypeError, "Vectors must be the same size");
+            PyErr_SetString(PyExc_ValueError, "Vectors must be the same size");
             return -1;
         }
 
@@ -1666,7 +1666,7 @@ _vector_distance_helper(pgVector *self, PyObject *other)
         }
 
         if (PySequence_Fast_GET_SIZE(fast_seq) != dim) {
-            PyErr_SetString(PyExc_TypeError,
+            PyErr_SetString(PyExc_ValueError,
                             "Vector and sequence must be the same size");
             return -1;
         }

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -562,21 +562,49 @@ class Vector2TypeTest(unittest.TestCase):
     def test_distance_to(self):
         diff = self.v1 - self.v2
         self.assertEqual(self.e1.distance_to(self.e2), math.sqrt(2))
+        self.assertEqual(self.e1.distance_to((0, 1)), math.sqrt(2))
+        self.assertEqual(self.e1.distance_to([0, 1]), math.sqrt(2))
         self.assertAlmostEqual(
             self.v1.distance_to(self.v2), math.sqrt(diff.x * diff.x + diff.y * diff.y)
         )
+        self.assertAlmostEqual(
+            self.v1.distance_to(self.t2), math.sqrt(diff.x * diff.x + diff.y * diff.y)
+        )
+        self.assertAlmostEqual(
+            self.v1.distance_to(self.l2), math.sqrt(diff.x * diff.x + diff.y * diff.y)
+        )
         self.assertEqual(self.v1.distance_to(self.v1), 0)
+        self.assertEqual(self.v1.distance_to(self.t1), 0)
+        self.assertEqual(self.v1.distance_to(self.l1), 0)
+        self.assertEqual(self.v1.distance_to(self.t2), self.v2.distance_to(self.t1))
+        self.assertEqual(self.v1.distance_to(self.l2), self.v2.distance_to(self.l1))
         self.assertEqual(self.v1.distance_to(self.v2), self.v2.distance_to(self.v1))
 
     def test_distance_squared_to(self):
         diff = self.v1 - self.v2
         self.assertEqual(self.e1.distance_squared_to(self.e2), 2)
+        self.assertEqual(self.e1.distance_squared_to((0, 1)), 2)
+        self.assertEqual(self.e1.distance_squared_to([0, 1]), 2)
         self.assertAlmostEqual(
             self.v1.distance_squared_to(self.v2), diff.x * diff.x + diff.y * diff.y
         )
+        self.assertAlmostEqual(
+            self.v1.distance_squared_to(self.t2), diff.x * diff.x + diff.y * diff.y
+        )
+        self.assertAlmostEqual(
+            self.v1.distance_squared_to(self.l2), diff.x * diff.x + diff.y * diff.y
+        )
         self.assertEqual(self.v1.distance_squared_to(self.v1), 0)
+        self.assertEqual(self.v1.distance_squared_to(self.t1), 0)
+        self.assertEqual(self.v1.distance_squared_to(self.l1), 0)
         self.assertEqual(
             self.v1.distance_squared_to(self.v2), self.v2.distance_squared_to(self.v1)
+        )
+        self.assertEqual(
+            self.v1.distance_squared_to(self.t2), self.v2.distance_squared_to(self.t1)
+        )
+        self.assertEqual(
+            self.v1.distance_squared_to(self.l2), self.v2.distance_squared_to(self.l1)
         )
 
     def test_update(self):
@@ -1895,12 +1923,26 @@ class Vector3TypeTest(unittest.TestCase):
     def test_distance_to(self):
         diff = self.v1 - self.v2
         self.assertEqual(self.e1.distance_to(self.e2), math.sqrt(2))
+        self.assertEqual(self.e1.distance_to((0, 1, 0)), math.sqrt(2))
+        self.assertEqual(self.e1.distance_to([0, 1, 0]), math.sqrt(2))
         self.assertEqual(
             self.v1.distance_to(self.v2),
             math.sqrt(diff.x * diff.x + diff.y * diff.y + diff.z * diff.z),
         )
+        self.assertEqual(
+            self.v1.distance_to(self.t2),
+            math.sqrt(diff.x * diff.x + diff.y * diff.y + diff.z * diff.z),
+        )
+        self.assertEqual(
+            self.v1.distance_to(self.l2),
+            math.sqrt(diff.x * diff.x + diff.y * diff.y + diff.z * diff.z),
+        )
         self.assertEqual(self.v1.distance_to(self.v1), 0)
+        self.assertEqual(self.v1.distance_to(self.t1), 0)
+        self.assertEqual(self.v1.distance_to(self.l1), 0)
         self.assertEqual(self.v1.distance_to(self.v2), self.v2.distance_to(self.v1))
+        self.assertEqual(self.v1.distance_to(self.t2), self.v2.distance_to(self.t1))
+        self.assertEqual(self.v1.distance_to(self.l2), self.v2.distance_to(self.l1))
 
     def test_distance_to_exceptions(self):
         v2 = Vector2(10, 10)
@@ -1994,13 +2036,31 @@ class Vector3TypeTest(unittest.TestCase):
     def test_distance_squared_to(self):
         diff = self.v1 - self.v2
         self.assertEqual(self.e1.distance_squared_to(self.e2), 2)
+        self.assertEqual(self.e1.distance_squared_to((0, 1, 0)), 2)
+        self.assertEqual(self.e1.distance_squared_to([0, 1, 0]), 2)
         self.assertAlmostEqual(
             self.v1.distance_squared_to(self.v2),
             diff.x * diff.x + diff.y * diff.y + diff.z * diff.z,
         )
+        self.assertAlmostEqual(
+            self.v1.distance_squared_to(self.t2),
+            diff.x * diff.x + diff.y * diff.y + diff.z * diff.z,
+        )
+        self.assertAlmostEqual(
+            self.v1.distance_squared_to(self.l2),
+            diff.x * diff.x + diff.y * diff.y + diff.z * diff.z,
+        )
         self.assertEqual(self.v1.distance_squared_to(self.v1), 0)
+        self.assertEqual(self.v1.distance_squared_to(self.t1), 0)
+        self.assertEqual(self.v1.distance_squared_to(self.l1), 0)
         self.assertEqual(
             self.v1.distance_squared_to(self.v2), self.v2.distance_squared_to(self.v1)
+        )
+        self.assertEqual(
+            self.v1.distance_squared_to(self.t2), self.v2.distance_squared_to(self.t1)
+        )
+        self.assertEqual(
+            self.v1.distance_squared_to(self.l2), self.v2.distance_squared_to(self.l1)
         )
 
     def test_swizzle(self):

--- a/test/math_test.py
+++ b/test/math_test.py
@@ -1902,6 +1902,95 @@ class Vector3TypeTest(unittest.TestCase):
         self.assertEqual(self.v1.distance_to(self.v1), 0)
         self.assertEqual(self.v1.distance_to(self.v2), self.v2.distance_to(self.v1))
 
+    def test_distance_to_exceptions(self):
+        v2 = Vector2(10, 10)
+        v3 = Vector3(1, 1, 1)
+
+        # illegal distance Vector3-Vector2 / Vector2-Vector3
+        self.assertRaises(ValueError, v2.distance_to, v3)
+        self.assertRaises(ValueError, v3.distance_to, v2)
+
+        # distance to illegal tuple/list positions
+        self.assertRaises(ValueError, v2.distance_to, (1, 1, 1))
+        self.assertRaises(ValueError, v2.distance_to, (1, 1, 0))
+        self.assertRaises(ValueError, v2.distance_to, (1,))
+        self.assertRaises(ValueError, v2.distance_to, [1, 1, 1])
+        self.assertRaises(ValueError, v2.distance_to, [1, 1, 0])
+        self.assertRaises(
+            ValueError,
+            v2.distance_to,
+            [
+                1,
+            ],
+        )
+        self.assertRaises(ValueError, v2.distance_to, (1, 1, 1))
+        # vec3
+        self.assertRaises(ValueError, v3.distance_to, (1, 1))
+        self.assertRaises(ValueError, v3.distance_to, (1,))
+        self.assertRaises(ValueError, v3.distance_to, [1, 1])
+        self.assertRaises(
+            ValueError,
+            v3.distance_to,
+            [
+                1,
+            ],
+        )
+
+        # illegal types as positions
+        self.assertRaises(TypeError, v2.distance_to, (1, "hello"))
+        self.assertRaises(TypeError, v2.distance_to, ([], []))
+        self.assertRaises(TypeError, v2.distance_to, (1, ("hello",)))
+
+        # illegal args number
+        self.assertRaises(TypeError, v2.distance_to)
+        self.assertRaises(TypeError, v2.distance_to, (1, 1), (1, 2))
+        self.assertRaises(TypeError, v2.distance_to, (1, 1), (1, 2), 1)
+
+    def test_distance_squared_to_exceptions(self):
+        v2 = Vector2(10, 10)
+        v3 = Vector3(1, 1, 1)
+        dist_t = v2.distance_squared_to
+        dist_t3 = v3.distance_squared_to
+        # illegal distance Vector3-Vector2 / Vector2-Vector3
+        self.assertRaises(ValueError, dist_t, v3)
+        self.assertRaises(ValueError, dist_t3, v2)
+
+        # distance to illegal tuple/list positions
+        self.assertRaises(ValueError, dist_t, (1, 1, 1))
+        self.assertRaises(ValueError, dist_t, (1, 1, 0))
+        self.assertRaises(ValueError, dist_t, (1,))
+        self.assertRaises(ValueError, dist_t, [1, 1, 1])
+        self.assertRaises(ValueError, dist_t, [1, 1, 0])
+        self.assertRaises(
+            ValueError,
+            dist_t,
+            [
+                1,
+            ],
+        )
+        self.assertRaises(ValueError, dist_t, (1, 1, 1))
+        # vec3
+        self.assertRaises(ValueError, dist_t3, (1, 1))
+        self.assertRaises(ValueError, dist_t3, (1,))
+        self.assertRaises(ValueError, dist_t3, [1, 1])
+        self.assertRaises(
+            ValueError,
+            dist_t3,
+            [
+                1,
+            ],
+        )
+
+        # illegal types as positions
+        self.assertRaises(TypeError, dist_t, (1, "hello"))
+        self.assertRaises(TypeError, dist_t, ([], []))
+        self.assertRaises(TypeError, dist_t, (1, ("hello",)))
+
+        # illegal args number
+        self.assertRaises(TypeError, dist_t)
+        self.assertRaises(TypeError, dist_t, (1, 1), (1, 2))
+        self.assertRaises(TypeError, dist_t, (1, 1), (1, 2), 1)
+
     def test_distance_squared_to(self):
         diff = self.v1 - self.v2
         self.assertEqual(self.e1.distance_squared_to(self.e2), 2)


### PR DESCRIPTION
One of #3343 
Follows a discussion we had on Discord. This PR optimizes the _vector_distance_helper() function, hence optimizing every other function that uses this one. 
Optimizations are mainly dedicated to vector-vector distance calculations, improving performance by 31%, but slightly improve(9%) vector-sequence distance calculation as well.
Some performance tests:
**NEW**
```
pygame vector:  0.7792468000001463
pygame vector (squared):  0.7629703400000836
pygame vector tup:  0.9840590200000406
pygame vector (squared) tup:  0.9708823000000848
```
**OLD**
```
pygame vector:  1.0366728799997873
pygame vector (squared):  1.0292829800000618
pygame vector tup:  1.0955151999999544
pygame vector (squared) tup:  1.0389712800000779
```

**Code**
```Python
import timeit
from statistics import fmean
import pygame


NUM = 10000000
v1 = pygame.math.Vector2(10, 10)
v2 = pygame.math.Vector2(20, 20)

GLOB2 = {"v1": v1, "v2": v2}

print("pygame vector: ", fmean(timeit.repeat("v1.distance_to(v2)", globals=GLOB2, number=NUM)))

print("pygame vector (squared): ", fmean(timeit.repeat("v1.distance_squared_to(v2)", globals=GLOB2, number=NUM)))

print("pygame vector tup: ", fmean(timeit.repeat("v1.distance_to((20, 20))", globals=GLOB2, number=NUM)))

print("pygame vector (squared) tup: ", fmean(timeit.repeat("v1.distance_squared_to((20, 20))", globals=GLOB2, number=NUM)))
```

