### PR TITLE
Deprecate `Color.set_length`

### DIFF
--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -214,6 +214,15 @@
       is useful if you want to unpack to r,g,b and not r,g,b,a. If you want to
       get the length of a Color do ``len(acolor)``.
 
+      .. note:: 
+         DEPRECATED: `set_length` will be deprecated from version 2.1.3
+         You may unpack the values you need like so, 
+         ``r, g, b, _ = pygame.Color(100, 100, 100)``
+         If you only want r, g and b
+         Or 
+         ``r, g, *_ = pygame.Color(100, 100, 100)`` 
+         if you only want r and g
+
       .. versionadded:: 1.9.0
 
       .. ## Color.set_length ##

--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -214,15 +214,7 @@
       is useful if you want to unpack to r,g,b and not r,g,b,a. If you want to
       get the length of a Color do ``len(acolor)``.
 
-      .. note:: 
-         DEPRECATED: `set_length` will be deprecated from version 2.1.3
-         You may unpack the values you need like so, 
-         ``r, g, b, _ = pygame.Color(100, 100, 100)``
-         If you only want r, g and b
-         Or 
-         ``r, g, *_ = pygame.Color(100, 100, 100)`` 
-         if you only want r and g
-
+      .. deprecated:: 2.1.3
       .. versionadded:: 1.9.0
 
       .. ## Color.set_length ##

--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -210,6 +210,14 @@
       | :sl:`Set the number of elements in the Color to 1,2,3, or 4.`
       | :sg:`set_length(len) -> None`
 
+      DEPRECATED: `set_length` will be deprecated from version 2.1.3
+      You may unpack the values you need like so, 
+      ``r, g, b, _ = pygame.Color(100, 100, 100)``
+      If you only want r, g and b
+      Or 
+      ``r, g, *_ = pygame.Color(100, 100, 100)`` 
+      if you only want r and g
+
       The default Color length is 4. Colors can have lengths 1,2,3 or 4. This
       is useful if you want to unpack to r,g,b and not r,g,b,a. If you want to
       get the length of a Color do ``len(acolor)``.

--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -210,8 +210,7 @@
       | :sl:`Set the number of elements in the Color to 1,2,3, or 4.`
       | :sg:`set_length(len) -> None`
 
-      DEPRECATED: `set_length` will be deprecated from version 2.1.3
-      You may unpack the values you need like so, 
+      DEPRECATED: You may unpack the values you need like so, 
       ``r, g, b, _ = pygame.Color(100, 100, 100)``
       If you only want r, g and b
       Or 

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1681,9 +1681,7 @@ _color_set_length(pgColorObject *color, PyObject *args)
 
     if (PyErr_WarnEx(
             PyExc_DeprecationWarning,
-            "You can selectively unpack the rgba values you want, without "
-            "having to set length.\nExample: r, g, b, _ = pygame.Color(200, "
-            "100, 42)\nSo, set_length() will be deprecated in pygame 2.1.3",
+            "pygame.Color.set_length deprecated since 2.1.3",
             1) == -1) {
         return NULL;
     }

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1679,10 +1679,9 @@ _color_set_length(pgColorObject *color, PyObject *args)
 {
     int clength;
 
-    if (PyErr_WarnEx(
-            PyExc_DeprecationWarning,
-            "pygame.Color.set_length deprecated since 2.1.3",
-            1) == -1) {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "pygame.Color.set_length deprecated since 2.1.3",
+                     1) == -1) {
         return NULL;
     }
 

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -1679,6 +1679,15 @@ _color_set_length(pgColorObject *color, PyObject *args)
 {
     int clength;
 
+    if (PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "You can selectively unpack the rgba values you want, without "
+            "having to set length.\nExample: r, g, b, _ = pygame.Color(200, "
+            "100, 42)\nSo, set_length() will be deprecated in pygame 2.1.3",
+            1) == -1) {
+        return NULL;
+    }
+
     if (!PyArg_ParseTuple(args, "i", &clength)) {
         if (!PyErr_ExceptionMatches(PyExc_OverflowError)) {
             return NULL;

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -268,12 +268,11 @@ class ColorTypeTest(unittest.TestCase):
         r, g, b = c
         self.assertEqual((1, 2, 3), (r, g, b))
 
-        # Checking if DeprecationWarning is triggered 
-        # when function is called 
+        # Checking if DeprecationWarning is triggered
+        # when function is called
         for i in range(1, 5):
             with self.assertWarns(DeprecationWarning):
-                c.set_length(i) 
-
+                c.set_length(i)
 
     def test_length(self):
         # should be able to unpack to r,g,b,a and r,g,b

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -268,6 +268,13 @@ class ColorTypeTest(unittest.TestCase):
         r, g, b = c
         self.assertEqual((1, 2, 3), (r, g, b))
 
+        # Checking if DeprecationWarning is triggered 
+        # when function is called 
+        for i in range(1, 5):
+            with self.assertWarns(DeprecationWarning):
+                c.set_length(i) 
+
+
     def test_length(self):
         # should be able to unpack to r,g,b,a and r,g,b
         c = pygame.Color(1, 2, 3, 4)


### PR DESCRIPTION
Resolves #3341 

Does:
  - Trigger `DeprecationWarning` on calling `pygame.Color.set_length`
  - Warns deprecation in documentation
  - Checks for `DeprecationWarning` in <a href="https://github.com/pygame/pygame/blob/main/test/color_test.py">color_test.py</a>


Screenshots:


![image](https://user-images.githubusercontent.com/77634274/181878313-157f5381-d49a-4dac-97b6-9e8853c6e717.png)

