### PR TITLE
Fix build errors on win_arm64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -767,7 +767,8 @@ if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
                             return
 
 
-        replace_scale_mmx()
+        if not 'ARM64' in sys.version:
+            replace_scale_mmx()
 
 # clean up the list of extensions
 for e in extensions[:]:

--- a/src_c/scale.h
+++ b/src_c/scale.h
@@ -29,10 +29,11 @@
 #if !defined(SCALE_HEADER)
 #define SCALE_HEADER
 
-#if (defined(__GNUC__) &&                                      \
-     ((defined(__x86_64__) && !defined(_NO_MMX_FOR_X86_64)) || \
-      defined(__i386__))) ||                                   \
-    (defined(MS_WIN32) && !((defined(_M_X64) || defined(_M_ARM64)) && defined(_NO_MMX_FOR_X86_64)))
+#if (defined(__GNUC__) &&                                             \
+     ((defined(__x86_64__) && !defined(_NO_MMX_FOR_X86_64)) ||        \
+      defined(__i386__))) ||                                          \
+    (defined(MS_WIN32) && !((defined(_M_X64) || defined(_M_ARM64)) && \
+                            defined(_NO_MMX_FOR_X86_64)))
 #define SCALE_MMX_SUPPORT
 
 /* These functions implement an area-averaging shrinking filter in the

--- a/src_c/scale.h
+++ b/src_c/scale.h
@@ -32,7 +32,7 @@
 #if (defined(__GNUC__) &&                                      \
      ((defined(__x86_64__) && !defined(_NO_MMX_FOR_X86_64)) || \
       defined(__i386__))) ||                                   \
-    (defined(MS_WIN32) && !(defined(_M_X64) && defined(_NO_MMX_FOR_X86_64)))
+    (defined(MS_WIN32) && !((defined(_M_X64) || defined(_M_ARM64)) && defined(_NO_MMX_FOR_X86_64)))
 #define SCALE_MMX_SUPPORT
 
 /* These functions implement an area-averaging shrinking filter in the


### PR DESCRIPTION
This PR disables x86/AMD64 specific SIMD functions when building for Windows on ARM64.