### PR TITLE
Updated the pygame.font.SysFont function so that it can accept keyword arguments

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -389,8 +389,8 @@ def font_constructor(fontpath, size, bold, italic):
 # the exported functions
 
 
-def SysFont(name, size, bold=False, italic=False, constructor=None):
-    """pygame.font.SysFont(name, size, bold=False, italic=False, constructor=None) -> Font
+def SysFont(name, size, bold=False, italic=False, constructor=None, **kwargs):
+    """pygame.font.SysFont(name, size, bold=False, italic=False, constructor=None, **kwargs) -> Font
     Create a pygame Font from system font resources.
 
     This will search the system fonts for the given font

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -69,6 +69,16 @@ class FontModuleTest(unittest.TestCase):
         self.assertTrue(isinstance(o, pygame_font.FontType))
         o = pygame_font.SysFont("thisisnotafont", 20)
         self.assertTrue(isinstance(o, pygame_font.FontType))
+        
+    def test_SysFont(self):
+        #Check if sysfont accepts keyword arguments
+        if "arial" in fonts:
+            font_name = "arial"
+        else:
+            font_name = sorted(fonts)[0]
+        o = pygame_font.SysFont(font_name, 20, foo=0, bar=1)
+        self.assertTrue(isinstance(o, pygame_font.FontType))
+        
 
     def test_get_default_font(self):
         self.assertEqual(pygame_font.get_default_font(), "freesansbold.ttf")

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -72,6 +72,7 @@ class FontModuleTest(unittest.TestCase):
         
     def test_SysFont_with_kwargs(self):
         #Check if sysfont accepts keyword arguments
+        fonts = pygame_font.get_fonts()
         if "arial" in fonts:
             font_name = "arial"
         else:

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -70,7 +70,7 @@ class FontModuleTest(unittest.TestCase):
         o = pygame_font.SysFont("thisisnotafont", 20)
         self.assertTrue(isinstance(o, pygame_font.FontType))
         
-    def test_SysFont(self):
+    def test_SysFont_with_kwargs(self):
         #Check if sysfont accepts keyword arguments
         if "arial" in fonts:
             font_name = "arial"


### PR DESCRIPTION
A trivial change to the `pygame.font.SysFont` function, so that it accepts keyword arguments. 
Also added a unit test to check whether the function can accept keyword arguments.

Originally, it would raise a `TypeError` if one would try to call the function with any keyword arguments.

Related to #808.