### PR TITLE
Relax strict pixel match tests in test_src_alpha_sdl2_blitter by allowing a small delta

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1588,7 +1588,9 @@ class GeneralSurfaceTests(AssertRaisesRegexMixin, unittest.TestCase):
                     key = ((dst_r, dst_b, dst_a), (src_r, src_b, src_a))
                     results[key] = tuple(dest_surf.get_at((65, 33)))
                     for i in range(4):
-                        self.assertAlmostEqual(results[key][i], results_expected[key][i], delta=4)
+                        self.assertAlmostEqual(
+                            results[key][i], results_expected[key][i], delta=4
+                        )
 
         # print("(dest_r, dest_b, dest_a), (src_r, src_b, src_a): color")
         # pprint(results)

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1588,7 +1588,7 @@ class GeneralSurfaceTests(AssertRaisesRegexMixin, unittest.TestCase):
                     key = ((dst_r, dst_b, dst_a), (src_r, src_b, src_a))
                     results[key] = tuple(dest_surf.get_at((65, 33)))
                     for i in range(4):
-                        self.assertAlmostEqual(results[key][i], results_expected[key][i], None, None, 4)
+                        self.assertAlmostEqual(results[key][i], results_expected[key][i], delta=4)
 
         # print("(dest_r, dest_b, dest_a), (src_r, src_b, src_a): color")
         # pprint(results)

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1586,12 +1586,13 @@ class GeneralSurfaceTests(AssertRaisesRegexMixin, unittest.TestCase):
                         src_surf, (0, 0), special_flags=pygame.BLEND_ALPHA_SDL2
                     )
                     key = ((dst_r, dst_b, dst_a), (src_r, src_b, src_a))
-                    results[key] = dest_surf.get_at((65, 33))
-                    self.assertEqual(results[key], results_expected[key])
+                    results[key] = tuple(dest_surf.get_at((65, 33)))
+                    for i in range(4):
+                        self.assertLessEqual(
+                            abs(results[key][i] - results_expected[key][i]), 2)
 
         # print("(dest_r, dest_b, dest_a), (src_r, src_b, src_a): color")
         # pprint(results)
-        self.assertEqual(results, results_expected)
 
     def test_opaque_destination_blit_with_set_alpha(self):
         # no set_alpha()

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -1588,8 +1588,7 @@ class GeneralSurfaceTests(AssertRaisesRegexMixin, unittest.TestCase):
                     key = ((dst_r, dst_b, dst_a), (src_r, src_b, src_a))
                     results[key] = tuple(dest_surf.get_at((65, 33)))
                     for i in range(4):
-                        self.assertLessEqual(
-                            abs(results[key][i] - results_expected[key][i]), 2)
+                        self.assertAlmostEqual(results[key][i], results_expected[key][i], None, None, 4)
 
         # print("(dest_r, dest_b, dest_a), (src_r, src_b, src_a): color")
         # pprint(results)


### PR DESCRIPTION
Resolves the small issue in a test raised by #3097 
Allows for a delta of up to 2 which resolves all errors presented in the original problem.