### PR TITLE
Support collide_mask as collided argument in spritecollide

### DIFF
--- a/buildconfig/stubs/pygame/sprite.pyi
+++ b/buildconfig/stubs/pygame/sprite.pyi
@@ -262,20 +262,26 @@ def collide_mask(
     left: _SupportsCollideMask, right: _SupportsCollideMask
 ) -> Optional[Tuple[int, int]]: ...
 def spritecollide(
-    sprite: _HasRect,
-    group: AbstractGroup[_TSprite],
+    sprite: _TSprite,
+    group: AbstractGroup[_TSprite2],
     dokill: bool | Literal[1] | Literal[0],
-    collided: Optional[Callable[[_HasRect, _TSprite], bool]] = None,
-) -> List[_TSprite]: ...
+    collided: Optional[
+        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
+    ] = None,
+) -> List[_TSprite2]: ...
 def groupcollide(
     groupa: AbstractGroup[_TSprite],
     groupb: AbstractGroup[_TSprite2],
     dokilla: bool | Literal[1] | Literal[0],
     dokillb: bool | Literal[1] | Literal[0],
-    collided: Optional[Callable[[_TSprite, _TSprite2], bool]] = None,
+    collided: Optional[
+        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
+    ] = None,
 ) -> Dict[_TSprite, List[_TSprite2]]: ...
 def spritecollideany(
-    sprite: _HasRect,
-    group: AbstractGroup[_TSprite],
-    collided: Optional[Callable[[_HasRect, _TSprite], bool]] = None,
-) -> Optional[_TSprite]: ...
+    sprite: _TSprite,
+    group: AbstractGroup[_TSprite2],
+    collided: Optional[
+        Callable[[_TSprite, _TSprite2], bool | Optional[Tuple[int, int]]]
+    ] = None,
+) -> Optional[_TSprite2]: ...


### PR DESCRIPTION
This PR attempts to fix #4089 by making the type of the `collided` argument of `pygame.sprite.spritecollide` and `pygame.sprite.spritecollideany` more strict/precise.
It also adds the `pygame.sprite.collide_mask` return type as one of the possible return types besides a boolean.
