### PR TITLE
Add vector zero constructor clarification

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -66,7 +66,7 @@ Multiple coordinates can be set using slices or swizzling
 .. class:: Vector2
 
    | :sl:`a 2-Dimensional Vector`
-   | :sg:`Vector2() -> Vector2`
+   | :sg:`Vector2() -> Vector2(0, 0)`
    | :sg:`Vector2(int) -> Vector2`
    | :sg:`Vector2(float) -> Vector2`
    | :sg:`Vector2(Vector2) -> Vector2`
@@ -505,7 +505,7 @@ Multiple coordinates can be set using slices or swizzling
 .. class:: Vector3
 
    | :sl:`a 3-Dimensional Vector`
-   | :sg:`Vector3() -> Vector3`
+   | :sg:`Vector3() -> Vector3(0, 0, 0)`
    | :sg:`Vector3(int) -> Vector3`
    | :sg:`Vector3(float) -> Vector3`
    | :sg:`Vector3(Vector3) -> Vector3`

--- a/src_c/doc/math_doc.h
+++ b/src_c/doc/math_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEMATH "pygame module for vector classes"
 #define DOC_PYGAMEMATHCLAMP "clamp(value, min, max) -> float\nreturns value clamped to min and max."
-#define DOC_PYGAMEMATHVECTOR2 "Vector2() -> Vector2\nVector2(int) -> Vector2\nVector2(float) -> Vector2\nVector2(Vector2) -> Vector2\nVector2(x, y) -> Vector2\nVector2((x, y)) -> Vector2\na 2-Dimensional Vector"
+#define DOC_PYGAMEMATHVECTOR2 "Vector2() -> Vector2(0, 0)\nVector2(int) -> Vector2\nVector2(float) -> Vector2\nVector2(Vector2) -> Vector2\nVector2(x, y) -> Vector2\nVector2((x, y)) -> Vector2\na 2-Dimensional Vector"
 #define DOC_VECTOR2DOT "dot(Vector2) -> float\ncalculates the dot- or scalar-product with the other vector"
 #define DOC_VECTOR2CROSS "cross(Vector2) -> float\ncalculates the cross- or vector-product"
 #define DOC_VECTOR2MAGNITUDE "magnitude() -> float\nreturns the Euclidean magnitude of the vector."
@@ -35,7 +35,7 @@
 #define DOC_VECTOR2CLAMPMAGNITUDEIP "clamp_magnitude_ip(max_length) -> None\nclamp_magnitude_ip(min_length, max_length) -> None\nClamps the vector's magnitude between max_length and min_length"
 #define DOC_VECTOR2UPDATE "update() -> None\nupdate(int) -> None\nupdate(float) -> None\nupdate(Vector2) -> None\nupdate(x, y) -> None\nupdate((x, y)) -> None\nSets the coordinates of the vector."
 #define DOC_VECTOR2EPSILON "Determines the tolerance of vector calculations."
-#define DOC_PYGAMEMATHVECTOR3 "Vector3() -> Vector3\nVector3(int) -> Vector3\nVector3(float) -> Vector3\nVector3(Vector3) -> Vector3\nVector3(x, y, z) -> Vector3\nVector3((x, y, z)) -> Vector3\na 3-Dimensional Vector"
+#define DOC_PYGAMEMATHVECTOR3 "Vector3() -> Vector3(0, 0, 0)\nVector3(int) -> Vector3\nVector3(float) -> Vector3\nVector3(Vector3) -> Vector3\nVector3(x, y, z) -> Vector3\nVector3((x, y, z)) -> Vector3\na 3-Dimensional Vector"
 #define DOC_VECTOR3DOT "dot(Vector3) -> float\ncalculates the dot- or scalar-product with the other vector"
 #define DOC_VECTOR3CROSS "cross(Vector3) -> Vector3\ncalculates the cross- or vector-product"
 #define DOC_VECTOR3MAGNITUDE "magnitude() -> float\nreturns the Euclidean magnitude of the vector."
@@ -98,7 +98,7 @@ pygame.math.clamp
 returns value clamped to min and max.
 
 pygame.math.Vector2
- Vector2() -> Vector2
+ Vector2() -> Vector2(0, 0)
  Vector2(int) -> Vector2
  Vector2(float) -> Vector2
  Vector2(Vector2) -> Vector2
@@ -245,7 +245,7 @@ pygame.math.Vector2.epsilon
 Determines the tolerance of vector calculations.
 
 pygame.math.Vector3
- Vector3() -> Vector3
+ Vector3() -> Vector3(0, 0, 0)
  Vector3(int) -> Vector3
  Vector3(float) -> Vector3
  Vector3(Vector3) -> Vector3


### PR DESCRIPTION
Fixes: https://github.com/pygame/pygame/issues/3573

I am not entirely sure if this is a good solution or not since I cannot find any other documentation methods similar to this. But since `Vector2()` will consistently always return `Vector2(0, 0)`, I think this is a good implementation.