### PR TITLE
Added a minor check if config is correctly initialised

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -34,6 +34,8 @@ class DependencyProg:
             config = (os.popen(command + ' ' + version_flag).readlines() +
                       os.popen(command + ' --cflags').readlines() +
                       os.popen(command + ' --libs').readlines())
+            if not config or len(config) < 3:
+                raise ValueError(f'Unexpected output from "{command}"')
             flags = ' '.join(config[1:]).split()
 
             # remove this GNU_SOURCE if there... since python has it already,


### PR DESCRIPTION
Made a minor update to the build config for unix to validate "config" and to throw an error if config is not initialised correctly