### PR TITLE
config_unix.py | deleted unused import of module

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -1,6 +1,6 @@
 """Config on Unix"""
 
-import os, sys
+import os
 from glob import glob
 import platform
 import logging


### PR DESCRIPTION
Fixed an alert from LGTM
[Click](https://lgtm.com/projects/g/pygame/pygame/snapshot/e994222bf50ccca061bc2908f4225c9e30ccb65e/files/buildconfig/config_unix.py?sort=name&dir=ASC&mode=heatmap#xa2c88a609f5f83a1:1)