### PR TITLE
Added kwargs for display.c and event.c

### DIFF
--- a/docs/reST/ref/display.rst
+++ b/docs/reST/ref/display.rst
@@ -412,6 +412,8 @@ required).
    it is a good idea to check the value of any requested OpenGL attributes. See
    ``pygame.display.gl_set_attribute()`` for a list of valid flags.
 
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
+
    .. ## pygame.display.gl_get_attribute ##
 
 .. function:: gl_set_attribute
@@ -489,6 +491,8 @@ required).
 
      Set to 1 to require hardware acceleration, or 0 to force software render.
      By default, both are allowed.
+
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
 
    .. ## pygame.display.gl_set_attribute ##
 
@@ -581,6 +585,8 @@ required).
 
    .. deprecated:: 2.2.0
 
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
+
    .. ## pygame.display.set_gamma ##
 
 .. function:: set_gamma_ramp
@@ -596,6 +602,8 @@ required).
    ramps, if the function succeeds it will return ``True``.
 
    .. deprecated:: 2.2.0
+
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
 
    .. ## pygame.display.set_gamma_ramp ##
 
@@ -629,6 +637,8 @@ required).
    window. In pygame 1.x, some systems supported an alternate shorter title to
    be used for minimized displays, but in pygame 2 ``icontitle`` does nothing.
 
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
+
    .. ## pygame.display.set_caption ##
 
 .. function:: get_caption
@@ -651,6 +661,8 @@ required).
    that is used to display the Surface. If no palette argument is passed, the
    system default palette will be restored. The palette is a sequence of
    ``RGB`` triplets.
+
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
 
    .. ## pygame.display.set_palette ##
 

--- a/docs/reST/ref/event.rst
+++ b/docs/reST/ref/event.rst
@@ -357,6 +357,8 @@ On Android, the following events can be generated
    "UserEvent" is returned for all values in the user event id range.
    "Unknown" is returned when the event type does not exist.
 
+   .. versionchanged:: 2.3.1 Added support for keyword arguments.
+
    .. ## pygame.event.event_name ##
 
 .. function:: set_blocked

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -609,11 +609,14 @@ pg_get_surface(PyObject *self, PyObject *_null)
 }
 
 static PyObject *
