### PR TITLE
docs: Add experimental feedback links to new APIs

### DIFF
--- a/docs/reST/ref/font.rst
+++ b/docs/reST/ref/font.rst
@@ -84,6 +84,9 @@ solves no longer exists, it will likely be removed in the future.
    | :sl:`gets SDL_ttf version`
    | :sg:`get_sdl_ttf_version(linked=True) -> (major, minor, patch)`
 
+   **Experimental:** feature still in development available for testing and feedback. It may change.
+   `Please leave get_sdl_ttf_version feedback with authors <https://github.com/pygame/pygame/pull/3095>`_
+
    Returns a tuple of integers that identify SDL_ttf's version.
    SDL_ttf is the underlying font rendering library, written in C,
    on which pygame's font module depends. If 'linked' is True (the default), 

--- a/docs/reST/ref/key.rst
+++ b/docs/reST/ref/key.rst
@@ -343,6 +343,9 @@ for ``KMOD_NONE``, which should be compared using equals ``==``). For example:
    corresponding key constant exists and is unique). If the return value is
    passed to the ``key_code`` function, the original constant will be returned.
 
+   **Experimental:** ``use_compat`` paramater still in development for testing and feedback. It may change.
+   `Please leave use_compat feedback with authors <https://github.com/pygame/pygame/pull/3312>`_
+
    If this argument is ``False``, the returned name may be prettier to display
    and may cover a wider range of keys than with ``use_compat``, but there are
    no guarantees that this name will be the same across different pygame

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -53,6 +53,9 @@ Multiple coordinates can be set using slices or swizzling
    | :sl:`returns value clamped to min and max.`
    | :sg:`clamp(value, min, max) -> float`
 
+   **Experimental:** feature still in development available for testing and feedback. It may change.
+   `Please leave clamp feedback with authors <https://github.com/pygame/pygame/pull/3326>`_
+
    Clamps a numeric ``value`` so that it's no lower than ``min``, and no higher
    than ``max``.
 
@@ -216,6 +219,9 @@ Multiple coordinates can be set using slices or swizzling
       | :sl:`returns a vector moved toward the target by a given distance.`
       | :sg:`move_towards(Vector2, float) -> Vector2`
 
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave move_towards feedback with authors <https://github.com/pygame/pygame/pull/2929>`_
+
       Returns a Vector which is moved towards the given Vector by a given
       distance and does not overshoot past its target Vector.
       The first parameter determines the target Vector, while the second
@@ -230,6 +236,9 @@ Multiple coordinates can be set using slices or swizzling
 
       | :sl:`moves the vector toward its target at a given distance.`
       | :sg:`move_towards_ip(Vector2, float) -> None`
+
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave move_towards_ip feedback with authors <https://github.com/pygame/pygame/pull/2929>`_
 
       Moves itself toward the given Vector at a given distance and does not
       overshoot past its target Vector.
@@ -406,8 +415,8 @@ Multiple coordinates can be set using slices or swizzling
       | :sg:`clamp_magnitude(max_length) -> Vector2`
       | :sg:`clamp_magnitude(min_length, max_length) -> Vector2`
 
-      **PLEASE NOTE:** This method is considered experimental for now and is
-      subject to potential changes in future versions.
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave clamp_magnitude feedback with authors <https://github.com/pygame/pygame/pull/2990>`_
 
       Returns a new copy of a vector with the magnitude clamped between 
       ``max_length`` and ``min_length``. If only one argument is passed, it is 
@@ -427,8 +436,8 @@ Multiple coordinates can be set using slices or swizzling
       | :sg:`clamp_magnitude_ip(max_length) -> None`
       | :sg:`clamp_magnitude_ip(min_length, max_length) -> None`
 
-      **PLEASE NOTE:** This method is considered experimental for now and is
-      subject to potential changes in future versions.
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave clamp_magnitude_ip feedback with authors <https://github.com/pygame/pygame/pull/2990>`_
 
       Clamps the vector's magnitude between ``max_length`` and ``min_length``.
       If only one argument is passed, it is taken to be the ``max_length``
@@ -653,6 +662,9 @@ Multiple coordinates can be set using slices or swizzling
       | :sl:`returns a vector moved toward the target by a given distance.`
       | :sg:`move_towards(Vector3, float) -> Vector3`
 
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave move_towards feedback with authors <https://github.com/pygame/pygame/pull/2929>`_
+
       Returns a Vector which is moved towards the given Vector by a given
       distance and does not overshoot past its target Vector.
       The first parameter determines the target Vector, while the second
@@ -667,6 +679,9 @@ Multiple coordinates can be set using slices or swizzling
 
       | :sl:`moves the vector toward its target at a given distance.`
       | :sg:`move_towards_ip(Vector3, float) -> None`
