### PR TITLE
Optimized rect getters

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -37,6 +37,27 @@
 static PyTypeObject pgRect_Type;
 #define pgRect_Check(x) ((x)->ob_type == &pgRect_Type)
 
+#define PG_RETURN_TUPLE_FROMVALUES_INT(val1, val2) \
+    do {                                           \
+        PyObject *tup = PyTuple_New(2);            \
+        if (!tup) {                                \
+            return NULL;                           \
+        }                                          \
+        PyObject *tmp = PyLong_FromLong(val1);     \
+        if (!tmp) {                                \
+            Py_DECREF(tup);                        \
+            return NULL;                           \
+        }                                          \
+        PyTuple_SET_ITEM(tup, 0, tmp);             \
+        tmp = PyLong_FromLong(val2);               \
+        if (!tmp) {                                \
+            Py_DECREF(tup);                        \
+            return NULL;                           \
+        }                                          \
+        PyTuple_SET_ITEM(tup, 1, tmp);             \
+        return tup;                                \
+    } while (0)
+
 static int
 pg_rect_init(pgRectObject *, PyObject *, PyObject *);
 
@@ -1835,13 +1856,7 @@ pg_rect_setcentery(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopleft(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x, self->r.y);
 }
 
 static int
@@ -1868,13 +1883,7 @@ pg_rect_settopleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopright(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + self->r.w));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + self->r.w, self->r.y);
 }
 
 static int
@@ -1901,13 +1910,7 @@ pg_rect_settopright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomleft(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + self->r.h));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x, self->r.y + self->r.h);
 }
 
 static int
@@ -1934,13 +1937,8 @@ pg_rect_setbottomleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomright(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + self->r.w));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + self->r.h));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + self->r.w,
+                                   self->r.y + self->r.h);
 }
 
 static int
@@ -1967,13 +1965,7 @@ pg_rect_setbottomright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidtop(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + (self->r.w >> 1)));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + (self->r.w >> 1), self->r.y);
 }
 
 static int
@@ -2000,13 +1992,7 @@ pg_rect_setmidtop(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidleft(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + (self->r.h >> 1)));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x, self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2033,13 +2019,8 @@ pg_rect_setmidleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidbottom(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + (self->r.w >> 1)));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + self->r.h));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + (self->r.w >> 1),
+                                   self->r.y + self->r.h);
 }
 
 static int
@@ -2066,13 +2047,8 @@ pg_rect_setmidbottom(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidright(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + self->r.w));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + (self->r.h >> 1)));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + self->r.w,
+                                   self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2099,13 +2075,8 @@ pg_rect_setmidright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getcenter(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + (self->r.w >> 1)));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + (self->r.h >> 1)));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + (self->r.w >> 1),
+                                   self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2132,13 +2103,7 @@ pg_rect_setcenter(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getsize(pgRectObject *self, void *closure)
 {
-    PyObject *tuple = PyTuple_New(2);
-    if (!tuple) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.w));
-    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.h));
-    return tuple;
+    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.w, self->r.h);
 }
 
 static int

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -2274,11 +2274,6 @@ MODINIT_DEFINE(rect)
         return NULL;
     }
 
-    import_pygame_math();
-    if (PyErr_Occurred()) {
-        return NULL;
-    }
-
     /* Create the module and add the functions */
     if (PyType_Ready(&pgRect_Type) < 0) {
         return NULL;

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -37,27 +37,6 @@
 static PyTypeObject pgRect_Type;
 #define pgRect_Check(x) ((x)->ob_type == &pgRect_Type)
 
-#define PG_RETURN_TUPLE_FROMVALUES_INT(val1, val2) \
-    do {                                           \
-        PyObject *tup = PyTuple_New(2);            \
-        if (!tup) {                                \
-            return NULL;                           \
-        }                                          \
-        PyObject *tmp = PyLong_FromLong(val1);     \
-        if (!tmp) {                                \
-            Py_DECREF(tup);                        \
-            return NULL;                           \
-        }                                          \
-        PyTuple_SET_ITEM(tup, 0, tmp);             \
-        tmp = PyLong_FromLong(val2);               \
-        if (!tmp) {                                \
-            Py_DECREF(tup);                        \
-            return NULL;                           \
-        }                                          \
-        PyTuple_SET_ITEM(tup, 1, tmp);             \
-        return tup;                                \
-    } while (0)
-
 static int
 pg_rect_init(pgRectObject *, PyObject *, PyObject *);
 
@@ -165,6 +144,31 @@ four_ints_from_obj(PyObject *obj, int *val1, int *val2, int *val3, int *val4)
     }
 
     return 1;
