### PR TITLE
fix arcs with width values greater than 1 being drawn with tiny holes

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -511,6 +511,7 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
     SDL_Surface *surf = NULL;
     Uint8 rgba[4];
     Uint32 color;
+    float ellipse_ratio;
     int loop;
     int width = 1; /* Default width. */
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -563,10 +563,17 @@ arc(PyObject *self, PyObject *arg, PyObject *kwargs)
 
     width = MIN(width, MIN(rect->w, rect->h) / 2);
 
-    for (loop = 0; loop < width; ++loop) {
+    if (rect->w / rect->h >= 1) {
+        ellipse_ratio = rect->w / rect->h;
+    } else {
+        ellipse_ratio = rect->h / rect->w;
+    }
+
+    for (loop = 0; loop * (2 * ellipse_ratio) < width; ++loop) {
         draw_arc(surf, rect->x + rect->w / 2, rect->y + rect->h / 2,
-                 rect->w / 2 - loop, rect->h / 2 - loop, angle_start,
-                 angle_stop, color, drawn_area);
+                 rect->w / 2 - loop / (2 * ellipse_ratio),
+                 rect->h / 2 - loop / (2 * ellipse_ratio),
+                 angle_start, angle_stop, color, drawn_area);
     }
 
     if (!pgSurface_Unlock(surfobj)) {


### PR DESCRIPTION
this should fix [#1663](https://github.com/pygame/pygame/issues/1663).

as highlighted by mushguys in the issue, using a smaller interval should fix the problem. as such, an interval of 0.5 * ellipse ratio is used in this fix. the ellipse ratio takes care of widening/heightening of the arc making the fix innefective by having an artificially higher interval on the long axis.