### PR TITLE
Add an AVX2 version of alphablit to opaque

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -219,21 +219,10 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                             src->format->Rmask == dst->format->Rmask &&
                             src->format->Gmask == dst->format->Gmask &&
                             src->format->Bmask == dst->format->Bmask) {
-                            /* If our source and destination are the same ARGB
-                               32bit format we can use SSE2 to speed up the
-                               blend */
-                            if ((SDL_HasAVX2() == SDL_TRUE) && (src != dst)) {
-                                if (info.src_blanket_alpha == 255 &&
-                                    !(SDL_ISPIXELFORMAT_ALPHA(
-                                          dst->format->format) &&
-                                      info.dst_blend != SDL_BLENDMODE_NONE)) {
-                                    alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
-                                        &info);
-                                    break;
-                                }
-                            }
-#if PG_ENABLE_ARM_NEON
-                            if ((SDL_HasNEON() == SDL_TRUE) && (src != dst)) {
+/* If our source and destination are the same ARGB 32bit
+   format we can use SSE2/NEON/AVX2 to speed up the blend */
+#if PG_ENABLE_SSE_NEON
+                            if ((pg_HasSSE_NEON()) && (src != dst)) {
                                 if (info.src_blanket_alpha != 255) {
                                     alphablit_alpha_sse2_argb_surf_alpha(
                                         &info);
@@ -243,6 +232,10 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                                             dst->format->format) &&
                                         info.dst_blend != SDL_BLENDMODE_NONE) {
                                         alphablit_alpha_sse2_argb_no_surf_alpha(
+                                            &info);
+                                    }
+                                    else if (SDL_HasAVX2()) {
+                                        alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
                                             &info);
                                     }
                                     else {

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -219,10 +219,21 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                             src->format->Rmask == dst->format->Rmask &&
                             src->format->Gmask == dst->format->Gmask &&
                             src->format->Bmask == dst->format->Bmask) {
-/* If our source and destination are the same ARGB 32bit
-   format we can use SSE2/NEON to speed up the blend */
-#if PG_ENABLE_SSE_NEON
-                            if ((pg_HasSSE_NEON()) && (src != dst)) {
+                            /* If our source and destination are the same ARGB
+                               32bit format we can use SSE2 to speed up the
+                               blend */
+                            if ((SDL_HasAVX2() == SDL_TRUE) && (src != dst)) {
+                                if (info.src_blanket_alpha == 255 &&
+                                    !(SDL_ISPIXELFORMAT_ALPHA(
+                                          dst->format->format) &&
+                                      info.dst_blend != SDL_BLENDMODE_NONE)) {
+                                    alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(
+                                        &info);
+                                    break;
+                                }
+                            }
+#if PG_ENABLE_ARM_NEON
+                            if ((SDL_HasNEON() == SDL_TRUE) && (src != dst)) {
                                 if (info.src_blanket_alpha != 255) {
                                     alphablit_alpha_sse2_argb_surf_alpha(
                                         &info);

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -63,6 +63,8 @@ premul_surf_color_by_alpha_sse2(SDL_Surface *src, SDL_Surface *dst);
 int
 pg_has_avx2();
 void
+alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info);
+void
 blit_blend_rgba_mul_avx2(SDL_BlitInfo *info);
 void
 blit_blend_rgb_mul_avx2(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -135,8 +135,8 @@ alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
     while (height--) {
         if (pre_8_width > 0) {
             /* ==== load 1-7 pixels into AVX registers ==== */
-            mm256_src = _mm256_maskload_epi32(srcp, mm256_mask);
-            mm256_dst = _mm256_maskload_epi32(dstp, mm256_mask);
+            mm256_src = _mm256_maskload_epi32((int *)srcp, mm256_mask);
+            mm256_dst = _mm256_maskload_epi32((int *)dstp, mm256_mask);
 
             /* ==== shuffle pixels out into two registers each, src
              * and dst set up for 16 bit math, like 0A0R0G0B ==== */
@@ -170,7 +170,7 @@ alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
 
             /* ==== recombine A and B pixels and store ==== */
             mm256_dst = _mm256_packus_epi16(mm256_dstA, mm256_dstB);
-            _mm256_maskstore_epi32(dstp, mm256_mask, mm256_dst);
+            _mm256_maskstore_epi32((int *)dstp, mm256_mask, mm256_dst);
 
             srcp += srcpxskip * pre_8_width;
             dstp += dstpxskip * pre_8_width;

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -237,8 +237,7 @@ alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
 void
 alphablit_alpha_avx2_argb_no_surf_alpha_opaque_dst(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    alphablit_alpha_sse2_argb_no_surf_alpha_opaque_dst(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */


### PR DESCRIPTION
Ok @MyreMylar I know I told you explicitly I was not going to do this, but I got interested and I did it anyways...

Points of interest:
- No stride switching, using mask load / store with a dynamic mask! Could my mask strategy be an efficiency / code simplicity boon for the other AVX2 blitters?
- I didn't mask out the alpha from the result before writing to dst, which the SSE blitter does.
    - dst is XRGB, I believe.
    - it seems to work fine, is this okay being undefined behavior?

Test program:
```py
import pygame
import time

pygame.init()

screen = pygame.Surface((800,100), depth=32)
screen.fill((60, 70, 80))

surf = pygame.Surface((800,100), pygame.SRCALPHA)
surf.fill((5,216,77,120))

print(screen, surf)

start = time.time()
for _ in range(100000):
    screen.blit(surf, (0, 0))    
print(time.time() - start)
```

Results:
```
# 100k 800x100 alpha opaque dst blits
# existing main: 5.84 seconds
# SSE2 enhanced: 4.84 seconds (my other SIMD PR)
# AVX2: 1.62 seconds
```