### PR TITLE
Replace deprecated pkg_resources with importlib.resources in pkgdata.py

### DIFF
--- a/docs/reST/ref/joystick.rst
+++ b/docs/reST/ref/joystick.rst
@@ -695,3 +695,14 @@ The controller is recognized as "Wireless Controller".
     Down -> Up      - Y Axis
     Left -> Right   - X Axis
 
+Joysticks and Background Input
+------------------------------
+
+By default, pygame does not process joystick input when the window is not in focus.
+To allow joystick events to be captured even while the window is in the background,
+set the :envvar:`SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS` environment variable.
+
+This must be set before calling :func:`pygame.init` or :func:`pygame.joystick.init`.
+
+
+

--- a/docs/reST/ref/pygame.rst
+++ b/docs/reST/ref/pygame.rst
@@ -496,10 +496,11 @@ on KDE linux. This variable is only used on x11/linux platforms.
 
 ::
 
- SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS
- Set to "1" to allow joysticks to be updated even when the window is out of focus
+.. envvar:: SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS
 
-By default, when the window is not in focus, input devices do not get
-updated. However, using this environment variable it is possible to get
-joystick updates even when the window is in the background. Must be set
-before calling :func:`pygame.init()` or :func:`pygame.joystick.init()`.
+   Set to "1" to allow joysticks to be updated even when the window is out of focus.
+
+   By default, when the window is not in focus, input devices do not get updated.
+   However, using this environment variable it is possible to get joystick updates even when the window is in the background.
+   Must be set before calling :func:`pygame.init` or :func:`pygame.joystick.init`.
+

--- a/src_py/pkgdata.py
+++ b/src_py/pkgdata.py
@@ -18,28 +18,22 @@ object (such as StringIO).
 """
 
 __all__ = ["getResource"]
+
 import sys
 import os
+import importlib.resources
 
-try:
-    from pkg_resources import resource_stream, resource_exists
-except ImportError:
 
-    def resource_exists(_package_or_requirement, _resource_name):
-        """
-        A stub for when we fail to import this function.
+def resource_stream(package, resource):
+    return importlib.resources.open_binary(package, resource)
 
-        :return: Always returns False
-        """
+
+def resource_exists(package, resource):
+    try:
+        importlib.resources.files(package).joinpath(resource).open("rb").close()
+        return True
+    except (FileNotFoundError, ModuleNotFoundError):
         return False
-
-    def resource_stream(_package_of_requirement, _resource_name):
-        """
-        A stub for when we fail to import this function.
-
-        Always raises a NotImplementedError when called.
-        """
-        raise NotImplementedError
 
 
 def getResource(identifier, pkgname=__name__):


### PR DESCRIPTION
This PR replaces usage of the deprecated `pkg_resources` module with the modern `importlib.resources` module in `src_py/pkgdata.py`.

- Replaces `resource_stream` and `resource_exists` with updated `importlib.resources` equivalents
- Removes dependency on `pkg_resources`, improving compatibility and performance
- Keeps behavior consistent with the original implementation

Closes #4506
