### PR TITLE
solved issue #4502

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1794,6 +1794,8 @@ surf_fill(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
 
         // clip the rect to be within the surface.
         if (sdlrect.x + sdlrect.w <= 0 || sdlrect.y + sdlrect.h <= 0) {
+            sdlrect.x = 0;
+            sdlrect.y = 0;
             sdlrect.w = 0;
             sdlrect.h = 0;
         }
@@ -1814,6 +1816,13 @@ surf_fill(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
             }
             if (sdlrect.h > maxh) {
                 sdlrect.h = maxh;
+            }
+
+            if (sdlrect.w <= 0 || sdlrect.h <= 0) {
+                sdlrect.x = 0;
+                sdlrect.y = 0;
+                sdlrect.w = 0;
+                sdlrect.h = 0;
             }
         }
 

--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1797,19 +1797,24 @@ surf_fill(pgSurfaceObject *self, PyObject *args, PyObject *keywds)
             sdlrect.w = 0;
             sdlrect.h = 0;
         }
-
-        if (sdlrect.x < 0) {
-            sdlrect.x = 0;
-        }
-        if (sdlrect.y < 0) {
-            sdlrect.y = 0;
-        }
-
-        if (sdlrect.x + sdlrect.w > surf->w) {
-            sdlrect.w = sdlrect.w + (surf->w - (sdlrect.x + sdlrect.w));
-        }
-        if (sdlrect.y + sdlrect.h > surf->h) {
-            sdlrect.h = sdlrect.h + (surf->h - (sdlrect.y + sdlrect.h));
+        else {
+            if (sdlrect.x < 0) {
+                sdlrect.w += sdlrect.x;
+                sdlrect.x = 0;
+            }
+            if (sdlrect.y < 0) {
+                sdlrect.h += sdlrect.y;
+                sdlrect.y = 0;
+            }
+            
+            int maxw = surf->w - sdlrect.x;
+            int maxh = surf->h - sdlrect.y;
+            if (sdlrect.w > maxw) {
+                sdlrect.w = maxw;
+            }
+            if (sdlrect.h > maxh) {
+                sdlrect.h = maxh;
+            }
         }
 
         if (sdlrect.w <= 0 || sdlrect.h <= 0) {

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -415,14 +415,16 @@ class SurfaceTypeTest(unittest.TestCase):
 
         s1 = pygame.Surface((32, 32), pygame.SRCALPHA, 32)
         r1 = s1.fill(color, fill_rect)
+        self.assertEqual(r1, pygame.Rect(0, 0, 6, 6))
         c = s1.get_at((0, 0))
         self.assertEqual(c, color)
 
         # make subsurface in the middle to test it doesn't over write.
         s2 = s1.subsurface((5, 5, 5, 5))
         r2 = s2.fill(color2, (-3, -3, 5, 5))
+        self.assertEqual(r2, pygame.Rect(0, 0, 2, 2))
         c2 = s1.get_at((4, 4))
-        self.assertEqual(c, color)
+        self.assertEqual(c2, color)
 
         # rect returns the area we actually fill.
         r3 = s2.fill(color2, (-30, -30, 5, 5))

--- a/test/surface_test.py
+++ b/test/surface_test.py
@@ -429,7 +429,7 @@ class SurfaceTypeTest(unittest.TestCase):
         # rect returns the area we actually fill.
         r3 = s2.fill(color2, (-30, -30, 5, 5))
         # since we are using negative coords, it should be an zero sized rect.
-        self.assertEqual(tuple(r3), (0, 0, 0, 0))
+        self.assertEqual(r3, pygame.Rect(0, 0, 0, 0))
 
     def test_fill_keyword_args(self):
         """Ensure fill() accepts keyword arguments."""


### PR DESCRIPTION
I solved the issue #4502.

The problem was that subsurface.fill, the function defined in surface.c, worked differently from the function pygame.draw.rect. 

As the author of issue #4502 showed with the example of 100 * 100 square, even with the same coordinates, surface.fill filled all the 100 * 100 area and pygame.draw.rect filled only the 50 * 50 area.

However, subsurface.fill should work in the same way of pygame.draw.rect, and it means that the function needs to fill the area from the start coordinates (x, y) to the coordinates (x + dx, y + dy) and cut off the area with negative coordinates.

I implemented this, so please check it.