### PR TITLE
Added Note for importing pygame.joystick before using it.

### DIFF
--- a/docs/reST/ref/joystick.rst
+++ b/docs/reST/ref/joystick.rst
@@ -8,6 +8,9 @@
 
 | :sl:`Pygame module for interacting with joysticks, gamepads, and trackballs.`
 
+.. note::
+   Use import pygame.joystic before using this module.
+
 The joystick module manages the joystick devices on a computer.
 Joystick devices include trackballs and video-game-style
 gamepads, and the module allows the use of multiple buttons and "hats".


### PR DESCRIPTION
## Added Note for importing pygame.joystick before using it.
- I aim to Close following Issue from this Pull Request. 
    - #3922 .
- if You Open the documentation Below You can see that it Doesn't have Any import Information.
    - https://www.pygame.org/docs/ref/joystick.html#module-pygame.joystick

If this PR Provides any value to the Project Consider Merging it.