### PR TITLE
Replace `music.set_pos` current error message with `SDL_GetError()`

### DIFF
--- a/src_c/music.c
+++ b/src_c/music.c
@@ -256,7 +256,7 @@ music_set_pos(PyObject *self, PyObject *arg)
     Py_END_ALLOW_THREADS;
 
     if (position_set == -1)
-        return RAISE(pgExc_SDLError, "set_pos unsupported for this codec");
+        return RAISE(pgExc_SDLError, SDL_GetError());
 
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
Fixes https://github.com/pygame/pygame/issues/3635

Essentially provides a clearer error message when calling `pygame.mixer.music.set_pos` without having loaded any music (file(s))