### PR TITLE
Optimized Vector move_towards() - move_towards_ip()

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1381,28 +1381,28 @@ _vector_move_towards_helper(Py_ssize_t dim, double *origin_coords,
 {
     Py_ssize_t i;
     double delta[VECTOR_MAX_SIZE];
-    double dist;
+    double dist, accum = 0;
 
     if (max_distance == 0)
         return;
 
-    for (i = 0; i < dim; ++i)
-        delta[i] = target_coords[i] - origin_coords[i];
+    for (i = 0; i < dim; ++i) {
+        double tmp = target_coords[i] - origin_coords[i];
+        accum += tmp * tmp;
+        delta[i] = tmp;
+    }
 
-    /* Get magnitude of Vector */
-    dist = sqrt(_scalar_product(delta, delta, dim));
-
+    dist = sqrt(accum);
     if (dist <= max_distance) {
         /* Return target Vector */
-        for (i = 0; i < dim; ++i)
-            origin_coords[i] = target_coords[i];
+        memcpy(origin_coords, target_coords, dim * sizeof(double));
         return;
     }
 
-    for (i = 0; i < dim; ++i)
-        origin_coords[i] = origin_coords[i] + delta[i] / dist * max_distance;
+    double fac = max_distance / dist;
 
-    return;
+    for (i = 0; i < dim; ++i)
+        origin_coords[i] += delta[i] * fac;
 }
 
 static PyObject *


### PR DESCRIPTION
## Info
(One of #3343)
Vector.move_towards and its in place versions are two very useful and recently added functions that could benefit from some optimizations. 
In particular i've made the following changes:
- Switched functions type to `METH_FASTCALL`
- Added a fast path for "Vector towards Vector" movement
- Optimized Vector towards sequence path
## Results
TLDR, here are the perf improvements:
```
VEC 2
-) move_towards: ~28% better
-) move_towards_ip: ~78% better
-) move_towards tup: ~55% better
-) move_towards_ip tup: ~108% better
VEC 3
-) move_towards: ~32% better
-) move_towards_ip: ~74% better
-) move_towards tup: ~61% better
-) move_towards_ip tup: ~99% better
```

And this is the data 
**OLD**
```
====||MOVE TOWARDS VEC2||====
-) move_towards: 1.77752334 s
-) move_towards_ip: 1.54389052 s
-) move_towards tup: 2.34829882 s
-) move_towards_ip tup: 2.1661703 s
______________
-) Mean time: 1.95897075

====||MOVE TOWARDS VEC3||====
-) move_towards: 1.88419112 s
-) move_towards_ip: 1.61218472 s
-) move_towards tup: 2.63010538 s
-) move_towards_ip tup: 2.29558336 s
______________
-) Mean time: 2.10551615
```
**NEW**
```
====||MOVE TOWARDS VEC2||====
-) move_towards: 1.38899652 s
-) move_towards_ip: 0.86529178 s
-) move_towards tup: 1.51511282 s
-) move_towards_ip tup: 1.03904514 s
______________
-) Mean time: 1.20211157

====||MOVE TOWARDS VEC3||====
-) move_towards: 1.42905712 s
-) move_towards_ip: 0.9246582 s
-) move_towards tup: 1.63172858 s
-) move_towards_ip tup: 1.15435236 s
______________
-) Mean time: 1.28494907
```

My test code:
```Python
import timeit
from statistics import fmean

from pygame import Vector2, Vector3

v2_1 = Vector2(0, 0)
v2_2 = Vector2(900, 900)

v3_1 = Vector3(0, 0, 0)
v3_2 = Vector3(900, 900, 900)


NUMBER = 10_000_000
GLOB = {"v2_1": v2_1, "v2_2": v2_2, "v3_1": v3_1, "v3_2": v3_2}

def test(test_name: str, func: str, mode: str = "mean") -> float:
    value = 0
    if mode == "mean":
        value = fmean(timeit.repeat(func, globals=GLOB, number=NUMBER))
    elif mode == "cumulative":
        value = timeit.timeit(func, globals=GLOB, number=NUMBER)
    else:
        raise NotImplementedError("Incorrect test mode")
    print("-) " + test_name + f": {round(value, 8)} s")
    return value


def test_group(group_name: str, sequence: list[str],
               tests_names: tuple[str, ...] = None,
               include_tot: bool = False, include_mean: bool = True,
               test_mode: str = "mean") -> float:
    print("\n====||" + group_name.upper() + "||====")

    test_data = [
        test(tests_names[i] if tests_names else str(i + 1), test_obj, test_mode)
        for
        i, test_obj in
        enumerate(sequence)]

    print("______________")
    if include_tot:
        print(f"-) Total time: {round(sum(test_data), 8)}")

    if include_mean:
        print(f"-) Mean time: {round(fmean(test_data), 8)}")

    return fmean(test_data)


test_group(
    "move towards Vec2",
    ["v2_1.move_towards(v2_2, 0.0001)",
     "v2_1.move_towards_ip(v2_2, 0.0001)",
     "v2_1.move_towards((900, 900), 0.0001)",
     "v2_1.move_towards_ip((900, 900), 0.0001)"
     ], ("move_towards", "move_towards_ip", "move_towards tup",
         "move_towards_ip tup"))

test_group(
    "move towards Vec3",
    ["v3_1.move_towards(v3_2, 0.0001)",
     "v3_1.move_towards_ip(v3_2, 0.0001)",
     "v3_1.move_towards((900, 900, 900), 0.0001)",
     "v3_1.move_towards_ip((900, 900, 900), 0.0001)"],
    ("move_towards", "move_towards_ip", "move_towards tup",
     "move_towards_ip tup")
)
```
