### PR TITLE
Add in memcpy only blit for opaque blits

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -99,9 +99,8 @@ extern void
 SDL_UnRLESurface(SDL_Surface *surface, int recode);
 
 static int
-OpaqueBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect,
-                 SDL_Surface *dst, SDL_Rect *dstrect,
-                 int the_args)
+OpaqueBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
+                 SDL_Rect *dstrect, int the_args)
 {
     SDL_bool overlap;
     Uint8 *src_pixels, *dst_pixels;
@@ -110,36 +109,36 @@ OpaqueBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect,
 
     w = srcrect->w * src->format->BytesPerPixel;
     h = srcrect->h;
-    src_pixels = (Uint8 *)src->pixels +
-                 (Uint16)srcrect->y * src->pitch +
+    src_pixels = (Uint8 *)src->pixels + (Uint16)srcrect->y * src->pitch +
                  (Uint16)srcrect->x * src->format->BytesPerPixel;
-    dst_pixels = (Uint8 *)dst->pixels +
-                 (Uint16)dstrect->y * dst->pitch +
+    dst_pixels = (Uint8 *)dst->pixels + (Uint16)dstrect->y * dst->pitch +
                  (Uint16)dstrect->x * dst->format->BytesPerPixel;
     srcskip = src->pitch;
     dstskip = dst->pitch;
 
     /* Properly handle overlapping blits */
     if (src_pixels < dst_pixels) {
-        overlap = (dst_pixels < (src_pixels + h*srcskip));
-    } else {
-        overlap = (src_pixels < (dst_pixels + h*dstskip));
+        overlap = (dst_pixels < (src_pixels + h * srcskip));
+    }
+    else {
+        overlap = (src_pixels < (dst_pixels + h * dstskip));
     }
     if (overlap) {
-        if ( dst_pixels < src_pixels ) {
-                while ( h-- ) {
-                        SDL_memmove(dst_pixels, src_pixels, w);
-                        src_pixels += srcskip;
-                        dst_pixels += dstskip;
-                }
-        } else {
-                src_pixels += ((h-1) * srcskip);
-                dst_pixels += ((h-1) * dstskip);
-                while ( h-- ) {
-                        SDL_memmove(dst_pixels, src_pixels, w);
-                        src_pixels -= srcskip;
-                        dst_pixels -= dstskip;
-                }
+        if (dst_pixels < src_pixels) {
+            while (h--) {
+                SDL_memmove(dst_pixels, src_pixels, w);
+                src_pixels += srcskip;
+                dst_pixels += dstskip;
+            }
+        }
+        else {
+            src_pixels += ((h - 1) * srcskip);
+            dst_pixels += ((h - 1) * dstskip);
+            while (h--) {
+                SDL_memmove(dst_pixels, src_pixels, w);
+                src_pixels -= srcskip;
+                dst_pixels -= dstskip;
+            }
         }
         return 0;
     }

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -116,32 +116,34 @@ OpaqueBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
     srcskip = src->pitch;
     dstskip = dst->pitch;
 
-    /* Properly handle overlapping blits */
-    if (src_pixels < dst_pixels) {
-        overlap = (dst_pixels < (src_pixels + h * srcskip));
-    }
-    else {
-        overlap = (src_pixels < (dst_pixels + h * dstskip));
-    }
-    if (overlap) {
-        if (dst_pixels < src_pixels) {
-            while (h--) {
-                SDL_memmove(dst_pixels, src_pixels, w);
-                src_pixels += srcskip;
-                dst_pixels += dstskip;
-            }
-        }
-        else {
-            src_pixels += ((h - 1) * srcskip);
-            dst_pixels += ((h - 1) * dstskip);
-            while (h--) {
-                SDL_memmove(dst_pixels, src_pixels, w);
-                src_pixels -= srcskip;
-                dst_pixels -= dstskip;
-            }
-        }
-        return 0;
-    }
+    /* Think the below is already taken care of by our rect clipping code
+       blits don't overlap surfaces edges because they have already been
+       clipped not to*/
+//    if (src_pixels < dst_pixels) {
+//        overlap = (dst_pixels < (src_pixels + h * srcskip));
+//    }
+//    else {
+//        overlap = (src_pixels < (dst_pixels + h * dstskip));
+//    }
+//    if (overlap) {
+//        if (dst_pixels < src_pixels) {
+//            while (h--) {
+//                SDL_memmove(dst_pixels, src_pixels, w);
+//                src_pixels += srcskip;
+//                dst_pixels += dstskip;
+//            }
+//        }
+//        else {
+//            src_pixels += ((h - 1) * srcskip);
+//            dst_pixels += ((h - 1) * dstskip);
+//            while (h--) {
+//                SDL_memmove(dst_pixels, src_pixels, w);
+//                src_pixels -= srcskip;
+//                dst_pixels -= dstskip;
+//            }
+//        }
+//        return 0;
+//    }
 
     while (h--) {
         SDL_memcpy(dst_pixels, src_pixels, w);

--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -103,26 +103,6 @@ OpaqueBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect,
                  SDL_Surface *dst, SDL_Rect *dstrect,
                  int the_args)
 {
-//    SDL_BlitInfo info;
-//
-//    /* Set up the blit information */
-//    info.width = srcrect->w;
-//    info.height = srcrect->h;
-//    info.s_pixels = (Uint8 *)src->pixels +
-//                    (Uint16)srcrect->y * src->pitch +
-//                    (Uint16)srcrect->x * src->format->BytesPerPixel;
-//    info.s_pxskip = src->format->BytesPerPixel;
-//    info.s_skip = src->pitch - info.width * src->format->BytesPerPixel;
-//    info.d_pixels = (Uint8 *)dst->pixels +
-//                    (Uint16)dstrect->y * dst->pitch +
-//                    (Uint16)dstrect->x * dst->format->BytesPerPixel;
-//    info.d_pxskip = dst->format->BytesPerPixel;
-//    info.d_skip = dst->pitch - info.width * dst->format->BytesPerPixel;
-//    info.src = src->format;
-//    info.dst = dst->format;
-//    SDL_GetSurfaceAlphaMod(src, &info.src_blanket_alpha);
-//    info.src_has_colorkey = SDL_GetColorKey(src, &info.src_colorkey) == 0;
-
     SDL_bool overlap;
     Uint8 *src_pixels, *dst_pixels;
     int w, h;
@@ -163,31 +143,6 @@ OpaqueBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect,
         }
         return 0;
     }
-
-//#ifdef __SSE__
-//    if (SDL_HasSSE() &&
-//        !((uintptr_t) src & 15) && !(srcskip & 15) &&
-//        !((uintptr_t) dst & 15) && !(dstskip & 15)) {
-//        while (h--) {
-//            SDL_memcpySSE(dst, src, w);
-//            src += srcskip;
-//            dst += dstskip;
-//        }
-//        return;
-//    }
-//#endif
-//
-//#ifdef __MMX__
-//    if (SDL_HasMMX() && !(srcskip & 7) && !(dstskip & 7)) {
-//        while (h--) {
-//            SDL_memcpyMMX(dst, src, w);
-//            src += srcskip;
-//            dst += dstskip;
-//        }
-//        _mm_empty();
-//        return;
-//    }
-//#endif
 
     while (h--) {
         SDL_memcpy(dst_pixels, src_pixels, w);

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3738,15 +3738,14 @@ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
             !(pg_EnvShouldBlendAlphaSDL2()) &&
             SDL_GetColorKey(src, &key) != 0 &&
             dst->format->BytesPerPixel == 4 &&
-            src->format->BytesPerPixel == 4 &&
-            !pg_HasSurfaceRLE(src) && !pg_HasSurfaceRLE(dst) &&
-            !(src->flags & SDL_RLEACCEL) && !(dst->flags & SDL_RLEACCEL)){
+            src->format->BytesPerPixel == 4 && !pg_HasSurfaceRLE(src) &&
+            !pg_HasSurfaceRLE(dst) && !(src->flags & SDL_RLEACCEL) &&
+            !(dst->flags & SDL_RLEACCEL)) {
             result = pygame_Opaque_Blit(src, srcrect, dst, dstrect, the_args);
         }
-        else{
+        else {
             result = SDL_BlitSurface(src, srcrect, dst, dstrect);
         }
-
 
         /* Py_END_ALLOW_THREADS */
     }

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -352,4 +352,8 @@ int
 pygame_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
             SDL_Rect *dstrect, int the_args);
 
