### PR TITLE
Add docs for SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS env variable

### DIFF
--- a/docs/reST/ref/joystick.rst
+++ b/docs/reST/ref/joystick.rst
@@ -695,3 +695,14 @@ The controller is recognized as "Wireless Controller".
     Down -> Up      - Y Axis
     Left -> Right   - X Axis
 
+Joysticks and Background Input
+------------------------------
+
+By default, pygame does not process joystick input when the window is not in focus.
+To allow joystick events to be captured even while the window is in the background,
+set the :envvar:`SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS` environment variable.
+
+This must be set before calling :func:`pygame.init` or :func:`pygame.joystick.init`.
+
+
+

--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -496,10 +496,11 @@ on KDE linux. This variable is only used on x11/linux platforms.
 
 ::
 
- SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS
- Set to "1" to allow joysticks to be updated even when the window is out of focus
+.. envvar:: SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS
 
-By default, when the window is not in focus, input devices do not get
-updated. However, using this environment variable it is possible to get
-joystick updates even when the window is in the background. Must be set
-before calling :func:`pygame.init()` or :func:`pygame.joystick.init()`.
+   Set to "1" to allow joysticks to be updated even when the window is out of focus.
+
+   By default, when the window is not in focus, input devices do not get updated.
+   However, using this environment variable it is possible to get joystick updates even when the window is in the background.
+   Must be set before calling :func:`pygame.init` or :func:`pygame.joystick.init`.
+


### PR DESCRIPTION
This PR adds and refines documentation for the SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS environment variable.

- Converted the existing note in `pygame.rst` into a properly formatted `.. envvar::` directive
- Added a new explanatory section in `joystick.rst` to clarify default behavior and how to enable joystick input in the background

Closes #2962
