### PR TITLE
test: Fix test_queue timing issue

### DIFF
--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -854,6 +854,7 @@ class ChannelTypeTest(unittest.TestCase):
         channel.play(sound1)
         channel.queue(sound2)
         channel.stop()
+        pygame.time.wait(100)
         self.assertIsNone(channel.get_queue())
         self.assertFalse(channel.get_busy())
 


### PR DESCRIPTION
Some "times" it would not finish the sound quick enough so the
test would fail.

See https://github.com/pygame/pygame/actions/runs/8936818742/job/25018896642?pr=4221#step:5:3096