### PR TITLE
fixed self.pos of move method in GameObject in Moving Multiple Images

### DIFF
--- a/docs/reST/tut/MoveIt.rst
+++ b/docs/reST/tut/MoveIt.rst
@@ -405,7 +405,7 @@ Here's the python code to create our class. ::
   ...         self.image = image
   ...         self.pos = image.get_rect().move(0, height)
   ...     def move(self):
-  ...         self.pos = self.pos.move(0, self.speed)
+  ...         self.pos = self.pos.move(self.speed, 0)
   ...         if self.pos.right > 600:
   ...             self.pos.left = 0
 


### PR DESCRIPTION
Error: Instead of moving the object horizontally it's moving vertically
`self.pos = self.pos.move(0, self.speed)`

Fix: Move the object horizontally
`self.pos = self.pos.move(self.speed, 0)`
