### PR TITLE
Update linter ubuntu version

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   format-lint-code-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3.0.2


### PR DESCRIPTION
So we can use some more recent python tooling.

- 20.04 is on Python 3.8. 
- 22.04 is on Python 3.10.