### PR TITLE
github/build-*: Fix Cython version specifier

### DIFF
--- a/.github/workflows/build-debian-multiarch.yml
+++ b/.github/workflows/build-debian-multiarch.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           export PIP_CONFIG_FILE=buildconfig/pip_config.ini
           echo "\nBuilding pygame wheel\n"
-          python3 -m pip install "Cython==3.0,<3.1"
+          python3 -m pip install "Cython>=3.0,<3.1"
           python3 setup.py docs
           pip3 wheel . --wheel-dir /artifacts -vvv
           echo "\nInstalling wheel\n"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -134,7 +134,7 @@ jobs:
         bash ./install_mac_deps.sh
 
       CIBW_BEFORE_BUILD: |
-        pip install requests numpy Sphinx "Cython==3.0,<3.1" setuptools wheel
+        pip install requests numpy Sphinx "Cython>=3.0,<3.1" setuptools wheel
         python setup.py docs
         
 

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -70,7 +70,7 @@ jobs:
 
       # command that runs before every build
       CIBW_BEFORE_BUILD: |
-        pip install Sphinx "Cython==3.0,<3.1" setuptools wheel
+        pip install Sphinx "Cython>=3.0,<3.1" setuptools wheel
         python setup.py docs
 
       CIBW_TEST_COMMAND: python -m pygame.tests -v --exclude opengl,music,timing --time_out 300

--- a/.github/workflows/build-ubuntu-sdist.yml
+++ b/.github/workflows/build-ubuntu-sdist.yml
@@ -65,14 +65,14 @@ jobs:
       run: |
         sudo apt-get update --fix-missing
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
-        python3 -m pip install sphinx numpy>=1.21.0 "Cython==3.0,<3.1"
+        python3 -m pip install sphinx numpy>=1.21.0 "Cython>=3.0,<3.1"
         
     - name: Install deps retry
       if: steps.install_deps.outcome == 'failure'
       run: |
         sudo apt-get update --fix-missing
         sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libfreetype6-dev libportmidi-dev libjpeg-dev python3-setuptools python3-dev
-        python3 -m pip install sphinx numpy>=1.21.0 "Cython==3.0,<3.1"
+        python3 -m pip install sphinx numpy>=1.21.0 "Cython>=3.0,<3.1"
     
     - name: Make sdist and install it
       env:


### PR DESCRIPTION
Had typo in there meaning 3.0.0 was installed always.
