### PR TITLE
draw.circle: Fixes when center is -x, and bounding rect

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -5594,8 +5594,17 @@ class DrawCircleMixin:
                     # Calculating the expected_rect after the circle is
                     # drawn (it uses what is actually drawn).
                     expected_rect = create_bounding_rect(surface, surf_color, pos)
+
                     # print("pos:%s:, radius:%s:, thickness:%s:" % (pos, radius, thickness))
-                    self.assertEqual(bounding_rect, expected_rect)
+                    # self.assertEqual(bounding_rect, expected_rect)
+                    with self.subTest(
+                        surface=surface,
+                        circle_color=circle_color,
+                        pos=pos,
+                        radius=radius,
+                        thickness=thickness,
+                    ):
+                        self.assertEqual(bounding_rect, expected_rect)
 
     def test_circle_negative_radius(self):
         """Ensures negative radius circles return zero sized bounding rect."""
@@ -5709,6 +5718,56 @@ class DrawCircleMixin:
             bounding_rect = self.draw_circle(surf, color, center, radius, width)
             self.assertEqual(bounding_rect.width, radius * 2)
             self.assertEqual(bounding_rect.height, radius * 2)
+
+    def test_x_bounds(self):
+        """ensures a circle is drawn properly when there is a negative x, or a big x."""
+
+        surf = pygame.Surface((200, 200))
+        bgcolor = (0, 0, 0, 255)
+        surf.fill(bgcolor)
+        color = (255, 0, 0, 255)
+        width = 1
+        radius = 10
+
+        where = (0, 30)
+        bounding_rect1 = self.draw_circle(surf, color, where, radius=radius)
+        self.assertEqual(
+            bounding_rect1,
+            pygame.Rect(0, where[1] - radius, where[0] + radius, radius * 2),
+        )
+        self.assertEqual(
+            surf.get_at((where[0] if where[0] > 0 else 0, where[1])), color
+        )
+        self.assertEqual(surf.get_at((where[0] + radius + 1, where[1])), bgcolor)
+        self.assertEqual(surf.get_at((where[0] + radius - 1, where[1])), color)
+
+        surf.fill(bgcolor)
+        where = (-1e30, 80)
+        bounding_rect1 = self.draw_circle(surf, color, where, radius=radius)
+        self.assertEqual(bounding_rect1, pygame.Rect(where[0], where[1], 0, 0))
+        self.assertEqual(surf.get_at((0 + radius, where[1])), bgcolor)
+
+        surf.fill(bgcolor)
+        where = (surf.get_width() + radius * 2, 80)
+        bounding_rect1 = self.draw_circle(surf, color, where, radius=radius)
+        self.assertEqual(bounding_rect1, pygame.Rect(where[0], where[1], 0, 0))
+        self.assertEqual(surf.get_at((0, where[1])), bgcolor)
+        self.assertEqual(surf.get_at((0 + radius // 2, where[1])), bgcolor)
+        self.assertEqual(surf.get_at((surf.get_width() - 1, where[1])), bgcolor)
+        self.assertEqual(surf.get_at((surf.get_width() - radius, where[1])), bgcolor)
+
+        surf.fill(bgcolor)
+        where = (-1, 80)
+        bounding_rect1 = self.draw_circle(surf, color, where, radius=radius)
+        self.assertEqual(
+            bounding_rect1,
+            pygame.Rect(0, where[1] - radius, where[0] + radius, radius * 2),
+        )
+        self.assertEqual(
+            surf.get_at((where[0] if where[0] > 0 else 0, where[1])), color
+        )
+        self.assertEqual(surf.get_at((where[0] + radius, where[1])), bgcolor)
+        self.assertEqual(surf.get_at((where[0] + radius - 1, where[1])), color)
 
 
 class DrawCircleTest(DrawCircleMixin, DrawTestCase):


### PR DESCRIPTION
Fixes #3778

Thanks [REX2626](https://github.com/REX2626) for the great bug report.