### PR TITLE
Add additional argument seconds argument for clock.tick

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -413,15 +413,10 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
-    int return_in_seconds = 0;
-    PyObject *seconds = NULL;
+    int seconds = 0;
 
-    if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
+    if (!PyArg_ParseTuple(arg, "|fp", &framerate, &seconds))
         return NULL;
-
-    if (seconds && PyObject_IsTrue(seconds)) {
-        return_in_seconds = 1;
-    }
 
     if (framerate) {
         int delay, endtime = (int)((1.0f / framerate) * 1000.0f);
@@ -469,7 +464,7 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
-    if (return_in_seconds) {
+    if (seconds) {
         return PyFloat_FromDouble(_clock->timepassed / 1000.0);
     }
 

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -413,9 +413,14 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
+    PyObject *seconds = NULL;
 
-    if (!PyArg_ParseTuple(arg, "|f", &framerate))
+    if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
         return NULL;
+    int return_in_seconds = 0;
+    if(seconds && PyObject_IsTrue(seconds)) {
+        return_in_seconds = 1;
+    }
 
     if (framerate) {
         int delay, endtime = (int)((1.0f / framerate) * 1000.0f);
@@ -463,7 +468,12 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
+    if(return_in_seconds) {
+        return(PyFloat_FromDouble(_clock->timepassed / 1000.0));
+    }
+    else {
     return PyLong_FromLong(_clock->timepassed);
+    }
 }
 
 static PyObject *

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -408,14 +408,16 @@ typedef struct {
 
 // to be called by the other tick functions.
 static PyObject *
-clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
+clock_tick_base(PyObject *self, PyObject *arg, PyObject *kwds,
+                int use_accurate_delay)
 {
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
     int seconds = 0;
-
-    if (!PyArg_ParseTuple(arg, "|fp", &framerate, &seconds))
+    static char *kwlist[] = {"framerate", "seconds", NULL};
+    if (!PyArg_ParseTupleAndKeywords(arg, kwds, "|fp", kwlist, &framerate,
+                                     &seconds))
         return NULL;
 
     if (framerate) {
@@ -472,15 +474,15 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
 }
 
 static PyObject *
-clock_tick(PyObject *self, PyObject *arg)
+clock_tick(PyObject *self, PyObject *arg, PyObject *kwds)
 {
-    return clock_tick_base(self, arg, 0);
+    return clock_tick_base(self, arg, kwds, 0);
 }
 
 static PyObject *
-clock_tick_busy_loop(PyObject *self, PyObject *arg)
+clock_tick_busy_loop(PyObject *self, PyObject *arg, PyObject *kwds)
 {
-    return clock_tick_base(self, arg, 1);
+    return clock_tick_base(self, arg, kwds, 1);
 }
 
 static PyObject *

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -418,7 +418,7 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
 
     if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
         return NULL;
-    
+
     if (seconds && PyObject_IsTrue(seconds)) {
         return_in_seconds = 1;
     }
@@ -474,7 +474,6 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     }
 
     return PyLong_FromLong(_clock->timepassed);
-    
 }
 
 static PyObject *

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -413,12 +413,13 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
+    int return_in_seconds = 0;
     PyObject *seconds = NULL;
 
     if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
         return NULL;
-    int return_in_seconds = 0;
-    if(seconds && PyObject_IsTrue(seconds)) {
+    
+    if (seconds && PyObject_IsTrue(seconds)) {
         return_in_seconds = 1;
     }
 
@@ -468,12 +469,12 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
-    if(return_in_seconds) {
-        return(PyFloat_FromDouble(_clock->timepassed / 1000.0));
+    if (return_in_seconds) {
+        return PyFloat_FromDouble(_clock->timepassed / 1000.0);
     }
-    else {
+
     return PyLong_FromLong(_clock->timepassed);
-    }
+    
 }
 
 static PyObject *

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -173,56 +173,6 @@ class ClockTypeTest(unittest.TestCase):
     @unittest.skipIf(
         os.environ.get("CI", None), "CI can have variable time slices, slow."
     )
-    def test_tick_with_seconds(self):
-    """Tests time.Clock.tick() with the seconds argument"""
-    # Adjust this value to increase the acceptable seconds jitter
-    epsilon_seconds = 0.005  
-
-    testing_framerate = 60
-    milliseconds = 5.0
-    seconds = milliseconds / 1000  
-
-    c = Clock()
-    collection_seconds = []
-
-    
-    c.tick(seconds=True)  # Initialize the clock
-    for i in range(100):
-        time.sleep(seconds)  
-        collection_seconds.append(c.tick(seconds=True))
-
-    # Remove the first highest and lowest value
-    for outlier in [min(collection_seconds), max(collection_seconds)]:
-        if abs(outlier - seconds) > epsilon_seconds:
-            collection_seconds.remove(outlier)
-
-    average_time_seconds = sum(collection_seconds) / len(collection_seconds)
-
-    # Assert the deviation from the intended delay in seconds is within the acceptable amount
-    self.assertAlmostEqual(average_time_seconds, seconds, delta=epsilon_seconds)
-
-    # Test frame-rate control with seconds=True
-    c = Clock()
-    collection_seconds = []
-
-    start = time.time()
-
-    for i in range(testing_framerate):
-        collection_seconds.append(c.tick(testing_framerate, seconds=True))
-
-    end = time.time()
-
-    # Calculate the expected duration in seconds for the given framerate
-    expected_duration = testing_framerate / testing_framerate
-
-    # Assert the duration with seconds=True is within an acceptable margin
-    self.assertAlmostEqual(end - start, expected_duration, delta=epsilon_seconds)
-
-    # Calculate the average tick time in seconds and assert it's close to the expected frame duration in seconds
-    average_tick_time_seconds = sum(collection_seconds) / len(collection_seconds)
-    expected_frame_duration_seconds = 1 / testing_framerate
-    self.assertAlmostEqual(average_tick_time_seconds, expected_frame_duration_seconds, delta=epsilon_seconds)
-
 
     def test_tick_busy_loop(self):
         """Test tick_busy_loop"""

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -169,67 +169,57 @@ class ClockTypeTest(unittest.TestCase):
             1000 / average_tick_time, testing_framerate, delta=epsilon3
         )
 
-    @unittest.skipIf(platform.machine() == "s390x", "Fails on s390x")
-    @unittest.skipIf(
-        os.environ.get("CI", None), "CI can have variable time slices, slow."
-    )
-    def test_tick_with_seconds(self):
-    """Tests time.Clock.tick(seconds=True)"""
-        """
-        Loops with a set delay a few times then checks what tick reports to
-        verify its accuracy. Then calls tick with a desired frame-rate and
-        verifies it is not faster than the desired frame-rate nor is it taking
-        a dramatically long time to complete. This is done using the optional
-        seconds argument
-        """
-    # Adjust this value to increase the acceptable seconds jitter
-    epsilon_seconds = 0.005  
+        # Repeating tests with seconds parameter set
+        epsilon_seconds = 0.005
 
-    testing_framerate = 60
-    milliseconds = 5.0
-    seconds = milliseconds / 1000  
+        testing_framerate = 60
+        milliseconds = 5.0
+        seconds = milliseconds / 1000
 
-    c = Clock()
-    collection_seconds = []
+        c = Clock()
+        collection_seconds = []
 
-    # Test with seconds=True
-    c.tick(seconds=True)  
-    for i in range(100):
-        time.sleep(seconds)  # Sleep in seconds
-        collection_seconds.append(c.tick(seconds=True))
+        # Test with seconds=True
+        c.tick(seconds=True)
+        for i in range(100):
+            time.sleep(seconds)  # Sleep in seconds
+            collection_seconds.append(c.tick(seconds=True))
 
-    # Remove the first highest and lowest value
-    for outlier in [min(collection_seconds), max(collection_seconds)]:
-        if abs(outlier - seconds) > epsilon_seconds:
-            collection_seconds.remove(outlier)
+        # Remove the first highest and lowest value
+        for outlier in [min(collection_seconds), max(collection_seconds)]:
+            if abs(outlier - seconds) > epsilon_seconds:
+                collection_seconds.remove(outlier)
 
-    average_time_seconds = sum(collection_seconds) / len(collection_seconds)
+        average_time_seconds = sum(collection_seconds) / len(collection_seconds)
 
-    # Assert the deviation from the intended delay in seconds is within the acceptable amount
-    self.assertAlmostEqual(average_time_seconds, seconds, delta=epsilon_seconds)
+        # Assert the deviation from the intended delay in seconds is within the acceptable amount
+        self.assertAlmostEqual(average_time_seconds, seconds, delta=epsilon_seconds)
 
-    # Test frame-rate control with seconds=True
-    c = Clock()
-    collection_seconds = []
+        # Test frame-rate control with seconds=True
+        c = Clock()
+        collection_seconds = []
 
-    start = time.time()
+        start = time.time()
 
-    for i in range(testing_framerate):
-        collection_seconds.append(c.tick(testing_framerate, seconds=True))
+        for i in range(testing_framerate):
+            collection_seconds.append(c.tick(testing_framerate, seconds=True))
 
-    end = time.time()
+        end = time.time()
 
-    # Calculate the expected duration in seconds for the given framerate
-    expected_duration = testing_framerate / testing_framerate
+        # Calculate the expected duration in seconds for the given framerate
+        expected_duration = testing_framerate / testing_framerate
 
-    # Assert the duration with seconds=True is within an acceptable margin
-    self.assertAlmostEqual(end - start, expected_duration, delta=epsilon_seconds)
+        # Assert the duration with seconds=True is within an acceptable margin
+        self.assertAlmostEqual(end - start, expected_duration, delta=epsilon_seconds)
 
-    # Calculate the average tick time in seconds and assert it's close to the expected frame duration in seconds
-    average_tick_time_seconds = sum(collection_seconds) / len(collection_seconds)
-    expected_frame_duration_seconds = 1 / testing_framerate
-    self.assertAlmostEqual(average_tick_time_seconds, expected_frame_duration_seconds, delta=epsilon_seconds)
-
+        # Calculate the average tick time in seconds and assert it's close to the expected frame duration in seconds
+        average_tick_time_seconds = sum(collection_seconds) / len(collection_seconds)
+        expected_frame_duration_seconds = 1 / testing_framerate
+        self.assertAlmostEqual(
+            average_tick_time_seconds,
+            expected_frame_duration_seconds,
+            delta=epsilon_seconds,
+        )
 
     def test_tick_busy_loop(self):
         """Test tick_busy_loop"""

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -169,6 +169,68 @@ class ClockTypeTest(unittest.TestCase):
             1000 / average_tick_time, testing_framerate, delta=epsilon3
         )
 
+    @unittest.skipIf(platform.machine() == "s390x", "Fails on s390x")
+    @unittest.skipIf(
+        os.environ.get("CI", None), "CI can have variable time slices, slow."
+    )
+    def test_tick_with_seconds(self):
+    """Tests time.Clock.tick(seconds=True)"""
+        """
+        Loops with a set delay a few times then checks what tick reports to
+        verify its accuracy. Then calls tick with a desired frame-rate and
+        verifies it is not faster than the desired frame-rate nor is it taking
+        a dramatically long time to complete. This is done using the optional
+        seconds argument
+        """
+    # Adjust this value to increase the acceptable seconds jitter
+    epsilon_seconds = 0.005  
+
+    testing_framerate = 60
+    milliseconds = 5.0
+    seconds = milliseconds / 1000  
+
+    c = Clock()
+    collection_seconds = []
+
+    # Test with seconds=True
+    c.tick(seconds=True)  
+    for i in range(100):
+        time.sleep(seconds)  # Sleep in seconds
+        collection_seconds.append(c.tick(seconds=True))
+
+    # Remove the first highest and lowest value
+    for outlier in [min(collection_seconds), max(collection_seconds)]:
+        if abs(outlier - seconds) > epsilon_seconds:
+            collection_seconds.remove(outlier)
+
+    average_time_seconds = sum(collection_seconds) / len(collection_seconds)
+
+    # Assert the deviation from the intended delay in seconds is within the acceptable amount
+    self.assertAlmostEqual(average_time_seconds, seconds, delta=epsilon_seconds)
+
+    # Test frame-rate control with seconds=True
+    c = Clock()
+    collection_seconds = []
+
+    start = time.time()
+
+    for i in range(testing_framerate):
+        collection_seconds.append(c.tick(testing_framerate, seconds=True))
+
+    end = time.time()
+
+    # Calculate the expected duration in seconds for the given framerate
+    expected_duration = testing_framerate / testing_framerate
+
+    # Assert the duration with seconds=True is within an acceptable margin
+    self.assertAlmostEqual(end - start, expected_duration, delta=epsilon_seconds)
+
+    # Calculate the average tick time in seconds and assert it's close to the expected frame duration in seconds
+    average_tick_time_seconds = sum(collection_seconds) / len(collection_seconds)
+    expected_frame_duration_seconds = 1 / testing_framerate
+    self.assertAlmostEqual(average_tick_time_seconds, expected_frame_duration_seconds, delta=epsilon_seconds)
+
+
     def test_tick_busy_loop(self):
         """Test tick_busy_loop"""
 

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -168,11 +168,6 @@ class ClockTypeTest(unittest.TestCase):
         self.assertAlmostEqual(
             1000 / average_tick_time, testing_framerate, delta=epsilon3
         )
-        
-    @unittest.skipIf(platform.machine() == "s390x", "Fails on s390x")
-    @unittest.skipIf(
-        os.environ.get("CI", None), "CI can have variable time slices, slow."
-    )
 
     def test_tick_busy_loop(self):
         """Test tick_busy_loop"""


### PR DESCRIPTION
### Issue Addressed
#3976 

### PR Summary
The goal of this PR was to add the additional functionality requested in #3976, for an additional optional argument to be added to the clock.tick method to allow for the user to request the return in seconds rather than milliseconds as is the current default behavior. I have added this additional optional argument, it should not affect any existing code as the default behavior is left unchanged but rather should only add additional options if needed. I have also added an additional set of tests, modelling the original clock.tick tests, to test the behavior when the seconds argument is enabled.