### PR TITLE
Update docs generation to sphinx 6.0

### DIFF
--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -11,8 +11,7 @@
 	<div class="flex-container">
 	<div class="logo">
 	  <a href="{{ theme_home_uri }}">
-{%-         set logo_path = logo_url %}
-	    <img src="{{ pathto(logo_path, 1) }}"/>
+	    <img src="{{logo_url}}"/>
 	  </a>
 	  <h5>pygame documentation</h5>
 	</div>

--- a/docs/reST/themes/classic/elements.html
+++ b/docs/reST/themes/classic/elements.html
@@ -11,7 +11,7 @@
 	<div class="flex-container">
 	<div class="logo">
 	  <a href="{{ theme_home_uri }}">
-{%-         set logo_path = '_static/' + logo %}
+{%-         set logo_path = logo_url %}
 	    <img src="{{ pathto(logo_path, 1) }}"/>
 	  </a>
 	  <h5>pygame documentation</h5>


### PR DESCRIPTION
'logo' was deprecated and replaced by 'logo_url' which includes the `_static` part.

fixes #3646