### PR TITLE
Fix line width being divided by the cosine of the angle from the closest orthogonal

### DIFF
--- a/src_py/draw_py.py
+++ b/src_py/draw_py.py
@@ -434,6 +434,13 @@ def draw_aaline(surf, color, from_point, to_point, blend=True):
 def draw_line(surf, color, from_point, to_point, width=1):
     """draw anti-aliased line between two endpoints."""
     line = [from_point[0], from_point[1], to_point[0], to_point[1]]
+    if width!=1:
+        '''angle=math.atan2(*map(float.__sub__,destination,initial))%(math.pi/2)
+        angle=min(angle,math.pi/2-angle)
+        width=int(width/math.cos(angle))'''
+        displacement=sorted([(d-i)**2 for d,i in zip(destination,initial)]) #lap(float.__sub__,destination,initial)
+        if displacement[1]!=0.0:
+            width=int(width*(displacement[0]/displacement[1]+1)**0.5)
     return _clip_and_draw_line_width(surf, surf.get_clip(), color, line, width)
 
 

--- a/src_py/draw_py.py
+++ b/src_py/draw_py.py
@@ -446,7 +446,7 @@ def draw_line(surf, color, from_point, to_point, width=1):
             #width=int(width*(displacement[0]/displacement[1]+1)**0.5)
         #more optimised
         (x,y)=[(d-i)**2 for d,i in zip(to_point,from_point)]
-        if displacement!=[0,0]:
+        if x!=0 or y!=0:
             width=int(width*((x/y if x<y else y/x)+1)**0.5)
 
     return _clip_and_draw_line_width(surf, surf.get_clip(), color, line, width)

--- a/src_py/draw_py.py
+++ b/src_py/draw_py.py
@@ -435,12 +435,20 @@ def draw_line(surf, color, from_point, to_point, width=1):
     """draw anti-aliased line between two endpoints."""
     line = [from_point[0], from_point[1], to_point[0], to_point[1]]
     if width!=1:
-        '''angle=math.atan2(*map(float.__sub__,destination,initial))%(math.pi/2)
-        angle=min(angle,math.pi/2-angle)
-        width=int(width/math.cos(angle))'''
-        displacement=sorted([(d-i)**2 for d,i in zip(destination,initial)]) #lap(float.__sub__,destination,initial)
-        if displacement[1]!=0.0:
-            width=int(width*(displacement[0]/displacement[1]+1)**0.5)
+        #trigonometry
+        #angle=math.atan2(*map(float.__sub__,destination,initial))%(math.pi/2)
+        #angle=min(angle,math.pi/2-angle)
+        #width=int(width/math.cos(angle))
+        #optimised by 1/cos(atan(x/y)=sqrt((x/y)**2+1)
+        #displacement=[(d-i)**2 for d,i in zip(to_point,from_point)]
+        #displacement.sort()
+        #if displacement[1]!=0.0:
+            #width=int(width*(displacement[0]/displacement[1]+1)**0.5)
+        #more optimised
+        (x,y)=[(d-i)**2 for d,i in zip(to_point,from_point)]
+        if displacement!=[0,0]:
+            width=int(width*((x/y if x<y else y/x)+1)**0.5)
+
     return _clip_and_draw_line_width(surf, surf.get_clip(), color, line, width)
 
 


### PR DESCRIPTION
For lines with width!=1, Pygame draws them as parallelograms, with one pair of opposite sides being the displacement from the origin to the destination, and the other being the line's width. However, this other pair is always orthogonal, meaning diagonal lines' width (as perceived by human eyes as the distance between either of the displacement sides perpendicular to their direction) is divided by sqrt(2) compared to orthogonal ones. This commit fixes it without use of trigonometry, due to the 1/cos(atan(x/y))=sqrt((x/y)**2+1) identity.
Here is a diagram, if you would like. (Note that the third one's width is perceptually the same as the first's)
![the diagram](https://user-images.githubusercontent.com/58664547/181861001-161b7c2b-d539-4c68-a482-8e4659ec9c47.png)
