### PR TITLE
Add 3.11.0.rc2 to Appveyor

### DIFF
--- a/buildconfig/appveyor.yml
+++ b/buildconfig/appveyor.yml
@@ -18,6 +18,7 @@ environment:
   matrix:
     - PYTHON: "pypy3.exe"
       PYTHON_VERSION: "3.6.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "32"
       PYPY_VERSION: "pypy3.6-v7.3.2-win32"
       PYPY_DOWNLOAD: "powershell buildconfig\\ci\\appveyor\\download_pypy.ps1"
@@ -25,60 +26,84 @@ environment:
     - PYTHON: "C:\\Python36\\python"
       PYTHONPATH: "C:\\Python36"
       PYTHON_VERSION: "3.6.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "32"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python37\\python"
       PYTHONPATH: "C:\\Python37"
       PYTHON_VERSION: "3.7.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "32"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python38\\python"
       PYTHONPATH: "C:\\Python38"
       PYTHON_VERSION: "3.8.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "32"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python39\\python"
       PYTHONPATH: "C:\\Python39"
       PYTHON_VERSION: "3.9.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "32"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python310\\python"
       PYTHONPATH: "C:\\Python310"
       PYTHON_VERSION: "3.10.0"
+      PYTHON_SUFFIX: ""
+      PYTHON_ARCH: "32"
+      USE_ANALYZE: ""
+
+    - PYTHON: "C:\\Python311\\python"
+      PYTHONPATH: "C:\\Python311"
+      PYTHON_VERSION: "3.11.0"
+      PYTHON_SUFFIX: "rc2"
       PYTHON_ARCH: "32"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python36-x64\\python"
       PYTHONPATH: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "64"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python37-x64\\python"
       PYTHONPATH: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "64"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python38-x64\\python"
       PYTHONPATH: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "64"
       USE_ANALYZE: "-enable-msvc-analyze"
 
     - PYTHON: "C:\\Python39-x64\\python"
       PYTHONPATH: "C:\\Python39-x64"
       PYTHON_VERSION: "3.9.0"
+      PYTHON_SUFFIX: ""
       PYTHON_ARCH: "64"
       USE_ANALYZE: ""
 
     - PYTHON: "C:\\Python310-x64\\python"
       PYTHONPATH: "C:\\Python310-x64"
       PYTHON_VERSION: "3.10.0"
+      PYTHON_SUFFIX: ""
+      PYTHON_ARCH: "64"
+      USE_ANALYZE: ""
+
+    - PYTHON: "C:\\Python311-x64\\python"
+      PYTHONPATH: "C:\\Python311-x64"
+      PYTHON_VERSION: "3.11.0"
+      PYTHON_SUFFIX: "rc2"
       PYTHON_ARCH: "64"
       USE_ANALYZE: ""
 
@@ -89,7 +114,7 @@ install:
 
   # https://github.com/appveyor/build-images/blob/master/scripts/Windows/install_python.ps1#L88-L108
   - ps: |
-      function InstallPythonEXE($version, $platform, $targetPath) {
+      function InstallPythonEXE($version, $platform, $suffix, $targetPath) {
           $urlPlatform = ""
           if ($platform -eq '64') {
               $urlPlatform = "-amd64"
@@ -97,7 +122,7 @@ install:
 
           Write-Host "Installing Python $version $platform to $($targetPath)..." -ForegroundColor Cyan
 
-          $downloadUrl = "https://www.python.org/ftp/python/$version/python-$version$urlPlatform.exe"
+          $downloadUrl = "https://www.python.org/ftp/python/$version/python-$version$suffix$urlPlatform.exe"
           Write-Host "Downloading $($downloadUrl)..."
           $exePath = "$env:TEMP\python-$version.exe"
           (New-Object Net.WebClient).DownloadFile($downloadUrl, $exePath)
@@ -113,7 +138,7 @@ install:
 
       if (-not (Test-Path env:PYPY_VERSION)) {
         if (-not (Test-Path $env:PYTHONPATH)) {
-          InstallPythonEXE $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHONPATH
+          InstallPythonEXE $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON_SUFFIX $env:PYTHONPATH
         }
       }
 


### PR DESCRIPTION
The Python 3.11 full release is coming soon, and `rc2` is going to be ABI compatible with 3.11.0, so this puts it in CI so we can generate Windows Python 3.11 wheels.