### PR TITLE
SSE alpha blitter optimization

### DIFF
--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -487,13 +487,18 @@ alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
                      * 000000000A1000A200 -> mm_src_alpha*/
                     mm_src_alpha = _mm_srli_si128(mm_src_alpha, 1);
 
-                    /* shuffle alpha channels to duplicate 16 byte pairs
-                     * 000000000A10A10A20A2 -> mm_src_alpha */
+                    /* shuffle alpha channels to duplicate 16 bit pairs
+                     * shuffle (3, 3, 1, 1) (backed 2 bit numbers)
+                     * [00][00][00][00][0A1][00][0A2][00] -> mm_src_alpha
+                     * [7 ][6 ][5 ][4 ][ 3 ][2 ][ 1 ][0 ]
+                     * Therefore the previous contents of 16 bit number #1
+                     * Goes into 16 bit number #1 and #2, and the previous
+                     * content of 16 bit number #3 goes into #2 and #3 */
                     mm_src_alpha =
                         _mm_shufflelo_epi16(mm_src_alpha, 0b11110101);
 
                     /* finally move into final config
-                     * spread out so they can be multipled in 16 bit math
+                     * spread out so they can be multiplied in 16 bit math
                      * against all RGBA of both pixels being blit
                      * 0A10A10A10A10A20A20A20A2 -> mm_src_alpha */
                     mm_src_alpha =


### PR DESCRIPTION
Specifically in `alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst`

I found an opportunity to reduce the amount of CPU clocks / instructions needed to move the alpha component from the src pixels into an interleaved 16 bit format.

In my testing, this got 10k 512x512 alpha blits (of this format) from around 2 seconds to around 1.6 seconds, a 15-20% improvement.

```py
import pygame
import time

pygame.init()

screen = pygame.Surface((1920,1080), depth=32)
screen.fill((255,0,23))

surf = pygame.Surface((512,512), pygame.SRCALPHA)
surf.fill((22,156,77,192))

print(screen, surf)

start = time.time()
for _ in range(10000):
    screen.blit(surf, (51, 67))
print(time.time() - start)
```
This is my test program. Note that the "screen" surface has a bit depth of 32 but does not have per pixel alpha.