### PR TITLE
Border radius for pygame.draw.polygon (resolves #3011)

### DIFF
--- a/src_c/doc/draw_doc.h
+++ b/src_c/doc/draw_doc.h
@@ -1,7 +1,7 @@
 /* Auto generated file: with makeref.py .  Docs go in docs/reST/ref/ . */
 #define DOC_PYGAMEDRAW "pygame module for drawing shapes"
 #define DOC_PYGAMEDRAWRECT "rect(surface, color, rect) -> Rect\nrect(surface, color, rect, width=0, border_radius=0, border_top_left_radius=-1, border_top_right_radius=-1, border_bottom_left_radius=-1, border_bottom_right_radius=-1) -> Rect\ndraw a rectangle"
-#define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0) -> Rect\ndraw a polygon"
+#define DOC_PYGAMEDRAWPOLYGON "polygon(surface, color, points) -> Rect\npolygon(surface, color, points, width=0, border_radius=0) -> Rect\ndraw a polygon"
 #define DOC_PYGAMEDRAWCIRCLE "circle(surface, color, center, radius) -> Rect\ncircle(surface, color, center, radius, width=0, draw_top_right=None, draw_top_left=None, draw_bottom_left=None, draw_bottom_right=None) -> Rect\ndraw a circle"
 #define DOC_PYGAMEDRAWELLIPSE "ellipse(surface, color, rect) -> Rect\nellipse(surface, color, rect, width=0) -> Rect\ndraw an ellipse"
 #define DOC_PYGAMEDRAWARC "arc(surface, color, rect, start_angle, stop_angle) -> Rect\narc(surface, color, rect, start_angle, stop_angle, width=1) -> Rect\ndraw an elliptical arc"

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -80,6 +80,9 @@ static void
 draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
                 int width, Uint32 color, int top_left, int top_right,
                 int bottom_left, int bottom_right, int *drawn_area);
+static void
+draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, 
+                    int num_points, Uint32 color, int *drawn_area);
 
 // validation of a draw color
 #define CHECK_LOAD_COLOR(colorobj)                                         \
@@ -2560,6 +2563,100 @@ draw_round_rect(SDL_Surface *surf, int x1, int y1, int x2, int y2, int radius,
         draw_circle_quadrant(surf, x2 - bottom_right + 1,
                              y2 - bottom_right + 1, bottom_right, width, color,
                              0, 0, 0, 1, drawn_area);
+    }
+}
+
+static void
+draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, int num_points, Uint32 color, int *drawn_area) {
+
+    Point path[2 * num_points];
+    Circle circles[num_points];
+
+    Point points[num_points];
+
+    for (int i = 0; i < num_points; i++) {
+        points[i].x = pts_x[i];
+        points[i].y = pts_y[i];
+    }
+
+    for (int i = 0; i < num_points; i++) {
+        int a, b;
+        if (i == 0) {
+            a = num_points - 1;
+            b = 1;
+        } else if (i == (num_points - 1)) {
+            a = num_points - 2;
+            b = 0;
+        } else if (i == (num_points - 2)) {
+            a = num_points - 3;
+            b = num_points - 1;
+        } else {
+            a = i - 1;
+            b = i + 1;
+        }
+
+        if (side(points[a], points[i], points[b]) == 0) {
+            printf("ValueError: Border-radius cannot be applied to a flat angle.\n"
+                    "Please ensure that the specified angle or curvature is within a valid range for border-radius drawing.\n");
+            return;
+        }
+
+        Line line1 = find_parallel_line(points[a], points[i], points[b], border_radius);
+        Line line2 = find_parallel_line(points[i], points[b], points[a], border_radius);
+        circles[i].center = intersection(line1.start, line1.end, line2.start, line2.end);
+
+        Point proj1 =
+            project_point_onto_segment(circles[i].center, points[a], points[i]);
+        Point proj2 =
+            project_point_onto_segment(circles[i].center, points[i], points[b]);
+
+        if ((sqrt(pow(proj1.x - points[i].x, 2) +
+            pow(proj1.y - points[i].y, 2)) >= sqrt(pow(points[a].x - points[i].x, 2) +
+                                                    pow(points[a].y - points[i].y, 2)) / 2) ||  
+            (sqrt(pow(proj2.x - points[i].x, 2) +
+                pow(proj2.y - points[i].y, 2)) >= sqrt(pow(points[b].x - points[i].x, 2) +
+                                                        pow(points[b].y - points[i].y, 2)) / 2)) {
+            printf("ValueError: Border-radius size must be smaller\n");
+            return;
+        }
+
+        path[2 * i] = proj1;
+        path[2 * i + 1] = proj2;
+
+        circles[i].radius = border_radius;
+    }
+
+    for (int i = 0; i < 2 * num_points; i += 2) {
+        Point pt1 = path[i % (2 * num_points)];
+        Point pt2 = path[(i + 1) % (2 * num_points)];
+        Point pt3 = path[(i + 2) % (2 * num_points)];
+        Circle circle = circles[i / 2];
+
+        double start_angle = angle(circle.center, pt1);
+        double end_angle = angle(circle.center, pt2);
+
+        if (side(pt1, pt2, pt3) == 1) {
+            double temp = start_angle;
+            start_angle = end_angle;
+            end_angle = temp;
+        }
+
+        if (end_angle < start_angle) {
+            // Angle is in radians
+            end_angle += 2 * M_PI;
+        }
+
+        draw_arc(surf,
+                circle.center.x,
+                circle.center.y,
+                circle.radius,
+                circle.radius,
+                start_angle,
+                end_angle,
+                color,
+                drawn_area);
+
+        draw_line(surf, pt2.x, pt2.y, pt3.x, pt3.y, color, drawn_area);
     }
 }
 

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2661,20 +2661,26 @@ double angle(Point center, Point point) {
     return -atan2(y, x);
 }
 
