### PR TITLE
Border radius for pygame.draw.polygon (resolves #3011)

### DIFF
--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
 #define DOC_PYGAMEDRAWRECT "rect(surface, color, rect) -> Rect\nrect(surface, color, rect, width=0, border_radius=0, border_top_left_radius=-1, border_top_right_radius=-1, border_bottom_left_radius=-1, border_bottom_right_radius=-1) -> Rect\ndraw a rectangle"
-#define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
+#define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0, border_radius=0) -> Rect\ndraw a polygon"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface, color, center, radius) -> Rect\ncircle(surface, color, center, radius, width=0, draw_top_right=None, draw_top_left=None, draw_bottom_left=None, draw_bottom_right=None) -> Rect\ndraw a circle"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
 #define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2563,6 +2563,98 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
     }
 }
 
+typedef struct {
+    double x;
+    double y;
+} Point;
+
+typedef struct {
+    Point center;
+    double radius;
+} Circle;
+
+typedef struct {
+    Point start;
+    Point end;
+} Line;
+
+int side(Point a, Point b, Point c) {
+    double det =
+        (a.x * b.y + b.x * c.y + c.x * a.y) - (a.y * b.x + b.y * c.x + c.y * a.x);
+    if (det > 0) {
+        return 1;
+    } else if (det < 0) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
+    Point direction_vector = {pt2.x - pt1.x, pt2.y - pt1.y};
+    float magnitude = sqrt(direction_vector.x * direction_vector.x + direction_vector.y * direction_vector.y);
+    Point normalized_direction = {direction_vector.x / magnitude, direction_vector.y / magnitude};
+    Point perpendicular_vector = {-normalized_direction.y, normalized_direction.x};
+    if (side(pt1, pt2, pt3) == -1) {
+        perpendicular_vector.x *= -1;
+        perpendicular_vector.y *= -1;
+    }
+    Point offset_vector = {perpendicular_vector.x * distance, perpendicular_vector.y * distance};
+    Line parallel_line = {{pt1.x + offset_vector.x, pt1.y + offset_vector.y}, {pt2.x + offset_vector.x, pt2.y + offset_vector.y}};
+    return parallel_line;
+}
+
+Point project_point_onto_segment(Point point, Point segment_start,
+                                 Point segment_end) {
+    Point segment_vector;
+    segment_vector.x = segment_end.x - segment_start.x;
+    segment_vector.y = segment_end.y - segment_start.y;
+
+    Point point_vector;
+    point_vector.x = point.x - segment_start.x;
+    point_vector.y = point.y - segment_start.y;
+
+    double t =
+        (point_vector.x * segment_vector.x + point_vector.y * segment_vector.y) /
+        (segment_vector.x * segment_vector.x +
+        segment_vector.y * segment_vector.y);
+    t = fmax(0, fmin(1, t));
+
+    Point projection;
+    projection.x = segment_start.x + t * segment_vector.x;
+    projection.y = segment_start.y + t * segment_vector.y;
+
+    return projection;
+}
+
+Point intersection(Point line1_start, Point line1_end, Point line2_start,
+                   Point line2_end) {
+    double A1 = line1_end.y - line1_start.y;
+    double B1 = line1_start.x - line1_end.x;
+    double C1 = A1 * line1_start.x + B1 * line1_start.y;
+
+    double A2 = line2_end.y - line2_start.y;
+    double B2 = line2_start.x - line2_end.x;
+    double C2 = A2 * line2_start.x + B2 * line2_start.y;
+
+    double det = A1 * B2 - A2 * B1;
+    if (det == 0) {
+        return (Point){0, 0};
+    } else {
+        double x = (B2 * C1 - B1 * C2) / det;
+        double y = (A1 * C2 - A2 * C1) / det;
+        return (Point){x, y};
+    }
+}
+
+double angle(Point center, Point point) {
+    double x = point.x - center.x;
+    double y = point.y - center.y;
+    return -atan2(y, x);
+}
+
+
+
 /* List of python functions */
 static PyMethodDef _draw_methods[] = {
     {"aaline", (PyCFunction)aaline, METH_VARARGS | METH_KEYWORDS,

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2653,6 +2653,99 @@ double angle(Point center, Point point) {
     return -atan2(y, x);
 }
 
+static void
+draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, int num_points, Uint32 color, int *drawn_area) {
+
+    Point path[2 * num_points];
+    Circle circles[num_points];
+
+    Point points[num_points];
+
+    for (int i = 0; i < num_points; i++) {
+        points[i].x = pts_x[i];
+        points[i].y = pts_y[i];
+    }
+
+    for (int i = 0; i < num_points; i++) {
+        int a, b;
+        if (i == 0) {
+            a = num_points - 1;
+            b = 1;
+        } else if (i == (num_points - 1)) {
+            a = num_points - 2;
+            b = 0;
+        } else if (i == (num_points - 2)) {
+            a = num_points - 3;
+            b = num_points - 1;
+        } else {
+            a = i - 1;
+            b = i + 1;
+        }
+
+        if (side(points[a], points[i], points[b]) == 0) {
+            printf("ValueError: Border-radius cannot be applied to a flat angle.\n"
+                    "Please ensure that the specified angle or curvature is within a valid range for border-radius drawing.\n");
+            return;
+        }
+
+        Line line1 = find_parallel_line(points[a], points[i], points[b], border_radius);
+        Line line2 = find_parallel_line(points[i], points[b], points[a], border_radius);
+        circles[i].center = intersection(line1.start, line1.end, line2.start, line2.end);
+
+        Point proj1 =
+            project_point_onto_segment(circles[i].center, points[a], points[i]);
+        Point proj2 =
+            project_point_onto_segment(circles[i].center, points[i], points[b]);
+
+        if ((sqrt(pow(proj1.x - points[i].x, 2) +
+            pow(proj1.y - points[i].y, 2)) >= sqrt(pow(points[a].x - points[i].x, 2) +
+                                                    pow(points[a].y - points[i].y, 2)) / 2) ||  
+            (sqrt(pow(proj2.x - points[i].x, 2) +
+                pow(proj2.y - points[i].y, 2)) >= sqrt(pow(points[b].x - points[i].x, 2) +
+                                                        pow(points[b].y - points[i].y, 2)) / 2)) {
+            printf("ValueError: Border-radius size must be smaller\n");
+            return;
+        }
+
+        path[2 * i] = proj1;
+        path[2 * i + 1] = proj2;
+        circles[i].radius = border_radius;
+    }
+
+    for (int i = 0; i < 2 * num_points; i += 2) {
+        Point pt1 = path[i % (2 * num_points)];
+        Point pt2 = path[(i + 1) % (2 * num_points)];
+        Point pt3 = path[(i + 2) % (2 * num_points)];
+        Circle circle = circles[i / 2];
+
+        double start_angle = angle(circle.center, pt1);
+        double end_angle = angle(circle.center, pt2);
+
+        if (side(pt1, pt2, pt3) == 1) {
+            double temp = start_angle;
+            start_angle = end_angle;
+            end_angle = temp;
+        }
+
+        if (end_angle < start_angle) {
+            // Angle is in radians
+            end_angle += 2 * M_PI;
+        }
+
+        draw_arc(surf,
+                circle.center.x,
+                circle.center.y,
+                circle.radius,
+                circle.radius,
+                start_angle,
+                end_angle,
+                color,
+                drawn_area);
+
+        draw_line(surf, pt2.x, pt2.y, pt3.x, pt3.y, color, drawn_area);
+    }
+}
+
 
 
 /* List of python functions */

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2571,21 +2571,26 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
     }
 }
 
