### PR TITLE
Compliance with PEP517 and PEP632

### DIFF
--- a/buildconfig/appveyor.yml
+++ b/buildconfig/appveyor.yml
@@ -168,8 +168,7 @@ install:
   - "%PYTHON% -m pip install Sphinx==4.5.0 sphinxcontrib-applehelp==1.0.2 pip install sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.0 sphinxcontrib-qthelp==1.0.3 sphinxcontrib-serializinghtml==1.1.5"
   - "%PYTHON% setup.py docs"
   - "%WITH_COMPILER% %PYTHON% -m buildconfig"
-  - "%WITH_COMPILER% %PYTHON% setup.py build -j4 %USE_ANALYZE%"
-  - "%WITH_COMPILER% %PYTHON% setup.py -setuptools %DISTRIBUTIONS%"
+  - "%WITH_COMPILER% %PYTHON% -m pip wheel . --wheel-dir=dist"
   - ps: "ls dist"
 
   # Install the wheel to test it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "pygame"
+authors = [{ name = "A community project.", email = "pygame@pygame.org" }]
+description = "Python Game Development"
+readme = "README.rst"  # Assuming long_description is in README.rst; adjust filename as needed
+license = { text = "LGPL" }
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
+    "Programming Language :: Assembly",
+    "Programming Language :: C",
+    "Programming Language :: Cython",
+    "Programming Language :: Objective C",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Games/Entertainment",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Sound/Audio :: MIDI",
+    "Topic :: Multimedia :: Sound/Audio :: Players",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Graphics :: Capture :: Digital Camera",
+    "Topic :: Multimedia :: Graphics :: Capture :: Screen Capture",
+    "Topic :: Multimedia :: Graphics :: Graphics Conversion",
+    "Topic :: Multimedia :: Graphics :: Viewers",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
+keywords = ["games", "multimedia", "graphics", "sound", "music", "development"]
+requires-python = ">=3.6"
+dynamic = [ "entry-points", "version" ]
+
+[project.urls]
+Documentation = "https://pygame.org/docs"
+"Bug Tracker" = "https://github.com/pygame/pygame/issues"
+Source = "https://github.com/pygame/pygame"
+Twitter = "https://twitter.com/pygame_org"
+
+[build-system]
+requires = ["setuptools>=59", "wheel==0.37.1", "cython==3.0.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,44 @@
+[metadata] # metadata for python 3.6 builds
+name = pygame
+author = A community project.
+author_email = pygame@pygame.org
+url = pygame.org
+description = Python Game Development
+long_description = file: README.rst
+keywords = games, multimedia, graphics, sound, music, development
+license = LGPL
+classifiers =
+    Development Status :: 6 - Mature
+    License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
+    Programming Language :: Assembly
+    Programming Language :: C
+    Programming Language :: Cython
+    Programming Language :: Objective C
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Games/Entertainment
+    Topic :: Multimedia :: Sound/Audio
+    Topic :: Multimedia :: Sound/Audio :: MIDI
+    Topic :: Multimedia :: Sound/Audio :: Players
+    Topic :: Multimedia :: Graphics
+    Topic :: Multimedia :: Graphics :: Capture :: Digital Camera
+    Topic :: Multimedia :: Graphics :: Capture :: Screen Capture
+    Topic :: Multimedia :: Graphics :: Graphics Conversion
+    Topic :: Multimedia :: Graphics :: Viewers
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Operating System :: MacOS
+
 [tox:tox]
 envlist = py{36,37,38,39,310,311,312}
 skip_missing_interpreters = True

--- a/setup.py
+++ b/setup.py
@@ -1,140 +1,32 @@
-#!/usr/bin/env python
-#
-# This is the distutils setup script for pygame.
-# Full instructions are in https://www.pygame.org/wiki/GettingStarted
-#
-# To configure, compile, install, just run this script.
-#     python setup.py install
+"""
 
-import glob
+Imports
+
+"""
 import platform
-import sysconfig
-
-with open('README.rst', encoding='utf-8') as readme:
-    LONG_DESCRIPTION = readme.read()
-
-EXTRAS = {}
-
-METADATA = {
-    "name": "pygame",
-    "version": "2.6.0.dev1",
-    "license": "LGPL",
-    "url": "https://www.pygame.org",
-    "author": "A community project.",
-    "author_email": "pygame@pygame.org",
-    "description": "Python Game Development",
-    "long_description": LONG_DESCRIPTION,
-    "long_description_content_type": "text/x-rst",
-    "project_urls": {
-        "Documentation": "https://pygame.org/docs",
-        "Bug Tracker": "https://github.com/pygame/pygame/issues",
-        "Source": "https://github.com/pygame/pygame",
-        "Twitter": "https://twitter.com/pygame_org",
-    },
-    "classifiers": [
-        "Development Status :: 6 - Mature",
-        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
-        "Programming Language :: Assembly",
-        "Programming Language :: C",
-        "Programming Language :: Cython",
-        "Programming Language :: Objective C",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Games/Entertainment",
-        "Topic :: Multimedia :: Sound/Audio",
-        "Topic :: Multimedia :: Sound/Audio :: MIDI",
-        "Topic :: Multimedia :: Sound/Audio :: Players",
-        "Topic :: Multimedia :: Graphics",
-        "Topic :: Multimedia :: Graphics :: Capture :: Digital Camera",
-        "Topic :: Multimedia :: Graphics :: Capture :: Screen Capture",
-        "Topic :: Multimedia :: Graphics :: Graphics Conversion",
-        "Topic :: Multimedia :: Graphics :: Viewers",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
-        "Operating System :: Unix",
-        "Operating System :: MacOS",
-    ],
-    "python_requires": '>=3.6',
-}
-
-import re
 import sys
 import os
+import glob
+import re
+import sysconfig
+import shutil
+import stat
+from setuptools import setup, Command
 
-# just import these always and fail early if not present
-from setuptools import setup
-import distutils
+METADATA = {'version': "2.6.0.dev1"}
+revision = ''
 
 
-if os.environ.get('PYGAME_DETECT_AVX2', '') != '':
-    import distutils.ccompiler
+"""
 
-    avx2_filenames = ['simd_blitters_avx2']
+Utils
 
-    compiler_options = {
-        'unix': ('-mavx2',),
-        'msvc': ('/arch:AVX2',)
-    }
-
-    def spawn(self, cmd, **kwargs):
-        should_use_avx2 = False
-        # try to be thorough in detecting that we are on a platform that potentially supports AVX2
-        machine_name = platform.machine()
-        if ((machine_name.startswith(("x86", "i686")) or
-            machine_name.lower() == "amd64") and
-                os.environ.get("MAC_ARCH") != "arm64"):
-            should_use_avx2 = True
-
-        if should_use_avx2:
-            extra_options = compiler_options.get(self.compiler_type)
-            if extra_options is not None:
-                # filenames are closer to the end of command line
-                for argument in reversed(cmd):
-                    # Check if argument contains a filename. We must check for all
-                    # possible extensions; checking for target extension is faster.
-                    if not argument.endswith(self.obj_extension):
-                        continue
-
-                    # check for a filename only to avoid building a new string
-                    # with variable extension
-                    for filename in avx2_filenames:
-                        off_end = -len(self.obj_extension)
-                        off_start = -len(filename) + off_end
-                        if argument.endswith(filename, off_start, off_end):
-                            if self.compiler_type == 'bcpp':
-                                # Borland accepts a source file name at the end,
-                                # insert the options before it
-                                cmd[-1:-1] = extra_options
-                            else:
-                                cmd += extra_options
-
-                    # filename is found, no need to search any further
-                    break
-
-        distutils.ccompiler.spawn(cmd, dry_run=self.dry_run, **kwargs)
-
-    distutils.ccompiler.CCompiler.__spawn = distutils.ccompiler.CCompiler.spawn
-    distutils.ccompiler.CCompiler.spawn = spawn
-
-# A (bit hacky) fix for https://github.com/pygame/pygame/issues/2613
-# This is due to the fact that distutils uses command line args to 
-# export PyInit_* functions on windows, but those functions are already exported
-# and that is why compiler gives warnings
-from distutils.command.build_ext import build_ext
-
-build_ext.get_export_symbols = lambda self, ext: []
-
-IS_PYPY = '__pypy__' in sys.builtin_module_names
-IS_MSC = sys.platform == "win32" and "MSC" in sys.version
+"""
+def consume_arg(name):
+    if name in sys.argv:
+        sys.argv.remove(name)
+        return True
+    return False
 
 def compilation_help():
     """ On failure point people to a web page for help.
@@ -185,32 +77,28 @@ def compilation_help():
     print('    https://www.pygame.org/contribute.html')
     print('---\n')
 
+cmdclass = {}
+def add_command(name):
+    def decorator(command):
+        assert issubclass(command, Command)
+        cmdclass[name] = command
+        return command
 
-if not hasattr(sys, 'version_info') or sys.version_info < (3, 6):
-    compilation_help()
-    raise SystemExit("Pygame requires Python3 version 3.6 or above.")
-if IS_PYPY and sys.pypy_version_info < (7,):
-    raise SystemExit("Pygame requires PyPy version 7.0.0 above, compatible with CPython >= 3.6")
-
-
-def consume_arg(name):
-    if name in sys.argv:
-        sys.argv.remove(name)
-        return True
-    return False
+    return decorator
 
 
-# get us to the correct directory
-path = os.path.split(os.path.abspath(sys.argv[0]))[0]
-os.chdir(path)
+"""
+
+Platform Constants / Flags
+
+"""
+IS_PYPY = '__pypy__' in sys.builtin_module_names
+
+IS_MSC = sys.platform == "win32" and "MSC" in sys.version
 
 STRIPPED = False
-
-# STRIPPED builds don't have developer resources like docs or tests
 if "PYGAME_ANDROID" in os.environ:
-    # test cases and docs are useless inside an APK
     STRIPPED = True
-
 if consume_arg('-stripped'):
     STRIPPED = True
 
@@ -223,6 +111,17 @@ if consume_arg('-enable-arm-neon'):
     cflags += '-mfpu=neon'
     os.environ['CFLAGS'] = cflags
 
+no_compilation = any(x in ['lint', 'format', 'docs'] for x in sys.argv)
+AUTO_CONFIG = not os.path.isfile('Setup') and not no_compilation
+if consume_arg('-auto'):
+    AUTO_CONFIG = True
+
+
+"""
+
+Cython Compilation
+
+"""
 compile_cython = False
 cython_only = False
 if consume_arg('cython'):
@@ -315,104 +214,12 @@ if compile_cython:
     if cython_only:
         sys.exit(0)
 
-no_compilation = 'docs' in sys.argv
-AUTO_CONFIG = not os.path.isfile('Setup') and not no_compilation
-if consume_arg('-auto'):
-    AUTO_CONFIG = True
 
-import os.path, glob, stat, shutil
-import distutils.sysconfig
-from distutils.core import setup, Command
-from distutils.extension import read_setup_file
-from distutils.command.install_data import install_data
-from distutils.command.sdist import sdist
+"""
 
-revision = ''
+C Extensions (run buildconfig, read in setup file, generate list of headers)
 
-
-def add_datafiles(data_files, dest_dir, pattern):
-    """Add directory structures to data files according to a pattern"""
-    src_dir, elements = pattern
-
-    def do_directory(root_dest_path, root_src_path, elements):
-        files = []
-        for e in elements:
-            if isinstance(e, list):
-                src_dir, elems = e
-                dest_path = '/'.join([root_dest_path, src_dir])
-                src_path = os.path.join(root_src_path, src_dir)
-                do_directory(dest_path, src_path, elems)
-            else:
-                files.extend(glob.glob(os.path.join(root_src_path, e)))
-        if files:
-            data_files.append((root_dest_path, files))
-
-    do_directory(dest_dir, src_dir, elements)
-
-
-# # allow optionally using setuptools for bdist_egg.
-# if consume_arg("-setuptools") in sys.argv:
-#     from setuptools import setup
-#     sys.argv.remove ("-setuptools")
-
-# we need to eat this argument in to distutils doesn't trip over it
-consume_arg("-setuptools")
-
-# NOTE: the bdist_mpkg_support is for darwin.
-try:
-    import bdist_mpkg_support
-except ImportError:
-    pass
-else:
-    EXTRAS.update({
-        'options': bdist_mpkg_support.options,
-        'setup_requires': ['bdist_mpkg>=0.4.2'],
-        # 'install_requires': ['pyobjc'],
-        # 'dependency_links': ['http://rene.f0o.com/~rene/stuff/macosx/']
-    })
-
-# headers to install
-headers = glob.glob(os.path.join('src_c', '*.h'))
-headers.remove(os.path.join('src_c', 'scale.h'))
-headers.append(os.path.join('src_c', 'include'))
-
-import distutils.command.install_headers
-
-
-# monkey patch distutils header install to copy over directories
-def run_install_headers(self):
-    headers = self.distribution.headers
-    if not headers:
-        return
-
-    self.mkpath(self.install_dir)
-    for header in headers:
-        if os.path.isdir(header):
-            destdir = os.path.join(self.install_dir, os.path.basename(header))
-            self.mkpath(destdir)
-            for entry in os.listdir(header):
-                header1 = os.path.join(header, entry)
-                if not os.path.isdir(header1):
-                    (out, _) = self.copy_file(header1, destdir)
-                    self.outfiles.append(out)
-        else:
-            (out, _) = self.copy_file(header, self.install_dir)
-            self.outfiles.append(out)
-
-
-distutils.command.install_headers.install_headers.run = run_install_headers
-
-# option for not installing the headers.
-if consume_arg("-noheaders"):
-    headers = []
-
-# sanity check for any arguments
-if len(sys.argv) == 1 and sys.stdout.isatty():
-    reply = input('\nNo Arguments Given, Perform Default Install? [Y/n]')
-    if not reply or reply[0].lower() != 'n':
-        sys.argv.append('install')
-
-# make sure there is a Setup file
+"""
 if AUTO_CONFIG:
     print('\n\nWARNING, No "Setup" File Exists, Running "buildconfig/config.py"')
     import buildconfig.config
@@ -440,6 +247,7 @@ if no_compilation:
 else:
     # get compile info for all extensions
     try:
+        from distutils.extension import read_setup_file
         extensions = read_setup_file('Setup')
     except:
         print("""Error with the "Setup" file,
@@ -482,11 +290,18 @@ for e in extensions:
         # Do -Werror only on CI, and exclude -Werror on Cython C files and gfxdraw
         e.extra_compile_args.append("/WX" if IS_MSC else "-Wundef")
 
+# headers to install
+headers = glob.glob(os.path.join('src_c', '*.h'))
+headers.remove(os.path.join('src_c', 'scale.h'))
+headers.append(os.path.join('src_c', 'include'))
+# option for not installing the headers.
+if consume_arg("-noheaders"):
+    headers = []
+
 # if not building font, try replacing with ftfont
 alternate_font = os.path.join('src_py', 'font.py')
 if os.path.exists(alternate_font):
     os.remove(alternate_font)
-
 have_font = False
 have_freetype = False
 for e in extensions:
@@ -497,8 +312,33 @@ for e in extensions:
 if not have_font and have_freetype:
     shutil.copyfile(os.path.join('src_py', 'ftfont.py'), alternate_font)
 
+
+"""
+
+Create list of data_files to be included in distribution
+
+"""
+def add_datafiles(data_files, dest_dir, pattern):
+    """Add directory structures to data files according to a pattern"""
+    src_dir, elements = pattern
+
+    def do_directory(root_dest_path, root_src_path, elements):
+        files = []
+        for e in elements:
+            if isinstance(e, list):
+                src_dir, elems = e
+                dest_path = '/'.join([root_dest_path, src_dir])
+                src_path = os.path.join(root_src_path, src_dir)
+                do_directory(dest_path, src_path, elems)
+            else:
+                files.extend(glob.glob(os.path.join(root_src_path, e)))
+        if files:
+            data_files.append((root_dest_path, files))
+
+    do_directory(dest_dir, src_dir, elements)
+
 # extra files to install
-data_path = os.path.join(distutils.sysconfig.get_python_lib(), 'pygame')
+data_path = os.path.join(sysconfig.get_paths()['purelib'], 'pygame')
 pygame_data_files = []
 data_files = [('pygame', pygame_data_files)]
 
@@ -570,82 +410,13 @@ add_datafiles(data_files, 'pygame/docs/generated',
                   ['ref',
                    ['*.txt']]]]]])
 
