### PR TITLE
Draft: Idea for gradually deprecating gfxdraw - share C code with draw

### DIFF
--- a/buildconfig/Setup.SDL2.in
+++ b/buildconfig/Setup.SDL2.in
@@ -41,7 +41,7 @@ _sdl2.controller src_c/_sdl2/controller.c $(SDL) $(DEBUG) -Isrc_c
 
 GFX = src_c/SDL_gfx/SDL_gfxPrimitives.c
 #GFX = src_c/SDL_gfx/SDL_gfxBlitFunc.c src_c/SDL_gfx/SDL_gfxPrimitives.c
-gfxdraw src_c/gfxdraw.c $(SDL) $(GFX) $(DEBUG)
+gfxdraw src_c/gfxdraw.c src_c/draw_shared.c $(SDL) $(GFX) $(DEBUG)
 
 #optional freetype module (do not break in multiple lines
 #or the configuration script will choke!)
@@ -65,7 +65,7 @@ surface src_c/simd_blitters_sse2.c src_c/simd_blitters_avx2.c src_c/surface.c sr
 surflock src_c/surflock.c $(SDL) $(DEBUG)
 time src_c/time.c $(SDL) $(DEBUG)
 joystick src_c/joystick.c $(SDL) $(DEBUG)
-draw src_c/draw.c $(SDL) $(DEBUG)
+draw src_c/draw.c src_c/draw_shared.c $(SDL) $(DEBUG)
 image src_c/image.c $(SDL) $(DEBUG)
 transform src_c/transform.c src_c/rotozoom.c src_c/scale2x.c src_c/scale_mmx.c $(SDL) $(DEBUG)
 mask src_c/mask.c src_c/bitmask.c $(SDL) $(DEBUG)

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -29,6 +29,8 @@
 
 #include "doc/draw_doc.h"
 
+#include "draw_shared.h"
+
 #include <math.h>
 
 #include <float.h>
@@ -74,22 +76,9 @@ static void
 draw_fillpoly(SDL_Surface *surf, int *vx, int *vy, Py_ssize_t n, Uint32 color,
               int *drawn_area);
 static void
-draw_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int width,
-          Uint32 color);
-static void
 draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                 int width, Uint32 color, int top_left, int top_right,
                 int bottom_left, int bottom_right, int *drawn_area);
-
-// validation of a draw color
-#define CHECK_LOAD_COLOR(colorobj)                                         \
-    if (PyLong_Check(colorobj))                                            \
-        color = (Uint32)PyLong_AsLong(colorobj);                           \
-    else if (pg_RGBAFromFuzzyColorObj(colorobj, rgba))                     \
-        color =                                                            \
-            SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]); \
-    else                                                                   \
-        return NULL; /* pg_RGBAFromFuzzyColorObj sets the exception for us */
 
 /* Definition of functions that get called in Python */
 
@@ -1124,44 +1113,6 @@ clip_line(SDL_Surface *surf, int *x1, int *y1, int *x2, int *y2)
     return 1;
 }
 
-static int
-set_at(SDL_Surface *surf, int x, int y, Uint32 color)
-{
-    SDL_PixelFormat *format = surf->format;
-    Uint8 *pixels = (Uint8 *)surf->pixels;
-    Uint8 *byte_buf, rgb[4];
-
-    if (x < surf->clip_rect.x || x >= surf->clip_rect.x + surf->clip_rect.w ||
-        y < surf->clip_rect.y || y >= surf->clip_rect.y + surf->clip_rect.h)
-        return 0;
-
-    switch (format->BytesPerPixel) {
-        case 1:
-            *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
-            break;
-        case 2:
-            *((Uint16 *)(pixels + y * surf->pitch) + x) = (Uint16)color;
-            break;
-        case 4:
-            *((Uint32 *)(pixels + y * surf->pitch) + x) = color;
-            break;
-        default: /*case 3:*/
-            SDL_GetRGB(color, format, rgb, rgb + 1, rgb + 2);
-            byte_buf = (Uint8 *)(pixels + y * surf->pitch) + x * 3;
-#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
-            *(byte_buf + (format->Rshift >> 3)) = rgb[0];
-            *(byte_buf + (format->Gshift >> 3)) = rgb[1];
-            *(byte_buf + (format->Bshift >> 3)) = rgb[2];
-#else
-            *(byte_buf + 2 - (format->Rshift >> 3)) = rgb[0];
-            *(byte_buf + 2 - (format->Gshift >> 3)) = rgb[1];
-            *(byte_buf + 2 - (format->Bshift >> 3)) = rgb[2];
-#endif
-            break;
-    }
-    return 1;
-}
-
 static void
 set_and_check_rect(SDL_Surface *surf, int x, int y, Uint32 color,
                    int *drawn_area)