+int
+pygame_Opaque_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
+                   SDL_Rect *dstrect, int the_args);
+
 #endif /* SURFACE_H */


### PR DESCRIPTION
These are the test results I'm seeing:

With this PR:
```
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 32, 32 :		6.005ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 31, 32 :		5.005ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 64, 64 :		8.007ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 63, 64 :		8.008ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 128, 128 :	        18.016ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 127, 128 :	        19.017ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 256, 256 :	        81.074ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 255, 256 :	        82.075ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 512, 512 :	        286.26ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 511, 512 :	        287.261ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 1024, 1024 :	        958.266ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 1023, 1024 :	        1032.856ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 16, 16 :		20.018ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 15, 16 :		20.018ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 8, 8 :		17.015ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 7, 8 :		17.015ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 4, 4 :		17.016ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 3, 4 :		16.014ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 2, 2 :		16.015ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 1, 2 :		16.015ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 1, 1 :		17.015ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 0, 1 :		15.014ms
Total test time:  2963.0043506622314
```

Without this PR:

```
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 32, 32 :	        5.997ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 31, 32 :	        4.004ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 64, 64 :	        14.014ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 63, 64 :	        9.007ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 128, 128 :	        37.034ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 127, 128 :	        28.025ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 256, 256 :	        157.143ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 255, 256 :	        158.144ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 512, 512 :	        684.929ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 511, 512 :	        447.406ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, even dimensions 1024, 1024 :	        2248.045ms
tested Blit NORMAL_NO_ALPHA - 10000 tries, odd dimensions 1023, 1024 :	        1648.496ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 16, 16 :	        21.019ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 15, 16 :	        18.017ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 8, 8 :		15.013ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 7, 8 :		16.014ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 4, 4 :		15.014ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 3, 4 :		14.012ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 2, 2 :		14.014ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 1, 2 :		14.012ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, even dimensions 1, 1 :		14.013ms
tested Blit NORMAL_NO_ALPHA - 50000 tries, odd dimensions 0, 1 :		12.012ms
Total test time:  5595.384120941162
```

