### PR TITLE
Move pg_tuple_from_values_int into header, rename & add triple variant

### DIFF
--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -483,7 +483,7 @@ PYGAMEAPI_EXTERN_SLOTS(math);
  *  functions in Python 3.
  */
 
-PG_INLINE PyObject *
+static PG_INLINE PyObject *
 pg_tuple_from_values_int(int val1, int val2)
 {
     PyObject *tup = PyTuple_New(2);

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -484,8 +484,12 @@ PYGAMEAPI_EXTERN_SLOTS(math);
  */
 
 static PG_INLINE PyObject *
-pg_tuple_from_values_int(int val1, int val2)
+pg_tuple_couple_from_values_int(int val1, int val2)
 {
+    /* This function turns two input integers into a python tuple object.
+     * Currently, 5th November 2022, this is faster than using Py_BuildValue
+     * to do the same thing.
+     */
     PyObject *tup = PyTuple_New(2);
     if (!tup) {
         return NULL;
@@ -504,6 +508,42 @@ pg_tuple_from_values_int(int val1, int val2)
         return NULL;
     }
     PyTuple_SET_ITEM(tup, 1, tmp);
+
+    return tup;
+}
+
+static PG_INLINE PyObject *
+pg_tuple_triple_from_values_int(int val1, int val2, int val3)
+{
+    /* This function turns three input integers into a python tuple object.
+     * Currently, 5th November 2022, this is faster than using Py_BuildValue
+     * to do the same thing.
+     */
+    PyObject *tup = PyTuple_New(3);
+    if (!tup) {
+        return NULL;
+    }
+
+    PyObject *tmp = PyLong_FromLong(val1);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 0, tmp);
+
+    tmp = PyLong_FromLong(val2);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 1, tmp);
+
+    tmp = PyLong_FromLong(val3);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 2, tmp);
 
     return tup;
 }

--- a/src_c/include/_pygame.h
+++ b/src_c/include/_pygame.h
@@ -477,3 +477,33 @@ PYGAMEAPI_EXTERN_SLOTS(math);
 #endif /* ~PYGAME_H */
 
 #endif /* PYGAME_H */
+
+/*  Use the end of this file for other cross module inline utility
+ *  functions There seems to be no good reason to stick to macro only
+ *  functions in Python 3.
+ */
+
+PG_INLINE PyObject *
+pg_tuple_from_values_int(int val1, int val2)
+{
+    PyObject *tup = PyTuple_New(2);
+    if (!tup) {
+        return NULL;
+    }
+
+    PyObject *tmp = PyLong_FromLong(val1);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 0, tmp);
+
+    tmp = PyLong_FromLong(val2);
+    if (!tmp) {
+        Py_DECREF(tup);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tup, 1, tmp);
+
+    return tup;
+}

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -147,31 +147,6 @@ four_ints_from_obj(PyObject *obj, int *val1, int *val2, int *val3, int *val4)
     return 1;
 }
 
-PyObject *
-pg_tuple_from_values_int(int val1, int val2)
-{
-    PyObject *tup = PyTuple_New(2);
-    if (!tup) {
-        return NULL;
-    }
-
-    PyObject *tmp = PyLong_FromLong(val1);
-    if (!tmp) {
-        Py_DECREF(tup);
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tup, 0, tmp);
-
-    tmp = PyLong_FromLong(val2);
-    if (!tmp) {
-        Py_DECREF(tup);
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tup, 1, tmp);
-
-    return tup;
-}
-
 static PyObject *
 _pg_rect_subtype_new4(PyTypeObject *type, int x, int y, int w, int h)
 {

--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1851,7 +1851,7 @@ pg_rect_setcentery(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopleft(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x, self->r.y);
+    return pg_tuple_couple_from_values_int(self->r.x, self->r.y);
 }
 
 static int
@@ -1878,7 +1878,7 @@ pg_rect_settopleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_gettopright(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x + self->r.w, self->r.y);
+    return pg_tuple_couple_from_values_int(self->r.x + self->r.w, self->r.y);
 }
 
 static int
@@ -1905,7 +1905,7 @@ pg_rect_settopright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomleft(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x, self->r.y + self->r.h);
+    return pg_tuple_couple_from_values_int(self->r.x, self->r.y + self->r.h);
 }
 
 static int
@@ -1932,8 +1932,8 @@ pg_rect_setbottomleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getbottomright(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x + self->r.w,
-                                    self->r.y + self->r.h);
+    return pg_tuple_couple_from_values_int(self->r.x + self->r.w,
+                                           self->r.y + self->r.h);
 }
 
 static int
@@ -1960,7 +1960,8 @@ pg_rect_setbottomright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidtop(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x + (self->r.w >> 1), self->r.y);
+    return pg_tuple_couple_from_values_int(self->r.x + (self->r.w >> 1),
+                                           self->r.y);
 }
 
 static int
@@ -1987,7 +1988,8 @@ pg_rect_setmidtop(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidleft(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x, self->r.y + (self->r.h >> 1));
+    return pg_tuple_couple_from_values_int(self->r.x,
+                                           self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2014,8 +2016,8 @@ pg_rect_setmidleft(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidbottom(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x + (self->r.w >> 1),
-                                    self->r.y + self->r.h);
+    return pg_tuple_couple_from_values_int(self->r.x + (self->r.w >> 1),
+                                           self->r.y + self->r.h);
 }
 
 static int
@@ -2042,8 +2044,8 @@ pg_rect_setmidbottom(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getmidright(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x + self->r.w,
-                                    self->r.y + (self->r.h >> 1));
+    return pg_tuple_couple_from_values_int(self->r.x + self->r.w,
+                                           self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2070,8 +2072,8 @@ pg_rect_setmidright(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getcenter(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.x + (self->r.w >> 1),
-                                    self->r.y + (self->r.h >> 1));
+    return pg_tuple_couple_from_values_int(self->r.x + (self->r.w >> 1),
+                                           self->r.y + (self->r.h >> 1));
 }
 
 static int
@@ -2098,7 +2100,7 @@ pg_rect_setcenter(pgRectObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_rect_getsize(pgRectObject *self, void *closure)
 {
-    return pg_tuple_from_values_int(self->r.w, self->r.h);
+    return pg_tuple_couple_from_values_int(self->r.w, self->r.h);
 }
 
 static int


### PR DESCRIPTION
Related to the suggestion in #3424 by @Starbuck5 to reduce code duplication by having copies of this function each time it gets used.

As far as I can tell there is no obvious reason _not_ to have inline functions in header files with Pygame 3. The existing #define style 'functions' in `include/_pygame.h` appear to have been designed that way for something called `CObject`s in Python 2 (according to the header comment in the file) which were then removed in Python 3.

Happy to hear wisdom otherwise, or create a new file instead if we think that is better, but the existing #define macro functions in this header are the most similar to the purpose of this function. Also, this header is already included everywhere.

**Testing work:** does this change the performance in any way versus having it directly in `rect.c`. It shouldn't but hey, compilers are weird.