### PR TITLE
rwobject.c: Use lseek64(3) only for GNU libc

### DIFF
--- a/src_c/rwobject.c
+++ b/src_c/rwobject.c
@@ -33,11 +33,10 @@
 
 #if defined(_WIN32)
 #define PG_LSEEK _lseeki64
-#elif defined(__APPLE__)
-/* Mac does not implement lseek64 */
-#define PG_LSEEK lseek
-#else
+#elif defined(__GLIBC__)
 #define PG_LSEEK lseek64
+#else
+#define PG_LSEEK lseek
 #endif
 
 typedef struct {


### PR DESCRIPTION
MacOS, FreeBSD and other C libraries like musl
neither have nor need lseek64(3).

[FreeBSD bug report #271857](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271857)