### PR TITLE
Fixed typo in `pygame.image.tobytes` docs

### DIFF
--- a/docs/reST/ref/image.rst
+++ b/docs/reST/ref/image.rst
@@ -227,8 +227,8 @@ following formats.
 
       * ``ARGB_PREMULT``, 32-bit image with colors scaled by alpha channel, alpha channel first
    
-   .. note:: this function is an alias for :func:`fromstring`. The use of this
-             function is recommended over :func:`fromstring` as of pygame 2.1.3.
+   .. note:: this function is an alias for :func:`tostring`. The use of this
+             function is recommended over :func:`tostring` as of pygame 2.1.3.
              This function was introduced so it matches nicely with other 
              libraries (PIL, numpy, etc), and with people's expectations.
 


### PR DESCRIPTION
`pygame.image.tobytes` said it was an alias for `pygame.image.fromstring`. Changed it to be an alias for `pygame.image.tostring`