### PR TITLE
Updated pygame installation instructions in pygame/README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,35 +19,103 @@ New contributors are welcome.
 Installation
 ------------
 
-Before installing pygame, you must check that Python is installed
-on your machine. To find out, open a command prompt (if you have
-Windows) or a terminal (if you have MacOS or Linux) and type this:
+Before installing Pygame, ensure Python and pip are installed on your machine.
+If you haven't already installed Python, download and install Python 3 from the
+official website (https://www.python.org/downloads/). Once Python is installed,
+open a command prompt (Windows) or a terminal (MacOS or Linux) and verify Python's
+installation by running:
+
 ::
 
    python --version
 
+or
 
-If a message such as "Python 3.8.10" appears, it means that Python
-is correctly installed. If an error message appears, it means that
-it is not installed yet. You must then go to the `official website
-<https://www.pygame.org/docs/>`_ and follow the instructions.
+::
 
-Once Python is installed, you have to perform a final check: you have
-to see if pip is installed. Generally, pip is pre-installed with
-Python but we are never sure. Same as for Python, type the following
-command:
+   python3 --version
+
+If Python is installed correctly, you'll see a message displaying the Python version
+like this. The actual version number may vary depending on your Python installation.
+
+::
+
+   Python 3.11.7
+
+Once Python is installed, you have to perform a final check: you have to see if
+pip is installed. Generally, pip is pre-installed with Python but we are never sure.
+Same as for Python, type the following command:
+
 ::
 
    pip --version
 
+or
 
-If a message such as "pip 20.0.2 from /usr/lib/python3/dist-packages/pip
-(python 3.8)" appears, you are ready to install pygame! To install
-it, enter this command:
 ::
 
-   pip install pygame
+   pip3 --version
 
+If pip is installed, you'll see a message displaying the pip version like this. 
+The actual version number may vary depending on your Python installation.
+
+::
+
+   pip 23.3.1 from /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pip (python 3.11)
+
+
+If pip is not installed, you can install it manually by following these steps:
+
+1. Windows: Pip usually comes bundled with Python installations on Windows. 
+If it's missing, you can download `get-pip.py` from https://bootstrap.pypa.io/get-pip.py 
+and run it using Python. Open a command prompt and navigate to the directory containing 
+`get-pip.py`, then run:
+
+::
+
+   python get-pip.py
+
+or
+
+::
+
+   python3 get-pip.py
+
+2. MacOS and Linux: On MacOS and Linux systems, you can install pip
+using the `ensurepip` module, which is included with Python. Open a
+terminal and run:
+
+::
+
+   python -m ensurepip --default-pip
+
+or
+
+::
+
+   python3 -m ensurepip --default-pip
+
+Once pip is installed, you can proceed to install Pygame by running:
+
+::
+
+   python -m pip install pygame
+
+or
+
+::
+
+   python3 -m pip install pygame
+
+This command will download and install Pygame and its dependencies. 
+After installation, you can verify the Pygame installation by importing
+it in a Python script:
+
+::
+
+   import pygame
+
+If no errors occur, Pygame is successfully installed on your system.
 
 Help
 ----


### PR DESCRIPTION
The updated instructions improve clarity and detail for installing Python and pip before setting up Pygame. They include separate commands for checking both python and python3 installations, as well as pip and pip3 to ensure compatibility with different system configurations. Also, the guide provides direct links for downloading Python, offers solutions if pip is missing, and includes specific commands for both Windows and MacOS/Linux users to install pip if necessary.