### PR TITLE
Cut SDL_PIXELFORMAT_ prefix off in vidinfo

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -308,6 +308,7 @@ required).
                  is called. (current_h, current_w are available since
                  SDL 1.2.10, and pygame 1.8.0). They are -1 on error, or if
                  an old SDL is being used.
+     pixel_format: A string representing the format of each pixel's color
 
    .. ## pygame.display.Info ##
 

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -323,6 +323,11 @@ pg_vidinfo_getattr(PyObject *self, char *name)
         return PyLong_FromLong(current_h);
     else if (!strcmp(name, "current_w"))
         return PyLong_FromLong(current_w);
+    else if (!strcmp(name, "pixel_format")) {
+        const char *name = SDL_GetPixelFormatName(info->vfmt->format);
+        // + 16 to remove SDL_PIXELFORMAT_ prefix
+        return PyUnicode_FromString(name + 16);
+    }
 
     return RAISE(PyExc_AttributeError, "does not exist in vidinfo");
 }
@@ -333,7 +338,10 @@ pg_vidinfo_str(PyObject *self)
     int current_w = -1;
     int current_h = -1;
     pg_VideoInfo *info = &((pgVidInfoObject *)self)->info;
-    const char *pixel_format_name = SDL_GetPixelFormatName(info->vfmt->format);
+
+    // + 16 to remove SDL_PIXELFORMAT_ prefix
+    const char *pixel_format_name =
+        SDL_GetPixelFormatName(info->vfmt->format) + 16;
 
     SDL_version versioninfo;
     SDL_VERSION(&versioninfo);


### PR DESCRIPTION
should fix #3526 
I also removed the `PIXELFORMAT_` part, since that also feels redundant and added `pixel_format` as an attribute (before it was only in its str method)