### PR TITLE
fixed run_tests.py | Quiet bug catch.

### DIFF
--- a/test/test_utils/run_tests.py
+++ b/test/test_utils/run_tests.py
@@ -1,7 +1,7 @@
 import sys
 
 if __name__ == "__main__":
-    raise ValueError("This module is for import only")
+    raise RuntimeError("This module is for import only")
 test_pkg_name = ".".join(__name__.split(".")[0:-2])
 is_pygame_pkg = test_pkg_name == "pygame.tests"
 test_runner_mod = test_pkg_name + ".test_utils.test_runner"

--- a/test/test_utils/run_tests.py
+++ b/test/test_utils/run_tests.py
@@ -1,8 +1,7 @@
 import sys
 
 if __name__ == "__main__":
-    sys.exit("This module is for import only")
-
+    raise ValueError("This module is for import only")
 test_pkg_name = ".".join(__name__.split(".")[0:-2])
 is_pygame_pkg = test_pkg_name == "pygame.tests"
 test_runner_mod = test_pkg_name + ".test_utils.test_runner"


### PR DESCRIPTION
If you somehow run this file without knowing which file exactly you are running, you will get no information, just "This module is for import only", So you will need to check every single file that was executed.
Fix:
Replaced it with raise ValueError() because it says what happened, and where exactly.