### PR TITLE
Refactored test from #3989 to work correctly and also apply to #4191 and fixed the bug being tested

### DIFF
--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2327,9 +2327,9 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
      * num_points : the number of points
      */
     Py_ssize_t i, i_previous;  // i_previous is the index of the point before i
-    int y, miny, maxy;
-    int x1, y1;
-    int x2, y2;
+    double y, miny, maxy;
+    double x1, y1;
+    double x2, y2;
     /* x_intersect are the x-coordinates of intersections of the polygon
      * with some horizontal line */
     int *x_intersect = PyMem_New(int, num_points);
@@ -2396,7 +2396,7 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
                 // add intersection if y crosses the edge (excluding the lower
                 // end), or when we are on the lowest line (maxy)
                 x_intersect[n_intersections++] =
-                    (y - y1) * (x2 - x1) / (y2 - y1) + x1;
+                    (int)((y - y1) * (x2 - x1) / (y2 - y1) + x1);
             }
         }
         qsort(x_intersect, n_intersections, sizeof(int), compare_int);

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2356,7 +2356,7 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
             minx = MIN(minx, point_x[i]);
             maxx = MAX(maxx, point_x[i]);
         }
-        drawhorzlineclipbounding(surf, color, minx, miny, maxx, drawn_area);
+        drawhorzlineclipbounding(surf, color, minx, (int)miny, maxx, drawn_area);
         PyMem_Free(x_intersect);
         return;
     }
@@ -2402,7 +2402,7 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
         qsort(x_intersect, n_intersections, sizeof(int), compare_int);
 
         for (i = 0; (i < n_intersections); i += 2) {
-            drawhorzlineclipbounding(surf, color, x_intersect[i], y,
+            drawhorzlineclipbounding(surf, color, x_intersect[i], (int)y,
                                      x_intersect[i + 1], drawn_area);
         }
     }
@@ -2421,7 +2421,7 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
         y = point_y[i];
 
         if ((miny < y) && (point_y[i_previous] == y) && (y < maxy)) {
-            drawhorzlineclipbounding(surf, color, point_x[i], y,
+            drawhorzlineclipbounding(surf, color, point_x[i], (int)y,
                                      point_x[i_previous], drawn_area);
         }
     }

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -2356,7 +2356,8 @@ draw_fillpoly(SDL_Surface *surf, int *point_x, int *point_y,
             minx = MIN(minx, point_x[i]);
             maxx = MAX(maxx, point_x[i]);
         }
-        drawhorzlineclipbounding(surf, color, minx, (int)miny, maxx, drawn_area);
+        drawhorzlineclipbounding(surf, color, minx, (int)miny, maxx,
+                                 drawn_area);
         PyMem_Free(x_intersect);
         return;
     }

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4280,7 +4280,7 @@ class DrawPolygonMixin:
                 surface.unlock()
 
     # Test cases for Issue #3989 (fixed on #4191)
-    # This tests the fill polygon bug to avoid    
+    # This tests the fill polygon bug to avoid
     def test_polygon_large_coords_3989(self):
         """
         Ensures draw polygon works correctly with large points.
@@ -4295,10 +4295,10 @@ class DrawPolygonMixin:
 
         surf_w = surf_h = 650
         surface = pygame.Surface((surf_w, surf_h))
-        
+
         green = (0, 255, 0)
         white = (0, 0, 0, 255)
-        
+
         # Draw white background
         pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)
 
@@ -4333,7 +4333,7 @@ class DrawPolygonMixin:
         self.draw_polygon(surface, green, (point_a, point_b, extreme_points_coords))
         extreme_points(self)
 
-        pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)        
+        pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)
         self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_coords))
         extreme_negative_pass(self)
         extreme_negative_fail(self)
@@ -4347,7 +4347,6 @@ class DrawPolygonMixin:
         self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_y))
         extreme_y_pass(self)
         extreme_y_fail(self)
-
 
 
 class DrawPolygonTest(DrawPolygonMixin, DrawTestCase):

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -4279,72 +4279,75 @@ class DrawPolygonMixin:
 
                 surface.unlock()
 
-    # Test cases for Issue #3989
-    # This tests the fill polygon bug to avoid
-    # Uncomment this code when working on this bug (commented to be built)
-    # def test_polygon_large_coords(self):
-    #     """
-    #     Ensures draw polygon works correctly with large points.
-    #     Testing the drawings of filled polygons
-    #     """
-    #     point_a = (600, 50)
-    #     point_b = (50, 600)
-    #     extreme_points_coords = (58000, 100000)
-    #     extreme_negative_coords = (-58000, -100000)
-    #     extreme_negative_x = (-58000, 100000)
-    #     extreme_negative_y = (58000, -100000)
+    # Test cases for Issue #3989 (fixed on #4191)
+    # This tests the fill polygon bug to avoid    
+    def test_polygon_large_coords_3989(self):
+        """
+        Ensures draw polygon works correctly with large points.
+        Testing the drawings of filled polygons
+        """
+        point_a = (600, 50)
+        point_b = (50, 600)
+        extreme_points_coords = (58000, 100000)
+        extreme_negative_coords = (-58000, -100000)
+        extreme_negative_x = (-58000, 100000)
+        extreme_negative_y = (58000, -100000)
 
