### PR TITLE
Fix bare except clauses in setup.py and test/test_utils/test_runner.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -431,7 +431,7 @@ if AUTO_CONFIG:
 
     try:
         buildconfig.config.main(AUTO_CONFIG)
-    except:
+    except Exception:
         compilation_help()
         raise
     if '-config' in sys.argv:
@@ -453,7 +453,7 @@ else:
     # get compile info for all extensions
     try:
         extensions = read_setup_file('Setup')
-    except:
+    except Exception:
         print("""Error with the "Setup" file,
     perhaps make a clean copy from "Setup.in".""")
         compilation_help()
@@ -990,6 +990,6 @@ PACKAGEDATA.update(EXTRAS)
 
 try:
     setup(**PACKAGEDATA)
-except:
+except Exception:
     compilation_help()
     raise

--- a/test/test_utils/test_runner.py
+++ b/test/test_utils/test_runner.py
@@ -244,7 +244,7 @@ def get_test_results(raw_return):
     if test_results:
         try:
             return eval(test_results.group(1))
-        except:
+        except Exception:
             print(f"BUGGY TEST RESULTS EVAL:\n {test_results.group(1)}")
             raise
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` in two files.

**Changes:**
- `setup.py`: 3 fixes — bare `except:` clauses around `buildconfig.config.main()`, `read_setup_file('Setup')`, and `setup(**PACKAGEDATA)`
- `test/test_utils/test_runner.py`: 1 fix — bare `except:` around `eval(test_results.group(1))`

All four catch-and-re-raise or catch-and-log patterns should use `except Exception:` rather than bare `except:` to avoid accidentally swallowing `SystemExit` and `KeyboardInterrupt`.