### PR TITLE
Clean bash-completion file in macdeps builds

### DIFF
--- a/buildconfig/macdependencies/clean_usr_local.sh
+++ b/buildconfig/macdependencies/clean_usr_local.sh
@@ -41,6 +41,10 @@ rm -rf /usr/local/share/doc/libsndfile
 rm -rf /usr/local/share/glib-2.0
 rm -rf /usr/local/share/gdb/auto-load
 
+# The installer fails when it tries to create this directory and it already
+# exists, so clean it before that
+rm -rf /usr/local/share/bash-completion
+
 rm -rf /usr/local/include/glib-2.0
 rm -rf /usr/local/include/gio-unix-2.0
 rm -rf /usr/local/include/brotli


### PR DESCRIPTION
The mac deps builds are failing on main atm for bizzare reasons (they somehow passed on the PR the changes were made)

I'll try to debug/quickfix this issue in this PR