+// Define a function to draw a rounded polygon on an SDL surface
 static void
 draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius, int num_points, Uint32 color, int *drawn_area) {
 
+    // Define arrays to store path points and circle information
     Point path[2 * num_points];
     Circle circles[num_points];
 
+    // Define an array to store original polygon points
     Point points[num_points];
 
+    // Convert input coordinates to Point structures
     for (int i = 0; i < num_points; i++) {
         points[i].x = pts_x[i];
         points[i].y = pts_y[i];
     }
 
+    // Iterate through each point in the polygon
     for (int i = 0; i < num_points; i++) {
+        // Determine neighboring points for the current point
         int a, b;
         if (i == 0) {
             a = num_points - 1;
@@ -2690,21 +2696,25 @@ draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius,
             b = i + 1;
         }
 
+        // Check if the border-radius can be applied to the current angle
         if (side(points[a], points[i], points[b]) == 0) {
             printf("ValueError: Border-radius cannot be applied to a flat angle.\n"
                     "Please ensure that the specified angle or curvature is within a valid range for border-radius drawing.\n");
             return;
         }
 
+        // Find parallel lines to the polygon sides at the current point
         Line line1 = find_parallel_line(points[a], points[i], points[b], border_radius);
         Line line2 = find_parallel_line(points[i], points[b], points[a], border_radius);
         circles[i].center = intersection(line1.start, line1.end, line2.start, line2.end);
 
+        // Project points onto the parallel lines
         Point proj1 =
             project_point_onto_segment(circles[i].center, points[a], points[i]);
         Point proj2 =
             project_point_onto_segment(circles[i].center, points[i], points[b]);
 
+        // Check if the border-radius size is valid
         if ((sqrt(pow(proj1.x - points[i].x, 2) +
             pow(proj1.y - points[i].y, 2)) >= sqrt(pow(points[a].x - points[i].x, 2) +
                                                     pow(points[a].y - points[i].y, 2)) / 2) ||  
@@ -2715,32 +2725,38 @@ draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int border_radius,
             return;
         }
 
+        // Store projected points and circle radius in arrays
         path[2 * i] = proj1;
         path[2 * i + 1] = proj2;
 
         circles[i].radius = border_radius;
     }
 
+    // Iterate through the projected points to draw arcs and connecting lines
     for (int i = 0; i < 2 * num_points; i += 2) {
         Point pt1 = path[i % (2 * num_points)];
         Point pt2 = path[(i + 1) % (2 * num_points)];
         Point pt3 = path[(i + 2) % (2 * num_points)];
         Circle circle = circles[i / 2];
 
+        // Calculate start and end angles for the arc
         double start_angle = angle(circle.center, pt1);
         double end_angle = angle(circle.center, pt2);
 
+        // Adjust angles based on the side of the polygon
         if (side(pt1, pt2, pt3) == 1) {
             double temp = start_angle;
             start_angle = end_angle;
             end_angle = temp;
         }
 
+        // Ensure the end angle is greater than the start angle (in radians)
         if (end_angle < start_angle) {
             // Angle is in radians
             end_angle += 2 * M_PI;
         }
 
+        // Draw the arc and connecting line
         draw_arc(surf,
                 circle.center.x,
                 circle.center.y,


### PR DESCRIPTION
### This pull request resolves the enhancement issue #3011 about implementing the border radius for pygame.draw.polygon


# Overview
- Added a new parameter _border_radius_ to the **_pygame.draw.polygon_** function to specify the border radius of the rounded polygon corners.
- Updated the list of keywords in _**pygame.draw.polygon**_ to include _"border_radius"_ in the function signature.
- Added a new function **_draw_round_polygon_** to handle the drawing of rounded polygons. This function takes care of the logic for calculating rounded corners.
- Integrated this function as a part of _**polygon**_ in draw.c.

## Geometry Calculations:
- Implemented various geometric calculation functions, such as **_find_parallel_line_**, **_project_point_onto_segment_**, and **_intersection_**(to calculate intersections between two lines), _**angle**_, _**side**_ ….


# draw_round_polygon Function:

**static void draw_round_polygon(SDL_Surface *surf, int *pts_x, int *pts_y, int radius, int num_points, Uint32 color, int *drawn_area)**

## Purpose:
This function is responsible for drawing a rounded polygon with a specified border radius. It calculates and draws circular segments at each corner of the polygon.
Parameters:
- _surf:_ The target surface to draw on.
- _pts_x:_ Array of x-coordinates of polygon vertices.
- _pts_y:_ Array of y-coordinates of polygon vertices.
- _border_radius:_ The border radius of the rounded corners.
- _num_points_: Number of vertices in the polygon.
- _color_: Color of the polygon.
- _drawn_area_: Array to store the bounding box of the drawn area.

## Details:

### Path calculation loop:
- Coordinate Initialization: Initializes arrays and structures to store calculated points and circles.
- Parallel Line Calculation: The **_find_parallel_line_** function calculates two parallel lines given three points: the current vertex and its adjacent vertices. The function ensures that the parallel lines are on the correct side of the vertex.
- Circle and Path Calculation: The center of the circular segment is found by calculating the intersection of two parallel lines (line1 and line2) using the **_intersection_** function.
- The circular arc's starting and ending points are obtained by projecting the center onto adjacent line segments using the **_project_point_onto_segment_** function.
- Stores these points in the path array.

### Drawing loop:
- For each segment in the path array, it calculates start and end angles and draws the circular arc using the **_draw_arc_** function.
- Draws a straight line between consecutive circular arcs.


## Debugging Output:
- During the calculation loop, if three consecutive points are aligned the loop is interrupted with a return statement to abort the function.
- A condition on the border_radius is verified on each vertex, at each iteration, to avoid incorrect drawing. if the condition is not satisfied the function is aborted.
- As the draw_round_polygon function returns void (a choice made to align with the same logic of other drawing functions), it is not possible to raise an error directly from draw_round_polygon. Instead, we settle for a return statement whenever an error should be raised to abort the function, and a printf of the error message.
