### PR TITLE
Fixed issue with Freetype not being clipped

### DIFF
--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -345,7 +345,7 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
      * Setup target surface struct.
      */
     SDL_Rect clip_rect;
-    SDL_GetClipRect(surface, &rect);
+    SDL_GetClipRect(surface, &clip_rect);
     font_surf.buffer = surface->pixels;
     /*
      * Previously clip size was not taken into account so

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -342,11 +342,18 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
     }
 
     /*
-     * Setup target surface struct
+     * Setup target surface struct.
      */
+    SDL_Rect clip_rect;
+    SDL_GetClipRect(surface, &rect);
     font_surf.buffer = surface->pixels;
-    font_surf.width = surface->w;
-    font_surf.height = surface->h;
+    /*
+     * Previously clip size was not taken into account so
+     * to fix this the clip rect is only applied when it is
+     * smaller than the width of the surface.
+     */
+    font_surf.width = clip_rect.w < surface->w ? clip_rect.w : surface->w;
+    font_surf.height = clip_rect.h < surface->h ? clip_rect.h : surface->h;
     font_surf.pitch = surface->pitch;
     font_surf.format = surface->format;
     font_surf.render_gray = __SDLrenderFuncs[surface->format->BytesPerPixel];

--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -352,8 +352,8 @@ _PGFT_Render_ExistingSurface(FreeTypeInstance *ft, pgFontObject *fontobj,
      * to fix this the clip rect is only applied when it is
      * smaller than the width of the surface.
      */
-    font_surf.width = clip_rect.w < surface->w ? clip_rect.w : surface->w;
-    font_surf.height = clip_rect.h < surface->h ? clip_rect.h : surface->h;
+    font_surf.width = clip_rect.w + clip_rect.x;
+    font_surf.height = clip_rect.h + clip_rect.y;
     font_surf.pitch = surface->pitch;
     font_surf.format = surface->format;
     font_surf.render_gray = __SDLrenderFuncs[surface->format->BytesPerPixel];

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1794,6 +1794,75 @@ class FreeTypeTest(unittest.TestCase):
 
         self.assertIsNone(error_msg)
 
+class VisualTests(unittest.TestCase):
+
+    __tags__ = ["interactive"]
+
+    screen = None
+    aborted = False
+
+    def setUp(self):
+        if self.screen is None:
+            pygame.init()
+            self.screen = pygame.display.set_mode((600, 200))
+            self.screen.fill((255, 255, 255))
+            pygame.display.flip()
+            self.f = pygame.freetype.Font(None)
+
+    def tearDown(self):
+        pygame.quit()
+    
+    def query(self, clip_rect, is_clipped=False):
+        self.screen.fill((255, 255, 255))
+        question = ""
+        if is_clipped:
+            question = "Is the text clipped? y/n"
+        else:
+            question = "Can the full text be seen? y/n"
+
+        self.f.render_to(
+            self.screen,
+            (100, 100),
+            question,
+            size=20,
+            fgcolor=(0,0,0)
+        )
+
+        if is_clipped:
+            self.screen.set_clip(clip_rect)
+        else:
+            self.screen.set_clip(None)
+    
+        pygame.draw.rect(self.screen, (255, 0, 0), clip_rect)
+        self.f.render_to(
+            self.screen,
+            (0, 0),
+            'this text should be clipped inside the red box',
+            size=20,
+            fgcolor=(255, 255, 255)
+        )
+
+        pygame.display.flip()
+
+        while True:
+            for evt in pygame.event.get():
+                if evt.type == pygame.KEYDOWN:
+                    if evt.key == pygame.K_ESCAPE:
+                        self.abort()
+                        return False
+                    if evt.key == pygame.K_y:
+                        return True
+                    if evt.key == pygame.K_n:
+                        return False
+                if evt.type == pygame.QUIT:
+                    self.abort()
+                    return False
+    
+    def test_clipped(self):
+        self.assertTrue(self.query(pygame.Rect(0,0,100,20), True))
+    
+    def test_notclipped(self):
+        self.assertTrue(self.query(pygame.Rect(0,0,600,20), False))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1814,7 +1814,7 @@ class VisualTests(unittest.TestCase):
         pygame.quit()
 
     def query(self, pos, clip_rect, is_clipped=False):
-        self.screen.fill((255, 255, 255))
+        self.screen.fill((128, 128, 128))
         question = ""
         message = ""
         if is_clipped:
@@ -1853,7 +1853,6 @@ class VisualTests(unittest.TestCase):
                     if evt.key == pygame.K_n:
                         return False
                 if evt.type == pygame.QUIT:
-                    self.abort()
                     return False
 
     def test_clipped(self):

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1814,7 +1814,7 @@ class VisualTests(unittest.TestCase):
         pygame.quit()
 
     def query(self, pos, clip_rect, is_clipped=False):
-        self.screen.fill((128, 255, 255))
+        self.screen.fill((128, 128, 128))
         question = ""
         message = ""
         if is_clipped:

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1814,7 +1814,7 @@ class VisualTests(unittest.TestCase):
         pygame.quit()
 
     def query(self, pos, clip_rect, is_clipped=False):
-        self.screen.fill((128, 128, 128))
+        self.screen.fill((128, 255, 255))
         question = ""
         message = ""
         if is_clipped:
@@ -1856,14 +1856,14 @@ class VisualTests(unittest.TestCase):
                     return False
 
     def test_clipped(self):
-        self.assertTrue(self.query((0,0), pygame.Rect(0, 0, 100, 20), True))
-        self.assertTrue(self.query((75,60), pygame.Rect(50, 50, 100, 30), True))
-        self.assertTrue(self.query((25,60), pygame.Rect(50, 50, 100, 30), True))
+        self.assertTrue(self.query((0, 0), pygame.Rect(0, 0, 100, 20), True))
+        self.assertTrue(self.query((75, 60), pygame.Rect(50, 50, 100, 30), True))
+        self.assertTrue(self.query((25, 60), pygame.Rect(50, 50, 100, 30), True))
 
     def test_not_clipped(self):
-        self.assertTrue(self.query((0,0), pygame.Rect(0, 0, 600, 20), False))
-        self.assertTrue(self.query((50,50), pygame.Rect(50, 50, 600, 20), False))
-        self.assertTrue(self.query((100,60), pygame.Rect(50, 50, 600, 30), False))
+        self.assertTrue(self.query((0, 0), pygame.Rect(0, 0, 600, 20), False))
+        self.assertTrue(self.query((50, 50), pygame.Rect(50, 50, 600, 20), False))
+        self.assertTrue(self.query((100, 60), pygame.Rect(50, 50, 600, 30), False))
 
 
 if __name__ == "__main__":

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1813,13 +1813,16 @@ class VisualTests(unittest.TestCase):
     def tearDown(self):
         pygame.quit()
 
-    def query(self, clip_rect, is_clipped=False):
+    def query(self, pos, clip_rect, is_clipped=False):
         self.screen.fill((255, 255, 255))
         question = ""
+        message = ""
         if is_clipped:
             question = "Is the text clipped? y/n"
+            message = "this text should be clipped inside the red box"
         else:
             question = "Can the full text be seen? y/n"
+            message = "this text shouldn't be clipped inside the red box"
 
         self.f.render_to(self.screen, (100, 100), question, size=20, fgcolor=(0, 0, 0))
 
@@ -1831,8 +1834,8 @@ class VisualTests(unittest.TestCase):
         pygame.draw.rect(self.screen, (255, 0, 0), clip_rect)
         self.f.render_to(
             self.screen,
-            (0, 0),
-            "this text should be clipped inside the red box",
+            pos,
+            message,
             size=20,
             fgcolor=(255, 255, 255),
         )
@@ -1854,10 +1857,14 @@ class VisualTests(unittest.TestCase):
                     return False
 
     def test_clipped(self):
-        self.assertTrue(self.query(pygame.Rect(0, 0, 100, 20), True))
+        self.assertTrue(self.query((0,0), pygame.Rect(0, 0, 100, 20), True))
+        self.assertTrue(self.query((75,60), pygame.Rect(50, 50, 100, 30), True))
+        self.assertTrue(self.query((25,60), pygame.Rect(50, 50, 100, 30), True))
 
-    def test_notclipped(self):
-        self.assertTrue(self.query(pygame.Rect(0, 0, 600, 20), False))
+    def test_not_clipped(self):
+        self.assertTrue(self.query((0,0), pygame.Rect(0, 0, 600, 20), False))
+        self.assertTrue(self.query((50,50), pygame.Rect(50, 50, 600, 20), False))
+        self.assertTrue(self.query((100,60), pygame.Rect(50, 50, 600, 30), False))
 
 
 if __name__ == "__main__":

--- a/test/freetype_test.py
+++ b/test/freetype_test.py
@@ -1794,6 +1794,7 @@ class FreeTypeTest(unittest.TestCase):
 
         self.assertIsNone(error_msg)
 
+
 class VisualTests(unittest.TestCase):
 
     __tags__ = ["interactive"]
@@ -1811,7 +1812,7 @@ class VisualTests(unittest.TestCase):
 
     def tearDown(self):
         pygame.quit()
-    
+
     def query(self, clip_rect, is_clipped=False):
         self.screen.fill((255, 255, 255))
         question = ""
@@ -1820,26 +1821,20 @@ class VisualTests(unittest.TestCase):
         else:
             question = "Can the full text be seen? y/n"
 
-        self.f.render_to(
-            self.screen,
-            (100, 100),
-            question,
-            size=20,
-            fgcolor=(0,0,0)
-        )
+        self.f.render_to(self.screen, (100, 100), question, size=20, fgcolor=(0, 0, 0))
 
         if is_clipped:
             self.screen.set_clip(clip_rect)
         else:
             self.screen.set_clip(None)
-    
+
         pygame.draw.rect(self.screen, (255, 0, 0), clip_rect)
         self.f.render_to(
             self.screen,
             (0, 0),
-            'this text should be clipped inside the red box',
+            "this text should be clipped inside the red box",
             size=20,
-            fgcolor=(255, 255, 255)
+            fgcolor=(255, 255, 255),
         )
 
         pygame.display.flip()
@@ -1857,12 +1852,13 @@ class VisualTests(unittest.TestCase):
                 if evt.type == pygame.QUIT:
                     self.abort()
                     return False
-    
+
     def test_clipped(self):
-        self.assertTrue(self.query(pygame.Rect(0,0,100,20), True))
-    
+        self.assertTrue(self.query(pygame.Rect(0, 0, 100, 20), True))
+
     def test_notclipped(self):
-        self.assertTrue(self.query(pygame.Rect(0,0,600,20), False))
+        self.assertTrue(self.query(pygame.Rect(0, 0, 600, 20), False))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #3346 

Simply the clip set for a Surface object was not being copied into a FontSurface object, just its width, and height.

My fix works by setting its width or height to its clip equivalent clip attribute if it is smaller than its counterpart. I hope this is an ok fix, I don't think any tests failed from it.