@@ -1368,66 +1319,6 @@ draw_aaline(SDL_Surface *surf, Uint32 color, float from_x, float from_y,
         }
         intersect_y += gradient;
     }
-}
-
-static void
-drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
-{
-    Uint8 *pixel, *end;
-
-    pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
-    end = pixel + x2 * surf->format->BytesPerPixel;
-    pixel += x1 * surf->format->BytesPerPixel;
-    switch (surf->format->BytesPerPixel) {
-        case 1:
-            for (; pixel <= end; ++pixel) {
-                *pixel = (Uint8)color;
-            }
-            break;
-        case 2:
-            for (; pixel <= end; pixel += 2) {
-                *(Uint16 *)pixel = (Uint16)color;
-            }
-            break;
-        case 3:
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-            color <<= 8;
-#endif
-            for (; pixel <= end; pixel += 3) {
-                memcpy(pixel, &color, 3 * sizeof(Uint8));
-            }
-            break;
-        default: /*case 4*/
-            for (; pixel <= end; pixel += 4) {
-                *(Uint32 *)pixel = color;
-            }
-            break;
-    }
-}
-
-static void
-drawhorzlineclip(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
-{
-    if (y1 < surf->clip_rect.y || y1 >= surf->clip_rect.y + surf->clip_rect.h)
-        return;
-
-    if (x2 < x1) {
-        int temp = x1;
-        x1 = x2;
-        x2 = temp;
-    }
-
-    x1 = MAX(x1, surf->clip_rect.x);
-    x2 = MIN(x2, surf->clip_rect.x + surf->clip_rect.w - 1);
-
-    if (x2 < surf->clip_rect.x || x1 >= surf->clip_rect.x + surf->clip_rect.w)
-        return;
-
-    if (x1 == x2) {
-        set_at(surf, x1, y1, color);
-        return;
-    }
-    drawhorzline(surf, color, x1, y1, x2);
 }
 
 static void
@@ -2379,21 +2270,6 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
         }
     }
     PyMem_Free(x_intersect);
-}
-
-static void
-draw_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int width,
-          Uint32 color)
-{
-    int i;
-    for (i = 0; i < width; i++) {
-        drawhorzlineclip(surf, color, x1, y1 + i, x2);
-        drawhorzlineclip(surf, color, x1, y2 - i, x2);
-    }
-    for (i = 0; i < (y2 - y1) - 2 * width + 1; i++) {
-        drawhorzlineclip(surf, color, x1, y1 + width + i, x1 + width - 1);
-        drawhorzlineclip(surf, color, x2 - width + 1, y1 + width + i, x2);
-    }
 }
 
 static void

