### PR TITLE
Fix pygame.camera backend detection on Windows Server

### DIFF
--- a/src_py/camera.py
+++ b/src_py/camera.py
@@ -125,14 +125,22 @@ def _setup_backend(backend):
 def get_backends():
     possible_backends = []
 
-    if sys.platform == "win32" and int(platform.win32_ver()[0].split(".")[0]) >= 8:
-        try:
-            # If cv2 is installed, prefer that on windows.
-            import cv2
+    if sys.platform == "win32":
+        version_code = platform.win32_ver()[0].split(".")[0]
+        if "Server" in version_code:
+            version_code = ''.join(filter(str.isdigit, version_code))[:4]
+            minimum_satisfied = int(version_code) >= 2012
+        else:
+            minimum_satisfied = int(version_code) >= 8
 
-            possible_backends.append("OpenCV")
-        except ImportError:
-            possible_backends.append("_camera (MSMF)")
+        if minimum_satisfied:
+            try:
+                # If cv2 is installed, prefer that on windows.
+                import cv2
+
+                possible_backends.append("OpenCV")
+            except ImportError:
+                possible_backends.append("_camera (MSMF)")
 
     if "linux" in sys.platform:
         possible_backends.append("_camera (V4L2)")


### PR DESCRIPTION
The code for pygame.camera backend detection trips when running on a Server variant of modern Windows, causing initialization of the camera system to fail entirely, as can be seen in this traceback generated on my Windows Server 2022 system:
```
Traceback (most recent call last):
  File "<my client program>", line 5, in <module>
    pygame.camera.init()
  File "[...]\python-3.12.3.amd64\Lib\site-packages\pygame\camera.py", line 168, in init
    backends = [b.lower() for b in get_backends()]
                                   ^^^^^^^^^^^^^^
  File "[...]\python-3.12.3.amd64\Lib\site-packages\pygame\camera.py", line 128, in get_backends
    if sys.platform == "win32" and int(platform.win32_ver()[0].split(".")[0]) >= 8:
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '2022Server'
```

Obviously, Windows Server with the standard desktop environment installed runs the rest of pygame just fine, as it supports webcams at a system level just fine, and this issue has only to do with the version detection code being written without Server in mind.

This commit simply expands the Windows version checking code to make sure that both desktop and Server Windows are handled correctly. I checked how Python returns the Windows version code (`_WIN32_SERVER_RELEASES ` in [platform.py](https://github.com/python/cpython/blob/main/Lib/platform.py)) and my code should handle every possible case. The minimum version check for Windows Server is set at version 2012, as that's equivalent to desktop version 8 as already present in the code before.