### PR TITLE
buildconfig: Add fallback to portmidi if porttime is not found

### DIFF
--- a/buildconfig/config_unix.py
+++ b/buildconfig/config_unix.py
@@ -196,7 +196,9 @@ def main(auto_config=False):
         if portmidi_as_porttime:
             return Dependency('PORTTIME', 'porttime.h', 'libportmidi.so', ['portmidi'])
         else:
-            return Dependency('PORTTIME', 'porttime.h', 'libporttime.so', ['porttime'])
+            dep = Dependency('PORTTIME', 'porttime.h', 'libporttime.so', ['porttime'])
+            if not dep.found:
+                return Dependency('PORTTIME', 'porttime.h', 'libportmidi.so', ['portmidi'])
 
     def find_freetype():
         """ modern freetype uses pkg-config. However, some older systems don't have that.


### PR DESCRIPTION
So that local installs of portmidi on Deb/Ubuntu can work.


Noticed whilst working on https://github.com/pygame/pygame/issues/4227