### PR TITLE
README.rst: Fix link to pyhon.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Windows) or a terminal (if you have MacOS or Linux) and type this:
 If a message such as "Python 3.8.10" appears, it means that Python
 is correctly installed. If an error message appears, it means that
 it is not installed yet. You must then go to the `official website
-<https://www.pygame.org/docs/>`_ and follow the instructions.
+<https://www.python.org/downloads/>`_ to download it.
 
 Once Python is installed, you have to perform a final check: you have
 to see if pip is installed. Generally, pip is pre-installed with


### PR DESCRIPTION
So far the link you shall visit if python is not installed leads to the Pygame Front Page (https://www.pygame.org/docs/). I propose changing it to leading directly to https://www.python.org/downloads/. I am quite new to contributing to open source so I am sorry if I did anything wrong here.