### PR TITLE
Adding kwarg support to color.c

### DIFF
--- a/docs/reST/ref/color.rst
+++ b/docs/reST/ref/color.rst
@@ -203,6 +203,8 @@
       Applies a certain gamma value to the Color and returns a new Color with
       the adjusted ``RGBA`` values.
 
+      .. versionchanged:: 2.5.0 Added support for keyword arguments.
+
       .. ## Color.correct_gamma ##
 
    .. method:: set_length

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -197,8 +197,8 @@ pg_RGBAFromFuzzyColorObj(PyObject *color, Uint8 rgba[]);
 static PyMethodDef _color_methods[] = {
     {"normalize", (PyCFunction)_color_normalize, METH_NOARGS,
      DOC_COLORNORMALIZE},
-    {"correct_gamma", (PyCFunction)_color_correct_gamma, METH_VARARGS,
-     DOC_COLORCORRECTGAMMA},
+    {"correct_gamma", (PyCFunction)_color_correct_gamma,
+     METH_VARARGS | METH_KEYWORDS, DOC_COLORCORRECTGAMMA},
     {"set_length", (PyCFunction)_color_set_length, METH_VARARGS,
      DOC_COLORSETLENGTH},
     {"lerp", (PyCFunction)_color_lerp, METH_VARARGS | METH_KEYWORDS,
@@ -756,13 +756,15 @@ _color_normalize(pgColorObject *color, PyObject *_null)
  * color.correct_gamma(x)
  */
 static PyObject *
-_color_correct_gamma(pgColorObject *color, PyObject *args)
+_color_correct_gamma(pgColorObject *color, PyObject *args, PyObject *kwargs)
 {
     double frgba[4];
     Uint8 rgba[4];
     double _gamma;
 
-    if (!PyArg_ParseTuple(args, "d", &_gamma)) {
+    static char *keywords[] = {"gamma", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "d", keywords, &_gamma)) {
         return NULL;
     }
 

--- a/src_c/color.c
+++ b/src_c/color.c
@@ -87,7 +87,7 @@ _color_iter(pgColorObject *);
 static PyObject *
 _color_normalize(pgColorObject *, PyObject *);
 static PyObject *
-_color_correct_gamma(pgColorObject *, PyObject *);
+_color_correct_gamma(pgColorObject *, PyObject *, PyObject *);
 static PyObject *
 _color_set_length(pgColorObject *, PyObject *);
 static PyObject *

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -1348,6 +1348,13 @@ class SubclassTest(unittest.TestCase):
         self.assertTrue(isinstance(mc2, self.MyColor))
         self.assertRaises(AttributeError, getattr, mc2, "an_attribute")
 
+    def test_correct_gamma_kwargs(self):
+        mc1 = self.MyColor(64, 70, 75, 255)
+        self.assertTrue(mc1.an_attribute)
+        mc2 = mc1.correct_gamma(gamma=0.03)
+        self.assertTrue(isinstance(mc2, self.MyColor))
+        self.assertRaises(AttributeError, getattr, mc2, "an_attribute")
+
     def test_collection_abc(self):
         mc1 = self.MyColor(64, 70, 75, 255)
         self.assertTrue(isinstance(mc1, Collection))


### PR DESCRIPTION
Implemented the below changes to color.c functions (per #3852) to add kwarg support:

- Kwarg support in color.c
- Doc updates in color.rst
- Test cases updated and passed

Functions covered:
- [x] `_color_correct_gamma`
- [x] `_color_set_length` - Deprecated, did not update

