### PR TITLE
Add additional argument seconds argument for clock.tick.

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -413,9 +413,14 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
+    PyObject *seconds = NULL;
 
-    if (!PyArg_ParseTuple(arg, "|f", &framerate))
+    if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
         return NULL;
+    int return_in_seconds = 0;
+    if(seconds && PyObject_IsTrue(seconds)) {
+        return_in_seconds = 1;
+    }
 
     if (framerate) {
         int delay, endtime = (int)((1.0f / framerate) * 1000.0f);
@@ -463,7 +468,12 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
+    if(return_in_seconds) {
+        return(PyFloat_FromDouble(_clock->timepassed / 1000.0));
+    }
+    else {
     return PyLong_FromLong(_clock->timepassed);
+    }
 }
 
 static PyObject *


### PR DESCRIPTION
### Issue Addressed
#3976 

### PR Summary
The goal of this PR was to add the additional functionality requested in #3976, for an additional optional argument to be added to the clock.tick method to allow for the user to request the return in seconds rather than milliseconds as is the current default behavior. I have added this additional optional argument, it should not affect any existing code as the default behavior is left unchanged but rather should only add additional options if needed. I have also added an additional set of tests, modelling the original clock.tick tests, to test the behavior when the seconds argument is enabled.