### PR TITLE
mouse.get_pos(), mouse.get_rel() optimizations

### DIFF
--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -29,6 +29,31 @@
 
 #include "doc/mouse_doc.h"
 
+PyObject *
+pg_tuple_from_values_int(int val1, int val2)
+{
+    PyObject *tup = PyTuple_New(2);
+    if (!tup) {
+        return NULL;
+    }
+
+    PyObject *tmp = PyLong_FromLong(val1);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 0, tmp);
+
+    tmp = PyLong_FromLong(val2);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 1, tmp);
+
+    return tup;
+}
+
 /* mouse module functions */
 static PyObject *
 mouse_set_pos(PyObject *self, PyObject *args)
@@ -97,7 +122,7 @@ mouse_get_pos(PyObject *self, PyObject *_null)
         }
     }
 
-    return Py_BuildValue("(ii)", x, y);
+    return pg_tuple_from_values_int(x, y);
 }
 
 static PyObject *
@@ -121,7 +146,7 @@ mouse_get_rel(PyObject *self, PyObject *_null)
             y/=scaley;
         }
     */
-    return Py_BuildValue("(ii)", x, y);
+    return pg_tuple_from_values_int(x, y);
 }
 
 static PyObject *

--- a/src_c/mouse.c
+++ b/src_c/mouse.c
@@ -29,31 +29,6 @@
 
 #include "doc/mouse_doc.h"
 
-PyObject *
-pg_tuple_from_values_int(int val1, int val2)
-{
-    PyObject *tup = PyTuple_New(2);
-    if (!tup) {
-        return NULL;
-    }
-
-    PyObject *tmp = PyLong_FromLong(val1);
-    if (!tmp) {
-        Py_DECREF(tup);
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tup, 0, tmp);
-
-    tmp = PyLong_FromLong(val2);
-    if (!tmp) {
-        Py_DECREF(tup);
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tup, 1, tmp);
-
-    return tup;
-}
-
 /* mouse module functions */
 static PyObject *
 mouse_set_pos(PyObject *self, PyObject *args)
@@ -122,7 +97,7 @@ mouse_get_pos(PyObject *self, PyObject *_null)
         }
     }
 
-    return pg_tuple_from_values_int(x, y);
+    return pg_tuple_couple_from_values_int(x, y);
 }
 
 static PyObject *
@@ -146,7 +121,7 @@ mouse_get_rel(PyObject *self, PyObject *_null)
             y/=scaley;
         }
     */
-    return pg_tuple_from_values_int(x, y);
+    return pg_tuple_couple_from_values_int(x, y);
 }
 
 static PyObject *


### PR DESCRIPTION
## Info
Analogue to #3401, this one implements the same optimization but for `mouse.get_pos()` and `mouse.get_rel()`, bringing a 30-40% improvement overall.
## Performance
Here are performance results and some quick graphs:

**OLD**
```
mean: 11.233, stdev: 0.549
mean: 9.143, stdev: 0.276
------
mean: 10.354, stdev: 0.218
mean: 8.479, stdev: 0.227
```
![myplot](https://user-images.githubusercontent.com/103119829/186014787-c77a2780-b22b-4d00-87fa-fb0a7cd2fdcb.png)
___

**NEW**
```
mean: 8.893, stdev: 0.581
mean: 7.033, stdev: 0.376
------
mean: 7.941, stdev: 0.231
mean: 6.13, stdev: 0.228
```

![myplot](https://user-images.githubusercontent.com/103119829/186014872-5e76daf6-f05e-40cc-bbd7-a18fc41eda6e.png)

### Code

```Python
from statistics import pstdev, fmean
from timeit import repeat

import pygame as pg
from pygame import mouse

from plotting import create_plot


def adjust(x: float) -> float:
    # adjust to milliseconds and round
    return round(x * 1000, 3)


win = pg.display.set_mode((500, 500))

GLOB = {"pg": pg, "mouse": mouse}

REPEATS = 200
NUM = 100000

data = repeat("pg.mouse.get_pos()", globals=GLOB, number=NUM, repeat=REPEATS)
data_1 = repeat("mouse.get_pos()", globals=GLOB, number=NUM, repeat=REPEATS)
data2 = repeat("pg.mouse.get_rel()", globals=GLOB, number=NUM, repeat=REPEATS)
data2_1 = repeat("mouse.get_rel()", globals=GLOB, number=NUM, repeat=REPEATS)

print(f"mean: {adjust(fmean(data))}, stdev: {adjust(pstdev(data))}")
print(f"mean: {adjust(fmean(data_1))}, stdev: {adjust(pstdev(data_1))}")
print("------")
print(f"mean: {adjust(fmean(data2))}, stdev: {adjust(pstdev(data2))}")
print(f"mean: {adjust(fmean(data2_1))}, stdev: {adjust(pstdev(data2_1))}")
```

