### PR TITLE
Fix grammatical mistakes in documentation

### DIFF
--- a/docs/reST/ref/rect.rst
+++ b/docs/reST/ref/rect.rst
@@ -14,12 +14,12 @@
 
    Pygame uses Rect objects to store and manipulate rectangular areas. A Rect
    can be created from a combination of left, top, width, and height values.
-   Rects can also be created from python objects that are already a Rect or
+   Rects can also be created from Python objects that are already a Rect or
    have an attribute named "rect".
 
-   Any pygame function that requires a Rect argument also accepts any of these
+   Any Pygame function that requires a Rect argument also accepts any of these
    values to construct a Rect. This makes it easier to create Rects on the fly
-   as arguments to functions.
+   as arguments for functions.
 
    The Rect functions that change the position or size of a Rect return a new
    copy of the Rect with the affected changes. The original Rect is not


### PR DESCRIPTION
This pull request addresses several grammatical mistakes and typo errors found in the documentation. The changes include:

- Capitalizing "Pygame" in "Any pygame function" for consistency.
- Capitalizing "Python" in "Rects can also be created from python objects" to adhere to proper naming conventions.
- Adjusting the sentence "This makes it easier to create Rects on the fly as arguments to functions" to "This makes it easier to 
create Rects on the fly as arguments for functions."