+}
+
+PyObject *
+pg_tuple_from_values_int(int val1, int val2)
+{
+    PyObject *tup = PyTuple_New(2);
+    if (!tup) {
+        return NULL;
+    }
+
+    PyObject *tmp = PyLong_FromLong(val1);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 0, tmp);
+
+    tmp = PyLong_FromLong(val2);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 1, tmp);
+
+    return tup;
 }
 
 static PyObject *
@@ -1856,7 +1860,7 @@ pg_rect_setcentery(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopleft(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x, self->r.y);
+    return pg_tuple_from_values_int(self->r.x, self->r.y);
 }
 
 static int
@@ -1883,7 +1887,7 @@ pg_rect_settopleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopright(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + self->r.w, self->r.y);
+    return pg_tuple_from_values_int(self->r.x + self->r.w, self->r.y);
 }
 
 static int
@@ -1910,7 +1914,7 @@ pg_rect_settopright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomleft(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x, self->r.y + self->r.h);
+    return pg_tuple_from_values_int(self->r.x, self->r.y + self->r.h);
 }
 
 static int
@@ -1937,8 +1941,8 @@ pg_rect_setbottomleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomright(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + self->r.w,
-                                   self->r.y + self->r.h);
+    return pg_tuple_from_values_int(self->r.x + self->r.w,
+                                    self->r.y + self->r.h);
 }
 
 static int
@@ -1965,7 +1969,7 @@ pg_rect_setbottomright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidtop(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + (self->r.w >> 1), self->r.y);
+    return pg_tuple_from_values_int(self->r.x + (self->r.w >> 1), self->r.y);
 }
 
 static int
@@ -1992,7 +1996,7 @@ pg_rect_setmidtop(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidleft(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x, self->r.y + (self->r.h >> 1));
+    return pg_tuple_from_values_int(self->r.x, self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2019,8 +2023,8 @@ pg_rect_setmidleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidbottom(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + (self->r.w >> 1),
-                                   self->r.y + self->r.h);
+    return pg_tuple_from_values_int(self->r.x + (self->r.w >> 1),
+                                    self->r.y + self->r.h);
 }
 
 static int
@@ -2047,8 +2051,8 @@ pg_rect_setmidbottom(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidright(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + self->r.w,
-                                   self->r.y + (self->r.h >> 1));
+    return pg_tuple_from_values_int(self->r.x + self->r.w,
+                                    self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2075,8 +2079,8 @@ pg_rect_setmidright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getcenter(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.x + (self->r.w >> 1),
-                                   self->r.y + (self->r.h >> 1));
+    return pg_tuple_from_values_int(self->r.x + (self->r.w >> 1),
+                                    self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2103,7 +2107,7 @@ pg_rect_setcenter(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getsize(pgRectObject *self, void *closure)
 {
-    PG_RETURN_TUPLE_FROMVALUES_INT(self->r.w, self->r.h);
+    return pg_tuple_from_values_int(self->r.w, self->r.h);
 }
 
 static int

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1835,7 +1835,13 @@ pg_rect_setcentery(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopleft(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x, self->r.y);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y));
+    return tuple;
 }
 
 static int
@@ -1862,7 +1868,13 @@ pg_rect_settopleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopright(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x + self->r.w, self->r.y);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + self->r.w));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y));
+    return tuple;
 }
 
 static int
@@ -1889,7 +1901,13 @@ pg_rect_settopright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomleft(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x, self->r.y + self->r.h);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + self->r.h));
+    return tuple;
 }
 
 static int
@@ -1916,7 +1934,13 @@ pg_rect_setbottomleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomright(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x + self->r.w, self->r.y + self->r.h);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + self->r.w));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + self->r.h));
+    return tuple;
 }
 
 static int
@@ -1943,7 +1967,13 @@ pg_rect_setbottomright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidtop(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x + (self->r.w >> 1), self->r.y);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + (self->r.w >> 1)));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y));
+    return tuple;
 }
 
 static int
@@ -1970,7 +2000,13 @@ pg_rect_setmidtop(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidleft(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x, self->r.y + (self->r.h >> 1));
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + (self->r.h >> 1)));
+    return tuple;
 }
 
 static int
