### PR TITLE
Vendor in SDL PNG save function, fix new 2.1.3 regression

### DIFF
--- a/test/image_test.py
+++ b/test/image_test.py
@@ -220,6 +220,36 @@ class ImageModuleTest(unittest.TestCase):
             del reader
             os.remove(f_path)
 
+    def testSavePNG8(self):
+        """see if we can save an 8 bit png correctly"""
+        # Create an 8-bit PNG file with known colors
+        set_pixels = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (170, 146, 170)]
+
+        size = (1, len(set_pixels))
+        surf = pygame.Surface(size, depth=8)
+        for cnt, pix in enumerate(set_pixels):
+            surf.set_at((0, cnt), pix)
+
+        f_path = tempfile.mktemp(suffix=".png")
+        pygame.image.save(surf, f_path)
+
+        try:
+            # Read the PNG file and verify that pygame saved it correctly
+            reader = png.Reader(filename=f_path)
+            width, height, pixels, _ = reader.asRGB8()
+
+            self.assertEqual(size, (width, height))
+
+            # pixels is a generator
+            self.assertEqual(list(map(tuple, pixels)), set_pixels)
+
+        finally:
+            # Ensures proper clean up.
+            if not reader.file.closed:
+                reader.file.close()
+            del reader
+            os.remove(f_path)
+
     def testSavePaletteAsPNG8(self):
         """see if we can save a png with color values in the proper channels."""
         # Create a PNG file with known colors

--- a/test/test_utils/png.py
+++ b/test/test_utils/png.py
@@ -2042,7 +2042,7 @@ class Reader:
             meta["alpha"] = bool(self.trns)
             meta["bitdepth"] = 8
             meta["planes"] = 3 + bool(self.trns)
-            plte = self.palette()
+            plte = list(self.palette())
 
             def iterpal(pixels):
                 for row in pixels:


### PR DESCRIPTION
PR to fix #3369

Since this is a regression from 2.1.2, it needs to be in before 2.1.3

I tried a fair bit to not vendor in the SDL function and instead patch the existing code, but no matter what I tried I could not fix the bug. I wrote a unit test to catch the bug which is also a part of this PR (for this to work, I had to make a small bugfix patch in the png util library used for testing pngs)

In the middle term, the goal is to use the SDL function directly without vendoring it (there is #3242 which is a draft ATM). So this PR should help with easing the transition to that
