### PR TITLE
Inline _PyArg_NoKeywords from Python 3.13 in case it is missing

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -4413,6 +4413,34 @@ com_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     return PyMethod_New(com->obj_callable, obj);
 }
 
+#ifndef _PyArg_NoKeywords
+/* For type constructors that don't take keyword args
+ *
+ * Sets a TypeError and returns 0 if the args/kwargs is
+ * not empty, returns 1 otherwise
+ *
+ * From Python 3.13.0b2, Python/getargs.c
+ */
+int
+_PyArg_NoKeywords(const char *funcname, PyObject *kwargs)
+{
+    if (kwargs == NULL) {
+        return 1;
+    }
+    if (!PyDict_CheckExact(kwargs)) {
+        PyErr_BadInternalCall();
+        return 0;
+    }
+    if (PyDict_GET_SIZE(kwargs) == 0) {
+        return 1;
+    }
+
+    PyErr_Format(PyExc_TypeError, "%.200s() takes no keyword arguments",
+                    funcname);
+    return 0;
+}
+#endif
+
 static int
 com_init(PyObject *self, PyObject *args, PyObject *kwds)
 {


### PR DESCRIPTION
Python 3.13 made this private:
https://github.com/python/cpython/pull/110966

Fixes https://github.com/pygame/pygame/issues/4099