-
-# generate the version module
-def parse_version(ver):
-    return ', '.join(s for s in re.findall(r'\d+', ver)[0:3])
-
-
-def parse_source_version():
-    pgh_major = -1
-    pgh_minor = -1
-    pgh_patch = -1
-    major_exp_search = re.compile(r'define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
-    minor_exp_search = re.compile(r'define\s+PG_MINOR_VERSION\s+([0-9]+)').search
-    patch_exp_search = re.compile(r'define\s+PG_PATCH_VERSION\s+([0-9]+)').search
-    pg_header = os.path.join('src_c', 'include', '_pygame.h')
-    with open(pg_header) as f:
-        for line in f:
-            if pgh_major == -1:
-                m = major_exp_search(line)
-                if m: pgh_major = int(m.group(1))
-            if pgh_minor == -1:
-                m = minor_exp_search(line)
-                if m: pgh_minor = int(m.group(1))
-            if pgh_patch == -1:
-                m = patch_exp_search(line)
-                if m: pgh_patch = int(m.group(1))
-    if pgh_major == -1:
-        raise SystemExit("_pygame.h: cannot find PG_MAJOR_VERSION")
-    if pgh_minor == -1:
-        raise SystemExit("_pygame.h: cannot find PG_MINOR_VERSION")
-    if pgh_patch == -1:
-        raise SystemExit("_pygame.h: cannot find PG_PATCH_VERSION")
-    return (pgh_major, pgh_minor, pgh_patch)
-
-
-def write_version_module(pygame_version, revision):
-    vernum = parse_version(pygame_version)
-    src_vernum = parse_source_version()
-    if vernum != ', '.join(str(e) for e in src_vernum):
-        raise SystemExit("_pygame.h version differs from 'METADATA' version"
-                         ": %s vs %s" % (vernum, src_vernum))
-    with open(os.path.join('buildconfig', 'version.py.in')) as header_file:
-        header = header_file.read()
-    with open(os.path.join('src_py', 'version.py'), 'w') as version_file:
-        version_file.write(header)
-        version_file.write('ver = "' + pygame_version + '"  # pylint: disable=invalid-name\n')
-        version_file.write(f'vernum = PygameVersion({vernum})\n')
-        version_file.write('rev = "' + revision + '"  # pylint: disable=invalid-name\n')
-        version_file.write('\n__all__ = ["SDL", "ver", "vernum", "rev"]\n')
-
-
-write_version_module(METADATA['version'], revision)
-
-# required. This will be filled if doing a Windows build.
-cmdclass = {}
-
-
-def add_command(name):
-    def decorator(command):
-        assert issubclass(command, distutils.cmd.Command)
-        cmdclass[name] = command
-        return command
-
-    return decorator
-
-
-# try to find DLLs and copy them too  (only on windows)
+# if windows build, get DLLs
 if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
-
-    from distutils.command.build_ext import build_ext
-
     # add dependency DLLs to the project
     lib_dependencies = {}
     for e in extensions:
         if e.name.startswith('COPYLIB_'):
             lib_dependencies[e.name[8:]] = e.libraries
-
 
     def dependencies(roots):
         """Return a set of dependencies for the list of library file roots
@@ -663,7 +434,6 @@ if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
                 root_set[root] = 1
                 root_set.update(dependencies(deps))
         return root_set
-
 
     the_dlls = {}
     required_dlls = {}
@@ -686,42 +456,67 @@ if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
         else:
             pygame_data_files.append(f)
 
-    if '-enable-msvc-analyze' in sys.argv:
-        # calculate the MSVC compiler version as an int
-        msc_pos = sys.version.find('MSC v.')
-        msc_ver = 1900
-        if msc_pos != -1:
-            msc_ver = int(sys.version[msc_pos + 6:msc_pos + 10])
-        print('Analyzing with MSC_VER =', msc_ver)
+# clean up the list of extensions
+for e in extensions[:]:
+    if e.name.startswith('COPYLIB_'):
+        extensions.remove(e)  # don't compile the COPYLIBs, just clean them
+    else:
+        e.name = 'pygame.' + e.name  # prepend package name on modules
 
-        # excluding system headers from analyze out put was only added after MSCV_VER 1913
-        if msc_ver >= 1913:
-            os.environ['CAExcludePath'] = 'C:\\Program Files (x86)\\'
+# Prune empty file lists.
+data_files = [(path, files) for path, files in data_files if files]
 
-        for e in extensions:
-            e.extra_compile_args.extend(
-                (
-                    "/analyze",
-                    "/wd28251",
-                    "/wd28301",
-                )
-            )
 
-            if msc_ver >= 1913:
-                e.extra_compile_args.extend(
-                    (
-                        "/experimental:external",
-                        "/external:W0",
-                        "/external:env:CAExcludePath",
-                    )
-                )
+"""
 
+Custom Commands
+
+"""
+@add_command('install_headers')
+class CustomInstallHeaders(Command):
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        install_cmd = self.get_finalized_command('install')
+        self.install_dir = getattr(install_cmd, 'install_lib')
+        headers = self.distribution.headers
+        if not headers:
+            return
+        self.mkpath(self.install_dir)
+        for header in headers:
+            if os.path.isdir(header):
+                destdir = os.path.join(self.install_dir, os.path.basename(header))
+                self.mkpath(destdir)
+                for entry in os.listdir(header):
+                    header1 = os.path.join(header, entry)
+                    if not os.path.isdir(header1):
+                        (out, _) = self.copy_file(header1, destdir)
+            else:
+                (out, _) = self.copy_file(header, self.install_dir)
+
+# using distutils install_data because setuptools does not work for .dll and .pyi
+from distutils.command.install_data import install_data
+@add_command('install_data')
+class smart_install_data(install_data):
+    def run(self):
+        # need to change self.install_dir to the actual library dir
+        install_cmd = self.get_finalized_command('install')
+        self.install_dir = getattr(install_cmd, 'install_lib')
+        return install_data.run(self)
+
+# custom build_ext for windows
+if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ and IS_MSC:
+    from setuptools.command.build_ext import build_ext
 
     def has_flag(compiler, flagname):
         """
         Adapted from here: https://github.com/pybind/python_example/blob/master/setup.py#L37
         """
-        from distutils.errors import CompileError
+        from setuptools.errors import CompileError
         import tempfile
         root_drive = os.path.splitdrive(sys.executable)[0] + '\\'
         with tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False) as f:
@@ -745,72 +540,31 @@ if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
                 pass
         return True
 
-
     # filter flags, returns list of accepted flags
     def flag_filter(compiler, *flags):
         return [flag for flag in flags if has_flag(compiler, flag)]
+    
+    @add_command('build_ext')
+    class WinBuildExt(build_ext):
+        """This build_ext sets necessary environment variables for MinGW"""
 
+        # __sdl_lib_dir is possible location of msvcrt replacement import
+        # libraries, if they exist. Pygame module base only links to SDL so
+        # should have the SDL library directory as its only -L option.
+        for e in extensions:
+            if e.name == 'base':
+                __sdl_lib_dir = e.library_dirs[0].replace('/', os.sep)
+                break
 
-    if IS_MSC:
-        @add_command('build_ext')
-        class WinBuildExt(build_ext):
-            """This build_ext sets necessary environment variables for MinGW"""
+        def build_extensions(self):
+            # Add supported optimisations flags to reduce code size with MSVC
+            opts = flag_filter(self.compiler, "/GF", "/Gy")
+            for extension in extensions:
+                extension.extra_compile_args += opts
 
-            # __sdl_lib_dir is possible location of msvcrt replacement import
-            # libraries, if they exist. Pygame module base only links to SDL so
-            # should have the SDL library directory as its only -L option.
-            for e in extensions:
-                if e.name == 'base':
-                    __sdl_lib_dir = e.library_dirs[0].replace('/', os.sep)
-                    break
+            build_ext.build_extensions(self)
 
-            def build_extensions(self):
-                # Add supported optimisations flags to reduce code size with MSVC
-                opts = flag_filter(self.compiler, "/GF", "/Gy")
-                for extension in extensions:
-                    extension.extra_compile_args += opts
-
-                build_ext.build_extensions(self)
-
-
-        # Add the precompiled smooth scale MMX functions to transform.
-        def replace_scale_mmx():
-            for e in extensions:
-                if e.name == 'transform':
-                    if '64 bit' in sys.version:
-                        e.extra_objects.append(
-                            os.path.join('buildconfig', 'obj', 'win64', 'scale_mmx.obj'))
-                    else:
-                        e.extra_objects.append(
-                            os.path.join('buildconfig', 'obj', 'win32', 'scale_mmx.obj'))
-                    for i in range(len(e.sources)):
-                        if e.sources[i].endswith('scale_mmx.c'):
-                            del e.sources[i]
-                            return
-
-
-        if not 'ARM64' in sys.version:
-            replace_scale_mmx()
-
-# clean up the list of extensions
-for e in extensions[:]:
-    if e.name.startswith('COPYLIB_'):
-        extensions.remove(e)  # don't compile the COPYLIBs, just clean them
-    else:
-        e.name = 'pygame.' + e.name  # prepend package name on modules
-
-
-# data installer with improved intelligence over distutils
-# data files are copied into the project directory instead
-# of willy-nilly
-@add_command('install_data')
-class smart_install_data(install_data):
-    def run(self):
-        # need to change self.install_dir to the actual library dir
-        install_cmd = self.get_finalized_command('install')
-        self.install_dir = getattr(install_cmd, 'install_lib')
-        return install_data.run(self)
-
+from setuptools.command.sdist import sdist
 
 @add_command('sdist')
 class OurSdist(sdist):
@@ -818,47 +572,6 @@ class OurSdist(sdist):
         sdist.initialize_options(self)
         # we do not want MANIFEST.in to appear in the root cluttering up things.
         self.template = os.path.join('buildconfig', 'MANIFEST.in')
-
-
-if "bdist_msi" in sys.argv:
-    # if you are making an msi, we want it to overwrite files
-    # we also want to include the repository revision in the file name
-    from distutils.command import bdist_msi
-    import msilib
-
-
-    @add_command('bdist_msi')
-    class bdist_msi_overwrite_on_install(bdist_msi.bdist_msi):
-        def run(self):
-            bdist_msi.bdist_msi.run(self)
-
-            # Remove obsolete files.
-            comp = "pygame1"  # Pygame component
-            prop = comp  # Directory property
-            records = [("surfarray.pyd", comp,
-                        "SURFAR~1.PYD|surfarray.pyd", prop, 1),
-                       ("sndarray.pyd", comp,
-                        "SNDARRAY.PYD|sndarray.pyd", prop, 1),
-                       ("camera.pyd", comp, "CAMERA.PYD|camera.pyd", prop, 1),
-                       ("color.py", comp, "COLOR.PY|color.py", prop, 1),
-                       ("color.pyc", comp, "COLOR.PYC|color.pyc", prop, 1),
-                       ("color.pyo", comp, "COLOR.PYO|color.pyo", prop, 1)]
-            msilib.add_data(self.db, "RemoveFile", records)
-
-            # Overwrite outdated files.
-            fullname = self.distribution.get_fullname()
-            installer_name = self.get_installer_filename(fullname)
-            print(f"changing {installer_name} to overwrite files on install")
-            msilib.add_data(self.db, "Property", [("REINSTALLMODE", "amus")])
-            self.db.Commit()
-
-        def get_installer_filename(self, fullname):
-            if revision:
-                fullname += '-hg_' + revision
-            return bdist_msi.bdist_msi.get_installer_filename(self, fullname)
-
-
-# test command.  For doing 'python setup.py test'
 
 @add_command('test')
 class TestCommand(Command):
@@ -876,7 +589,6 @@ class TestCommand(Command):
         '''
         import subprocess
         return subprocess.call([sys.executable, os.path.join('test', '__main__.py')])
-
 
 @add_command('docs')
 class DocsCommand(Command):
@@ -914,11 +626,150 @@ class DocsCommand(Command):
             raise SystemExit("Failed to build documentation")
 
 
-# Prune empty file lists.
-data_files = [(path, files) for path, files in data_files if files]
 
-# finally,
-# call distutils with all needed info
+"""
+
+Misc. Platform Specific Compilation Stuff
+
+"""
+if sys.platform == 'win32' and not 'WIN32_DO_NOT_INCLUDE_DEPS' in os.environ:
+    if os.environ.get('USE_ANALYZE', '') != '':
+        # calculate the MSVC compiler version as an int
+        msc_pos = sys.version.find('MSC v.')
+        msc_ver = 1900
+        if msc_pos != -1:
+            msc_ver = int(sys.version[msc_pos + 6:msc_pos + 10])
+        print('Analyzing with MSC_VER =', msc_ver)
+
+        # excluding system headers from analyze out put was only added after MSCV_VER 1913
+        if msc_ver >= 1913:
+            os.environ['CAExcludePath'] = 'C:\\Program Files (x86)\\'
+
+        for e in extensions:
+            e.extra_compile_args.extend(
+                (
+                    "/analyze",
+                    "/wd28251",
+                    "/wd28301",
+                )
+            )
+            if msc_ver >= 1913:
+                e.extra_compile_args.extend(
+                    (
+                        "/experimental:external",
+                        "/external:W0",
+                        "/external:env:CAExcludePath",
+                    )
+                )
+    if IS_MSC:
+        # Add the precompiled smooth scale MMX functions to transform.
+        def replace_scale_mmx():
+            for e in extensions:
+                if e.name == 'pygame.transform':
+                    if '64 bit' in sys.version:
+                        e.extra_objects.append(
+                            os.path.join('buildconfig', 'obj', 'win64', 'scale_mmx.obj'))
+                    else:
+                        e.extra_objects.append(
+                            os.path.join('buildconfig', 'obj', 'win32', 'scale_mmx.obj'))
+                    for i in range(len(e.sources)):
+                        if e.sources[i].endswith('scale_mmx.c'):
+                            del e.sources[i]
+                            return
+
+        if not 'ARM64' in sys.version:
+            replace_scale_mmx()
+
+# avx2
+if os.environ.get('PYGAME_DETECT_AVX2', '') != '':
+    avx2_filenames = ['simd_blitters_avx2']
+    compiler_options = {
+        'unix': '-mavx2',
+        'msvc': '/arch:AVX2'
+    }
+    # infer compiler type from os
+    operating_system = platform.system()
+    if operating_system == 'Windows':
+        compiler_type = 'msvc'
+    elif operating_system in ('Linux', 'Darwin'):
+        compiler_type = 'unix'
+    else:
+        compiler_type = 'other'
+    should_use_avx2 = False
+    # try to be thorough in detecting that we are on a platform that potentially supports AVX2
+    machine_name = platform.machine()
+    if ((machine_name.startswith(("x86", "i686")) or
+        machine_name.lower() == "amd64") and
+            os.environ.get("MAC_ARCH") != "arm64"):
+        should_use_avx2 = True
+    
+    if should_use_avx2:
+        extra_options = compiler_options.get(compiler_type)
+        if extra_options is not None:
+            for e in extensions:
+                if any([f in source for source in e.sources for f in avx2_filenames]):
+                    e.extra_compile_args.append(extra_options)
+
+
+"""
+
+Version Module
+
+"""
+# generate the version module
+def parse_version(ver):
+    return ', '.join(s for s in re.findall(r'\d+', ver)[0:3])
+
+def parse_source_version():
+    pgh_major = -1
+    pgh_minor = -1
+    pgh_patch = -1
+    major_exp_search = re.compile(r'define\s+PG_MAJOR_VERSION\s+([0-9]+)').search
+    minor_exp_search = re.compile(r'define\s+PG_MINOR_VERSION\s+([0-9]+)').search
+    patch_exp_search = re.compile(r'define\s+PG_PATCH_VERSION\s+([0-9]+)').search
+    pg_header = os.path.join('src_c', 'include', '_pygame.h')
+    with open(pg_header) as f:
+        for line in f:
+            if pgh_major == -1:
+                m = major_exp_search(line)
+                if m: pgh_major = int(m.group(1))
+            if pgh_minor == -1:
+                m = minor_exp_search(line)
+                if m: pgh_minor = int(m.group(1))
+            if pgh_patch == -1:
+                m = patch_exp_search(line)
+                if m: pgh_patch = int(m.group(1))
+    if pgh_major == -1:
+        raise SystemExit("_pygame.h: cannot find PG_MAJOR_VERSION")
+    if pgh_minor == -1:
+        raise SystemExit("_pygame.h: cannot find PG_MINOR_VERSION")
+    if pgh_patch == -1:
+        raise SystemExit("_pygame.h: cannot find PG_PATCH_VERSION")
+    return (pgh_major, pgh_minor, pgh_patch)
+
+def write_version_module(pygame_version, revision):
+    vernum = parse_version(pygame_version)
+    src_vernum = parse_source_version()
+    if vernum != ', '.join(str(e) for e in src_vernum):
+        raise SystemExit("_pygame.h version differs from 'METADATA' version"
+                         ": %s vs %s" % (vernum, src_vernum))
+    with open(os.path.join('buildconfig', 'version.py.in')) as header_file:
+        header = header_file.read()
+    with open(os.path.join('src_py', 'version.py'), 'w') as version_file:
+        version_file.write(header)
+        version_file.write('ver = "' + pygame_version + '"  # pylint: disable=invalid-name\n')
+        version_file.write(f'vernum = PygameVersion({vernum})\n')
+        version_file.write('rev = "' + revision + '"  # pylint: disable=invalid-name\n')
+        version_file.write('\n__all__ = ["SDL", "ver", "vernum", "rev"]\n')
+
+write_version_module(METADATA['version'], revision)
+
+
+"""
+
+Finally, build pygame!
+
+"""
 PACKAGEDATA = {
     "cmdclass": cmdclass,
     "packages": ['pygame',
@@ -970,11 +821,32 @@ if STRIPPED:
                         'pygame.threads': 'src_py/threads'},
         "ext_modules": extensions,
         "zip_safe": False,
-        "data_files": data_files
+        "data_files": data_files,
     }
 
-PACKAGEDATA.update(METADATA)
+EXTRAS = {}
+try:
+    import bdist_mpkg_support
+except ImportError:
+    pass
+else:
+    EXTRAS.update({
+        'options': bdist_mpkg_support.options,
+        'setup_requires': ['bdist_mpkg>=0.4.2'],
+        # 'install_requires': ['pyobjc'],
+        # 'dependency_links': ['http://rene.f0o.com/~rene/stuff/macosx/']
+    })
+
 PACKAGEDATA.update(EXTRAS)
+PACKAGEDATA.update(METADATA)
+
+# we need to eat this argument in to distutils doesn't trip over it
+consume_arg("-setuptools")
+# sanity check for any arguments
+if len(sys.argv) == 1 and sys.stdout.isatty():
+    reply = input('\nNo Arguments Given, Perform Default Install? [Y/n]')
+    if not reply or reply[0].lower() != 'n':
+        sys.argv.append('install')
 
 try:
     setup(**PACKAGEDATA)


### PR DESCRIPTION
**Description**
This PR is an extension of PR #4211 with the goal of continuing to remove deprecated libraries, simplifying the build process and bringing the Pygame build configuration into compliance with PEP-517 and PEP-632. This PR is focused on the refractor of the `setup.py` file, the introduction of `pyproject.toml` and the removal of `disutils` from `setup.py`. The end goal is a more simplified and intuitive build system that uses `pip install` as the primary build command rather than running `setup.py install`.

**Changes**
* `pyproject.toml`: This was added and metadata information and build dependencies that were previously defined in `setup.py` have been moved here.
    * The addition of the `pyproject.toml` file brings the build structure in line with PEP-517 allowing for build dependencies and the `setuptools` backend to be specified within.
* `setup.cfg`: Added duplicate metadata to allow builds on Python 3.6.
    * Prior to Python 3.7, `pip` looked for metadata within the `setup.cfg` rather than the `pyproject.toml`. Duplicating the metadata was a simple fix to ensure continued support for Python 3.6.
* `setup.py`: Refactored for organization, `distutils` was removed and replaced with `setuptools`, and metadata was removed.
    * The overall refactoring intent was to allow future maintainers to more easily make changes to smaller parts of the build system without having to parse through the entire process. This should hopefully help future-proof the process by allowing for deprecated dependencies to more easily be swapped out.
    * `disutils` was removed in most places in compliance with PEP-632, usages of `distutils` have been replaced by the appropriate counterparts in `setuptools`. If no appropriate counterpart was found a custom implementation of the utility was created.
    * Metadata removed from the `setup.py` file in favor of being moved to `pyproject.toml` and `setup.cfg` as described above.
* `buildconfig/appveyor.yml`: Appveyor build changed to use `pip` instead of calling `setup.py` directly.
    * mscv analyze option is now specified via environment variable, `USE_ANALYZE`, which gets detected by the `setup.py` script similar to `PYGAME_DETECT_AVX2`. This is because you cannot pass arguments to the `setup.py` when building with `pip`.

**Tests**
These changes will be tested through Appveyor to ensure that the build process works similar to PR #4211. If the Appveyor targets record successful builds with all tests passing then that will be our indication that the updated build system functions as intended and works within the legacy code base.