### PR TITLE
Performance improvement for draw.circle

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1043,6 +1043,23 @@ add_pixel_to_drawn_list(int x, int y, int *pts)
     }
 }
 
+static void
+add_line_to_drawn_list(int x1, int y1, int x2, int *pts)
+{
+    if (x1 < pts[0]) {
+        pts[0] = x1;
+    }
+    if (y1 < pts[1]) {
+        pts[1] = y1;
+    }
+    if (x2 > pts[2]) {
+        pts[2] = x2;
+    }
+    if (y1 > pts[3]) {
+        pts[3] = y1;
+    }
+}
+
 static int
 clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2)
 {
@@ -1358,19 +1375,9 @@ drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
 {
     Uint8 *pixel, *end;
 
-    if (x1 == x2) {
-        return;
-    }
-
     pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
-    if (x1 < x2) {
-        end = pixel + x2 * surf->format->BytesPerPixel;
-        pixel += x1 * surf->format->BytesPerPixel;
-    }
-    else {
-        end = pixel + x1 * surf->format->BytesPerPixel;
-        pixel += x2 * surf->format->BytesPerPixel;
-    }
+    end = pixel + x2 * surf->format->BytesPerPixel;
+    pixel += x1 * surf->format->BytesPerPixel;
     switch (surf->format->BytesPerPixel) {
         case 1:
             for (; pixel <= end; ++pixel) {
@@ -1447,8 +1454,7 @@ drawhorzlineclipbounding(SDL_Surface *surf, Uint32 color, int x1, int y1,
         return;
     }
 
-    add_pixel_to_drawn_list(x1, y1, pts);
-    add_pixel_to_drawn_list(x2, y1, pts);
+    add_line_to_drawn_list(x1, y1, x2, pts);
 
     drawhorzline(surf, color, x1, y1, x2);
 }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1699,10 +1699,10 @@ draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
                                      x0 - (int)x_inner, drawn_area);
             drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1,
                                      x0 - (int)x_inner, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y,
-                                     x0 + (int)x_inner - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1,
-                                     y0 + (int)y - 1, x0 + (int)x_inner - 1,
+            drawhorzlineclipbounding(surf, color, x0 + (int)x_inner - 1,
+                                     y0 - (int)y, x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x_inner - 1,
+                                     y0 + (int)y - 1, x0 + (int)x - 1,
                                      drawn_area);
         }
         x++;
@@ -1739,10 +1739,10 @@ draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
                                      x0 - (int)x_inner, drawn_area);
             drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1,
                                      x0 - (int)x_inner, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y,
-                                     x0 + (int)x_inner - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1,
-                                     y0 + (int)y - 1, x0 + (int)x_inner - 1,
+            drawhorzlineclipbounding(surf, color, x0 + (int)x_inner - 1,
+                                     y0 - (int)y, x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x_inner - 1,
+                                     y0 + (int)y - 1, x0 + (int)x - 1,
                                      drawn_area);
         }
         if (d1 > 0) {

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1689,21 +1689,29 @@ draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
             d1 += dx + radius_squared;
         }
         if (line) {
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 + (int)x - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y,
+                                     x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1,
+                                     x0 + (int)x - 1, drawn_area);
         }
         else {
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 - (int)x_inner, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 - (int)x_inner, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y, x0 + (int)x_inner - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 + (int)y - 1, x0 + (int)x_inner - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y,
+                                     x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1,
+                                     x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y,
+                                     x0 + (int)x_inner - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1,
+                                     y0 + (int)y - 1, x0 + (int)x_inner - 1,
+                                     drawn_area);
         }
         x++;
         y--;
         dx += double_radius_squared;
         dy -= double_radius_squared;
         d1 += dx - dy + radius_squared;
-        if (line && y < radius_inner) line = 0;
+        if (line && y < radius_inner)
+            line = 0;
         if (!line) {
             while (d1_inner < 0) {
                 x_inner += 1;
@@ -1717,17 +1725,25 @@ draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
             d1_inner += dx_inner - dy_inner + radius_inner_squared;
         }
     }
