### PR TITLE
Add anchor kwarg to blit()

### DIFF
--- a/buildconfig/stubs/pygame/surface.pyi
+++ b/buildconfig/stubs/pygame/surface.pyi
@@ -58,6 +58,18 @@ class Surface:
         dest: Union[Coordinate, RectValue],
         area: Optional[RectValue] = None,
         special_flags: int = 0,
+        anchor: Union[
+            Literal["topleft"],
+            Literal["topright"],
+            Literal["bottomleft"],
+            Literal["bottomright"],
+            Literal["midleft"],
+            Literal["midright"],
+            Literal["midtop"],
+            Literal["midbottom"],
+            Literal["center"],
+            None
+        ] = None,
     ) -> Rect: ...
     def blits(
         self,

--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -120,6 +120,21 @@
          different approximations used for the alpha blending formula. The SDL2 blitter also supports
          RLE on alpha blended surfaces which the pygame one does not.
 
+      .. versionadded:: 2.1.3
+         Optional kwargs for position draw has been added.
+         Replace ``<draw_pos>`` with any of the following:
+
+         ::
+
+            topleft, bottomleft, topright, bottomright
+            midtop, midleft, midbottom, midright, center
+         
+         Here's an example:
+
+         ::
+         
+            surface.blit(text_surf, center=(256, 224))
+
       The return rectangle is the area of the affected pixels, excluding any
       pixels outside the destination Surface, or outside the clipping area.
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1830,7 +1830,7 @@ surf_blit(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
     SDL_Rect dest_rect;
     int sx, sy;
     int the_args = 0; /* Represents special_flags */
-    PyObject *anchor = PyUnicode_FromString("topleft");
+    PyObject *anchor = NULL;
     PyObject *anchor_rect;
     SDL_Rect *temp_anchor_rect;
 
@@ -1867,7 +1867,8 @@ surf_blit(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
         src_rect = &temp;
     }
 
-    if (PyUnicode_CompareWithASCIIString(anchor, "topleft") != 0) {
+    if (anchor != NULL &&
+        PyUnicode_CompareWithASCIIString(anchor, "topleft") != 0) {
         anchor_rect = pgRect_New4(0, 0, src->w, src->h);
 
         if (PyObject_HasAttr(anchor_rect, anchor)) {

--- a/test/blit_test.py
+++ b/test/blit_test.py
@@ -150,6 +150,114 @@ class BlitTest(unittest.TestCase):
             TypeError, dst.blits, [(pygame.Surface((10, 10), SRCALPHA, 32), None)]
         )
 
+    def test_topleft_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="topleft")
+        self.assertEqual(dst.get_at((50, 50)), (255, 0, 0))
+
+        self.assertEqual(dst.get_at((57, 57)), (255, 0, 0))
+        self.assertEqual(dst.get_at((64, 64)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(50, 50, 15, 15))
+
+    def test_topright_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="topright")
+        self.assertEqual(dst.get_at((50, 50)), (0, 0, 0))
+
+        self.assertEqual(dst.get_at((43, 57)), (255, 0, 0))
+        self.assertEqual(dst.get_at((35, 64)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(35, 50, 15, 15))
+
+    def test_bottomleft_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="bottomleft")
+        self.assertEqual(dst.get_at((50, 50)), (0, 0, 0))
+
+        self.assertEqual(dst.get_at((64, 35)), (255, 0, 0))
+        self.assertEqual(dst.get_at((57, 43)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(50, 35, 15, 15))
+
+    def test_bottomright_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="bottomright")
+        self.assertEqual(dst.get_at((50, 50)), (0, 0, 0))
+
+        self.assertEqual(dst.get_at((36, 36)), (255, 0, 0))
+        self.assertEqual(dst.get_at((43, 43)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(35, 35, 15, 15))
+
+    def test_midleft_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="midleft")
+        self.assertEqual(dst.get_at((50, 50)), (255, 0, 0))
+
+        self.assertEqual(dst.get_at((50, 43)), (255, 0, 0))
+        self.assertEqual(dst.get_at((64, 57)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(50, 43, 15, 15))
+
+    def test_midright_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="midright")
+        self.assertEqual(dst.get_at((50, 50)), (0, 0, 0))
+
+        self.assertEqual(dst.get_at((36, 43)), (255, 0, 0))
+        self.assertEqual(dst.get_at((49, 57)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(35, 43, 15, 15))
+
+    def test_midtop_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="midtop")
+        self.assertEqual(dst.get_at((50, 50)), (255, 0, 0))
+
+        self.assertEqual(dst.get_at((43, 50)), (255, 0, 0))
+        self.assertEqual(dst.get_at((57, 64)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(43, 50, 15, 15))
+
+    def test_midbottom_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="midbottom")
+        self.assertEqual(dst.get_at((50, 50)), (0, 0, 0))
+
+        self.assertEqual(dst.get_at((43, 35)), (255, 0, 0))
+        self.assertEqual(dst.get_at((57, 50)), (0, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(43, 35, 15, 15))
+
+    def test_center_pos(self):
+        square = pygame.Surface((15, 15))
+        square.fill((255, 0, 0))
+        dst = pygame.Surface((100, 100))
+        result = dst.blit(square, (50, 50), anchor="center")
+        self.assertEqual(dst.get_at((50, 50)), (255, 0, 0))
+
+        self.assertEqual(dst.get_at((43, 43)), (255, 0, 0))
+        self.assertEqual(dst.get_at((57, 57)), (255, 0, 0))
+
+        self.assertEqual(result, pygame.Rect(43, 43, 15, 15))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes: https://github.com/pygame/pygame/issues/3202

@Starbuck5 and I had a conversation on how to optimize this better, but we couldn't get it to be faster than the Python code using `get_rect()`. If someone has any idea on how to optimize this, that'll be great.

```
pygame 2.1.3.dev5 (SDL 2.0.22, Python 3.9.0)
Hello from the pygame community. https://www.pygame.org/contribute.html
## ANCHOR KWARG ##
no kwargs: 0.2553597000000001 seconds
topleft: 0.4961052 seconds
topright: 0.6383643999999999 seconds
bottomleft: 0.6494785000000001 seconds
bottomright: 0.6352516000000001 seconds
midleft: 0.6348135999999998 seconds
midright: 0.6555408000000003 seconds
midtop: 0.6400424000000005 seconds
midbottom: 0.6353241000000001 seconds
center: 0.6293594000000002 seconds
PS C:\Users\novia\Desktop\blit kwargs test> python test3.py
pygame 2.1.3.dev5 (SDL 2.0.22, Python 3.9.0)
Hello from the pygame community. https://www.pygame.org/contribute.html
## GET_RECT() ##
no rect: 0.2463491 seconds
topleft: 0.40525160000000005 seconds
topright: 0.4099286999999999 seconds
bottomleft: 0.40654049999999997 seconds
bottomright: 0.4106080000000001 seconds
midleft: 0.41274900000000025 seconds
midright: 0.4012313999999999 seconds
midtop: 0.4056690999999999 seconds
midbottom: 0.40756900000000007 seconds
center: 0.4032928 seconds
```