### PR TITLE
Remove lint logic from setup.py

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.0.2
+      - name: Install deps
+        run: python3 -m pip install sphinx
       - name: Check docs changes are checked in
         run: |
           python3 setup.py docs

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -28,6 +28,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.0.2
-
-      # This job will be completly be replaced by the pre-commit job in #4200
-
+      - name: Check docs changes are checked in
+        run: |
+          python3 setup.py docs
+          if [[ `git status --porcelain` ]]; then
+            echo "Generating docs caused changes. Please check them in."
+            echo "You may need to run: python3 setup.py docs --fullgeneration"
+            # Run git status again, so people can see what changed.
+            git status --porcelain
+            exit 1
+          fi

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -29,19 +29,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
 
-      - name: Install deps
-        run: python3 -m pip install pylint==2.15.5 black clang-format sphinx
+      # This job will be completly be replaced by the pre-commit job in #4200
 
-      - name: Check code Formatting and Linting
-        run: python3 setup.py lint
-
-      - name: Check docs changes are checked in
-        run: |
-          python3 setup.py docs
-          if [[ `git status --porcelain` ]]; then
-            echo "Generating docs caused changes. Please check them in."
-            echo "You may need to run: python3 setup.py docs --fullgeneration"
-            # Run git status again, so people can see what changed.
-            git status --porcelain
-            exit 1
-          fi

--- a/setup.py
+++ b/setup.py
@@ -305,7 +305,7 @@ if compile_cython:
     if cython_only:
         sys.exit(0)
 
-no_compilation = any(x in ['lint', 'format', 'docs'] for x in sys.argv)
+no_compilation = any(x in ('docs') for x in sys.argv)
 AUTO_CONFIG = not os.path.isfile('Setup') and not no_compilation
 if consume_arg('-auto'):
     AUTO_CONFIG = True
@@ -866,100 +866,6 @@ class TestCommand(Command):
         '''
         import subprocess
         return subprocess.call([sys.executable, os.path.join('test', '__main__.py')])
-
-
-class LintFormatCommand(Command):
-    """ Used for formatting or linting. See Lint and Format Sub classes.
-    """
-    user_options = []
-    lint = False
-    format = False
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        """Check the existence and launch linters."""
-        import subprocess
-        import sys
-        import warnings
-        import pathlib
-
-        def check_linter_exists(linter):
-            if shutil.which(linter) is None:
-                msg = "Please install '%s' in your environment. (hint: 'python3 -m pip install %s')"
-                warnings.warn(msg % (linter, linter))
-                sys.exit(1)
-
-        def filter_files(path_obj, all_files, allowed_files, disallowed_files):
-            files = []
-            for file in all_files:
-                for disallowed in disallowed_files:
-                    if file.match(str(path_obj / disallowed)):
-                        break
-                else:  # no-break
-                    files.append(str(file))
-                    continue
-
-                for allowed in allowed_files:
-                    if file.match(str(path_obj / allowed)):
-                        files.append(str(file))
-                        break
-
-            return files
-
-        path_obj = pathlib.Path(path, "src_c")
-        c_files_unfiltered = path_obj.glob("**/*.[ch]")
-        c_file_disallow = [
-            "_sdl2/**",
-            "pypm.c",
-            "SDL_gfx/**",
-            "**/sse2neon.h",
-            "doc/**",
-            "_sprite.c",
-        ]
-        c_file_allow = ["_sdl2/touch.c"]
-        c_files = filter_files(path_obj, c_files_unfiltered, c_file_allow, c_file_disallow)
-
-
-        # Other files have too many issues for now. setup.py, buildconfig, etc
-        python_directories = ["src_py", "test", "examples"]
-        if self.lint:
-            commands = {
-                "clang-format": ["--dry-run", "--Werror", "-i"] + c_files,
-                "black": ["--check", "--diff"] + python_directories,
-                # Test directory has too much pylint warning for now
-                "pylint": ["src_py"],
-            }
-        else:
-            commands = {
-                "clang-format": ["-i"] + c_files,
-                "black": python_directories,
-            }
-
-        formatters = ["black", "clang-format"]
-        for linter, option in commands.items():
-            print(" ".join([linter] + option))
-            check_linter_exists(linter)
-            result = subprocess.run([linter] + option)
-            if result.returncode:
-                msg = f"'{linter}' failed."
-                msg += " Please run: python setup.py format" if linter in formatters else ""
-                msg += f" Do you have the latest version of {linter}?"
-                raise SystemExit(msg)
-
-
-@add_command("lint")
-class LintCommand(LintFormatCommand):
-    lint = True
-
-
-@add_command("format")
-class FormatCommand(LintFormatCommand):
-    format = True
 
 
 @add_command('docs')

--- a/setup.py
+++ b/setup.py
@@ -305,7 +305,7 @@ if compile_cython:
     if cython_only:
         sys.exit(0)
 
-no_compilation = any(x in ('docs') for x in sys.argv)
+no_compilation = 'docs' in sys.argv
 AUTO_CONFIG = not os.path.isfile('Setup') and not no_compilation
 if consume_arg('-auto'):
     AUTO_CONFIG = True


### PR DESCRIPTION
~**After** #4200 is merged~ remove lint logic from setup.py
* #4200

To replace the commands that were removed from `setup.py`, the following will work...
* `pre-commit run black`
* `pre-commit run clang-format`
* `pre-commit run --all-files`