### PR TITLE
Use memcpy and memset when appropriate

### DIFF
--- a/src_c/color.c
+++ b/src_c/color.c
@@ -541,10 +541,7 @@ _color_new_internal_length(PyTypeObject *type, const Uint8 rgba[],
         return NULL;
     }
 
-    color->data[0] = rgba[0];
-    color->data[1] = rgba[1];
-    color->data[2] = rgba[2];
-    color->data[3] = rgba[3];
+    memcpy(color->data, rgba, 4);
     color->len = length;
 
     return color;

--- a/src_c/math.c
+++ b/src_c/math.c
@@ -2261,8 +2261,7 @@ vector2_rotate_rad_ip(pgVector *self, PyObject *angleObject)
         return NULL;
     }
 
-    tmp[0] = self->coords[0];
-    tmp[1] = self->coords[1];
+    memcpy(tmp, self->coords, 2 * sizeof(double));
     if (!_vector2_rotate_helper(self->coords, tmp, angle, self->epsilon)) {
         return NULL;
     }
@@ -2315,8 +2314,7 @@ vector2_rotate_ip(pgVector *self, PyObject *angleObject)
     }
     angle = DEG2RAD(angle);
 
-    tmp[0] = self->coords[0];
-    tmp[1] = self->coords[1];
+    memcpy(tmp, self->coords, 2 * sizeof(double));
     if (!_vector2_rotate_helper(self->coords, tmp, angle, self->epsilon)) {
         return NULL;
     }

--- a/src_c/pixelarray_methods.c
+++ b/src_c/pixelarray_methods.c
@@ -234,9 +234,7 @@ _make_surface(pgPixelArrayObject *array, PyObject *args)
                 pixel_p = pixelrow;
                 new_pixel_p = new_pixelrow;
                 for (x = 0; x < dim0; ++x) {
-                    new_pixel_p[0] = pixel_p[0];
-                    new_pixel_p[1] = pixel_p[1];
-                    new_pixel_p[2] = pixel_p[2];
+                    memcpy(new_pixel_p, pixel_p, 3);
                     pixel_p += stride0;
                     new_pixel_p += new_stride0;
                 }

--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -277,9 +277,7 @@ rotate90(SDL_Surface *src, int angle)
                 dstpix = dstrow;
                 srcpix = srcrow;
                 for (loopx = 0; loopx < dstwidth; ++loopx) {
-                    dstpix[0] = srcpix[0];
-                    dstpix[1] = srcpix[1];
-                    dstpix[2] = srcpix[2];
+                    memcpy(dstpix, srcpix, 3);
                     srcpix += srcstepx;
                     dstpix += dststepx;
                 }
@@ -480,9 +478,7 @@ stretch(SDL_Surface *src, SDL_Surface *dst)
                 Uint8 *srcpix = (Uint8 *)srcrow, *dstpix = (Uint8 *)dstrow;
                 w_err = srcwidth2 - dstwidth2;
                 for (loopw = 0; loopw < dstwidth; ++loopw) {
-                    dstpix[0] = srcpix[0];
-                    dstpix[1] = srcpix[1];
-                    dstpix[2] = srcpix[2];
+                    memcpy(dstpix, srcpix, 3);
                     dstpix += 3;
                     while (w_err >= 0) {
                         srcpix += 3;
@@ -812,9 +808,8 @@ surf_flip(PyObject *self, PyObject *args, PyObject *kwargs)
 
     if (!xaxis) {
         if (!yaxis) {
-            for (loopy = 0; loopy < surf->h; ++loopy)
-                memcpy(dstpix + loopy * dstpitch, srcpix + loopy * srcpitch,
-                       surf->w * surf->format->BytesPerPixel);
+            assert(srcpitch == dstpitch);
+            memcpy(dstpix, srcpix, srcpitch * surf->h);
         }
         else {
             for (loopy = 0; loopy < surf->h; ++loopy)
@@ -868,9 +863,7 @@ surf_flip(PyObject *self, PyObject *args, PyObject *kwargs)
                                        (surf->h - 1 - loopy) * srcpitch)) +
                             surf->w * 3 - 3;
                         for (loopx = 0; loopx < surf->w; ++loopx) {
-                            dst[0] = src[0];
-                            dst[1] = src[1];
-                            dst[2] = src[2];
+                            memcpy(dst, src, 3);
                             dst += 3;
                             src -= 3;
                         }
@@ -913,9 +906,7 @@ surf_flip(PyObject *self, PyObject *args, PyObject *kwargs)
                         Uint8 *src = ((Uint8 *)(srcpix + loopy * srcpitch)) +
                                      surf->w * 3 - 3;
                         for (loopx = 0; loopx < surf->w; ++loopx) {
-                            dst[0] = src[0];
-                            dst[1] = src[1];
-                            dst[2] = src[2];
+                            memcpy(dst, src, 3);
                             dst += 3;
                             src -= 3;
                         }
@@ -1024,9 +1015,7 @@ chop(SDL_Surface *src, int x, int y, int width, int height)
                             *(Uint16 *)dstpix = *(Uint16 *)srcpix;
                             break;
                         case 3:
-                            dstpix[0] = srcpix[0];
-                            dstpix[1] = srcpix[1];
-                            dstpix[2] = srcpix[2];
+                            memcpy(dstpix, srcpix, 3);
                             break;
                         case 4:
                             *(Uint32 *)dstpix = *(Uint32 *)srcpix;
@@ -2208,10 +2197,7 @@ laplacian(SDL_Surface *surf, SDL_Surface *destsurf)
                 sample[8] = LAPLACIAN_NUM;
             }
 
-            total[0] = 0;
-            total[1] = 0;
-            total[2] = 0;
-            total[3] = 0;
+            memset(total, 0, 4 * sizeof(int));
 
             for (ii = 0; ii < 9; ii++) {
                 SDL_GetRGBA(sample[ii], format, &c1r, &c1g, &c1b, &c1a);


### PR DESCRIPTION
I was looking around and found a couple places where we should be using memcpy or memset. I was pursuing performance with this project, but there aren't good speedups in this, as far as I can tell, unfortunately.

I did get one performance "win" - for transform.flip(surf, False, False). This is a "flip" that doesn't flip x or y, so it's just a copy. Previously this copy was pixel line by pixel line, but I've changed it to copy the whole buffer in one memcpy call. This is now 20% faster.