@@ -1997,8 +2033,13 @@ pg_rect_setmidleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidbottom(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x + (self->r.w >> 1),
-                         self->r.y + self->r.h);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + (self->r.w >> 1)));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + self->r.h));
+    return tuple;
 }
 
 static int
@@ -2025,8 +2066,13 @@ pg_rect_setmidbottom(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidright(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x + self->r.w,
-                         self->r.y + (self->r.h >> 1));
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + self->r.w));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + (self->r.h >> 1)));
+    return tuple;
 }
 
 static int
@@ -2053,8 +2099,13 @@ pg_rect_setmidright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getcenter(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.x + (self->r.w >> 1),
-                         self->r.y + (self->r.h >> 1));
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.x + (self->r.w >> 1)));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.y + (self->r.h >> 1)));
+    return tuple;
 }
 
 static int
@@ -2081,7 +2132,13 @@ pg_rect_setcenter(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getsize(pgRectObject *self, void *closure)
 {
-    return Py_BuildValue("(ii)", self->r.w, self->r.h);
+    PyObject *tuple = PyTuple_New(2);
+    if (!tuple) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tuple, 0, PyLong_FromLong(self->r.w));
+    PyTuple_SET_ITEM(tuple, 1, PyLong_FromLong(self->r.h));
+    return tuple;
 }
 
 static int
@@ -2213,6 +2270,11 @@ MODINIT_DEFINE(rect)
        the module is not loaded.
     */
     import_pygame_base();
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    import_pygame_math();
     if (PyErr_Occurred()) {
         return NULL;
     }


### PR DESCRIPTION
# Info
A big part of rect getters returns a tuple of two int values by using `Py_BuildValue`. Apparently this function is slower than creating a tuple, setting its values and returning it, so i changed those getters to do just that.
# Performance
This change brings an approx. 40% performance improvement on average, some results:
OLD
```
====||RECT||====
-) size: 0.73509932 s
-) center: 0.66942516 s
-) topright: 0.61553792 s
-) topleft: 0.6227682 s
-) bottomright: 0.61191862 s
-) bottomleft: 0.6156618 s
-) midtop: 0.61765648 s
-) midbottom: 0.63002794 s
-) midleft: 0.61581018 s
-) midright: 0.60969368 s
______________
-) Mean time: 0.63435993
```
NEW
```
====||RECT||====
-) size: 0.49888236 s
-) center: 0.54001986 s
-) topright: 0.50331364 s
-) topleft: 0.45303602 s
-) bottomright: 0.41383036 s
-) bottomleft: 0.43431768 s
-) midtop: 0.41643356 s
-) midbottom: 0.41696528 s
-) midleft: 0.42823242 s
-) midright: 0.41350376 s
______________
-) Mean time: 0.45185349
```

Code i used:
```Python
import timeit
from statistics import fmean

import pygame

pygame.init()


def test(test_name: str, func: str, globs: dict, num: int,
         mode: str = "mean") -> float:
    value = 0
    if mode == "mean":
        value = fmean(timeit.repeat(func, globals=globs, number=num))
    elif mode == "cumulative":
        value = timeit.timeit(func, globals=globs, number=num)
    else:
        raise NotImplementedError("Incorrect test mode")
    print("-) " + test_name + f": {round(value, 8)} s")
    return value


def test_group(group_name: str, sequence: list[str],
               globs: dict,
               tests_names: tuple[str, ...] = None, num: int = 10_000_000,
               include_tot: bool = False, include_mean: bool = True,
               test_mode: str = "mean") -> float:
    print("\n====||" + group_name.upper() + "||====")

    test_data = [
        test(tests_names[i] if tests_names else str(i + 1), test_obj, globs,
             num, test_mode)
        for
        i, test_obj in
        enumerate(sequence)]

    print("______________")
    if include_tot:
        print(f"-) Total time: {round(sum(test_data), 8)}")

    if include_mean:
        print(f"-) Mean time: {round(fmean(test_data), 8)}")

    return fmean(test_data)


r1 = pygame.rect.Rect(0, 0, 10, 10)

NUMBER = 10000000
GLOB = {"r1": r1}

test_names = (
    "size", "center", "topright", "topleft", "bottomright", "bottomleft", "midtop",
    "midbottom", "midleft", "midright")
test_group(
    "Rect", [
        "r1.size",
        "r1.center",
        "r1.topright",
        "r1.topleft",
        "r1.bottomright",
        "r1.bottomleft",
        "r1.midtop",
        "r1.midbottom",
        "r1.midleft",
        "r1.midright",
    ],
    GLOB,
    test_names
)
```
