### PR TITLE
Add debian s390x and ppc64le tests to CI

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -1,0 +1,93 @@
+# Tests pygame on more exotic architectures. This is not something that is
+# actively supported, but source code support for this is nice to have. We
+# don't do any releases from here.
+
+name: Debian Multiarch
+
+# Run CI only when a release is created, on changes to main branch, or any PR 
+# to main. Do not run CI on any other branch. Also, skip any non-source changes 
+# from running on CI
+on:
+  release:
+    types: [created]
+  push:
+    branches: main
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/build-debian-multiarch.yml'
+
+  pull_request:
+    branches: main
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - '.gitignore'
+      - '*.rst'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/build-debian-multiarch.yml'
+
+jobs:
+  build-multiarch:
+    name: Debian (Bullseye - 11) [${{ matrix.arch }}]
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false  # if a particular matrix build fails, don't skip the rest
+      matrix:
+        # maybe more things could be added in here in the future (if needed)
+        arch: [s390x, ppc64le]
+
+    steps:
+    - uses: actions/checkout@v3.0.2
+
+    - name: Build sources and run tests
+      uses: uraimo/run-on-arch-action@v2.3.0
+      id: build
+      with:
+        arch: ${{ matrix.arch }}
+        distro: bullseye
+
+        # Not required, but speeds up builds
+        githubToken: ${{ github.token }}
+
+        # Create an artifacts directory
+        setup: mkdir -p ~/artifacts
+
+        # Mount the artifacts directory as /artifacts in the container
+        dockerRunArgs: --volume ~/artifacts:/artifacts
+
+        # The shell to run commands with in the container
+        shell: /bin/sh
+
+        # Install some dependencies in the container. This speeds up builds if
+        # you are also using githubToken. Any dependencies installed here will
+        # be part of the container image that gets cached, so subsequent
+        # builds don't have to re-install them. The image layer is cached
+        # publicly in your project's package repository, so it is vital that
+        # no secrets are present in the container state or logs.
+        install: |
+          apt-get update --fix-missing
+          apt-get upgrade -y
+          apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev fontconfig -y
+          apt-get install python3-setuptools python3-dev python3-pip python3-wheel python3-sphinx -y
+
+        # Build a wheel, install it for running unit tests
+        run: |
+          export PIP_CONFIG_FILE=buildconfig/pip_config.ini
+          echo "\nBuilding pygame wheel\n"
+          python3 setup.py docs
+          pip3 wheel . --wheel-dir /artifacts -vvv
+          echo "\nInstalling wheel\n"
+          pip3 install --no-index --pre --find-links /artifacts pygame
+          echo "\nRunning tests\n"
+          export SDL_VIDEODRIVER=dummy
+          export SDL_AUDIODRIVER=disk
+          python3 -m pygame.tests -v --exclude opengl,music,timing --time_out 300

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -54,10 +54,12 @@ jobs:
       run: |
         sudo apt-get update --fix-missing
         sudo apt-get upgrade
-        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg8-dev python3-setuptools python3-dev
+        sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
         pip3 install sphinx numpy>=1.21.0
 
     - name: Make sdist and install it
+      env:
+        PIP_CONFIG_FILE: "buildconfig/pip_config.ini"
       run: |
         python3 setup.py docs
         python3 setup.py sdist
@@ -67,7 +69,7 @@ jobs:
       env:
         SDL_VIDEODRIVER: "dummy"
         SDL_AUDIODRIVER: "disk"
-      run: python3 -m pygame.tests -v --exclude opengl,timing --time_out 300
+      run: python3 -m pygame.tests -v --exclude opengl,music,timing --time_out 300
     
     - name: Test typestubs
       if: matrix.os == 'ubuntu-22.04' # run stubest only once

--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -592,8 +592,10 @@ pg_mixer_get_init(PyObject *self, PyObject *_null)
         Py_RETURN_NONE;
 
     // create a signed or unsigned number of bits per sample
-    // XXX: When mixer is init'd with a format of -8, this returns +8
-    realform = (format & ~0xff) ? -(format & 0xff) : format & 0xff;
+    realform = SDL_AUDIO_BITSIZE(format);
+    if (SDL_AUDIO_ISSIGNED(format)) {
+        realform = -realform;
+    }
     return Py_BuildValue("(iii)", freq, realform, channels);
 }
 


### PR DESCRIPTION
PR to close #1291, and progress on #3098

This is an experimental PR to add exotic architectures s390x (which is big endian) and ppc64le.

## Why?

We probably don't have many actual users running on these architectures, but having source code support for these (with no official releases) probably makes things easier for debian packaging folks, who occasionally report that big endian fail, or weird architecture specific fail. We already have aarch64 support now, so it make sense if these two follow. Hopefully this PR makes things easier for debian packagers to adopt new pygame releases faster, when they don't have to worry about this.

This should probably be least prioritized among other CI runs, but atleast having this CI in the background would make it easier to track which commit broke what if someone needs to look at history.

## Technical details

This is implemented internally with QEMU and docker (but abstracted away by a github action). Naturally there is some QEMU slowness, but the action can cache dependencies in docker base images (which is lives in github packages, but I think it needs some perms set up for it?)