### PR TITLE
Fixed incorrect volume when chunk is NULL

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -725,6 +725,9 @@ snd_get_volume(PyObject *self, PyObject *_null)
     MIXER_INIT_CHECK();
 
     volume = Mix_VolumeChunk(chunk, -1);
+    if (volume == -1) {
+        return PyLong_FromLong(volume);
+    }
     return PyFloat_FromDouble(volume / 128.0);
 }
 


### PR DESCRIPTION
Slight bug fix to `get_volume` in the Sound class.

`Mix_VolumeChunk` when passed `NULL` returns -1 but it was mistakenly divided by 128 instead of returning -1.