-    #     surf_w = surf_h = 650
-    #     surface = pygame.Surface((surf_w, surf_h))
+        surf_w = surf_h = 650
+        surface = pygame.Surface((surf_w, surf_h))
+        
+        green = (0, 255, 0)
+        white = (0, 0, 0, 255)
+        
+        # Draw white background
+        pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)
 
-    #     green = (0, 255, 0)
-    #     white = (0, 0, 0, 255)
+        # Extreme points case
+        def extreme_points(self):
+            self.assertEqual(surface.get_at((640, 50)), white)
+            self.assertEqual(surface.get_at((50, 640)), white)
 
-    #     # Extreme points case
-    #     def extreme_points(self):
-    #         self.assertEqual(surface.get_at((640, 50)), white)
-    #         self.assertEqual(surface.get_at((50, 640)), white)
+        # Extreme negative points case
+        def extreme_negative_pass(self):
+            self.assertEqual(surface.get_at((600, 25)), white)
 
-    #     # Extreme negative points case
-    #     def extreme_negative_pass(self):
-    #         self.assertEqual(surface.get_at((600, 25)), white)
+        def extreme_negative_fail(self):
+            self.assertNotEqual(surface.get_at((5, 5)), white)
 
-    #     @unittest.expectedFailure
-    #     def extreme_negative_fail(self):
-    #         self.assertEqual(surface.get_at((5, 5)), white)
+        # Extreme negative x case
+        def extreme_x_pass(self):
+            self.assertEqual(surface.get_at((600, 600)), white)
 
-    #     # Extreme negative x case
-    #     def extreme_x_pass(self):
-    #         self.assertEqual(surface.get_at((600, 600)), white)
+        def extreme_x_fail(self):
+            self.assertNotEqual(surface.get_at((100, 640)), white)
 
-    #     @unittest.expectedFailure
-    #     def extreme_x_fail(self):
-    #         self.assertEqual(surface.get_at((100, 640)), white)
+        # Extreme negative y case
+        def extreme_y_pass(self):
+            self.assertEqual(surface.get_at((600, 600)), white)
 
-    #     # Extreme negative y case
-    #     def extreme_y_pass(self):
-    #         self.assertEqual(surface.get_at((600, 600)), white)
+        def extreme_y_fail(self):
+            self.assertNotEqual(surface.get_at((300, 300)), white)
 
-    #     @unittest.expectedFailure
-    #     def extreme_y_fail(self):
-    #         self.assertEqual(surface.get_at((300, 300)), white)
+        # Checks the surface point to ensure the polygon has been drawn correctly.
+        # Uses multiple passing and failing test cases depending on the polygon
+        self.draw_polygon(surface, green, (point_a, point_b, extreme_points_coords))
+        extreme_points(self)
 
-    #     # Checks the surface point to ensure the polygon has been drawn correctly.
-    #     # Uses multiple passing and failing test cases depending on the polygon
-    #     self.draw_polygon(surface, green, (point_a, point_b, extreme_points_coords))
-    #     extreme_points(self)
+        pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)        
+        self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_coords))
+        extreme_negative_pass(self)
+        extreme_negative_fail(self)
 
-    #     self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_coords))
-    #     extreme_negative_pass(self)
-    #     extreme_negative_fail(self)
+        pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)
+        self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_x))
+        extreme_x_pass(self)
+        extreme_x_fail(self)
 
-    #     self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_x))
-    #     extreme_x_pass(self)
-    #     extreme_x_fail(self)
+        pygame.draw.rect(surface, white, (0, 0, surf_w, surf_h), 0)
+        self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_y))
+        extreme_y_pass(self)
+        extreme_y_fail(self)
 
-    #     self.draw_polygon(surface, green, (point_a, point_b, extreme_negative_y))
-    #     extreme_y_pass(self)
-    #     extreme_y_fail(self)
 
 
 class DrawPolygonTest(DrawPolygonMixin, DrawTestCase):


### PR DESCRIPTION
Fixed overflow bug in src_c/draw.c:draw_fillpoly from #4191 by changing y, miny, maxy, x1, y1, x2, y2 from int type to double. Uncommented and refactored a test that was previously meant to test the same bug

fixes #4191 
fixes #3989 