### PR TITLE
Fix pypy rect freelist issue, unskip tests

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -175,7 +175,7 @@ pg_tuple_from_values_int(int val1, int val2)
 static PyObject *
 _pg_rect_subtype_new4(PyTypeObject *type, int x, int y, int w, int h)
 {
-    pgRectObject *rect = type->tp_new(type, NULL, NULL);
+    pgRectObject *rect = (pgRectObject *)type->tp_new(type, NULL, NULL);
 
     if (rect) {
         rect->r.x = x;

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -1,12 +1,9 @@
 import math
-import platform
 import unittest
 from collections.abc import Collection, Sequence
 
 from pygame import Rect, Vector2
 from pygame.tests import test_utils
-
-IS_PYPY = "PyPy" == platform.python_implementation()
 
 
 class RectTypeTest(unittest.TestCase):
@@ -69,7 +66,6 @@ class RectTypeTest(unittest.TestCase):
 
         self.assertEqual(test_rect, expected_normalized_rect)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy sometimes")
     def test_normalize__positive_height(self):
         """Ensures normalize works with a negative width and a positive height."""
         test_rect = Rect((1, 2), (-3, 6))
@@ -82,7 +78,6 @@ class RectTypeTest(unittest.TestCase):
 
         self.assertEqual(test_rect, expected_normalized_rect)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy sometimes")
     def test_normalize__positive_width(self):
         """Ensures normalize works with a positive width and a negative height."""
         test_rect = Rect((1, 2), (3, -6))
@@ -95,7 +90,6 @@ class RectTypeTest(unittest.TestCase):
 
         self.assertEqual(test_rect, expected_normalized_rect)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy sometimes")
     def test_normalize__zero_height(self):
         """Ensures normalize works with a negative width and a zero height."""
         test_rect = Rect((1, 2), (-3, 0))
@@ -108,7 +102,6 @@ class RectTypeTest(unittest.TestCase):
 
         self.assertEqual(test_rect, expected_normalized_rect)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy sometimes")
     def test_normalize__zero_width(self):
         """Ensures normalize works with a zero width and a negative height."""
         test_rect = Rect((1, 2), (0, -6))
@@ -121,7 +114,6 @@ class RectTypeTest(unittest.TestCase):
 
         self.assertEqual(test_rect, expected_normalized_rect)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy")
     def test_normalize__non_negative(self):
         """Ensures normalize works when width and height are both non-negative.
 
@@ -1264,7 +1256,6 @@ class RectTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 clipped_line = rect.clipline(*line)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy sometimes")
     def test_move(self):
         r = Rect(1, 2, 3, 4)
         move_x = 10
@@ -1273,7 +1264,6 @@ class RectTypeTest(unittest.TestCase):
         expected_r2 = Rect(r.left + move_x, r.top + move_y, r.width, r.height)
         self.assertEqual(expected_r2, r2)
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy sometimes")
     def test_move_ip(self):
         r = Rect(1, 2, 3, 4)
         r2 = Rect(r)
@@ -1404,7 +1394,6 @@ class RectTypeTest(unittest.TestCase):
             "r1 collides with Rect(r1.right, r1.bottom, 1, 1)",
         )
 
-    @unittest.skipIf(IS_PYPY, "fails on pypy3 sometimes")
     def testEquals(self):
         """check to see how the rect uses __eq__"""
         r1 = Rect(1, 2, 3, 4)
@@ -2546,7 +2535,6 @@ class RectTypeTest(unittest.TestCase):
         self.assertFalse(isinstance(r, Sequence))
 
 
-@unittest.skipIf(IS_PYPY, "fails on pypy")
 class SubclassTest(unittest.TestCase):
     class MyRect(Rect):
         def __init__(self, *args, **kwds):


### PR DESCRIPTION
PR to fix #669

As correctly pointed out by folks in that issue, the pypy rect freelist implementation has a subtle bug. What is currently happening is that there's no sort of check whatsoever on the exact type of rects going into the freelist. So when anyone tries to instantiate a rect subclass, they can get an instance of the base rect object, or they may also get a rect subclass instance when they try to instantiate a base rect instance.

In this PR I'm taking the easier approach to make things working again, I just disabled the freelist implementation for subclasses entirely. This means that instantiating subclasses will be comparatively slower than the Rect baseclass on pypy, but Rect objects are used far more commonly than Rect subclasses, so I think this is fine for now.