### PR TITLE
camera: Make opencv backend default on win if cv2 imports

### DIFF
--- a/src_py/_camera_opencv.py
+++ b/src_py/_camera_opencv.py
@@ -194,7 +194,7 @@ class Camera:
 
 
 class CameraMac(Camera):
-    def __init__(self, device=0, size=(640, 480), mode="RGB"):
+    def __init__(self, device=0, size=(640, 480), mode="RGB", api_preference=None):
         if isinstance(device, int):
             _dev = device
         elif isinstance(device, str):
@@ -205,4 +205,4 @@ class CameraMac(Camera):
                 str(type(device)),
             )
 
-        super().__init__(_dev, size, mode)
+        super().__init__(_dev, size, mode, api_preference)

--- a/src_py/camera.py
+++ b/src_py/camera.py
@@ -126,7 +126,13 @@ def get_backends():
     possible_backends = []
 
     if sys.platform == "win32" and int(platform.win32_ver()[0].split(".")[0]) >= 8:
-        possible_backends.append("_camera (MSMF)")
+        try:
+            # If cv2 is installed, prefer that on windows.
+            import cv2
+
+            possible_backends.append("OpenCV")
+        except ImportError:
+            possible_backends.append("_camera (MSMF)")
 
     if "linux" in sys.platform:
         possible_backends.append("_camera (V4L2)")
@@ -134,7 +140,8 @@ def get_backends():
     if "darwin" in sys.platform:
         possible_backends.append("OpenCV-Mac")
 
-    possible_backends.append("OpenCV")
+    if "OpenCV" not in possible_backends:
+        possible_backends.append("OpenCV")
 
     if sys.platform == "win32":
         possible_backends.append("VideoCapture")


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/3728

The windows camera backend has numerous serious issues still, so prefer the opencv backend if it's installed.