### PR TITLE
Python 3.11 on mac/manylinux (with updated cibuildwheel)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
     environment:
       # these environment variables will be passed to the docker container
       - CIBW_ENVIRONMENT: PIP_CONFIG_FILE=buildconfig/pip_config.ini PORTMIDI_INC_PORTTIME=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk
-      - CIBW_BUILD: cp* pp*
       - CIBW_ARCHS: aarch64
       - CIBW_SKIP: '*-musllinux_*'
       - CIBW_MANYLINUX_AARCH64_IMAGE: pygame/manylinux2014_base_aarch64
@@ -28,7 +27,7 @@ jobs:
       - run:
           name: Build the Linux wheels.
           command: |
-            pip3 install --user cibuildwheel==2.5.0
+            pip3 install --user cibuildwheel==2.10.2
             PATH="$HOME/.local/bin:$PATH" cibuildwheel --output-dir wheelhouse
 
       - store_artifacts:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -75,36 +75,39 @@ jobs:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
         # Split job into 5 matrix builds, because GH actions provides 5 concurrent
-        # builds on macOS
+        # builds on macOS. This needs to be manually kept updated so that each
+        # of these builds take roughly the same time
         include:
           - { 
-            name: "x86_64 (cp36-cp310)",
+            name: "x86_64 (CPython 3.6 3.10 and above)",
             macarch: x86_64,
-            pyversions: cp36-* cp310-*
+            # pattern matches 6 or any 2 digit number
+            pyversions: "cp3{6,[1-9][0-9]}-*"
           }
 
           - { 
-            name: "x86_64 (cp37-pp37)",
+            name: "x86_64 (Python 3.7)",
             macarch: x86_64,
-            pyversions: cp37-* pp37-*
+            pyversions: "?p37-*"
           }
 
           - { 
-            name: "x86_64 (cp38-pp38)",
+            name: "x86_64 (Python 3.8)",
             macarch: x86_64,
-            pyversions: cp38-* pp38-*
+            pyversions: "?p38-*"
           }
 
           - { 
-            name: "x86_64 (cp39-pp39)",
+            name: "x86_64 (Python 3.9)",
             macarch: x86_64,
-            pyversions: cp39-* pp39-*
+            pyversions: "?p39-*"
           }
 
           - { 
-            name: "arm64 (cp38-cp39-cp310)",
+            name: "arm64 (CPython 3.8 and above)",
             macarch: arm64,
-            pyversions: cp38-* cp39-* cp310-*
+            # pattern matches any number from 8 to 99
+            pyversions: "cp3{8,9,[1-9][0-9]}-*"
           }
 
     env:
@@ -151,7 +154,7 @@ jobs:
           key: macdep-${{ hashFiles('buildconfig/manylinux-build/**') }}-${{ hashFiles('buildconfig/macdependencies/*.sh') }}-${{ matrix.macarch }}
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.10.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -32,24 +32,29 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.image }} [${{ matrix.arch }}]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # if a particular matrix build fails, don't skip the rest
       matrix:
         # Split job into many matrix builds, because GH actions provides 20
-        # concurrent builds on ubuntu. 10 are used here
+        # concurrent builds on ubuntu. 6 are used here
         include:
           # no pypy and cpython >= cp310 on manylinux1
-          - { image: manylinux1, arch: x86_64, pyversions: cp36-* cp37-* cp38-* cp39-* }
-          - { image: manylinux1, arch: i686, pyversions: cp36-* cp37-* cp38-* cp39-* }
+          - { image: manylinux1, arch: x86_64, pyversions: "cp3[6-9]-*" }
+          - { image: manylinux1, arch: i686, pyversions: "cp3[6-9]-*" }
 
-          # no pypy 3.9 on manylinux2010
-          - { image: manylinux2010, arch: x86_64, pyversions: cp* pp37-* pp38-* }
-          - { image: manylinux2010, arch: i686, pyversions: cp* pp37-* pp38-* }
+          # no pypy >= 3.9 and cpython >= cp311 on manylinux2010
+          - { image: manylinux2010, arch: x86_64, pyversions: "cp3{[6-9],10}-* pp3{7,8}-*" }
+          - { image: manylinux2010, arch: i686, pyversions: "cp3{[6-9],10}-* pp3{7,8}-*" }
 
-          # all cpython and pypy versions should support this
-          - { image: manylinux2014, arch: x86_64, pyversions: cp* pp* }
-          - { image: manylinux2014, arch: i686, pyversions: cp* pp* }
+          # all cpython and pypy versions should support this for now
+          # The * here essentially tells cibuildwheel to follow its default behaviour 
+          # of building all possible build configurations the particular cibuildwheel
+          # version supports. Unless cibuildwheel itself is bumped to the next version,
+          # this will stay constant and do the same set of builds everytime.
+          - { image: manylinux2014, arch: x86_64, pyversions: "*" }
+          - { image: manylinux2014, arch: i686, pyversions: "*" }
 
     env:
       # load pip config from this file. Define this in 'CIBW_ENVIRONMENT'
@@ -91,7 +96,7 @@ jobs:
     - uses: actions/checkout@v3.0.2
 
     - name: Build and test wheels
-      uses: pypa/cibuildwheel@v2.5.0
+      uses: pypa/cibuildwheel@v2.10.2
 
     # We upload the generated files under github actions assets
     - name: Upload dist

--- a/buildconfig/macdependencies/clean_usr_local.sh
+++ b/buildconfig/macdependencies/clean_usr_local.sh
@@ -34,8 +34,6 @@ rm -rf /usr/local/Cellar/opusfile
 rm -rf /usr/local/Cellar/opus
 rm -rf /usr/local/Cellar/freetype
 
-rm -rf /usr/local/opt/gettext
-
 rm -rf /usr/local/share/doc/tiff-*
 rm -rf /usr/local/share/doc/libsndfile
 rm -rf /usr/local/share/doc/opusfile


### PR DESCRIPTION
Updates cibuildwheel so that we can release the next dev release with 3.11 (rc2) support on mac/manylinux. This is a release candidate, but since it is intended to be ABI compatible with the final release, python encourages library devs to release with these.

~~Also removes manylinux1_i686 and manylinux2010_i686. The rationale is that manylinux1 and manylinux2010 wheels are needed by (probably) less than 5% of our users, and 32bit linux looks like it is almost non-existent these days. Besides, even if we have a user on a 32bit linux and they come with a bug report, we can always recommend them to update pip so that it picks up the manylinux2014_i686 wheel (which we should still keep around for some time IMHO)~~

~~Also does some cleanups and bugfixes (the pull targets were fixed, and manylinux1 was uncommented out) to some manylinux buildconfig code~~
EDIT: the latter have been deferred to future PRs