### PR TITLE
Fix **go_over_there** example bug in Python 3.12 as per issue #4046

### DIFF
--- a/examples/go_over_there.py
+++ b/examples/go_over_there.py
@@ -40,7 +40,8 @@ def reset():
     balls = []
     for x in range(MAX_BALLS):
         pos = pg.Vector2(
-            random.randint(0, SCREEN_SIZE.x), random.randint(0, SCREEN_SIZE.y)
+            random.randint(0, int(SCREEN_SIZE.x)),
+            random.randint(0, int(SCREEN_SIZE.y))
         )
         speed = random.uniform(MIN_SPEED, MAX_SPEED)
 

--- a/examples/go_over_there.py
+++ b/examples/go_over_there.py
@@ -40,8 +40,7 @@ def reset():
     balls = []
     for x in range(MAX_BALLS):
         pos = pg.Vector2(
-            random.randint(0, int(SCREEN_SIZE.x)),
-            random.randint(0, int(SCREEN_SIZE.y))
+            random.randint(0, int(SCREEN_SIZE.x)), random.randint(0, int(SCREEN_SIZE.y))
         )
         speed = random.uniform(MIN_SPEED, MAX_SPEED)
 


### PR DESCRIPTION
For Python 3.12, **pygame.examples.go_over_there** fails with exception:

    [snip]
      File "[...]/pygame/examples/go_over_there.py", line 43, in reset
        random.randint(0, SCREEN_SIZE.x), random.randint(0, SCREEN_SIZE.y)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        [snip]
    TypeError: 'float' object cannot be interpreted as an integer

It is a documented Python 3.12 change that `randint` now only accepts integer arguments. This pull request fixes the problem and is backward compatible.