### PR TITLE
Added import information in camera and sdl2 controller modules docs

### DIFF
--- a/docs/reST/ref/camera.rst
+++ b/docs/reST/ref/camera.rst
@@ -8,6 +8,9 @@
 
 | :sl:`pygame module for camera use`
 
+.. note::
+   Use import pygame.camera before using this module.
+
 Pygame currently supports Linux (V4L2) and Windows (MSMF) cameras natively,
 with wider platform support available via an integrated OpenCV backend.
 

--- a/docs/reST/ref/sdl2_controller.rst
+++ b/docs/reST/ref/sdl2_controller.rst
@@ -8,6 +8,9 @@
 
 | :sl:`Pygame module to work with controllers.`
 
+.. note::
+   Use import pygame._sdl2.controller before using this module.
+
 This module offers control over common controller types like the dualshock 4 or
 the xbox 360 controllers: They have two analog sticks, two triggers, two shoulder buttons,
 a dpad, 4 buttons on the side, 2 (or 3) buttons in the middle.


### PR DESCRIPTION
#3922  have added a Note in the documentation to import the modules before using them.

![Capture1](https://github.com/pygame/pygame/assets/82987868/59f553cb-74d2-4608-a55f-b3877be29ce3)
![Capture](https://github.com/pygame/pygame/assets/82987868/130bed74-9cec-481a-b40e-5e8dd6a4e7e1)