### PR TITLE
Fix test_magic NameError by renaming helper function

### DIFF
--- a/test/image_test.py
+++ b/test/image_test.py
@@ -18,7 +18,7 @@ if _sdl_image_ver is not None:
     )
 
 
-def test_magic(f, magic_hexes):
+def _test_magic(f, magic_hexes):
     """Tests a given file to see if the magic hex matches."""
     data = f.read(len(magic_hexes))
     if len(data) != len(magic_hexes):
@@ -332,7 +332,7 @@ class ImageModuleTest(unittest.TestCase):
                     # Test the magic numbers at the start of the file to ensure
                     # they are saved as the correct file type.
                     self.assertEqual(
-                        (1, fmt), (test_magic(handle, magic_hex[fmt.lower()]), fmt)
+                        (1, fmt), (_test_magic(handle, magic_hex[fmt.lower()]), fmt)
                     )
 
                 # load the file to make sure it was saved correctly.
@@ -416,7 +416,7 @@ class ImageModuleTest(unittest.TestCase):
                         # ensure they are saved as the correct file type.
                         handle.seek(0)
                         self.assertEqual(
-                            (1, fmt), (test_magic(handle, magic_hex[fmt.lower()]), fmt)
+                            (1, fmt), (_test_magic(handle, magic_hex[fmt.lower()]), fmt)
                         )
                     # load the file to make sure it was saved correctly.
                     handle.flush()
@@ -1241,7 +1241,7 @@ class ImageModuleTest(unittest.TestCase):
             with open(temp_file_name, "rb") as file:
                 # Test the magic numbers at the start of the file to ensure
                 # they are saved as the correct file type.
-                self.assertEqual(1, (test_magic(file, magic_hex[fmt.lower()])))
+                self.assertEqual(1, (_test_magic(file, magic_hex[fmt.lower()])))
             # load the file to make sure it was saved correctly
             loaded_file = pygame.image.load(temp_file_name)
             self.assertEqual(loaded_file.get_at((0, 0)), surf.get_at((0, 0)))


### PR DESCRIPTION
When we use pytest to test image_test.py, test_magic is considered like a test. so we rename it into  _test_magic