### PR TITLE
Clarification of Vector2 Math in documentation

### DIFF
--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -13,16 +13,16 @@ dimensions, ``Vector2`` and ``Vector3`` respectively.
 
 They support the following numerical operations: ``vec + vec``, ``vec - vec``, 
 ``vec * number``, ``number * vec``, ``vec / number``, ``vec // number``, ``vec += vec``, 
-``vec -= vec``, `vec *= vec`, ``vec *= number``, ``vec /= number``, ``vec //= number``, 
+``vec -= vec``, ``vec *= vec``, ``vec *= number``, ``vec /= number``, ``vec //= number``, 
 ``round(vec, ndigits=0)``. 
 
 All these operations will be performed elementwise.
-Note: ``vec += vec``, ``vec -= vec``, , ``vec *= number``, ``vec /= number``, operations
+
+Note: ``vec += vec``, ``vec -= vec``, ``vec *= number``, ``vec /= number``, operations
 will mutate the original Vector2 object, preserving the object identiy, while `vec *= vec` 
-and ``vec //= number`` will create a new object In addition ``vec * vec`` will perform a
-scalar-product (a.k.a. dot-product). 
-If you want to multiply every element from vector v with every element from 
-vector w you can use the elementwise method: ``v.elementwise() * w``
+and ``vec //= number`` will create a new object. In addition ``vec * vec`` will perform a
+scalar-product (a.k.a. dot-product). If you want to multiply every element from vector v 
+with every element from vector w you can use the elementwise method: ``v.elementwise() * w``
 
 The coordinates of a vector can be retrieved or set using attributes or
 subscripts

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -12,17 +12,18 @@ The pygame math module currently provides Vector classes in two and three
 dimensions, ``Vector2`` and ``Vector3`` respectively.
 
 They support the following numerical operations: ``vec + vec``, ``vec - vec``, 
-``vec * number``, ``number * vec``, ``vec / number``, ``vec // number``, ``vec += vec``, 
-``vec -= vec``, ``vec *= vec``, ``vec *= number``, ``vec /= number``, ``vec //= number``, 
-``round(vec, ndigits=0)``. 
+``vec * number``, ``number * vec``, ``vec / number``, ``vec // number``, 
+``vec += vec``, ``vec -= vec``, ``vec *= vec``, ``vec *= number``,
+``vec /= number``, ``vec //= number``, ``round(vec, ndigits=0)``. 
 
 All these operations will be performed elementwise.
 
-Note: ``vec += vec``, ``vec -= vec``, ``vec *= number``, ``vec /= number``, operations
-will mutate the original Vector2 object, preserving the object identiy, while ``vec *= vec`` 
-and ``vec //= number`` will create a new object. In addition ``vec * vec`` will perform a
-scalar-product (a.k.a. dot-product). If you want to multiply every element from vector v 
-with every element from vector w you can use the elementwise method: ``v.elementwise() * w``
+Note: ``vec += vec``, ``vec -= vec``, ``vec *= number``, ``vec /= number``,
+operations will mutate the original Vector2 object, preserving the object
+identiy, while ``vec *= vec`` and ``vec //= number`` will create a new object.
+In addition ``vec * vec`` will perform a scalar-product (a.k.a. dot-product). 
+If you want to multiply every element from vector v with every element from
+vector w you can use the elementwise method: ``v.elementwise() * w``
 
 The coordinates of a vector can be retrieved or set using attributes or
 subscripts

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -13,10 +13,14 @@ dimensions, ``Vector2`` and ``Vector3`` respectively.
 
 They support the following numerical operations: ``vec + vec``, ``vec - vec``, 
 ``vec * number``, ``number * vec``, ``vec / number``, ``vec // number``, ``vec += vec``, 
-``vec -= vec``, ``vec *= number``, ``vec /= number``, ``vec //= number``, ``round(vec, ndigits=0)``. 
+``vec -= vec``, `vec *= vec`, ``vec *= number``, ``vec /= number``, ``vec //= number``, 
+``round(vec, ndigits=0)``. 
 
 All these operations will be performed elementwise.
-In addition ``vec * vec`` will perform a scalar-product (a.k.a. dot-product). 
+Note: ``vec += vec``, ``vec -= vec``, , ``vec *= number``, ``vec /= number``, operations
+will mutate the original Vector2 object, preserving the object identiy, while `vec *= vec` 
+and ``vec //= number`` will create a new object In addition ``vec * vec`` will perform a
+scalar-product (a.k.a. dot-product). 
 If you want to multiply every element from vector v with every element from 
 vector w you can use the elementwise method: ``v.elementwise() * w``
 

--- a/docs/reST/ref/math.rst
+++ b/docs/reST/ref/math.rst
@@ -19,7 +19,7 @@ They support the following numerical operations: ``vec + vec``, ``vec - vec``,
 All these operations will be performed elementwise.
 
 Note: ``vec += vec``, ``vec -= vec``, ``vec *= number``, ``vec /= number``, operations
-will mutate the original Vector2 object, preserving the object identiy, while `vec *= vec` 
+will mutate the original Vector2 object, preserving the object identiy, while ``vec *= vec`` 
 and ``vec //= number`` will create a new object. In addition ``vec * vec`` will perform a
 scalar-product (a.k.a. dot-product). If you want to multiply every element from vector v 
 with every element from vector w you can use the elementwise method: ``v.elementwise() * w``


### PR DESCRIPTION
Updates the Vector2 section of documentation to clarify when object identity changes when using augmented assignment operators. The discrepancy between the operations was noted in issue #4516.
