### PR TITLE
Remove references to Numeric in the documentation

### DIFF
--- a/docs/es/tutorials/SurfarrayIntro.rst
+++ b/docs/es/tutorials/SurfarrayIntro.rst
@@ -35,15 +35,14 @@ principio aquí para ir avanzando.
 
 Ahora bien, no voy a engañarte para que pienses que todo va a ser muy sencillo. 
 Lograr efectos avanzados modificando los valores de píxeles puede ser complicado.
-Solo dominar Numeric Python, NumPy, (el paquete de matrices original de 
-SciPy era Numeric, el predecesor de NumPy) requiere aprendizaje. En este tutorial 
-me centraré en lo básico y utilizaré muchos ejemplos en un intento de sembrar las 
-semillas de la sabiduría. Después de haber terminado el tutorial, deberías tener 
-una comprensión básica de cómo funciona el surfarray.
+Solo dominar NumPy requiere aprendizaje. En este tutorial me centraré en lo
+básico y utilizaré muchos ejemplos en un intento de sembrar las semillas de la
+sabiduría. Después de haber terminado el tutorial, deberías tener una comprensión
+básica de cómo funciona el surfarray.
 
 
-Numeric Python
---------------
+NumPy
+-----
 
 Si no tenés instalado el paquete NumPy de python, 
 necesitarás hacerlo. Podés descargar el paquete dede la página de 
@@ -596,7 +595,7 @@ truncación indefinida.
 Graduación
 ----------
 
-Bueno, ahí está. Mi breve introducción a Numeric Python y surfarray.
+Bueno, ahí está. Mi breve introducción a NumPy y surfarray.
 Espero que ahora veas lo que es posible, y aunque nunca los uses por 
 ti mismo, no tengas miedo cuando veas código que los use. Echale un 
 vistazo al ejemplo vgrade para ver más sobre los arrays numéricos. También, 

--- a/docs/reST/ref/mixer.rst
+++ b/docs/reST/ref/mixer.rst
@@ -292,7 +292,7 @@ change the default buffer by calling :func:`pygame.mixer.pre_init` before
    it and the Sound object.
 
    For now buffer and array support is consistent with ``sndarray.make_sound``
-   for Numeric arrays, in that sample sign and byte order are ignored. This
+   for NumPy arrays, in that sample sign and byte order are ignored. This
    will change, either by correctly handling sign and byte order, or by raising
    an exception when different. Also, source samples are truncated to fit the
    audio sample size. This will not change.

--- a/docs/reST/tut/SurfarrayIntro-rest
+++ b/docs/reST/tut/SurfarrayIntro-rest
@@ -103,7 +103,7 @@ between 0 and 255, or you will get some undefined truncating.
 Graduation
 ==========
 
-Well there you have it. My quick primer on Numeric Python and surfarray.
+Well there you have it. My quick primer on NumPy and surfarray.
 Hopefully now you see what is possible, and even if you never use them for
 yourself, you do not have to be afraid when you see code that does. Look into
 the vgrade example for more numeric array action. There are also some *"flame"*

--- a/docs/reST/tut/SurfarrayIntro.rst
+++ b/docs/reST/tut/SurfarrayIntro.rst
@@ -33,14 +33,13 @@ to work your way up.
 
 Now I won't try to fool you into thinking everything is very easy. To get
 more advanced effects by modifying pixel values is very tricky. Just mastering
-Numeric Python (SciPy's original array package was Numeric, the predecessor of NumPy)
-takes a lot of learning. In this tutorial I'll be sticking with
+NumPy takes a lot of learning. In this tutorial I'll be sticking with
 the basics and using a lot of examples in an attempt to plant seeds of wisdom.
 After finishing the tutorial you should have a basic handle on how the surfarray
 works.
 
 
-Numeric Python
+NumPy
 --------------
 
 If you do not have the python NumPy package installed,
@@ -569,7 +568,7 @@ between 0 and 255, or you will get some undefined truncating.
 Graduation
 ----------
 
-Well there you have it. My quick primer on Numeric Python and surfarray.
+Well there you have it. My quick primer on NumPy and surfarray.
 Hopefully now you see what is possible, and even if you never use them for
 yourself, you do not have to be afraid when you see code that does. Look into
 the vgrade example for more numeric array action. There are also some *"flame"*


### PR DESCRIPTION
Numeric was the predecessor of NumPy, but NumPy has been established for a long time, and so references to Numeric are now quite dated. This pull request removes references to Numeric, since nowadays they're just likely to confuse people.

There is one remaining reference in `examples/sound_array_demos.py`, but in this case, it is part of the changelog. The code it talks about (looking for Numeric instead of NumPy) was removed in 2019 so it may make more sense just to remove the changelog (which hasn't been kept updated), but for now I have left this as-is.