### PR TITLE
Fix: Grammatical Error in MoveIt.rst

### DIFF
--- a/docs/reST/tut/MoveIt.rst
+++ b/docs/reST/tut/MoveIt.rst
@@ -117,7 +117,7 @@ in his new position. This is exactly the reason we need to "erase" the hero
 in his old position before we draw him in the new position. To erase him,
 we need to change that value in the list back to what it was before the hero
 was there. That means we need to keep track of the values on the screen before
-the hero replaced them. There's several way you could do this, but the easiest
+the hero replaced them. There's several ways you could do this, but the easiest
 is usually to keep a separate copy of the screen background. This means
 we  need to make some changes to our little game.
 


### PR DESCRIPTION
Fixes #4000 

This PR fixes a grammatical error in the docs/reST/tut/MoveIt.rst file on line 120. The error was in the phrase:
"There's several **way** you could do this"
which is now changed to 
"There's several **ways** you could do this"

**Before:**
![image](https://github.com/pygame/pygame/assets/96529359/4bb6474f-6b33-4e65-a811-102a15481796)

**Now:**
![image](https://github.com/pygame/pygame/assets/96529359/83ddbc62-ba2c-4475-a860-05ff57969ab2)
