### PR TITLE
[Chores] Fix deprecated codes and enabling compiling

### DIFF
--- a/buildconfig/vstools.py
+++ b/buildconfig/vstools.py
@@ -5,6 +5,7 @@ try:
     from distutils.msvccompiler import MSVCCompiler, get_build_architecture
 except ImportError:
     from setuptools._distutils._msvccompiler import MSVCCompiler
+    from setuptools._distutils.compilers.C.msvc import _find_exe
     import sys
     def get_build_architecture():
         # Alternative to distutils.msvccompiler.get_build_architecture()
@@ -33,7 +34,11 @@ class DumpbinParseError(DumpbinError):
 
 
 def find_symbols(dll):
-    dumpbin_path = compiler.find_exe('dumpbin.exe')
+    try:
+        dumpbin_path = compiler.find_exe('dumpbin.exe')
+    except AttributeError:
+        dumpbin_path = _find_exe('dumpbin.exe')
+
     try:
         output = subprocess.check_output(
             [dumpbin_path, '/nologo', '/exports', dll],

--- a/buildconfig/vstools.py
+++ b/buildconfig/vstools.py
@@ -1,9 +1,21 @@
 import re
+import string
 
 try:
     from distutils.msvccompiler import MSVCCompiler, get_build_architecture
 except ImportError:
-    from setuptools._distutils.msvccompiler import MSVCCompiler, get_build_architecture
+    from setuptools._distutils._msvccompiler import MSVCCompiler
+    import sys
+    def get_build_architecture():
+        # Alternative to distutils.msvccompiler.get_build_architecture()
+        # copied from https://chromium.googlesource.com/external/googleappengine/python/+/bedccc3dd4178880371cdf44064b222d82a5f30d/lib/distutils/distutils/msvccompiler.py#176
+        prefix = " bit ("
+        i = string.find(sys.version, prefix)
+        if i == -1:
+            return "Intel"
+        j = string.find(sys.version, ")", i)
+        return sys.version[i+len(prefix):j]
+
 import subprocess
 import os
 

--- a/buildconfig/vstools.py
+++ b/buildconfig/vstools.py
@@ -9,12 +9,12 @@ except ImportError:
     import sys
     def get_build_architecture():
         # Alternative to distutils.msvccompiler.get_build_architecture()
-        # copied from https://chromium.googlesource.com/external/googleappengine/python/+/bedccc3dd4178880371cdf44064b222d82a5f30d/lib/distutils/distutils/msvccompiler.py#176
+        # ref: https://chromium.googlesource.com/external/googleappengine/python/+/bedccc3dd4178880371cdf44064b222d82a5f30d/lib/distutils/distutils/msvccompiler.py#176
         prefix = " bit ("
-        i = string.find(sys.version, prefix)
+        i = sys.version.find(prefix)
         if i == -1:
             return "Intel"
-        j = string.find(sys.version, ")", i)
+        j = sys.version.find(")", i)
         return sys.version[i+len(prefix):j]
 
 import subprocess


### PR DESCRIPTION
## Problems occurred

The `main` branch could not be compiled because of deprecated codes of `distutils`
ref: #4534 #4375

## What is fixed

The original code was using both:
- `distutils` importing pattern for **legacy** Python
- `setuptools.distutils` importing pattern for **modern** Python

But `setuptools.distutils` has been changed to `setuptools._distutils` a few years ago.

I leave the `distutils` one for legacy Python and updated the `setuptools.distutils` pattern.
I tried to leave other codes as it was, just changing the importing code. (Not sure I made `vstools.py` is too dirty or not...)

## After fixing
Able to compile by
```
py -m pip install setuptools requests wheel numpy -U
py -m buildconfig --download
py -m install .
```