### PR TITLE
Correct set_(shifts/masks) docs and cleanup code

### DIFF
--- a/docs/reST/ref/surface.rst
+++ b/docs/reST/ref/surface.rst
@@ -769,8 +769,10 @@
 
       This is not needed for normal pygame usage.
 
-      .. note:: In SDL2, the masks are read-only and accordingly this method will raise
-                an AttributeError if called.
+      .. note:: Starting in pygame 2.0, the masks are read-only and
+         accordingly this method will raise a TypeError if called.
+
+      .. deprecated:: 2.0.0
 
       .. versionadded:: 1.8.1
 
@@ -795,8 +797,10 @@
 
       This is not needed for normal pygame usage.
 
-      .. note:: In SDL2, the shifts are read-only and accordingly this method will raise
-                an AttributeError if called.
+      .. note:: Starting in pygame 2.0, the shifts are read-only and
+         accordingly this method will raise a TypeError if called.
+
+      .. deprecated:: 2.0.0
 
       .. versionadded:: 1.8.1
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -2383,15 +2383,6 @@ surf_get_masks(PyObject *self, PyObject *_null)
 static PyObject *
 surf_set_masks(PyObject *self, PyObject *args)
 {
-    SDL_Surface *surf = pgSurface_AsSurface(self);
-    /* Need to use 64bit vars so this works on 64 bit pythons. */
-    unsigned long r, g, b, a;
-
-    if (!PyArg_ParseTuple(args, "(kkkk)", &r, &g, &b, &a))
-        return NULL;
-    if (!surf)
-        return RAISE(pgExc_SDLError, "display Surface quit");
-
     return RAISE(PyExc_TypeError, "The surface masks are read-only in SDL2");
 }
 
@@ -2409,14 +2400,6 @@ surf_get_shifts(PyObject *self, PyObject *_null)
 static PyObject *
 surf_set_shifts(PyObject *self, PyObject *args)
 {
-    SDL_Surface *surf = pgSurface_AsSurface(self);
-    unsigned long r, g, b, a;
-
-    if (!PyArg_ParseTuple(args, "(kkkk)", &r, &g, &b, &a))
-        return NULL;
-    if (!surf)
-        return RAISE(pgExc_SDLError, "display Surface quit");
-
     return RAISE(PyExc_TypeError, "The surface shifts are read-only in SDL2");
 }
 


### PR DESCRIPTION
I was looking through Surface.c and display.c with Matt and I found some stuff to do.

- The docs were wrong-- the function raises a TypeError, not an AttributeError
- The docs should have the "deprecated" label
- The C code doesn't need to carefully parse args before doing an unconditional TypeError

I was tempted to do the full removal of these functions (they've been deprecated for a long time, probably not many people used them ever), but I decided to hold off on that. In the future, yes they will be removed.