### PR TITLE
blitters fix compile error when no SIMD

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -40,7 +40,7 @@
 
 // Check GCC
 #if __GNUC__
-#if __x86_64__ || __ppc64__
+#if __x86_64__ || __ppc64__ || __aarch64__
 #define ENV64BIT
 #endif
 #endif
@@ -259,7 +259,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Bmask == dst->format->Bmask &&
                         !(src->format->Amask != 0 && dst->format->Amask != 0 &&
                           src->format->Amask != dst->format->Amask) &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgb_add_avx2(&info);
                         break;
                     }
@@ -304,7 +304,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Bmask == dst->format->Bmask &&
                         !(src->format->Amask != 0 && dst->format->Amask != 0 &&
                           src->format->Amask != dst->format->Amask) &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgb_sub_avx2(&info);
                         break;
                     }
@@ -349,7 +349,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Bmask == dst->format->Bmask &&
                         !(src->format->Amask != 0 && dst->format->Amask != 0 &&
                           src->format->Amask != dst->format->Amask) &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgb_mul_avx2(&info);
                         break;
                     }
@@ -394,7 +394,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Bmask == dst->format->Bmask &&
                         !(src->format->Amask != 0 && dst->format->Amask != 0 &&
                           src->format->Amask != dst->format->Amask) &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgb_min_avx2(&info);
                         break;
                     }
@@ -439,7 +439,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Bmask == dst->format->Bmask &&
                         !(src->format->Amask != 0 && dst->format->Amask != 0 &&
                           src->format->Amask != dst->format->Amask) &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgb_max_avx2(&info);
                         break;
                     }
@@ -484,7 +484,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
                         info.src_blend != SDL_BLENDMODE_NONE &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgba_add_avx2(&info);
                         break;
                     }
@@ -526,7 +526,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
                         info.src_blend != SDL_BLENDMODE_NONE &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgba_sub_avx2(&info);
                         break;
                     }
@@ -568,7 +568,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
                         info.src_blend != SDL_BLENDMODE_NONE &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgba_mul_avx2(&info);
                         break;
                     }
@@ -610,7 +610,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
                         info.src_blend != SDL_BLENDMODE_NONE &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgba_min_avx2(&info);
                         break;
                     }
@@ -652,7 +652,7 @@ SoftBlitPyGame(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
                         src->format->Gmask == dst->format->Gmask &&
                         src->format->Bmask == dst->format->Bmask &&
                         info.src_blend != SDL_BLENDMODE_NONE &&
-                        SDL_HasAVX2() && (src != dst)) {
+                        pg_has_avx2() && (src != dst)) {
                         blit_blend_rgba_max_avx2(&info);
                         break;
                     }

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -39,6 +39,8 @@ void
 blit_blend_premultiplied_sse2(SDL_BlitInfo *info);
 #endif /* (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON)) */
 
+int
+pg_has_avx2();
 void
 blit_blend_rgba_mul_avx2(SDL_BlitInfo *info);
 void

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -4,13 +4,27 @@
 #include <immintrin.h>
 #endif /* defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H) */
 
-#define RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING()     \
-    char warning[128];                                 \
-    PyOS_snprintf(warning, sizeof(warning),            \
-                  "Blitting with SSE2 blitter on AVX2" \
-                  " capable system. Pygame may be "    \
-                  "compiled without AVX2 support.");   \
-    PyErr_WarnEx(PyExc_RuntimeWarning, warning, 0)
+#define BAD_AVX2_FUNCTION_CALL                                               \
+    printf(                                                                  \
+        "Fatal Error: Attempted calling an AVX2 function when both compile " \
+        "time and runtime support is missing. If you are seeing this "       \
+        "message, you have stumbled across a pygame bug, please report it "  \
+        "to the devs!");                                                     \
+    PG_EXIT(1)
+
+/* helper function that does a runtime check for AVX2. It has the added
+ * functionality of also returning 0 if compile time support is missing */
+int
+pg_has_avx2()
+{
+#if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+    !defined(SDL_DISABLE_IMMINTRIN_H)
+    return SDL_HasAVX2();
+#else
+    return 0;
+#endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+          !defined(SDL_DISABLE_IMMINTRIN_H) */
+}
 
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
@@ -129,8 +143,7 @@ blit_blend_rgba_mul_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgba_mul_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgba_mul_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -263,8 +276,7 @@ blit_blend_rgb_mul_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgb_mul_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgb_mul_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -336,8 +348,7 @@ blit_blend_rgba_add_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgba_add_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgba_add_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -418,8 +429,7 @@ blit_blend_rgb_add_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgb_add_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgb_add_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -491,8 +501,7 @@ blit_blend_rgba_sub_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgba_sub_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgba_sub_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -573,8 +582,7 @@ blit_blend_rgb_sub_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgb_sub_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgb_sub_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -646,8 +654,7 @@ blit_blend_rgba_max_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgba_max_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgba_max_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -728,8 +735,7 @@ blit_blend_rgb_max_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgb_max_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgb_max_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -801,8 +807,7 @@ blit_blend_rgba_min_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgba_min_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgba_min_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */
@@ -883,8 +888,7 @@ blit_blend_rgb_min_avx2(SDL_BlitInfo *info)
 void
 blit_blend_rgb_min_avx2(SDL_BlitInfo *info)
 {
-    RAISE_AVX2_RUNTIME_SSE2_COMPILED_WARNING();
-    blit_blend_rgb_min_sse2(info);
+    BAD_AVX2_FUNCTION_CALL;
 }
 #endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
           !defined(SDL_DISABLE_IMMINTRIN_H) */

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -14,7 +14,7 @@
 
 // Check GCC
 #if __GNUC__
-#if __x86_64__ || __ppc64__
+#if __x86_64__ || __ppc64__ || __aarch64__
 #define ENV64BIT
 #endif
 #endif


### PR DESCRIPTION
I'm making this PR to tackle the ppc64le and s390x compile fails from #3496

Basically, after the recent SIMD changes, the code fails to compile when *both* avx2 and sse2 (or neon on ARM) are missing. Currently, the avx2 functions are always defined, but when avx2 is missing at compile time, the sse2 fallback is used without testing for (compile time) sse2 presence.

~~As usual, while I was looking into fixing this, the urge to do related cleanups was also strong 😓 and I ended up cleaning up some repetition, and the like. Without doing this, the changes I wanted to make would only increase the ifdef hell in those parts of the code and it was getting fairly hard to read. So I'm hoping this cleanup actually makes review easier 😉~~ 
EDIT: This has been reverted now, with an alternate fix in place