+// Define a structure representing a point with x and y coordinates.
 typedef struct {
     double x;
     double y;
 } Point;
 
+// Define a structure representing a circle with a center (Point) and a radius.
 typedef struct {
     Point center;
     double radius;
 } Circle;
 
+// Define a structure representing a line segment with start and end points.
 typedef struct {
     Point start;
     Point end;
 } Line;
 
+// Function to determine the side of point 'c' relative to the line formed by points 'a' and 'b'.
+// Returns 1 if on the left side, -1 if on the right side, and 0 if collinear.
 int side(Point a, Point b, Point c) {
     double det =
         (a.x * b.y + b.x * c.y + c.x * a.y) - (a.y * b.x + b.y * c.x + c.y * a.x);
@@ -2598,22 +2603,31 @@ int side(Point a, Point b, Point c) {
     }
 }
 
+// Function to find a parallel line to the line formed by 'pt1' and 'pt2' at a given distance.
+// Returns a Line struct representing the parallel line.
 Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
-    Point direction_vector = {pt2.x - pt1.x, pt2.y - pt1.y};
+    // Calculate direction vector, normalize it, and find the perpendicular vector.
     float magnitude = sqrt(direction_vector.x * direction_vector.x + direction_vector.y * direction_vector.y);
     Point normalized_direction = {direction_vector.x / magnitude, direction_vector.y / magnitude};
