### PR TITLE
Fixed issue #3999: Modification to pg_rect_clipline in rect.c

### DIFF
--- a/src_c/rect.c
+++ b/src_c/rect.c
@@ -1307,6 +1307,21 @@ pg_rect_clipline(pgRectObject *self, PyObject *args, PyObject *kwargs)
                      "clipline() takes 1, 2, or 4 arguments (3 given)");
     }
 
+
+    //Modification here
+    if (x1 == x2) {
+        // Handle 180-degree angle case separately
+        if (x1 >= self->r.x && x1 <= self->r.x + self->r.w) {
+            // The line is within the x-coordinate of the rectangle.
+            if ((y1 <= self->r.y && y2 >= self->r.y) || (y2 <= self->r.y && y1 >= self->r.y)) {
+                // The line intersects the top edge of the rectangle.
+                // Adjust the y-coordinate to the top edge of the rectangle.
+                if (y1 < self->r.y) y1 = self->r.y;
+                if (y2 < self->r.y) y2 = self->r.y;
+            }
+        }
+    }
+
     if ((self->r.w < 0) || (self->r.h < 0)) {
         /* Make a copy of the rect so it can be normalized. */
         rect_copy = &pgRect_AsRect(pgRect_New(&self->r));


### PR DESCRIPTION
In the modified code, when the line has a 180-degree angle (i.e., it's nearly vertical), it checks if the line intersects with the top edge of the rectangle (the ground). If the line is within the x-coordinate range of the rectangle and intersects with the top edge, it adjusts the y-coordinate of the intersection point to match the top edge of the rectangle.