### PR TITLE
setup.py | io module no longer used.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@
 # To configure, compile, install, just run this script.
 #     python setup.py install
 
-import io
 import platform
 
 with open('README.rst', encoding='utf-8') as readme:


### PR DESCRIPTION
setup.py no longer use this module in any way.
Previously it was here for with io.open() function, but then was deleted in this merge: https://github.com/pygame/pygame/commit/e815c442e8bd82a68d1c228e96b65a56eab00084