### PR TITLE
Warn when SIMD is usable but not compiled

### DIFF
--- a/src_c/alphablit.c
+++ b/src_c/alphablit.c
@@ -3062,3 +3062,25 @@ pygame_AlphaBlit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
 {
     return pygame_Blit(src, srcrect, dst, dstrect, the_args);
 }
+
+#define _PG_WARN_SIMD(s)                                              \
+    if (pg_##s##_at_runtime_but_uncompiled()) {                       \
+        if (PyErr_WarnEx(                                             \
+                PyExc_RuntimeWarning,                                 \
+                "Your system is " #s " capable but pygame was not "   \
+                "built with support for it. The performance of some " \
+                "of your blits could be adversely affected",          \
+                1) < 0) {                                             \
+            return -1;                                                \
+        }                                                             \
+    }
+
+/* On error, returns -1 with python error set. */
+int
+pg_warn_simd_at_runtime_but_uncompiled()
+{
+    _PG_WARN_SIMD(avx2)
+    _PG_WARN_SIMD(sse2)
+    _PG_WARN_SIMD(neon)
+    return 0;
+}

--- a/src_c/simd_blitters.h
+++ b/src_c/simd_blitters.h
@@ -8,6 +8,13 @@
 #define PG_ENABLE_ARM_NEON 1
 #endif
 
+int
+pg_sse2_at_runtime_but_uncompiled();
+int
+pg_neon_at_runtime_but_uncompiled();
+int
+pg_avx2_at_runtime_but_uncompiled();
+
 #if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
 void
 alphablit_alpha_sse2_argb_surf_alpha(SDL_BlitInfo *info);

--- a/src_c/simd_blitters_avx2.c
+++ b/src_c/simd_blitters_avx2.c
@@ -12,6 +12,23 @@
                   "compiled without AVX2 support.");   \
     PyErr_WarnEx(PyExc_RuntimeWarning, warning, 0)
 
+/* This returns 1 when avx2 is available at runtime but support for it isn't
+ * compiled in, 0 in all other cases */
+int
+pg_avx2_at_runtime_but_uncompiled()
+{
+    if (SDL_HasAVX2()) {
+#if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+    !defined(SDL_DISABLE_IMMINTRIN_H)
+        return 0;
+#else
+        return 1;
+#endif /* defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
+          !defined(SDL_DISABLE_IMMINTRIN_H) */
+    }
+    return 0;
+}
+
 #if defined(__AVX2__) && defined(HAVE_IMMINTRIN_H) && \
     !defined(SDL_DISABLE_IMMINTRIN_H)
 void

--- a/src_c/simd_blitters_sse2.c
+++ b/src_c/simd_blitters_sse2.c
@@ -19,6 +19,36 @@
 #endif
 #endif
 
+/* This returns 1 when sse2 is available at runtime but support for it isn't
+ * compiled in, 0 in all other cases */
+int
+pg_sse2_at_runtime_but_uncompiled()
+{
+    if (SDL_HasSSE2()) {
+#ifdef __SSE2__
+        return 0;
+#else
+        return 1;
+#endif /* __SSE2__ */
+    }
+    return 0;
+}
+
+/* This returns 1 when neon is available at runtime but support for it isn't
+ * compiled in, 0 in all other cases */
+int
+pg_neon_at_runtime_but_uncompiled()
+{
+    if (SDL_HasNEON()) {
+#ifdef PG_ENABLE_ARM_NEON
+        return 0;
+#else
+        return 1;
+#endif /* PG_ENABLE_ARM_NEON */
+    }
+    return 0;
+}
+
 #if (defined(__SSE2__) || defined(PG_ENABLE_ARM_NEON))
 
 /* See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=32869

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -3804,6 +3804,10 @@ MODINIT_DEFINE(surface)
     if (module == NULL) {
         return NULL;
     }
+    if (pg_warn_simd_at_runtime_but_uncompiled() < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
     Py_INCREF(&pgSurface_Type);
     if (PyModule_AddObject(module, "SurfaceType",
                            (PyObject *)&pgSurface_Type)) {

--- a/src_c/surface.h
+++ b/src_c/surface.h
@@ -352,4 +352,7 @@ int
 pygame_Blit(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst,
             SDL_Rect *dstrect, int the_args);
 
+int
+pg_warn_simd_at_runtime_but_uncompiled();
+
 #endif /* SURFACE_H */


### PR DESCRIPTION
Commit was initially a part of #3498 but is now separated for better clarity.

That PR is fixing the compile error (and is therefore, more urgent than this PR)

This PR is just adding warnings for when there's runtime support for X (can be neon/sse2/avx2) but was skipped at compile time