### PR TITLE
Remove `:return` from `sysfont._parse_font_entry_win`

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -99,8 +99,6 @@ def _parse_font_entry_win(name, font, fonts):
     :param name: The font name
     :param font: The font file path
     :param fonts: The pygame font dictionary
-
-    :return: Tuple of (bold, italic, name)
     """
     true_type_suffix = "(TrueType)"
     mods = ("demibold", "narrow", "light", "unicode", "bt", "mt")


### PR DESCRIPTION
Remove `:return` from `sysfont._parse_font_entry_win` as it doesn't actually return anything.