### PR TITLE
Optimized the collision detection logic behind the `clipline` function

### DIFF
--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -1,4 +1,6 @@
 import math
+import pygame
+import numpy as np
 import unittest
 from collections.abc import Collection, Sequence
 import platform
@@ -17,6 +19,56 @@ _int_max = 2147483647  # max value of int in C
 
 def _random_int():
     return random.randint(_int_min, _int_max)
+
+class PygameCliplineTest(unittest.TestCase):
+
+    def setUp(self):
+        self.rects = [
+            pygame.Rect(50, 50, 100, 100),
+            pygame.Rect(200, 50, 100, 100),
+            pygame.Rect(50, 200, 100, 100),
+            pygame.Rect(200, 200, 100, 100)
+        ]
+        self.origin = (185, 100)
+
+    
+    
+    
+    def test_clipline_angle(self):
+        pygame.init()
+        ray_length = 150
+
+        for angle in range(180):  
+            radian = np.radians(angle)  
+            end_x = self.origin[0] + ray_length * np.cos(radian)  
+            end_y = self.origin[1] + ray_length * np.sin(radian) 
+
+            line = (self.origin[0], self.origin[1], end_x, end_y)
+
+            for rect in self.rects:
+                result = rect.clipline(line)
+                if result:  # If there are intersections
+                    # Asserting the intersections must be on the boundaries of the rectangle
+                    for point in result:
+                        self.assertTrue(
+                            point[0] == rect.left or point[0] == rect.right or rect.top <= point[1] <= rect.bottom,
+                            f"Intersection point {point} is not on the boundary of rectangle {rect}"
+                        )
+                        self.assertTrue(
+                            point[1] == rect.top or point[1] == rect.bottom or rect.left <= point[0] <= rect.right,
+                            f"Intersection point {point} is not on the boundary of rectangle {rect}"
+                        )
+                else:  # If there are no intersections
+                    # Asserting that the line segment does not intersect the rectangle
+                    self.assertFalse(
+                        rect.colliderect(pygame.Rect(line[0], line[1], line[2] - line[0], line[3] - line[1])),
+                        f"Though clipline returns False, line segment {line} intersects rectangle {rect}"
+                    )
+                        
+   
+
+    def tearDown(self):
+        pass
 
 
 class RectTypeTest(unittest.TestCase):


### PR DESCRIPTION
### Contributor
Name: Yilun Fan (u7277320)
### Issue Addressed
#3999
### PR Summary
The issue i am fixing now is about the bug occurs in `Rect.clipline()` function dealing with the collision between lines of different angles, and 4 or more  than 4 rectangles. For dealing with this, i have reproduced the problem at first, by creating 4 rectangles and lines of the angle within 0-180 degrees inclusive so that we can use `Rect.clipline` function to check whether a collision has been occured. The result is shown below and we supposed line has the red color if a collision has benn dectected and green color otherwise. 
<img width="755" alt="屏幕截图 2023-10-20 145003" src="https://github.com/pygame/pygame/assets/100391900/74253577-f154-465f-a02c-95e0a0e1b906">
We can observe that most of the lines are still green although the line is actually colliding with the other rectangles.
And then, according to the issue description, we have two tasks to deal with:
 1. Add a small test case proving the issue in test/rect.py
 2. The code for Rect.clipline is in src_c/rect.c@pg_rect_clipline

For task 1, I have added the unittest for `Rect.clipline()` in `test/test_rect.py` file (i cannot find `rect.py` in `test` folder and only find this). This unittest is mainly testing the case of the collision with 4 or more rectangles using the function `Rect.clipline()` and get the following failure:
<img width="737" alt="屏幕截图 2023-10-20 145852" src="https://github.com/pygame/pygame/assets/100391900/627c745c-0500-42b1-88e1-c2933b5810f5">

For task 2, I have modified the code in rect.c@pg_rect_clipline to optimize the Intersection collision detection logic with the basic argument analysis unchanged. The ideas behind the change are summarized as follows:
1. First, we need to make sure that the data of the rectangle is normalized, that is, the width and height cannot be negative. This is because negative width or height can lead to false collision detection results. The pgRect_Normalize function is used for this purpose.
2. We need to check whether each end point of the line segment is already inside the rectangle. If so, these points should be treated as intersections. The point_inside_rect function does this.
3. If not enough intersections are found (less than 2), we next need to check if the line segment intersects any boundaries of the rectangle. This means that we check to see if the incoming line segment intersects any of the four sides of the rectangle. The line_intersects_line function is used to find the points of intersection between line segments and determine if they intersect.
4. Return the correct intersection: Based on the intersection found, the function can return one of the following:
    - If no intersection is found, return None.
    - If an intersection is found, return to it.
    - If you find two points of intersection, return to those two points.

The code avoids unnecessary calculations by checking the endpoints first, and only then checking the intersection of the line segment with the rectangular boundary. Only when it cannot find enough intersections will it continue to look for more possible intersections. In this way, the function is now able to more accurately identify all possible points at which a line segment intersects a rectangle and return those points if appropriate. This solves the original problem where sometimes collisions between line segments (rays) and rectangles (floors) are not detected correctly.