-    d1 = radius_squared * (x + 0.5) * (x + 0.5) + radius_squared * (y - 1) * (y - 1) - radius_squared * radius_squared;
+    d1 = radius_squared *
+         ((x + 0.5) * (x + 0.5) + (y - 1) * (y - 1) - radius_squared);
     while (y >= 0) {
         if (line) {
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 + (int)x - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y,
+                                     x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1,
+                                     x0 + (int)x - 1, drawn_area);
         }
         else {
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 - (int)x_inner, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 - (int)x_inner, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y, x0 + (int)x_inner - 1, drawn_area);
-            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 + (int)y - 1, x0 + (int)x_inner - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y,
+                                     x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1,
+                                     x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y,
+                                     x0 + (int)x_inner - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1,
+                                     y0 + (int)y - 1, x0 + (int)x_inner - 1,
+                                     drawn_area);
         }
         if (d1 > 0) {
             y--;
@@ -1741,7 +1757,8 @@ draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
             dy -= double_radius_squared;
             d1 += dx - dy + radius_squared;
         }
-        if (line && y < radius_inner) line = 0;
+        if (line && y < radius_inner)
+            line = 0;
         if (!line) {
             if (dx_inner < dy_inner) {
                 while (d1_inner < 0) {
@@ -1756,7 +1773,11 @@ draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
                 d1_inner += dx_inner - dy_inner + radius_inner_squared;
             }
             else {
-                if (!d2_inner) d2_inner = radius_inner_squared * (x_inner + 0.5) * (x_inner + 0.5) + radius_inner_squared * (y_inner - 1) * (y_inner - 1) - radius_inner_squared * radius_inner_squared;
+                if (!d2_inner)
+                    d2_inner =
+                        radius_inner_squared *
+                        ((x_inner + 0.5) * (x_inner + 0.5) +
+                         (y_inner - 1) * (y_inner - 1) - radius_inner_squared);
                 if (d2_inner > 0) {
                     y_inner--;
                     dy_inner -= double_radius_inner_squared;

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -1663,69 +1663,113 @@ static void
 draw_circle_bresenham(SDL_Surface *surf, int x0, int y0, int radius,
                       int thickness, Uint32 color, int *drawn_area)
 {
-    int f = 1 - radius;
-    int ddF_x = 0;
-    int ddF_y = -2 * radius;
-    int x = 0;
-    int y = radius;
-    int y1;
-    int i_y = radius - thickness;
-    int thickness_inner = thickness;
-    int i_f = 1 - i_y;
-    int i_ddF_x = 0;
-    int i_ddF_y = -2 * i_y;
-    int i;
+    long long x = 0;
+    long long y = radius;
+    long long radius_squared = radius * radius;
+    long long double_radius_squared = 2 * radius_squared;
+    double d1 = radius_squared * (1.25 - radius);
+    long long dx = 0;
+    long long dy = double_radius_squared * y;
 
-    while (x < y) {
-        if (f >= 0) {
-            y--;
-            ddF_y += 2;
-            f += ddF_y;
+    int line = 1;
+    long long radius_inner = radius - thickness + 1;
+    long long x_inner = 0;
+    long long y_inner = radius_inner;
+    long long radius_inner_squared = radius_inner * radius_inner;
+    long long double_radius_inner_squared = 2 * radius_inner_squared;
+    double d1_inner = radius_inner_squared * (1.25 - radius_inner);
+    double d2_inner = 0;
+    long long dx_inner = 0;
+    long long dy_inner = double_radius_inner_squared * y_inner;
+
+    while (dx < dy) {
+        while (d1 < 0) {
+            x++;
+            dx += double_radius_squared;
+            d1 += dx + radius_squared;
         }
-        /* inner circle*/
-        if (i_f >= 0) {
-            i_y--;
-            i_ddF_y += 2;
-            i_f += i_ddF_y;
-        }
-        x++;
-        ddF_x += 2;
-        f += ddF_x + 1;
-
-        /* inner circle*/
-        i_ddF_x += 2;
-        i_f += i_ddF_x + 1;
-
-        if (x > i_y) {
-            /* Distance between outer circle and 45-degree angle */
-            /* plus one pixel so there's no gap */
-            thickness_inner = y - x + 1;
+        if (line) {
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 + (int)x - 1, drawn_area);
         }
         else {
-            /* Distance between outer and inner circle */
-            thickness_inner = y - i_y;
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y, x0 + (int)x_inner - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 + (int)y - 1, x0 + (int)x_inner - 1, drawn_area);
         }
-
-        /* Numbers represent parts of circle function draw in radians
-           interval: [number - 1 * pi / 4, number * pi / 4] */
-        for (i = 0; i < thickness_inner; i++) {
-            y1 = y - i;
-            set_and_check_rect(surf, x0 + x - 1, y0 + y1 - 1, color,
-                               drawn_area); /* 7 */
-            set_and_check_rect(surf, x0 - x, y0 + y1 - 1, color,
-                               drawn_area); /* 6 */
-            set_and_check_rect(surf, x0 + x - 1, y0 - y1, color,
-                               drawn_area); /* 2 */
-            set_and_check_rect(surf, x0 - x, y0 - y1, color,
-                               drawn_area); /* 3 */
-            set_and_check_rect(surf, x0 + y1 - 1, y0 + x - 1, color,
-                               drawn_area); /* 8 */
-            set_and_check_rect(surf, x0 + y1 - 1, y0 - x, color,
-                               drawn_area); /* 1 */
-            set_and_check_rect(surf, x0 - y1, y0 + x - 1, color,
-                               drawn_area); /* 5 */
-            set_and_check_rect(surf, x0 - y1, y0 - x, color,
-                               drawn_area); /* 4 */
+        x++;
+        y--;
+        dx += double_radius_squared;
+        dy -= double_radius_squared;
+        d1 += dx - dy + radius_squared;
+        if (line && y < radius_inner) line = 0;
+        if (!line) {
+            while (d1_inner < 0) {
+                x_inner += 1;
+                dx_inner += double_radius_inner_squared;
+                d1_inner += dx_inner + radius_inner_squared;
+            }
+            x_inner++;
+            y_inner--;
+            dx_inner += double_radius_inner_squared;
+            dy_inner -= double_radius_inner_squared;
+            d1_inner += dx_inner - dy_inner + radius_inner_squared;
+        }
+    }
+    d1 = radius_squared * (x + 0.5) * (x + 0.5) + radius_squared * (y - 1) * (y - 1) - radius_squared * radius_squared;
+    while (y >= 0) {
+        if (line) {
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 + (int)x - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 + (int)x - 1, drawn_area);
+        }
+        else {
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 - (int)y, x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 - (int)x, y0 + (int)y - 1, x0 - (int)x_inner, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 - (int)y, x0 + (int)x_inner - 1, drawn_area);
+            drawhorzlineclipbounding(surf, color, x0 + (int)x - 1, y0 + (int)y - 1, x0 + (int)x_inner - 1, drawn_area);
+        }
+        if (d1 > 0) {
+            y--;
+            dy -= double_radius_squared;
+            d1 += radius_squared - dy;
+        }
+        else {
+            y--;
+            x++;
+            dx += double_radius_squared;
+            dy -= double_radius_squared;
+            d1 += dx - dy + radius_squared;
+        }
+        if (line && y < radius_inner) line = 0;
+        if (!line) {
+            if (dx_inner < dy_inner) {
+                while (d1_inner < 0) {
+                    x_inner += 1;
+                    dx_inner += double_radius_inner_squared;
+                    d1_inner += dx_inner + radius_inner_squared;
+                }
+                x_inner++;
+                y_inner--;
+                dx_inner += double_radius_inner_squared;
+                dy_inner -= double_radius_inner_squared;
+                d1_inner += dx_inner - dy_inner + radius_inner_squared;
+            }
+            else {
+                if (!d2_inner) d2_inner = radius_inner_squared * (x_inner + 0.5) * (x_inner + 0.5) + radius_inner_squared * (y_inner - 1) * (y_inner - 1) - radius_inner_squared * radius_inner_squared;
+                if (d2_inner > 0) {
+                    y_inner--;
+                    dy_inner -= double_radius_inner_squared;
+                    d2_inner += radius_inner_squared - dy_inner;
+                }
+                else {
+                    y_inner--;
+                    x_inner++;
+                    dx_inner += double_radius_inner_squared;
+                    dy_inner -= double_radius_inner_squared;
+                    d2_inner += dx_inner - dy_inner + radius_inner_squared;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This should improve circles drawn with thickness, for example `pygame.draw.circle(screen, "YELLOW", (200, 200), 100, 40)` (and a few percent improvement to some other draw functions, but that is not relevant)