### PR TITLE
Removing redudancy in regex

### DIFF
--- a/buildconfig/config.py
+++ b/buildconfig/config.py
@@ -142,7 +142,7 @@ def writesetupfile(deps, basepath, additional_lines):
         for line in lines:
             useit = 1
             if not line.startswith('COPYLIB') and not (line and line[0]=='#'):
-                lineDeps = set(re.findall(r'\$\([a-z0-9\w]+\)', line, re.I))
+                lineDeps = set(re.findall(r'\$\([\w]+\)', line, re.I))
                 if lineDeps.difference(legalVars):
                     newsetup.write('#'+line)
                     useit = 0


### PR DESCRIPTION
Fixing square brackets class redudancy : \w class is strictly containing a-z0-9 in itself (also contain A-Z and _).

Classes equivalences were also tested on regex101.com.
