### PR TITLE
Fix some METH_NOARGS usage, use METH_O where possible

### DIFF
--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1529,14 +1529,13 @@ event_name(PyObject *self, PyObject *arg)
 static PyObject *
 set_grab(PyObject *self, PyObject *arg)
 {
-    int doit;
-    SDL_Window *win = NULL;
-
-    if (!PyArg_ParseTuple(arg, "p", &doit))
+    int doit = PyObject_IsTrue(arg);
+    if (doit == -1)
         return NULL;
+
     VIDEO_INIT_CHECK();
 
-    win = pg_GetDefaultWindow();
+    SDL_Window *win = pg_GetDefaultWindow();
     if (win) {
         if (doit) {
             SDL_SetWindowGrab(win, SDL_TRUE);
@@ -2190,7 +2189,7 @@ static PyMethodDef _event_methods[] = {
 
     {"event_name", event_name, METH_VARARGS, DOC_PYGAMEEVENTEVENTNAME},
 
-    {"set_grab", set_grab, METH_VARARGS, DOC_PYGAMEEVENTSETGRAB},
+    {"set_grab", set_grab, METH_O, DOC_PYGAMEEVENTSETGRAB},
     {"get_grab", (PyCFunction)get_grab, METH_NOARGS, DOC_PYGAMEEVENTGETGRAB},
 
     {"pump", (PyCFunction)pg_event_pump, METH_NOARGS, DOC_PYGAMEEVENTPUMP},

--- a/src_c/font.c
+++ b/src_c/font.c
@@ -261,12 +261,13 @@ font_get_bold(PyObject *self, PyObject *_null)
 
 /* Implements set_bold(bool) */
 static PyObject *
-font_set_bold(PyObject *self, PyObject *args)
+font_set_bold(PyObject *self, PyObject *arg)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int val;
-    if (!PyArg_ParseTuple(args, "p", &val))
+    int val = PyObject_IsTrue(arg);
+    if (val == -1) {
         return NULL;
+    }
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_BOLD, val);
 
@@ -307,13 +308,13 @@ font_get_italic(PyObject *self, PyObject *_null)
 
 /* Implements set_italic(bool) */
 static PyObject *
-font_set_italic(PyObject *self, PyObject *args)
+font_set_italic(PyObject *self, PyObject *arg)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int val;
-
-    if (!PyArg_ParseTuple(args, "p", &val))
+    int val = PyObject_IsTrue(arg);
+    if (val == -1) {
         return NULL;
+    }
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_ITALIC, val);
 
@@ -354,13 +355,13 @@ font_get_underline(PyObject *self, PyObject *_null)
 
 /* Implements set_underline(bool) */
 static PyObject *
-font_set_underline(PyObject *self, PyObject *args)
+font_set_underline(PyObject *self, PyObject *arg)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int val;
-
-    if (!PyArg_ParseTuple(args, "p", &val))
+    int val = PyObject_IsTrue(arg);
+    if (val == -1) {
         return NULL;
+    }
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_UNDERLINE, val);
 
@@ -401,13 +402,13 @@ font_get_strikethrough(PyObject *self, PyObject *args)
 
 /* Implements set_strikethrough(bool) */
 static PyObject *
-font_set_strikethrough(PyObject *self, PyObject *args)
+font_set_strikethrough(PyObject *self, PyObject *arg)
 {
     TTF_Font *font = PyFont_AsFont(self);
-    int val;
-
-    if (!PyArg_ParseTuple(args, "p", &val))
+    int val = PyObject_IsTrue(arg);
+    if (val == -1) {
         return NULL;
+    }
 
     _font_set_or_clear_style_flag(font, TTF_STYLE_STRIKETHROUGH, val);
 
@@ -519,16 +520,11 @@ font_render(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-font_size(PyObject *self, PyObject *args)
+font_size(PyObject *self, PyObject *text)
 {
     TTF_Font *font = PyFont_AsFont(self);
     int w, h;
-    PyObject *text;
     const char *string;
-
-    if (!PyArg_ParseTuple(args, "O", &text)) {
-        return NULL;
-    }
 
     if (PyUnicode_Check(text)) {
         PyObject *bytes = PyUnicode_AsEncodedString(text, "utf-8", "strict");
@@ -557,11 +553,10 @@ font_size(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-font_metrics(PyObject *self, PyObject *args)
+font_metrics(PyObject *self, PyObject *textobj)
 {
     TTF_Font *font = PyFont_AsFont(self);
     PyObject *list;
-    PyObject *textobj;
     Py_ssize_t length;
     Py_ssize_t i;
     int minx;
@@ -575,10 +570,6 @@ font_metrics(PyObject *self, PyObject *args)
     Uint16 ch;
     PyObject *temp;
     int surrogate;
-
-    if (!PyArg_ParseTuple(args, "O", &textobj)) {
-        return NULL;
-    }
 
     if (PyUnicode_Check(textobj)) {
         obj = textobj;
@@ -664,19 +655,19 @@ static PyMethodDef font_methods[] = {
     {"get_linesize", font_get_linesize, METH_NOARGS, DOC_FONTGETLINESIZE},
 
     {"get_bold", font_get_bold, METH_NOARGS, DOC_FONTGETBOLD},
-    {"set_bold", font_set_bold, METH_VARARGS, DOC_FONTSETBOLD},
+    {"set_bold", font_set_bold, METH_O, DOC_FONTSETBOLD},
     {"get_italic", font_get_italic, METH_NOARGS, DOC_FONTGETITALIC},
-    {"set_italic", font_set_italic, METH_VARARGS, DOC_FONTSETITALIC},
+    {"set_italic", font_set_italic, METH_O, DOC_FONTSETITALIC},
     {"get_underline", font_get_underline, METH_NOARGS, DOC_FONTGETUNDERLINE},
-    {"set_underline", font_set_underline, METH_VARARGS, DOC_FONTSETUNDERLINE},
+    {"set_underline", font_set_underline, METH_O, DOC_FONTSETUNDERLINE},
     {"get_strikethrough", font_get_strikethrough, METH_NOARGS,
      DOC_FONTGETSTRIKETHROUGH},
-    {"set_strikethrough", font_set_strikethrough, METH_VARARGS,
+    {"set_strikethrough", font_set_strikethrough, METH_O,
      DOC_FONTSETSTRIKETHROUGH},
 
-    {"metrics", font_metrics, METH_VARARGS, DOC_FONTMETRICS},
+    {"metrics", font_metrics, METH_O, DOC_FONTMETRICS},
     {"render", font_render, METH_VARARGS, DOC_FONTRENDER},
-    {"size", font_size, METH_VARARGS, DOC_FONTSIZE},
+    {"size", font_size, METH_O, DOC_FONTSIZE},
 
     {NULL, NULL, 0, NULL}};
 

--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -97,13 +97,9 @@ mask_call_copy(PyObject *self, PyObject *_null)
 }
 
 static PyObject *
-mask_get_size(PyObject *self, PyObject *args)
+mask_get_size(PyObject *self, PyObject *_null)
 {
     bitmask_t *mask = pgMask_AsBitmap(self);
-
-    if (!PyArg_ParseTuple(args, ""))
-        return NULL;
-
     return Py_BuildValue("(ii)", mask->w, mask->h);
 }
 
@@ -2321,7 +2317,7 @@ to_surface_error:
 static PyMethodDef mask_methods[] = {
     {"__copy__", mask_copy, METH_NOARGS, DOC_MASKCOPY},
     {"copy", mask_call_copy, METH_NOARGS, DOC_MASKCOPY},
-    {"get_size", mask_get_size, METH_VARARGS, DOC_MASKGETSIZE},
+    {"get_size", mask_get_size, METH_NOARGS, DOC_MASKGETSIZE},
     {"get_rect", (PyCFunction)mask_get_rect, METH_VARARGS | METH_KEYWORDS,
      DOC_MASKGETRECT},
     {"get_at", (PyCFunction)mask_get_at, METH_VARARGS | METH_KEYWORDS,

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -1035,16 +1035,17 @@ chan_play(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-chan_queue(PyObject *self, PyObject *args)
+chan_queue(PyObject *self, PyObject *sound)
 {
     int channelnum = pgChannel_AsInt(self);
-    PyObject *sound;
     Mix_Chunk *chunk;
 
-    if (!PyArg_ParseTuple(args, "O!", &pgSound_Type, &sound))
-        return NULL;
-    chunk = pgSound_AsChunk(sound);
+    if (!pgSound_Check(sound)) {
+        return RAISE(PyExc_TypeError,
+                     "The argument must be an instance of Sound");
+    }
 
+    chunk = pgSound_AsChunk(sound);
     if (!channeldata[channelnum].sound) /*nothing playing*/
     {
         Py_BEGIN_ALLOW_THREADS;
@@ -1245,7 +1246,7 @@ chan_get_endevent(PyObject *self, PyObject *_null)
 static PyMethodDef channel_methods[] = {
     {"play", (PyCFunction)chan_play, METH_VARARGS | METH_KEYWORDS,
      DOC_CHANNELPLAY},
-    {"queue", chan_queue, METH_VARARGS, DOC_CHANNELQUEUE},
+    {"queue", chan_queue, METH_O, DOC_CHANNELQUEUE},
     {"get_busy", (PyCFunction)chan_get_busy, METH_NOARGS, DOC_CHANNELGETBUSY},
     {"fadeout", chan_fadeout, METH_VARARGS, DOC_CHANNELFADEOUT},
     {"stop", (PyCFunction)chan_stop, METH_NOARGS, DOC_CHANNELSTOP},

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -101,7 +101,7 @@ mouse_get_pos(PyObject *self, PyObject *_null)
 }
 
 static PyObject *
-mouse_get_rel(PyObject *self)
+mouse_get_rel(PyObject *self, PyObject *_null)
 {
     int x, y;
 
@@ -214,7 +214,7 @@ mouse_get_visible(PyObject *self, PyObject *_null)
 }
 
 static PyObject *
-mouse_get_focused(PyObject *self)
+mouse_get_focused(PyObject *self, PyObject *_null)
 {
     VIDEO_INIT_CHECK();
     return PyBool_FromLong(SDL_GetMouseFocus() != NULL);
@@ -465,14 +465,14 @@ static PyMethodDef _mouse_methods[] = {
     {"set_pos", mouse_set_pos, METH_VARARGS, DOC_PYGAMEMOUSESETPOS},
     {"get_pos", (PyCFunction)mouse_get_pos, METH_NOARGS,
      DOC_PYGAMEMOUSEGETPOS},
-    {"get_rel", (PyCFunction)mouse_get_rel, METH_VARARGS,
+    {"get_rel", (PyCFunction)mouse_get_rel, METH_NOARGS,
      DOC_PYGAMEMOUSEGETREL},
     {"get_pressed", (PyCFunction)mouse_get_pressed,
      METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEMOUSEGETPRESSED},
     {"set_visible", mouse_set_visible, METH_VARARGS,
      DOC_PYGAMEMOUSESETVISIBLE},
     {"get_visible", mouse_get_visible, METH_NOARGS, DOC_PYGAMEMOUSEGETVISIBLE},
-    {"get_focused", (PyCFunction)mouse_get_focused, METH_VARARGS,
+    {"get_focused", (PyCFunction)mouse_get_focused, METH_NOARGS,
      DOC_PYGAMEMOUSEGETFOCUSED},
     {"set_system_cursor", mouse_set_system_cursor, METH_VARARGS,
      "set_system_cursor(constant) -> None\nset the mouse cursor to a system "

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -146,7 +146,7 @@ surf_get_palette(PyObject *self, PyObject *args);
 static PyObject *
 surf_get_palette_at(PyObject *self, PyObject *args);
 static PyObject *
-surf_set_palette(PyObject *self, PyObject *args);
+surf_set_palette(PyObject *self, PyObject *list);
 static PyObject *
 surf_set_palette_at(PyObject *self, PyObject *args);
 static PyObject *
@@ -306,7 +306,7 @@ static struct PyMethodDef surface_methods[] = {
     {"get_palette", surf_get_palette, METH_NOARGS, DOC_SURFACEGETPALETTE},
     {"get_palette_at", surf_get_palette_at, METH_VARARGS,
      DOC_SURFACEGETPALETTEAT},
-    {"set_palette", surf_set_palette, METH_VARARGS, DOC_SURFACESETPALETTE},
+    {"set_palette", surf_set_palette, METH_O, DOC_SURFACESETPALETTE},
     {"set_palette_at", surf_set_palette_at, METH_VARARGS,
      DOC_SURFACESETPALETTEAT},
 
@@ -1092,7 +1092,7 @@ surf_get_palette_at(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_set_palette(PyObject *self, PyObject *args)
+surf_set_palette(PyObject *self, PyObject *list)
 {
     /* This method works differently from the SDL 1.2 equivalent.
      * It replaces colors in the surface's existing palette. So, if the
@@ -1104,15 +1104,14 @@ surf_set_palette(PyObject *self, PyObject *args)
     SDL_Color colors[256];
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SDL_Palette *pal = NULL;
-    PyObject *list, *item;
+    PyObject *item;
     int i, len;
     Uint8 rgba[4];
     int ecode;
 
-    if (!PyArg_ParseTuple(args, "O", &list))
-        return NULL;
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
+
     if (!PySequence_Check(list))
         return RAISE(PyExc_ValueError, "Argument must be a sequence type");
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -146,7 +146,7 @@ surf_get_palette(PyObject *self, PyObject *args);
 static PyObject *
 surf_get_palette_at(PyObject *self, PyObject *args);
 static PyObject *
-surf_set_palette(PyObject *self, PyObject *list);
+surf_set_palette(PyObject *self, PyObject *seq);
 static PyObject *
 surf_set_palette_at(PyObject *self, PyObject *args);
 static PyObject *
@@ -1092,7 +1092,7 @@ surf_get_palette_at(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-surf_set_palette(PyObject *self, PyObject *list)
+surf_set_palette(PyObject *self, PyObject *seq)
 {
     /* This method works differently from the SDL 1.2 equivalent.
      * It replaces colors in the surface's existing palette. So, if the
@@ -1112,7 +1112,7 @@ surf_set_palette(PyObject *self, PyObject *list)
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
 
-    if (!PySequence_Check(list))
+    if (!PySequence_Check(seq))
         return RAISE(PyExc_ValueError, "Argument must be a sequence type");
 
     pal = surf->format->palette;
@@ -1124,10 +1124,10 @@ surf_set_palette(PyObject *self, PyObject *list)
         return RAISE(pgExc_SDLError, "Surface is not palettitized\n");
     old_colors = pal->colors;
 
-    len = (int)MIN(pal->ncolors, PySequence_Length(list));
+    len = (int)MIN(pal->ncolors, PySequence_Length(seq));
 
     for (i = 0; i < len; i++) {
-        item = PySequence_GetItem(list, i);
+        item = PySequence_GetItem(seq, i);
 
         ecode = pg_RGBAFromObj(item, rgba);
         Py_DECREF(item);

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -258,7 +258,7 @@ time_wait(PyObject *self, PyObject *arg)
 {
     int ticks, start;
     if (!PyLong_Check(arg))
-        return RAISE(PyExc_TypeError, "delay requires one integer argument");
+        return RAISE(PyExc_TypeError, "wait requires one integer argument");
 
     if (!SDL_WasInit(SDL_INIT_TIMER)) {
         if (SDL_InitSubSystem(SDL_INIT_TIMER)) {

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -240,16 +240,10 @@ static PyObject *
 time_delay(PyObject *self, PyObject *arg)
 {
     int ticks;
-    PyObject *arg0;
-
-    /*for some reason PyArg_ParseTuple is puking on -1's! BLARG!*/
-    if (PyTuple_Size(arg) != 1)
-        return RAISE(PyExc_ValueError, "delay requires one integer argument");
-    arg0 = PyTuple_GET_ITEM(arg, 0);
-    if (!PyLong_Check(arg0))
+    if (!PyLong_Check(arg))
         return RAISE(PyExc_TypeError, "delay requires one integer argument");
 
-    ticks = PyLong_AsLong(arg0);
+    ticks = PyLong_AsLong(arg);
     if (ticks < 0)
         ticks = 0;
 
@@ -263,13 +257,7 @@ static PyObject *
 time_wait(PyObject *self, PyObject *arg)
 {
     int ticks, start;
-    PyObject *arg0;
-
-    /*for some reason PyArg_ParseTuple is puking on -1's! BLARG!*/
-    if (PyTuple_Size(arg) != 1)
-        return RAISE(PyExc_ValueError, "delay requires one integer argument");
-    arg0 = PyTuple_GET_ITEM(arg, 0);
-    if (!PyLong_Check(arg0))
+    if (!PyLong_Check(arg))
         return RAISE(PyExc_TypeError, "delay requires one integer argument");
 
     if (!SDL_WasInit(SDL_INIT_TIMER)) {
@@ -278,7 +266,7 @@ time_wait(PyObject *self, PyObject *arg)
         }
     }
 
-    ticks = PyLong_AsLong(arg0);
+    ticks = PyLong_AsLong(arg);
     if (ticks < 0)
         ticks = 0;
 
@@ -540,8 +528,8 @@ static PyMethodDef _time_methods[] = {
      "auto quit function for time"},
     {"get_ticks", (PyCFunction)time_get_ticks, METH_NOARGS,
      DOC_PYGAMETIMEGETTICKS},
-    {"delay", time_delay, METH_VARARGS, DOC_PYGAMETIMEDELAY},
-    {"wait", time_wait, METH_VARARGS, DOC_PYGAMETIMEWAIT},
+    {"delay", time_delay, METH_O, DOC_PYGAMETIMEDELAY},
+    {"wait", time_wait, METH_O, DOC_PYGAMETIMEWAIT},
     {"set_timer", (PyCFunction)time_set_timer, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMETIMESETTIMER},
 


### PR DESCRIPTION
This PR is primarily intended for better code quality and better error reporting, but this also helps a (really tiny) bit with performance.

Some functions that were supposed to be `METH_NOARGS` were `METH_VARAGS` (which means that you could pass any arbitrary arguments to these functions and python would not complain)

I also tried to apply `METH_O` in some places where they make the code clearer
