### PR TITLE
Fix docs for `cursors.Cursor.copy()`

### DIFF
--- a/docs/reST/ref/cursors.rst
+++ b/docs/reST/ref/cursors.rst
@@ -214,6 +214,7 @@ The following strings can be converted into cursor bitmaps with
    correct size for the given width and height. Otherwise an exception is raised.
    
    .. method:: copy
+
       | :sl:`copy the current cursor`
       | :sg:`copy() -> Cursor`
       

--- a/src_c/doc/cursors_doc.h
+++ b/src_c/doc/cursors_doc.h
@@ -3,7 +3,7 @@
 #define DOC_PYGAMECURSORSCOMPILE "compile(strings, black='X', white='.', xor='o') -> data, mask\ncreate binary cursor data from simple strings"
 #define DOC_PYGAMECURSORSLOADXBM "load_xbm(cursorfile) -> cursor_args\nload_xbm(cursorfile, maskfile) -> cursor_args\nload cursor data from an XBM file"
 #define DOC_PYGAMECURSORSCURSOR "Cursor(size, hotspot, xormasks, andmasks) -> Cursor\nCursor(hotspot, surface) -> Cursor\nCursor(constant) -> Cursor\nCursor(Cursor) -> Cursor\nCursor() -> Cursor\npygame object representing a cursor"
-#define DOC_CURSORCOPY ""
+#define DOC_CURSORCOPY "copy() -> Cursor\ncopy the current cursor"
 #define DOC_CURSORTYPE "type -> string\nGets the cursor type"
 #define DOC_CURSORDATA "data -> tuple\nGets the cursor data"
 
@@ -33,7 +33,8 @@ pygame.cursors.Cursor
 pygame object representing a cursor
 
 pygame.cursors.Cursor.copy
-
+ copy() -> Cursor
+copy the current cursor
 
 pygame.cursors.Cursor.type
  type -> string


### PR DESCRIPTION
Previously, the docstring for `cursors.Cursor.copy()` was empty and it wasn't formatted correctly on the website (https://www.pygame.org/docs/ref/cursors.html#pygame.cursors.Cursor.copy):
![image](https://user-images.githubusercontent.com/102254594/225108531-3ab5718a-8600-43db-bcd4-49fc01d7016a.png)
