### PR TITLE
Use macos-12 for all Mac CI builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,14 +32,12 @@ on:
 
 jobs:
   deps:
-    name: ${{ matrix.macarch }} deps (macos-${{ matrix.os }})
-    runs-on: macos-${{ matrix.os }}
+    name: ${{ matrix.macarch }} deps
+    runs-on: macos-12
     strategy:
       matrix:
         # make arm64 deps and x86_64 deps
-        include:
-          - { os: '11', macarch: arm64 }
-          - { os: '10.15' , macarch: x86_64 }
+        macarch: [arm64, x86_64]
 
     steps:
       - uses: actions/checkout@v3.0.2
@@ -72,7 +70,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     needs: deps
-    runs-on: macos-${{ matrix.os }}
+    runs-on: macos-12
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
@@ -81,35 +79,30 @@ jobs:
         include:
           - { 
             name: "x86_64 (cp36-cp310)",
-            os: '10.15',
             macarch: x86_64,
             pyversions: cp36-* cp310-*
           }
 
           - { 
             name: "x86_64 (cp37-pp37)",
-            os: '10.15',
             macarch: x86_64,
             pyversions: cp37-* pp37-*
           }
 
           - { 
             name: "x86_64 (cp38-pp38)",
-            os: '10.15',
             macarch: x86_64,
             pyversions: cp38-* pp38-*
           }
 
           - { 
             name: "x86_64 (cp39-pp39)",
-            os: '10.15',
             macarch: x86_64,
             pyversions: cp39-* pp39-*
           }
 
           - { 
             name: "arm64 (cp38-cp39-cp310)",
-            os: '11',
             macarch: arm64,
             pyversions: cp38-* cp39-* cp310-*
           }

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -692,16 +692,14 @@ static int SDLCALL
 pg_ResizeEventWatch(void *userdata, SDL_Event *event)
 {
     SDL_Window *pygame_window;
-    PyObject *self;
     _DisplayState *state;
     SDL_Window *window;
 
     if (event->type != SDL_WINDOWEVENT)
         return 0;
 
-    self = (PyObject *)userdata;
     pygame_window = pg_GetDefaultWindow();
-    state = DISPLAY_MOD_STATE(self);
+    state = DISPLAY_MOD_STATE((PyObject *)userdata);
 
     window = SDL_GetWindowFromID(event->window.windowID);
     if (window != pygame_window)


### PR DESCRIPTION
[Github Actions is removing mac 10.15 runners](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/)

This PR does a simple version bump to mac 12, this should hopefully not have much of an impact on our builds (the intel wheels will continue to be built with mac 10.9+ support and the mac arm builds should continue supporting mac 11+)