### PR TITLE
display set_mode: Remove SDL_WINDOW_FULLSCREEN_DESKTOP

### DIFF
--- a/src_c/display.c
+++ b/src_c/display.c
@@ -931,11 +931,11 @@ pg_set_mode(PyObject *self, PyObject *arg, PyObject *kwds)
             if (flags & PGS_SCALED) {
                 sdl_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
             }
-            else if (w == display_mode.w && h == display_mode.h) {
-                /* No need to change physical resolution.
-               Borderless fullscreen is preferred when possible */
-                sdl_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-            }
+            // else if (w == display_mode.w && h == display_mode.h) {
+            //     /* No need to change physical resolution.
+            //    Borderless fullscreen is preferred when possible */
+            //     sdl_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+            // }
             else {
                 sdl_flags |= SDL_WINDOW_FULLSCREEN;
             }


### PR DESCRIPTION
Because this seems to break compatibility with full screen vsync,
and therefore pygame 1.9.