-pg_gl_set_attribute(PyObject *self, PyObject *arg)
+pg_gl_set_attribute(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
     int flag, value, result;
     VIDEO_INIT_CHECK();
-    if (!PyArg_ParseTuple(arg, "ii", &flag, &value))
+
+    static char *kwids[] = {"flag", "value", NULL};
+
+    if (!PyArg_ParseTuple(arg, kwarg, "ii", kwids, &flag, &value))
         return NULL;
     if (flag == -1) /*an undefined/unsupported val, ignore*/
         Py_RETURN_NONE;
@@ -624,11 +627,13 @@ pg_gl_set_attribute(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-pg_gl_get_attribute(PyObject *self, PyObject *arg)
+pg_gl_get_attribute(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
     int flag, value, result;
+    static char *kwids[] = {"flag", NULL};
+
     VIDEO_INIT_CHECK();
-    if (!PyArg_ParseTuple(arg, "i", &flag))
+    if (!PyArg_ParseTuple(arg, kwarg, "i", kwids, &flag))
         return NULL;
     result = SDL_GL_GetAttribute(flag, &value);
     if (result == -1)
@@ -1697,7 +1702,7 @@ pg_update(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-pg_set_palette(PyObject *self, PyObject *args)
+pg_set_palette(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     pgSurfaceObject *surface = pg_GetDefaultWindowSurface();
     SDL_Surface *surf;
@@ -1707,8 +1712,10 @@ pg_set_palette(PyObject *self, PyObject *args)
     int i, len;
     Uint8 rgba[4];
 
+    static char *kwids[] = {"list", NULL};
+
     VIDEO_INIT_CHECK();
-    if (!PyArg_ParseTuple(args, "|O", &list))
+    if (!PyArg_ParseTuple(args, kwargs, "|O", kwids, &list))
         return NULL;
     if (!surface)
         return RAISE(pgExc_SDLError, "No display mode is set");
@@ -1791,7 +1798,7 @@ pg_set_palette(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-pg_set_gamma(PyObject *self, PyObject *arg)
+pg_set_gamma(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "pygame.display.set_gamma deprecated since 2.2.0",
@@ -1805,7 +1812,9 @@ pg_set_gamma(PyObject *self, PyObject *arg)
     SDL_Window *win = pg_GetDefaultWindow();
     Uint16 *gamma_ramp;
 
-    if (!PyArg_ParseTuple(arg, "f|ff", &r, &g, &b))
+    static char *kwids[] = {"red", "green", "blue", NULL};
+
+    if (!PyArg_ParseTuple(arg, kwarg, "f|ff", kwids, &r, &g, &b))
         return NULL;
     if (PyTuple_Size(arg) == 1)
         g = b = r;
@@ -1883,7 +1892,7 @@ pg_convert_to_uint16(PyObject *python_array, Uint16 *c_uint16_array)
 }
 
 static PyObject *
-pg_set_gamma_ramp(PyObject *self, PyObject *arg)
+pg_set_gamma_ramp(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "pygame.display.set_gamma_ramp deprecated since 2.2.0",
@@ -1901,7 +1910,10 @@ pg_set_gamma_ramp(PyObject *self, PyObject *arg)
     r = gamma_ramp;
     g = gamma_ramp + 256;
     b = gamma_ramp + 512;
-    if (!PyArg_ParseTuple(arg, "O&O&O&", pg_convert_to_uint16, r,
+
+    static char *kwids[] = {"red", "green", "blue", NULL};
+
+    if (!PyArg_ParseTuple(arg, kwarg, "O&O&O&", kwids, pg_convert_to_uint16, r,
                           pg_convert_to_uint16, g, pg_convert_to_uint16, b)) {
         free(gamma_ramp);
         return NULL;
@@ -1925,7 +1937,7 @@ pg_set_gamma_ramp(PyObject *self, PyObject *arg)
 }
 
 static PyObject *
-pg_set_caption(PyObject *self, PyObject *arg)
+pg_set_caption(PyObject *self, PyObject *arg, PyObject *kwarg)
 {
     _DisplayState *state = DISPLAY_MOD_STATE(self);
     SDL_Window *win = pg_GetDefaultWindow();
@@ -1937,7 +1949,9 @@ pg_set_caption(PyObject *self, PyObject *arg)
     __analysis_assume(title = "inited");
 #endif
 
-    if (!PyArg_ParseTuple(arg, "s|s", &title, &icontitle))
+    static char *kwids = {"title", "icon_title", NULL};
+
+    if (!PyArg_ParseTuple(arg, kwargs, "s|s", kwids, &title, &icontitle))
         return NULL;
 
     if (state->title)

--- a/src_c/display.c
+++ b/src_c/display.c
@@ -1712,7 +1712,7 @@ pg_set_palette(PyObject *self, PyObject *args, PyObject *kwargs)
     int i, len;
     Uint8 rgba[4];
 
-    static char *kwids[] = {"list", NULL};
+    static char *kwids[] = {"palette", NULL};
 
     VIDEO_INIT_CHECK();
     if (!PyArg_ParseTuple(args, kwargs, "|O", kwids, &list))
@@ -1949,7 +1949,7 @@ pg_set_caption(PyObject *self, PyObject *arg, PyObject *kwarg)
     __analysis_assume(title = "inited");
 #endif
 
-    static char *kwids = {"title", "icon_title", NULL};
+    static char *kwids = {"title", "icontitle", NULL};
 
     if (!PyArg_ParseTuple(arg, kwargs, "s|s", kwids, &title, &icontitle))
         return NULL;
@@ -2567,12 +2567,15 @@ static PyMethodDef _pg_display_methods[] = {
     {"flip", (PyCFunction)pg_flip, METH_NOARGS, DOC_PYGAMEDISPLAYFLIP},
     {"update", (PyCFunction)pg_update, METH_VARARGS, DOC_PYGAMEDISPLAYUPDATE},
 
-    {"set_palette", pg_set_palette, METH_VARARGS, DOC_PYGAMEDISPLAYSETPALETTE},
-    {"set_gamma", pg_set_gamma, METH_VARARGS, DOC_PYGAMEDISPLAYSETGAMMA},
-    {"set_gamma_ramp", pg_set_gamma_ramp, METH_VARARGS,
+    {"set_palette", pg_set_palette, METH_VARARGS | METH_KEYWORDSMETH_KEYWORDS,
+     DOC_PYGAMEDISPLAYSETPALETTE},
+    {"set_gamma", pg_set_gamma, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEDISPLAYSETGAMMA},
+    {"set_gamma_ramp", pg_set_gamma_ramp, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDISPLAYSETGAMMARAMP},
 
-    {"set_caption", pg_set_caption, METH_VARARGS, DOC_PYGAMEDISPLAYSETCAPTION},
+    {"set_caption", pg_set_caption, METH_VARARGS | METH_KEYWORDS,
+     DOC_PYGAMEDISPLAYSETCAPTION},
     {"get_caption", (PyCFunction)pg_get_caption, METH_NOARGS,
      DOC_PYGAMEDISPLAYGETCAPTION},
     {"set_icon", pg_set_icon, METH_O, DOC_PYGAMEDISPLAYSETICON},
@@ -2594,9 +2597,9 @@ static PyMethodDef _pg_display_methods[] = {
     {"is_fullscreen", (PyCFunction)pg_is_fullscreen, METH_NOARGS,
      "provisional API, subject to change"},
 
-    {"gl_set_attribute", pg_gl_set_attribute, METH_VARARGS,
+    {"gl_set_attribute", pg_gl_set_attribute, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDISPLAYGLSETATTRIBUTE},
-    {"gl_get_attribute", pg_gl_get_attribute, METH_VARARGS,
+    {"gl_get_attribute", pg_gl_get_attribute, METH_VARARGS | METH_KEYWORDS,
      DOC_PYGAMEDISPLAYGLGETATTRIBUTE},
 
     {"get_allow_screensaver", (PyCFunction)pg_get_allow_screensaver,

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -1542,10 +1542,11 @@ pgEvent_New2(int type, PyObject *dict)
 /* event module functions */
 
 static PyObject *
-event_name(PyObject *self, PyObject *arg)
+event_name(PyObject *self, PyObject *arg, PyObjext *kwargs)
 {
     int type;
-    if (!PyArg_ParseTuple(arg, "i", &type))
+    static char *keywords[] = {"type", NULL};
+    if (!PyArg_ParseTuple(arg, kwargs, "i", keywords, &type))
         return NULL;
 
     return PyUnicode_FromString(_pg_name_from_eventtype(type));

--- a/src_c/event.c
+++ b/src_c/event.c
@@ -2213,7 +2213,7 @@ static PyMethodDef _event_methods[] = {
     {"_internal_mod_quit", (PyCFunction)pgEvent_AutoQuit, METH_NOARGS,
      "auto quit for event module"},
 
-    {"event_name", event_name, METH_VARARGS, DOC_PYGAMEEVENTEVENTNAME},
+    {"event_name", event_name, METH_VARARGS | METH_KEYWORDS, DOC_PYGAMEEVENTEVENTNAME},
 
     {"set_grab", set_grab, METH_O, DOC_PYGAMEEVENTSETGRAB},
     {"get_grab", (PyCFunction)get_grab, METH_NOARGS, DOC_PYGAMEEVENTGETGRAB},


### PR DESCRIPTION
In reference to issue #808, I've added kwargs to both event.c and display.c where relevant. Take a look and let me know if this needs any changes before being approved. Updates made affected the following functions:

Event.c
• pg_event_init(pgEventObject *self, PyObject *args, PyObject *kwargs)

Display.c
• pg_gl_set_attribute(PyObject *self, PyObject *arg, PyObject *kwarg)
• pg_gl_get_attribute(PyObject *self, PyObject *arg, PyObject *kwarg)
• pg_set_palette(PyObject *self, PyObject *args, PyObject *kwargs)
• pg_set_gamma(PyObject *self, PyObject *arg, PyObject *kwarg) - Noticed after the fact that this was actually deprecated. I can remove if desired!
• pg_set_gamma_ramp(PyObject *self, PyObject *arg, PyObject *kwarg)  - Noticed after the fact that this was actually deprecated. I can remove if desired!
• pg_set_caption(PyObject *self, PyObject *arg)

Associated documentation in display.rst and event.rst have been updated as well.