--- a/src_c/draw_shared.c
+++ b/src_c/draw_shared.c
@@ -1,0 +1,116 @@
+#include "_surface.h"
+
+#include "draw_shared.h"
+
+int
+set_at(SDL_Surface *surf, int x, int y, Uint32 color)
+{
+    SDL_PixelFormat *format = surf->format;
+    Uint8 *pixels = (Uint8 *)surf->pixels;
+    Uint8 *byte_buf, rgb[4];
+
+    if (x < surf->clip_rect.x || x >= surf->clip_rect.x + surf->clip_rect.w ||
+        y < surf->clip_rect.y || y >= surf->clip_rect.y + surf->clip_rect.h)
+        return 0;
+
+    switch (format->BytesPerPixel) {
+        case 1:
+            *((Uint8 *)pixels + y * surf->pitch + x) = (Uint8)color;
+            break;
+        case 2:
+            *((Uint16 *)(pixels + y * surf->pitch) + x) = (Uint16)color;
+            break;
+        case 4:
+            *((Uint32 *)(pixels + y * surf->pitch) + x) = color;
+            break;
+        default: /*case 3:*/
+            SDL_GetRGB(color, format, rgb, rgb + 1, rgb + 2);
+            byte_buf = (Uint8 *)(pixels + y * surf->pitch) + x * 3;
+#if (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+            *(byte_buf + (format->Rshift >> 3)) = rgb[0];
+            *(byte_buf + (format->Gshift >> 3)) = rgb[1];
+            *(byte_buf + (format->Bshift >> 3)) = rgb[2];
+#else
+            *(byte_buf + 2 - (format->Rshift >> 3)) = rgb[0];
+            *(byte_buf + 2 - (format->Gshift >> 3)) = rgb[1];
+            *(byte_buf + 2 - (format->Bshift >> 3)) = rgb[2];
+#endif
+            break;
+    }
+    return 1;
+}
+
+void
+drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
+{
+    Uint8 *pixel, *end;
+
+    pixel = ((Uint8 *)surf->pixels) + surf->pitch * y1;
+    end = pixel + x2 * surf->format->BytesPerPixel;
+    pixel += x1 * surf->format->BytesPerPixel;
+    switch (surf->format->BytesPerPixel) {
+        case 1:
+            for (; pixel <= end; ++pixel) {
+                *pixel = (Uint8)color;
+            }
+            break;
+        case 2:
+            for (; pixel <= end; pixel += 2) {
+                *(Uint16 *)pixel = (Uint16)color;
+            }
+            break;
+        case 3:
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+            color <<= 8;
+#endif
+            for (; pixel <= end; pixel += 3) {
+                memcpy(pixel, &color, 3 * sizeof(Uint8));
+            }
+            break;
+        default: /*case 4*/
+            for (; pixel <= end; pixel += 4) {
+                *(Uint32 *)pixel = color;
+            }
+            break;
+    }
+}
+
+static void
+drawhorzlineclip(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2)
+{
+    if (y1 < surf->clip_rect.y || y1 >= surf->clip_rect.y + surf->clip_rect.h)
+        return;
+
+    if (x2 < x1) {
+        int temp = x1;
+        x1 = x2;
+        x2 = temp;
+    }
+
+    x1 = MAX(x1, surf->clip_rect.x);
+    x2 = MIN(x2, surf->clip_rect.x + surf->clip_rect.w - 1);
+
+    if (x2 < surf->clip_rect.x || x1 >= surf->clip_rect.x + surf->clip_rect.w)
+        return;
+
+    if (x1 == x2) {
+        set_at(surf, x1, y1, color);
+        return;
+    }
+    drawhorzline(surf, color, x1, y1, x2);
+}
+
+void
+draw_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int width,
+          Uint32 color)
+{
+    int i;
+    for (i = 0; i < width; i++) {
+        drawhorzlineclip(surf, color, x1, y1 + i, x2);
+        drawhorzlineclip(surf, color, x1, y2 - i, x2);
+    }
+    for (i = 0; i < (y2 - y1) - 2 * width + 1; i++) {
+        drawhorzlineclip(surf, color, x1, y1 + width + i, x1 + width - 1);
+        drawhorzlineclip(surf, color, x2 - width + 1, y1 + width + i, x2);
+    }
+}

