### PR TITLE
Fix support for OpenBSD and NetBSD

### DIFF
--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -47,7 +47,7 @@
 
 /* on openbsd and netbsd we need to include videoio.h */
 
-#if defined(__OpenBSD__) || defined (__NetBSD__)
+#if defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/videoio.h>
 #endif
 

--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -46,7 +46,6 @@
 #endif
 
 /* on openbsd and netbsd we need to include videoio.h */
-
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/videoio.h>
 #endif

--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -51,10 +51,6 @@
 #include <sys/videoio.h>
 #endif
 
-// #ifdef __NetBSD__
-// #include <sys/videoio.h>
-// #endif
-
 #ifdef __FreeBSD__
 #include <linux/videodev2.h>
 #endif

--- a/src_c/camera.h
+++ b/src_c/camera.h
@@ -40,10 +40,22 @@
 #include <sys/ioctl.h>
 
 /* on freebsd there is no asm/types */
-#ifdef linux
+#ifdef __linux__
 #include <asm/types.h> /* for videodev2.h */
+#include <linux/videodev2.h>
 #endif
 
+/* on openbsd and netbsd we need to include videoio.h */
+
+#if defined(__OpenBSD__) || defined (__NetBSD__)
+#include <sys/videoio.h>
+#endif
+
+// #ifdef __NetBSD__
+// #include <sys/videoio.h>
+// #endif
+
+#ifdef __FreeBSD__
 #include <linux/videodev2.h>
 #endif
 
@@ -250,3 +262,4 @@ windows_init_device(pgCameraObject *self);
 #endif
 
 #endif /* !CAMERA_H */
+#endif


### PR DESCRIPTION
Hi.  I wasn't able to get Pygame to compile on OpenBSD due to the OS not having the <linux/videodev2.h> header and instead using <sys/videoio.h>.  This is my first ever actual pull request to a project so if someone could check to make sure my change doesn't break anything that would be greatly appreciated.  Thank you.