+
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave move_towards_ip feedback with authors <https://github.com/pygame/pygame/pull/2929>`_
 
       Moves itself toward the given Vector at a given distance and does not
       overshoot past its target Vector.
@@ -1026,8 +1041,8 @@ Multiple coordinates can be set using slices or swizzling
       | :sg:`clamp_magnitude(max_length) -> Vector3`
       | :sg:`clamp_magnitude(min_length, max_length) -> Vector3`
 
-      **PLEASE NOTE:** This method is considered experimental for now and is
-      subject to potential changes in future versions.
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave clamp_magnitude feedback with authors <https://github.com/pygame/pygame/pull/2990>`_
 
       Returns a new copy of a vector with the magnitude clamped between 
       ``max_length`` and ``min_length``. If only one argument is passed, it is 
@@ -1047,8 +1062,8 @@ Multiple coordinates can be set using slices or swizzling
       | :sg:`clamp_magnitude_ip(max_length) -> None`
       | :sg:`clamp_magnitude_ip(min_length, max_length) -> None`
 
-      **PLEASE NOTE:** This method is considered experimental for now and is
-      subject to potential changes in future versions.
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave clamp_magnitude_ip feedback with authors <https://github.com/pygame/pygame/pull/2990>`_
 
       Clamps the vector's magnitude between ``max_length`` and ``min_length``.
       If only one argument is passed, it is taken to be the ``max_length``

--- a/docs/reST/ref/rect.rst
+++ b/docs/reST/ref/rect.rst
@@ -407,6 +407,9 @@
       | :sg:`collideobjects(rect_list) -> object`
       | :sg:`collideobjects(obj_list, key=func) -> object`
 
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave collideobjects feedback with authors <https://github.com/pygame/pygame/pull/3026>`_
+
       Test whether the rectangle collides with any object in the sequence.
       The object of the first collision found is returned. If no collisions are
       found then ``None`` is returned
@@ -464,6 +467,9 @@
       | :sl:`test if all objects in a list intersect`
       | :sg:`collideobjectsall(rect_list) -> objects`
       | :sg:`collideobjectsall(obj_list, key=func) -> objects`
+
+      **Experimental:** feature still in development available for testing and feedback. It may change.
+      `Please leave collideobjectsall feedback with authors <https://github.com/pygame/pygame/pull/3026>`_
 
       Returns a list of all the objects that contain rectangles that collide
       with the Rect. If no intersecting objects are found, an empty list is

--- a/docs/reST/ref/transform.rst
+++ b/docs/reST/ref/transform.rst
@@ -54,6 +54,9 @@ Instead, always begin with the original image and scale to the desired size.)
    | :sl:`resize to new resolution, using scalar(s)`
    | :sg:`scale_by(surface, factor, dest_surface=None) -> Surface`
 
+   **Experimental:** feature still in development available for testing and feedback. It may change.
+   `Please leave scale_by feedback with authors <https://github.com/pygame/pygame/pull/2723>`_
+
    Same as :func:`scale()`, but scales by some factor, rather than taking
    the new size explicitly. For example, :code:`transform.scale_by(surf, 3)`
    will triple the size of the surface in both dimensions. Optionally, the
@@ -136,6 +139,9 @@ Instead, always begin with the original image and scale to the desired size.)
 
    | :sl:`resize to new resolution, using scalar(s)`
    | :sg:`smoothscale_by(surface, factor, dest_surface=None) -> Surface`
+
+   **Experimental:** feature still in development available for testing and feedback. It may change.
+   `Please leave smoothscale_by feedback with authors <https://github.com/pygame/pygame/pull/2723>`_
 
    Same as :func:`smoothscale()`, but scales by some factor, rather than
    taking the new size explicitly. For example,


### PR DESCRIPTION
For 2.1.3 release https://github.com/pygame/pygame/issues/3408

See [closed new API PRs](https://github.com/pygame/pygame/pulls?q=is%3Apr+label%3A%22New+API%22+is%3Aclosed)

These links were added to the documentation.

- get_sdl_ttf_version feedback with authors https://github.com/pygame/pygame/pull/3095
- use_compat feedback with authors https://github.com/pygame/pygame/pull/3312
- clamp feedback with authors https://github.com/pygame/pygame/pull/3326
- clamp_magnitude feedback with authors https://github.com/pygame/pygame/pull/2990
- clamp_magnitude_ip feedback with authors https://github.com/pygame/pygame/pull/2990
- move_towards feedback with authors https://github.com/pygame/pygame/pull/2929
- move_towards_ip feedback with authors https://github.com/pygame/pygame/pull/2929
- collideobjects feedback with authors https://github.com/pygame/pygame/pull/3026
- collideobjectsall feedback with authors https://github.com/pygame/pygame/pull/3026
- scale_by feedback with authors https://github.com/pygame/pygame/pull/2723
- smoothscale_by feedback with authors https://github.com/pygame/pygame/pull/2723