--- a/src_c/draw_shared.h
+++ b/src_c/draw_shared.h
@@ -1,0 +1,24 @@
+/*
+ * An attempt to share draw functions between draw and gfxdraw with a view to
+   eventually deprecating new code from gfxdraw.
+ */
+
+// validation of a draw color
+#define CHECK_LOAD_COLOR(colorobj)                                         \
+    if (PyLong_Check(colorobj))                                            \
+        color = (Uint32)PyLong_AsLong(colorobj);                           \
+    else if (pg_RGBAFromFuzzyColorObj(colorobj, rgba))                     \
+        color =                                                            \
+            SDL_MapRGBA(surf->format, rgba[0], rgba[1], rgba[2], rgba[3]); \
+    else                                                                   \
+        return NULL; /* pg_RGBAFromFuzzyColorObj sets the exception for us */
+
+int
+set_at(SDL_Surface *surf, int x, int y, Uint32 color);
+
+void
+draw_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int width,
+          Uint32 color);
+
+void
+drawhorzline(SDL_Surface *surf, Uint32 color, int x1, int y1, int x2);

--- a/src_c/gfxdraw.c
+++ b/src_c/gfxdraw.c
@@ -40,6 +40,8 @@
 
 #include "SDL_gfx/SDL_gfxPrimitives.h"
 
+#include "draw_shared.h"
+
 static PyObject *
 _gfx_pixelcolor(PyObject *self, PyObject *args);
 static PyObject *
@@ -244,14 +246,15 @@ _gfx_vlinecolor(PyObject *self, PyObject *args)
 static PyObject *
 _gfx_rectanglecolor(PyObject *self, PyObject *args)
 {
-    PyObject *surface, *color, *rect;
+    PyObject *surface, *colorobj, *rect;
+    SDL_Surface *surf = NULL;
     SDL_Rect temprect, *sdlrect;
-    Sint16 x1, x2, _y1, y2;
+    Uint32 color;
     Uint8 rgba[4];
 
     ASSERT_VIDEO_INIT(NULL);
 
-    if (!PyArg_ParseTuple(args, "OOO:rectangle", &surface, &rect, &color)) {
+    if (!PyArg_ParseTuple(args, "OOO:rectangle", &surface, &rect, &colorobj)) {
         /* Exception already set */
         return NULL;
     }
@@ -265,22 +268,12 @@ _gfx_rectanglecolor(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "invalid rect style argument");
         return NULL;
     }
+    surf = pgSurface_AsSurface(surface);
+    CHECK_LOAD_COLOR(colorobj)
 
-    if (!pg_RGBAFromObj(color, rgba)) {
-        PyErr_SetString(PyExc_TypeError, "invalid color argument");
-        return NULL;
-    }
+    draw_rect(surf, sdlrect->x, sdlrect->y, sdlrect->x + sdlrect->w - 1,
+              sdlrect->y + sdlrect->h - 1, 1, color);
 
-    x1 = sdlrect->x;
-    _y1 = sdlrect->y;
-    x2 = (Sint16)(sdlrect->x + sdlrect->w - 1);
-    y2 = (Sint16)(sdlrect->y + sdlrect->h - 1);
-
-    if (rectangleRGBA(pgSurface_AsSurface(surface), x1, _y1, x2, y2, rgba[0],
-                      rgba[1], rgba[2], rgba[3]) == -1) {
-        PyErr_SetString(pgExc_SDLError, SDL_GetError());
-        return NULL;
-    }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
This is one idea I have had to start solving the 'too much duplicated functionality' problem in pygame.

In this case I'm looking at trying to eventually remove the 'gfxdraw' module because it is too similar to the 'draw' module. I have similar issues with the 'freetype' module duplicating functionality in font.

Ideally we can take any good things from these similar modules and bring them into one final superior module that does it all.

---

In this draft I'm investigating clearing out code that does the exact same thing in two different places e.g. we can draw an outlined rectangle with `draw.rect` or with `gfxdraw.rectangle()`. 

At the minute this PR literally does the minimal work to replace gfxdraw's simple rectangle drawing with the main function in draw.

**Potential impacts:**

 - Code performance.
 - Code size (some of the same code will be compiled into two different modules - but we also will be able to get rid of some code so it is probably a wash.