### PR TITLE
Add VScode? _headers/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ dist
 *.egg-info/
 *.so
 __pycache__
+_headers/*


### PR DESCRIPTION
VS code keeps putting a "_headers" directory at my local pygame top level with a bunch of header files in it, and I haven't been able to figure out what's doing it-- this is practically unsearchable.

So could we just add it to the gitignore please? 😄 