### PR TITLE
remove 'expermiental' compiler flag for static analyser builds after MSCVER 1928

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -684,10 +684,15 @@ if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
                 )
             )
 
-            if msc_ver >= 1913:
+            if 1913 <= msc_ver < 1929:
                 e.extra_compile_args.extend(
                     (
                         "/experimental:external",
+                    )
+                )
+            if msc_ver >= 1913:
+                e.extra_compile_args.extend(
+                    (
                         "/external:W0",
                         "/external:env:CAExcludePath",
                     )


### PR DESCRIPTION
According to [this](https://learn.microsoft.com/en-us/cpp/build/reference/external-external-headers-diagnostics?view=msvc-170):

> The /external compiler options are available starting in Visual Studio 2017 version 15.6. In versions of Visual Studio before Visual Studio 2019 version 16.10, the /external options require you also set the /experimental:external compiler option.

it is no longer required.

You can see the MSC versions versus visual studio versions comparisons on [this list here](https://dev.to/yumetodo/list-of-mscver-and-mscfullver-8nd).

Thought this might slightly reduce the amount of appveyor spam. Originally noticed this when I was looking into why appveyor says the external options are not recognised, then found [this bug report](https://help.appveyor.com/discussions/problems/27377-command-line-warning-d9002-ignoring-unknown-option-experimentalexternal) by myself from two years ago, Short answer, they do work on appveyor it just produces a false error about them.

Our real problem with the static analyser build is it hates Cython generated C code and floods the output with about one million complaints about it. 

**EDIT:** It won't actually help with the appveyor spam as our appveyor build is on Python 3.8 and only using 1916. Ah well.