+    
+    // Adjust the perpendicular vector based on the side of 'pt3' relative to 'pt1' and 'pt2'.
     Point perpendicular_vector = {-normalized_direction.y, normalized_direction.x};
     if (side(pt1, pt2, pt3) == -1) {
         perpendicular_vector.x *= -1;
         perpendicular_vector.y *= -1;
     }
+
+    // Create an offset vector and generate the parallel line.
     Point offset_vector = {perpendicular_vector.x * distance, perpendicular_vector.y * distance};
     Line parallel_line = {{pt1.x + offset_vector.x, pt1.y + offset_vector.y}, {pt2.x + offset_vector.x, pt2.y + offset_vector.y}};
     return parallel_line;
 }
 
+// Function to project a point onto a line segment defined by 'segment_start' and 'segment_end'.
+// Returns the projected point on the line segment.
 Point project_point_onto_segment(Point point, Point segment_start,
                                  Point segment_end) {
+    // Calculate vectors, find the parameter 't' for projection, and calculate the projection.
     Point segment_vector;
     segment_vector.x = segment_end.x - segment_start.x;
     segment_vector.y = segment_end.y - segment_start.y;
@@ -2635,8 +2649,11 @@ Point project_point_onto_segment(Point point, Point segment_start,
     return projection;
 }
 
+// Function to find the intersection point of two line segments.
+// Returns the intersection point as a Point struct.
 Point intersection(Point line1_start, Point line1_end, Point line2_start,
                    Point line2_end) {
+    // Calculate coefficients for each line equation.
     double A1 = line1_end.y - line1_start.y;
     double B1 = line1_start.x - line1_end.x;
     double C1 = A1 * line1_start.x + B1 * line1_start.y;
@@ -2645,16 +2662,20 @@ Point intersection(Point line1_start, Point line1_end, Point line2_start,
     double B2 = line2_start.x - line2_end.x;
     double C2 = A2 * line2_start.x + B2 * line2_start.y;
 
+    // Check if the lines are parallel (det == 0) and handle the case
     double det = A1 * B2 - A2 * B1;
     if (det == 0) {
         return (Point){0, 0};
     } else {
+        // Calculate the intersection point using Cramer's rule.
         double x = (B2 * C1 - B1 * C2) / det;
         double y = (A1 * C2 - A2 * C1) / det;
         return (Point){x, y};
     }
 }
 
+// Function to calculate the angle (in radians) between a center point and another point.
+// Returns the angle in radians.
 double angle(Point center, Point point) {
     double x = point.x - center.x;
     double y = point.y - center.y;

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2625,8 +2625,7 @@ Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
 
 // Function to project a point onto a line segment defined by 'segment_start' and 'segment_end'.
 // Returns the projected point on the line segment.
-Point project_point_onto_segment(Point point, Point segment_start,
-                                 Point segment_end) {
+Point project_point_onto_segment(Point point, Point segment_start, Point segment_end) {
     // Calculate vectors, find the parameter 't' for projection, and calculate the projection.
     Point segment_vector;
     segment_vector.x = segment_end.x - segment_start.x;
@@ -2685,7 +2684,6 @@ double angle(Point center, Point point) {
 // Define a function to draw a rounded polygon on an SDL surface
 static void
 draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, int num_points, Uint32 color, int *drawn_area) {
-
 
     // Define arrays to store path points and circle information
     Point path[2 * num_points];

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -782,15 +782,16 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
     Uint32 color;
     int *xlist = NULL, *ylist = NULL;
     int width = 0; /* Default width. */
+    int border_radius = 0; /* Default radius. */
     int x, y, result, l, t;
     int drawn_area[4] = {INT_MAX, INT_MAX, INT_MIN,
                          INT_MIN}; /* Used to store bounding box values */
     Py_ssize_t loop, length;
-    static char *keywords[] = {"surface", "color", "points", "width", NULL};
+    static char *keywords[] = {"surface", "color", "points", "width", "border_radius", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OO|i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(arg, kwargs, "O!OO|ii", keywords,
                                      &pgSurface_Type, &surfobj, &colorobj,
-                                     &points, &width)) {
+                                     &points, &width, &border_radius)) {
         return NULL; /* Exception already set. */
     }
 
@@ -872,7 +873,11 @@ polygon(PyObject *self, PyObject *arg, PyObject *kwargs)
         return RAISE(PyExc_RuntimeError, "error locking surface");
     }
 
-    draw_fillpoly(surf, xlist, ylist, length, color, drawn_area);
+    if(border_radius != 0 && width==0){ 
+        draw_round_polygon(surf, xlist, ylist, border_radius, length, color, drawn_area);
+    } else {
+        draw_fillpoly(surf, xlist, ylist, length, color, drawn_area);
+    }
     PyMem_Free(xlist);
     PyMem_Free(ylist);
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2682,7 +2682,7 @@ double angle(Point center, Point point) {
     return -atan2(y, x);
 }
 
-// Define a function to draw a rounded polygon on an SDL surface
+// Define a function to draw a rounded polygon 
 static void
 draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, int num_points, Uint32 color, int *drawn_area) {
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2607,6 +2607,7 @@ int side(Point a, Point b, Point c) {
 // Returns a Line struct representing the parallel line.
 Line find_parallel_line(Point pt1, Point pt2, Point pt3, int distance) {
     // Calculate direction vector, normalize it, and find the perpendicular vector.
+    Point direction_vector = {pt2.x - pt1.x, pt2.y - pt1.y};
     float magnitude = sqrt(direction_vector.x * direction_vector.x + direction_vector.y * direction_vector.y);
     Point normalized_direction = {direction_vector.x / magnitude, direction_vector.y / magnitude};
     

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -81,6 +81,9 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                 int width, Uint32 color, int top_left, int top_right,
                 int bottom_left, int bottom_right, int *drawn_area);
 
+draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, 
+                    int num_points, Uint32 color, int *drawn_area);
+
 // validation of a draw color
 #define CHECK_LOAD_COLOR(colorobj)                                         \
     if (PyLong_Check(colorobj))                                            \

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -80,7 +80,7 @@ static void
 draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                 int width, Uint32 color, int top_left, int top_right,
                 int bottom_left, int bottom_right, int *drawn_area);
-
+static void
 draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, 
                     int num_points, Uint32 color, int *drawn_area);
 


### PR DESCRIPTION
### This pull request resolves the enhancement issue #3011 about implementing the border radius for pygame.draw.polygon


# Overview
- Added a new parameter _border_radius_ to the **_pygame.draw.polygon_** function to specify the border radius of the rounded polygon corners.
- Updated the list of keywords in _**pygame.draw.polygon**_ to include _"border_radius"_ in the function signature.
- Added a new function **_draw_round_polygon_** to handle the drawing of rounded polygons. This function takes care of the logic for calculating rounded corners.
- Integrated this function as a part of _**polygon**_ in draw.c.

## Geometry Calculations:
- Implemented various geometric calculation functions, such as **_find_parallel_line_**, **_project_point_onto_segment_**, and **_intersection_**(to calculate intersections between two lines), _**angle**_, _**side**_ ….


# draw_round_polygon Function:

**static void draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int radius, int num_points, Uint32 color, int *drawn_area)**

## Purpose:
This function is responsible for drawing a rounded polygon with a specified border radius. It calculates and draws circular segments at each corner of the polygon.
Parameters:
- _surf:_ The target surface to draw on.
- _pts_x:_ Array of x-coordinates of polygon vertices.
- _pts_y:_ Array of y-coordinates of polygon vertices.
- _border_radius:_ The border radius of the rounded corners.
- _num_points_: Number of vertices in the polygon.
- _color_: Color of the polygon.
- _drawn_area_: Array to store the bounding box of the drawn area.

## Details:

### Path calculation loop:
- Coordinate Initialization: Initializes arrays and structures to store calculated points and circles.
- Parallel Line Calculation: The **_find_parallel_line_** function calculates two parallel lines given three points: the current vertex and its adjacent vertices. The function ensures that the parallel lines are on the correct side of the vertex.
- Circle and Path Calculation: The center of the circular segment is found by calculating the intersection of two parallel lines (line1 and line2) using the **_intersection_** function.
- The circular arc's starting and ending points are obtained by projecting the center onto adjacent line segments using the **_project_point_onto_segment_** function.
- Stores these points in the path array.

### Drawing loop:
- For each segment in the path array, it calculates start and end angles and draws the circular arc using the **_draw_arc_** function.
- Draws a straight line between consecutive circular arcs.


## Debugging Output:
- During the calculation loop, if three consecutive points are aligned the loop is interrupted with a return statement to abort the function.
- A condition on the border_radius is verified on each vertex, at each iteration, to avoid incorrect drawing. if the condition is not satisfied the function is aborted.
- As the draw_round_polygon function returns void (a choice made to align with the same logic of other drawing functions), it is not possible to raise an error directly from draw_round_polygon. Instead, we settle for a return statement whenever an error should be raised to abort the function, and a printf of the error message.
