### PR TITLE
Adjust surface masks to create a proper 24 bit Surface

### DIFF
--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -2023,7 +2023,7 @@ class GeneralSurfaceTests(unittest.TestCase):
             mask8 = (224, 28, 3, 0)
             mask15 = (31744, 992, 31, 0)
             mask16 = (63488, 2016, 31, 0)
-            mask24 = (4278190080, 16711680, 65280, 0)
+            mask24 = (16711680, 65280, 255, 0)
             mask32 = (4278190080, 16711680, 65280, 255)
 
             # Surfaces with standard depths and masks


### PR DESCRIPTION
The SDL 2.26.0 pre-release rejects a 24 bit Surface created with this mask, which is the right call, as it needs 32 bits of space. Older SDL went ahead and created a 32 bit surface anyway, which it probably shouldn't have.