Basically greater than 32ish widths and memcpy seems to be better, at least on my windows machine. 32 and lower widths seem to favour the SDL SSE copy routine.

Draft because:

A) I want to see if we can get some performance comparisons on different platforms/different performance checks than my suite.
B) it is hackily implemented (opaque blit in `alphablit.c`, surface checks with the 32bit alphablits could be combined, might be able to do other surface formats too?) 
C) to see if the tests pass.
D) to see if other people have any other ideas I have not thought of.

Current test program:

```
import time
import math
import pygame


def test(target_surf, test_surf, methods, tries, blit_pos, extra_desc):
    total_results = 0.0
    for method in methods:
        start = time.time()
        name = method(target_surf, test_surf, tries, blit_pos)
        results = (time.time() - start) * 1000
        desc_string_start = 'tested {}' + extra_desc + ':'
        name_tab_length = math.ceil((len(desc_string_start.format(name)) + 1) / 4)
        tabs = '\t' * (19 - name_tab_length)
        string_to_format = desc_string_start + tabs + '{}ms'
        print(string_to_format.format(name, round(results, 3)))
        total_results += results
    return total_results


def blend_normal_no_alpha(target_surf, blit_surf, tries, blit_pos):
    for t in range(tries):
        target_surf.blit(blit_surf, blit_pos)
    return 'Blit NORMAL_NO_ALPHA'


def run_rgb32_blit_test(target_surf, iterations, width, height, blend_mode_funcs):
    test_name = 'Blend RGB 32 Test'
    test_surf = pygame.Surface((width, height), depth=32)
    test_surf.fill((100, 100, 100))
    num_tries = iterations
    start_pos = ((screen.get_width() - width), screen.get_height() - height)
    odd_start_pos = ((screen.get_width() - width) + 1, screen.get_height() - height)
    # print(f'\nTest type - {test_name}: {num_tries} blits of image size {width}, {height}')
    even_result = test(target_surf, test_surf, blend_mode_funcs,
         num_tries, start_pos, f' - {num_tries} tries, even dimensions {width}, {height} ')
    odd_result = test(target_surf, test_surf, blend_mode_funcs,
         num_tries, odd_start_pos, f' - {num_tries} tries, odd dimensions {width-1}, {height} ')

    return even_result + odd_result


pygame.init()
screen = pygame.display.set_mode((1280, 1024))


blend_modes_to_test = [blend_normal_no_alpha]  # (blend_rgba_add, blend_rgb_add, blend_rgba_mult, blend_rgb_mult)

rgb_surf_to_blit_onto = pygame.Surface((1280, 1024), depth=32)
rgb_surf_to_blit_onto.fill((50, 50, 50))
# standard size ranges
test_iterations = 10000
test_total = 0.0
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 32, 32, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 64, 64, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 128, 128, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 256, 256, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 512, 512, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 1024, 1024, blend_modes_to_test)

# very small size ranges
test_iterations = 50000
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 16, 16, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 8, 8, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 4, 4, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 2, 2, blend_modes_to_test)
test_total += run_rgb32_blit_test(rgb_surf_to_blit_onto, test_iterations, 1, 1, blend_modes_to_test)

print("Total test time: ", test_total)
```
