### PR TITLE
Remove Python < 3.2 compatibility shim

### DIFF
--- a/test/mask_test.py
+++ b/test/mask_test.py
@@ -8,7 +8,6 @@ import sys
 import pygame
 from pygame.locals import *
 from pygame.math import Vector2
-from pygame.tests.test_utils import AssertRaisesRegexMixin
 
 
 IS_PYPY = "PyPy" == platform.python_implementation()
@@ -144,7 +143,7 @@ def assertMaskEqual(testcase, m1, m2, msg=None):
 
 
 # @unittest.skipIf(IS_PYPY, "pypy has lots of mask failures")  # TODO
-class MaskTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+class MaskTypeTest(unittest.TestCase):
     ORIGIN_OFFSETS = (
         (0, 0),
         (0, 1),

--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -4,7 +4,7 @@ import unittest
 import pathlib
 import platform
 
-from pygame.tests.test_utils import example_path, AssertRaisesRegexMixin
+from pygame.tests.test_utils import example_path
 
 import pygame
 from pygame import mixer
@@ -655,7 +655,7 @@ class MixerModuleTest(unittest.TestCase):
 ############################## CHANNEL CLASS TESTS #############################
 
 
-class ChannelTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+class ChannelTypeTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Initializing the mixer is slow, so minimize the times it is called.
@@ -914,7 +914,7 @@ class ChannelTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
 ############################### SOUND CLASS TESTS ##############################
 
 
-class SoundTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+class SoundTypeTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         mixer.quit()

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -3,7 +3,6 @@ import unittest
 from pygame.tests import test_utils
 from pygame.tests.test_utils import (
     example_path,
-    AssertRaisesRegexMixin,
     SurfaceSubclass,
 )
 
@@ -23,7 +22,7 @@ import ctypes
 IS_PYPY = "PyPy" == platform.python_implementation()
 
 
-class SurfaceTypeTest(AssertRaisesRegexMixin, unittest.TestCase):
+class SurfaceTypeTest(unittest.TestCase):
     def test_surface__pixel_format_as_surface_subclass(self):
         """Ensure a subclassed surface can be used for pixel format
         when creating a new surface."""
@@ -1065,7 +1064,7 @@ class TestSurfaceBlit(unittest.TestCase):
         target.blit(source, (0, 0))
 
 
-class GeneralSurfaceTests(AssertRaisesRegexMixin, unittest.TestCase):
+class GeneralSurfaceTests(unittest.TestCase):
     @unittest.skipIf(
         os.environ.get("SDL_VIDEODRIVER") == "dummy",
         'requires a non-"dummy" SDL_VIDEODRIVER',

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -20,27 +20,6 @@ def geterror():
     return sys.exc_info()[1]
 
 
-class AssertRaisesRegexMixin:
-    """Provides a way to prevent DeprecationWarnings in python >= 3.2.
-
-    For this mixin to override correctly it needs to be before the
-    unittest.TestCase in the multiple inheritance hierarchy.
-    e.g. class TestClass(AssertRaisesRegexMixin, unittest.TestCase)
-
-    This class/mixin and its usage can be removed when pygame no longer
-    supports python < 3.2.
-    """
-
-    def assertRaisesRegex(self, *args, **kwargs):
-        try:
-            return super().assertRaisesRegex(*args, **kwargs)
-        except AttributeError:
-            try:
-                return super().assertRaisesRegexp(*args, **kwargs)
-            except AttributeError:
-                self.skipTest("No assertRaisesRegex/assertRaisesRegexp method")
-
-
 ###############################################################################
 
 this_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Noticed because I was checking removed things in the Python 3.12 release notes, and saw that we had an instance of one of the removed things, `assertRaisesRegexp`.